### PR TITLE
do not require model name to be present, remove 3.5

### DIFF
--- a/frontend/components/pipeline/nodes/components/model-select.tsx
+++ b/frontend/components/pipeline/nodes/components/model-select.tsx
@@ -56,7 +56,7 @@ export default function LanguageModelSelect({
       <Popover open={open} onOpenChange={setOpen} modal>
         <PopoverTrigger asChild disabled={disabled}>
           <Button variant="outline" className="justify-between">
-            {model!.name}
+            {model?.name ?? ''}
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>

--- a/frontend/components/pipeline/nodes/llm.tsx
+++ b/frontend/components/pipeline/nodes/llm.tsx
@@ -26,7 +26,7 @@ export default function LLM({
 
   // stores what was last selected in the model select, so we can restore it after re-disabling the model input
   const [selectedModelId, setSelectedModelId] = useState<string>(
-    data.model ?? 'openai:gpt-3.5-turbo'
+    data.model ?? 'openai:gpt-4o-mini'
   );
   const [isPromptDisabled, setIsPromptDisabled] = useState<boolean>(false);
   useEffect(() => {

--- a/frontend/lib/flow/utils.ts
+++ b/frontend/lib/flow/utils.ts
@@ -465,7 +465,7 @@ export function createNodeData(id: string, nodeType: NodeType): GenericNode {
           type: NodeHandleType.STRING
         }
       ],
-      model: 'openai:gpt-3.5-turbo',
+      model: 'openai:gpt-4o-mini',
       prompt: '{{prompt}}',
       modelParams: null,
       stream: false


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update default model to `openai:gpt-4o-mini` and handle undefined model names in `model-select.tsx`.
> 
>   - **Behavior**:
>     - In `model-select.tsx`, change model name display to handle undefined model names by showing an empty string.
>     - In `llm.tsx`, update default model from `openai:gpt-3.5-turbo` to `openai:gpt-4o-mini`.
>     - In `utils.ts`, update default model in `createNodeData()` for `LLM` nodes to `openai:gpt-4o-mini`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for eb25894ce2b6793956858b00bef3809003ff6c0a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->