### PR TITLE
Docs: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ if __name__ == "__main__":
 
 #### Sending events
 
-To send an evant, call `L.event(name, value)`.
+To send an event, call `L.event(name, value)`.
 
 Read our [docs](https://docs.lmnr.ai) to learn more about events and how they are created.
 


### PR DESCRIPTION
Corrected "evant" to "event" in [README.md].

This pull request addresses a minor typo found in repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.