### PR TITLE
overwrite span on repeated insert

### DIFF
--- a/app-server/src/db/spans.rs
+++ b/app-server/src/db/spans.rs
@@ -87,8 +87,21 @@ pub async fn record_span(pool: &PgPool, span: &Span) -> Result<()> {
             $10,
             $11,
             $12,
-            $13
-   )",
+            $13)
+        ON CONFLICT (span_id) DO UPDATE SET 
+            version = EXCLUDED.version,
+            trace_id = EXCLUDED.trace_id,
+            parent_span_id = EXCLUDED.parent_span_id,
+            start_time = EXCLUDED.start_time,
+            end_time = EXCLUDED.end_time,
+            name = EXCLUDED.name,
+            attributes = EXCLUDED.attributes,
+            input = EXCLUDED.input,
+            output = EXCLUDED.output,
+            span_type = EXCLUDED.span_type,
+            input_preview = EXCLUDED.input_preview,
+            output_preview = EXCLUDED.output_preview
+    ",
     )
     .bind(&span.version)
     .bind(&span.span_id)

--- a/app-server/src/traces/consumer.rs
+++ b/app-server/src/traces/consumer.rs
@@ -161,11 +161,15 @@ pub async fn process_queue_spans(
         )
         .await;
         if let Err(e) = update_attrs_res {
-            log::error!("Failed to update trace attributes: {:?}", e);
+            log::error!(
+                "Failed to update trace attributes [{}]: {:?}",
+                span.span_id,
+                e
+            );
         }
 
         if let Err(e) = db::spans::record_span(&db.pool, &span).await {
-            log::error!("Failed to record span: {:?}", e);
+            log::error!("Failed to record span [{}]: {:?}", span.span_id, e);
         } else {
             // ack the message as soon as the span is recorded
             let _ = delivery


### PR DESCRIPTION
Overwrite the span on conflict, because client may send the span twice. We must not fail on primary key conflict.

Also update logs to output affected span id
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add conflict resolution to `record_span()` and improve logging with span ID in `consumer.rs`.
> 
>   - **Behavior**:
>     - In `record_span()` in `spans.rs`, added `ON CONFLICT` clause to update span fields on `span_id` conflict.
>     - Logs in `process_queue_spans()` in `consumer.rs` now include `span_id` when errors occur during span recording and trace attribute updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 9b9c75f8b60e85eaab1ded57850828752d46c65b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->