### PR TITLE
pre-built self-host images

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,64 @@
+name: Build & publish lmnr images
+on:
+  release:
+    types:
+      - published
+
+env:
+  REGISTRY_GH: ghcr.io
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./app-server/Dockerfile
+            context: ./app-server
+            image: ghcr.io/lmnr-ai/app-server
+          - dockerfile: ./frontend/Dockerfile
+            context: ./frontend
+            image: ghcr.io/lmnr-ai/frontend
+          - dockerfile: ./semantic-search-service/Dockerfile
+            context: ./semantic-search-service
+            image: ghcr.io/lmnr-ai/semantic-search-service
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY_GH }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ matrix.image }}
+
+      - name: Build and push Docker images
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ matrix.image }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ This will spin up the following containers:
 - postgres – the database for all the application data
 - clickhouse – columnar OLAP database for more efficient event and trace analytics
 
+#### Local development
+
+The simple set up above will pull latest Laminar images from Github Container Registry.
+
+If you want to test your local changes, you will need to build from source using [Local docker compose](./docker-compose-local-dev.yml)
+
+```sh
+docker compose -f docker-compose-local-dev.yml up --build
+```
+
 ### Instrumenting Python code
 
 First, create a project and generate a Project API Key. Then,

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -47,7 +47,9 @@ services:
         hard: 262144
 
   semantic-search-service:
-    image: ghcr.io/lmnr-ai/semantic-search-service
+    build:
+      context: ./semantic-search-service
+    container_name: semantic-search-service
     ports:
       - "8080:8080"
     depends_on:
@@ -74,7 +76,11 @@ services:
         target: /var/lib/postgresql/data
 
   app-server:
-    image: ghcr.io/lmnr-ai/app-server
+    build:
+      context: ./app-server
+      args:
+        DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+    container_name: app-server
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -98,7 +104,9 @@ services:
       - CLICKHOUSE_USER=${CLICKHOUSE_USER}
 
   frontend:
-    image: ghcr.io/lmnr-ai/frontend
+    build:
+      context: ./frontend
+    container_name: frontend
     ports:
       - "3000:3000"
     env_file: ./frontend/.env.local.example


### PR DESCRIPTION
This commit brings in a
- `.github/workflows` action files that will update docker images in the registry
- moves `docker-compose.yml` -> `docker-compose-local-dev.yml`
- updates default `docker-compose.yml` to pull from ghcr
- updates README accordingly