### PR TITLE
Input costs sessions

### DIFF
--- a/app-server/src/db/trace.rs
+++ b/app-server/src/db/trace.rs
@@ -555,10 +555,14 @@ pub async fn get_single_trace(pool: &PgPool, id: Uuid) -> Result<Trace> {
 #[serde(rename_all = "camelCase")]
 pub struct Session {
     pub id: String,
+    pub input_token_count: i64,
+    pub output_token_count: i64,
     pub total_token_count: i64,
     pub start_time: DateTime<Utc>,
     pub end_time: DateTime<Utc>,
     pub duration: f64,
+    pub input_cost: f64,
+    pub output_cost: f64,
     pub cost: f64,
     pub trace_count: i64,
 }
@@ -575,10 +579,14 @@ pub async fn get_sessions(
         "SELECT
             session_id as id,
             count(id)::int8 as trace_count,
+            sum(input_token_count)::int8 as input_token_count,
+            sum(output_token_count)::int8 as output_token_count,
             sum(total_token_count)::int8 as total_token_count,
             min(start_time) as start_time,
             max(end_time) as end_time,
             sum(extract(epoch from (end_time - start_time)))::float8 as duration,
+            sum(input_cost)::float8 as input_cost,
+            sum(output_cost)::float8 as output_cost,
             sum(cost)::float8 as cost
             FROM traces
             WHERE session_id is not null and project_id = ",

--- a/frontend/components/traces/traces-table-sessions-view.tsx
+++ b/frontend/components/traces/traces-table-sessions-view.tsx
@@ -142,13 +142,33 @@ export default function SessionsTable({ onRowClick }: SessionsTableProps) {
       header: 'Duration',
     },
     {
+      accessorFn: (row) => "$" + row.data.inputCost?.toFixed(5),
+      header: 'Input cost',
+      id: 'cost'
+    },
+    {
+      accessorFn: (row) => "$" + row.data.outputCost?.toFixed(5),
+      header: 'Output cost',
+      id: 'cost'
+    },
+    {
       accessorFn: (row) => '$' + row.data.cost?.toFixed(5),
       header: 'Cost',
       id: 'cost'
     },
     {
+      accessorFn: (row) => row.data.inputTokenCount,
+      header: 'Input token count',
+      id: 'input_token_count'
+    },
+    {
+      accessorFn: (row) => row.data.outputTokenCount,
+      header: 'Output token count',
+      id: 'output_token_count'
+    },
+    {
       accessorFn: (row) => row.data.totalTokenCount,
-      header: 'Token Count',
+      header: 'Token count',
       id: 'total_token_count'
     },
     {

--- a/frontend/components/traces/traces-table-sessions-view.tsx
+++ b/frontend/components/traces/traces-table-sessions-view.tsx
@@ -144,12 +144,12 @@ export default function SessionsTable({ onRowClick }: SessionsTableProps) {
     {
       accessorFn: (row) => "$" + row.data.inputCost?.toFixed(5),
       header: 'Input cost',
-      id: 'cost'
+      id: 'input_cost'
     },
     {
       accessorFn: (row) => "$" + row.data.outputCost?.toFixed(5),
       header: 'Output cost',
-      id: 'cost'
+      id: 'output_cost'
     },
     {
       accessorFn: (row) => '$' + row.data.cost?.toFixed(5),

--- a/frontend/lib/traces/types.ts
+++ b/frontend/lib/traces/types.ts
@@ -1,5 +1,5 @@
 import { Event } from "../events/types";
-import { GraphMessagePreview } from "../pipeline/types"
+import { GraphMessagePreview } from "../pipeline/types";
 
 export type TraceMessages = { [key: string]: GraphMessagePreview }
 

--- a/frontend/lib/traces/types.ts
+++ b/frontend/lib/traces/types.ts
@@ -1,5 +1,5 @@
-import { Event } from '../events/types';
-import { GraphMessagePreview } from '../pipeline/types';
+import { Event } from "../events/types";
+import { GraphMessagePreview } from "../pipeline/types"
 
 export type TraceMessages = { [key: string]: GraphMessagePreview }
 
@@ -33,11 +33,11 @@ export type SpanLabel = {
 }
 
 export enum SpanType {
-  DEFAULT = 'DEFAULT',
-  LLM = 'LLM',
-  EXECUTOR = 'EXECUTOR',
-  EVALUATOR = 'EVALUATOR',
-  EVALUATION = 'EVALUATION',
+  DEFAULT = "DEFAULT",
+  LLM = "LLM",
+  EXECUTOR = "EXECUTOR",
+  EVALUATOR = "EVALUATOR",
+  EVALUATION = "EVALUATION",
 }
 
 export type Span = {
@@ -125,10 +125,14 @@ export type TraceMetricDatapoint = {
 export type SessionPreview = {
   id: string;
   traceCount: number;
+  inputCost: number;
+  outputCost: number;
   cost: number;
   startTime: string;
   endTime: string;
   duration: number;
+  inputTokenCount: number;
+  outputTokenCount: number;
   totalTokenCount: number;
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add input/output cost and token count to session data in backend and frontend components.
> 
>   - **Backend**:
>     - Add `input_cost`, `output_cost`, `input_token_count`, and `output_token_count` to `Session` struct in `trace.rs`.
>     - Update `get_sessions()` query in `trace.rs` to include new fields.
>   - **Frontend**:
>     - Add columns for `inputCost`, `outputCost`, `inputTokenCount`, and `outputTokenCount` in `traces-table-sessions-view.tsx`.
>     - Update `SessionPreview` type in `types.ts` to include new fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for ce16dceec5e210eac2a38dc80b881e03b5d152c1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->