### PR TITLE
fix: only warn on lines too long

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -3,7 +3,7 @@
   "rules": {
     "indent": ["error", 2],
     "eol-last": ["error", "always"],
-    "max-len": ["error", { "code": 120, "ignoreUrls": true, "ignoreStrings": true, "ignoreTemplateLiterals": true }],
+    "max-len": ["warn", { "code": 120, "ignoreUrls": true, "ignoreStrings": true, "ignoreTemplateLiterals": true }],
     "semi": ["error", "always"], 
     "no-trailing-spaces": ["error"], 
     "arrow-body-style": ["warn", "as-needed"] 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `max-len` rule severity from `error` to `warn` in `frontend/.eslintrc.json` for lines exceeding 120 characters.
> 
>   - **ESLint Configuration**:
>     - Change `max-len` rule severity from `error` to `warn` in `frontend/.eslintrc.json`.
>     - Affects lines exceeding 120 characters, ignoring URLs, strings, and template literals.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 571cc0003505106afc30ce7a14ef5e9a1cf30fc0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->