### PR TITLE
increased interval on rabbit in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
     healthcheck:
       test: rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
-      interval: 5s
-      timeout: 5s
+      interval: 10s
+      timeout: 10s
       retries: 3
 
   clickhouse:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increased RabbitMQ healthcheck interval and timeout from 5s to 10s in `docker-compose.yml`.
> 
>   - **Docker Compose**:
>     - Increased `interval` and `timeout` for RabbitMQ healthcheck from `5s` to `10s` in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 0670dff8811c06e618a919d3f2a252aade9ec492. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->