### PR TITLE
increased number of comsumers + small refactor

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -318,16 +318,19 @@ fn main() -> anyhow::Result<()> {
                         cache_for_http.clone(),
                     ));
 
-                    tokio::task::spawn(process_queue_spans(
-                        pipeline_runner.clone(),
-                        db_for_http.clone(),
-                        cache_for_http.clone(),
-                        semantic_search.clone(),
-                        language_model_runner.clone(),
-                        rabbitmq_connection.clone(),
-                        clickhouse.clone(),
-                        chunker_runner.clone(),
-                    ));
+                    // start 8 threads per core to process spans from RabbitMQ
+                    for _ in 0..8 {
+                        tokio::spawn(process_queue_spans(
+                            pipeline_runner.clone(),
+                            db_for_http.clone(),
+                            cache_for_http.clone(),
+                            semantic_search.clone(),
+                            language_model_runner.clone(),
+                            rabbitmq_connection.clone(),
+                            clickhouse.clone(),
+                            chunker_runner.clone(),
+                        ));
+                    }
 
                     App::new()
                         .wrap(Logger::default())

--- a/app-server/src/traces/consumer.rs
+++ b/app-server/src/traces/consumer.rs
@@ -61,6 +61,8 @@ pub async fn process_queue_spans(
         .await
         .unwrap();
 
+    log::info!("Started processing spans from RabbitMQ");
+
     while let Some(delivery) = consumer.next().await {
         let Ok(delivery) = delivery else {
             log::error!("Failed to get delivery from RabbitMQ. Continuing...");

--- a/frontend/components/traces/span-type-icon.tsx
+++ b/frontend/components/traces/span-type-icon.tsx
@@ -23,7 +23,7 @@ export default function SpanTypeIcon({
 }: SpanTypeIconProps) {
   return (
     <div
-      className={cn("flex items-center justify-center z-30 rounded", className)}
+      className={cn("flex items-center justify-center z-10 rounded", className)}
       style={{
         backgroundColor: SPAN_TYPE_TO_COLOR[spanType],
         width: containerWidth,

--- a/frontend/components/traces/spans-table.tsx
+++ b/frontend/components/traces/spans-table.tsx
@@ -143,7 +143,7 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
       header: 'Type',
       id: 'span_type',
       cell: (row) => <div className='flex space-x-2'>
-        <SpanTypeIcon className='z-20' spanType={row.getValue()} />
+        <SpanTypeIcon spanType={row.getValue()} />
         <div className='flex'>{row.getValue() === 'DEFAULT' ? 'SPAN' : row.getValue()}</div>
       </div>,
       size: 120
@@ -231,7 +231,8 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
       cell: (row) => (
         <ClientTimestampFormatter timestamp={String(row.getValue())} />
       ),
-      id: 'start_time'
+      id: 'start_time',
+      size: 125
     },
     {
       accessorFn: (row) => {
@@ -243,52 +244,23 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
       },
       header: 'Latency',
       id: 'latency',
-      size: 100
+      size: 80
     },
     {
-      accessorFn: (row) => (row.attributes as Record<string, any>)['llm.usage.total_tokens'] ?? '-',
-      header: 'Total tokens',
-      id: 'total_token_count',
-      cell: (row) =>
-        <TooltipProvider delayDuration={250}>
-          <Tooltip>
-            <TooltipTrigger className="relative p-0">
-              <div
-                style={{
-                  width: row.column.getSize() - 32
-                }}
-                className="relative"
-              >
-                <div className="absolute inset-0 top-[-4px] items-center h-full flex">
-                  <div className="text-ellipsis flex">
-                    {row.getValue()}
-                    {row.getValue() !== '-' &&
-                      <>
-                        {` (${row.row.original.attributes['gen_ai.usage.input_tokens'] ?? '-'}`}
-                        <ArrowRight size={12} className='mt-[4px]'/>
-                        {`${row.row.original.attributes['gen_ai.usage.output_tokens'] ?? '-'})`}
-                      </>
-                    }
-                  </div>
-                </div>
-              </div>
-            </TooltipTrigger>
-            {row.getValue() !== '-' &&
-              <TooltipContent side="bottom" className="p-2 border">
-                <div>
-                  <div>
-                    <span>Input tokens{' '}</span>
-                    <span>{row.row.original.attributes['gen_ai.usage.input_tokens'] ?? '-'}</span>
-                  </div>
-                  <div>
-                    <span>Output tokens{' '}</span>
-                    <span>{row.row.original.attributes['gen_ai.usage.output_tokens'] ?? '-'}</span>
-                  </div>
-                </div>
-              </TooltipContent>
-            }
-          </Tooltip>
-        </TooltipProvider>,
+      accessorFn: (row) => (row.attributes as Record<string, any>)['llm.usage.total_tokens'],
+      header: 'Tokens',
+      id: 'tokens',
+      cell: (row) => {
+        if (row.getValue()) {
+          return <div className='flex items-center'>
+            {`${row.row.original.attributes['gen_ai.usage.input_tokens'] ?? '-'}`}
+            <ArrowRight size={12} className='mx-1 min-w-[12px]' />
+            {`${row.row.original.attributes['gen_ai.usage.output_tokens'] ?? '-'}`}
+            {` (${row.getValue() ?? '-'})`}
+          </div>;
+        }
+        return <div className='flex items-center'></div>;
+      },
       size: 150
     },
     {
@@ -296,7 +268,7 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
       header: 'Cost',
       id: 'cost',
       cell: (row) =>
-        <TooltipProvider delayDuration={250}>
+        <TooltipProvider delayDuration={100}>
           <Tooltip>
             <TooltipTrigger className="relative p-0">
               <div
@@ -306,7 +278,7 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
                 className="relative"
               >
                 <div className="absolute inset-0 top-[-4px] items-center h-full flex">
-                  <div className="text-ellipsis flex">
+                  <div className="text-ellipsis overflow-hidden whitespace-nowrap">
                     {renderCost(row.getValue())}
                   </div>
                 </div>
@@ -315,12 +287,12 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
             {row.getValue() != undefined &&
               <TooltipContent side="bottom" className="p-2 border">
                 <div>
-                  <div>
-                    <span>Input cost{' '}</span>
+                  <div className='flex justify-between space-x-2'>
+                    <span>Input cost</span>
                     <span>{renderCost(row.row.original.attributes['gen_ai.usage.input_cost'])}</span>
                   </div>
-                  <div>
-                    <span>Output cost{' '}</span>
+                  <div className='flex justify-between space-x-2'>
+                    <span>Output cost</span>
                     <span>{renderCost(row.row.original.attributes['gen_ai.usage.output_cost'])}</span>
                   </div>
                 </div>

--- a/frontend/components/traces/traces-table.tsx
+++ b/frontend/components/traces/traces-table.tsx
@@ -9,7 +9,7 @@ import { useState, useEffect, useMemo } from 'react';
 import ClientTimestampFormatter from '../client-timestamp-formatter';
 import StatusLabel from '../ui/status-label';
 import TracesPagePlaceholder from './page-placeholder';
-import { Event, EventTemplate } from '@/lib/events/types';
+import { EventTemplate } from '@/lib/events/types';
 import DateRangeFilter from '../ui/date-range-filter';
 import { DataTable } from '../ui/datatable';
 import DataTableFilter from '../ui/datatable-filter';
@@ -26,8 +26,6 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from '../ui/tooltip';
-import { ScrollArea } from '../ui/scroll-area';
-import { renderNodeInput } from '@/lib/flow/utils';
 import { Feature } from '@/lib/features/features';
 import { isFeatureEnabled } from '@/lib/features/features';
 import SpanTypeIcon from './span-type-icon';
@@ -145,32 +143,28 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
   };
 
   const columns: ColumnDef<Trace, any>[] = [
+    // {
+    //   accessorFn: (row) => (row.success ? 'Success' : 'Failed'),
+    //   header: 'Status',
+    //   cell: (row) => <StatusLabel success={row.getValue() === 'Success'} />,
+    //   id: 'status',
+    //   size: 100
+    // },
     {
-      accessorFn: (row) => (row.success ? 'Success' : 'Failed'),
-      header: 'Status',
-      cell: (row) => <StatusLabel success={row.getValue() === 'Success'} />,
-      id: 'status',
-      size: 100
-    },
-    {
-      cell: (row) => <Mono>{row.getValue()}</Mono>,
+      cell: (row) => <Mono className='text-xs'>{row.getValue()}</Mono>,
       header: 'ID',
       accessorKey: 'id',
       id: 'id'
     },
     {
-      accessorKey: 'sessionId',
-      header: 'Session ID',
-      id: 'session_id',
-    },
-    {
       accessorKey: 'topSpanType',
-      header: 'Top span type',
+      header: 'Top level span',
       id: 'top_span_type',
-      cell: (row) => <div className='flex space-x-2'>
-        <SpanTypeIcon className='z-20' spanType={row.getValue()} />
-        <div className='flex'>{row.getValue() === 'DEFAULT' ? 'SPAN' : row.getValue()}</div>
-      </div>
+      cell: (row) => <div className='flex space-x-2 items-center'>
+        <SpanTypeIcon className='z-10' spanType={row.getValue()} />
+        <div className='flex text-sm'>{row.getValue() === 'DEFAULT' ? 'SPAN' : row.getValue()}</div>
+      </div>,
+      size: 120
     },
     {
       accessorKey: 'topSpanName',
@@ -179,31 +173,6 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
     },
     {
       cell: (row) => row.getValue(),
-      // <TooltipProvider delayDuration={250}>
-      //   <Tooltip>
-      //     <TooltipTrigger className="relative">
-      //       <div
-      //         style={{
-      //           width: row.column.getSize() - 32
-      //         }}
-      //         className="relative"
-      //       >
-      //         <div className="absolute inset-0 top-[-4px] items-center h-full flex">
-      //           <div className="text-ellipsis overflow-hidden whitespace-nowrap">
-      //             {row.getValue()}
-      //           </div>
-      //         </div>
-      //       </div>
-      //     </TooltipTrigger>
-      //     <TooltipContent side="bottom" className="p-0 border">
-      //       <ScrollArea className="max-h-48 overflow-y-auto p-4">
-      //         <p className="max-w-sm break-words whitespace-pre-wrap">
-      //           {row.getValue()}
-      //         </p>
-      //       </ScrollArea>
-      //     </TooltipContent>
-      //   </Tooltip>
-      // </TooltipProvider>,
       accessorKey: 'topSpanInputPreview',
       header: 'Input',
       id: 'input',
@@ -249,7 +218,8 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
       cell: (row) => (
         <ClientTimestampFormatter timestamp={String(row.getValue())} />
       ),
-      id: 'start_time'
+      id: 'start_time',
+      size: 125
     },
     {
       accessorFn: (row) => {
@@ -260,14 +230,15 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
         return `${(duration / 1000).toFixed(2)}s`;
       },
       header: 'Latency',
-      id: 'latency'
+      id: 'latency',
+      size: 80
     },
     {
-      accessorFn: (row) => row.cost ,
+      accessorFn: (row) => row.cost,
       header: 'Cost',
       id: 'cost',
       cell: (row) =>
-        <TooltipProvider delayDuration={250}>
+        <TooltipProvider delayDuration={100}>
           <Tooltip>
             <TooltipTrigger className="relative p-0">
               <div
@@ -277,7 +248,7 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
                 className="relative"
               >
                 <div className="absolute inset-0 top-[-4px] items-center h-full flex">
-                  <div className="text-ellipsis flex">
+                  <div className="text-ellipsis overflow-hidden whitespace-nowrap">
                     {renderCost(row.getValue())}
                   </div>
                 </div>
@@ -286,12 +257,12 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
             {row.getValue() != undefined &&
               <TooltipContent side="bottom" className="p-2 border">
                 <div>
-                  <div>
-                    <span>Input cost{' '}</span>
+                  <div className='flex justify-between space-x-2'>
+                    <span>Input cost</span>
                     <span>{renderCost(row.row.original.inputCost)}</span>
                   </div>
-                  <div>
-                    <span>Output cost{' '}</span>
+                  <div className='flex justify-between space-x-2'>
+                    <span>Output cost</span>
                     <span>{renderCost(row.row.original.outputCost)}</span>
                   </div>
                 </div>
@@ -305,46 +276,12 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
       accessorFn: (row) => row.totalTokenCount ?? '-',
       header: 'Tokens',
       id: 'total_token_count',
-      cell: (row) =>
-        <TooltipProvider delayDuration={250}>
-          <Tooltip>
-            <TooltipTrigger className="relative p-0">
-              <div
-                style={{
-                  width: row.column.getSize() - 32
-                }}
-                className="relative"
-              >
-                <div className="absolute inset-0 top-[-4px] items-center h-full flex">
-                  <div className="text-ellipsis flex">
-                    {row.getValue()}
-                    {row.getValue() !== '-' &&
-                      <>
-                        {` (${row.row.original.inputTokenCount ?? '-'}`}
-                        <ArrowRight size={12} className='mt-[4px]'/>
-                        {`${row.row.original.outputTokenCount ?? '-'})`}
-                      </>
-                    }
-                  </div>
-                </div>
-              </div>
-            </TooltipTrigger>
-            {row.getValue() !== '-' &&
-              <TooltipContent side="bottom" className="p-2 border">
-                <div>
-                  <div>
-                    <span>Input tokens{' '}</span>
-                    <span>{row.row.original.inputTokenCount ?? '-'}</span>
-                  </div>
-                  <div>
-                    <span>Output tokens{' '}</span>
-                    <span>{row.row.original.outputTokenCount ?? '-'}</span>
-                  </div>
-                </div>
-              </TooltipContent>
-            }
-          </Tooltip>
-        </TooltipProvider>,
+      cell: (row) => <div className='flex items-center'>
+        {`${row.row.original.inputTokenCount ?? '-'}`}
+        <ArrowRight size={12} className='mx-1 min-w-[12px]' />
+        {`${row.row.original.outputTokenCount ?? '-'}`}
+        {` (${row.row.original.totalTokenCount ?? '-'})`}
+      </div>,
       size: 150
     },
   ];

--- a/frontend/components/ui/mono.tsx
+++ b/frontend/components/ui/mono.tsx
@@ -9,7 +9,7 @@ export default function Mono({
   children: ReactNode;
 }) {
   return (
-    <span className={cn('font-mono text-[12px] pt-1', className)}>
+    <span className={cn('font-mono text-xs', className)}>
       {children}
     </span>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increased span processing concurrency and made UI adjustments in span and trace tables.
> 
>   - **Concurrency**:
>     - In `main.rs`, increased span processing threads to 8 per core using `tokio::spawn`.
>   - **Logging**:
>     - Added log statement in `process_queue_spans()` in `consumer.rs` to indicate start of span processing.
>   - **UI Adjustments**:
>     - Changed `z-index` from 30 to 10 in `SpanTypeIcon` component.
>     - Removed `z-index` from `SpanTypeIcon` usage in `spans-table.tsx` and `traces-table.tsx`.
>     - Adjusted tooltip delay to 100ms in `spans-table.tsx` and `traces-table.tsx`.
>     - Updated `Mono` component to use `text-xs` class for font size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 1ad257bdb4e59e6bcee6b3ed2e8c2e89f0cb9eda. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->