### PR TITLE
increased interval on rabbit in docker compose (#74)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
     healthcheck:
       test: rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
-      interval: 5s
-      timeout: 5s
+      interval: 10s
+      timeout: 10s
       retries: 3
 
   clickhouse:


### PR DESCRIPTION
#74
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increased RabbitMQ healthcheck interval and timeout to 10 seconds in `docker-compose.yml`.
> 
>   - **Docker Compose**:
>     - Increased `interval` and `timeout` for RabbitMQ `healthcheck` from `5s` to `10s` in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for b30dd8777b4fb0280223f76841c3f64fc772a9bc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->