### PR TITLE
minor fix: add frontend dockerignore

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/.next


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `.dockerignore` to `frontend` to exclude `node_modules` and `.next` directories from Docker builds.
> 
>   - **Docker Ignore**:
>     - Add `.dockerignore` to `frontend` to exclude `**/node_modules` and `**/.next` directories from Docker builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 778f51996870d3cc1992f6e2140f1d2d83498cd8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->