### PR TITLE
minor fix: add frontend dockerignore (#70)

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/.next


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `frontend/.dockerignore` to exclude `node_modules` and `.next` directories from Docker builds.
> 
>   - **Dockerignore**:
>     - Add `frontend/.dockerignore` to exclude `**/node_modules` and `**/.next` directories from Docker builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 0ea0ae97d165265167048567ca7c303d70f1710b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->