### PR TITLE
add api to pull datapoints from datasets

### DIFF
--- a/app-server/src/api/v1/datasets.rs
+++ b/app-server/src/api/v1/datasets.rs
@@ -1,0 +1,49 @@
+use actix_web::{get, web, HttpResponse};
+use serde::Deserialize;
+
+use crate::{
+    db::{datapoints, datasets, project_api_keys::ProjectApiKey, DB},
+    routes::{types::ResponseResult, PaginatedResponse},
+};
+
+#[derive(Deserialize)]
+pub struct GetDatapointsRequestParams {
+    name: String,
+    limit: usize,
+    offset: usize,
+}
+
+#[get("/datasets/datapoints")]
+async fn get_datapoints(
+    params: web::Query<GetDatapointsRequestParams>,
+    db: web::Data<DB>,
+    project_api_key: ProjectApiKey,
+) -> ResponseResult {
+    let project_id = project_api_key.project_id;
+    let db = db.into_inner();
+    let query = params.into_inner();
+
+    let dataset = datasets::get_dataset_by_name(&db.pool, &query.name, project_id).await?;
+
+    let Some(dataset) = dataset else {
+        return Ok(HttpResponse::NotFound().body(format!("dataset {} not found", &query.name)));
+    };
+
+    let datapoints = datapoints::get_datapoints(
+        &db.pool,
+        dataset.id,
+        query.limit as i64,
+        query.offset as i64,
+    )
+    .await?;
+
+    let total_count = datapoints::count_datapoints(&db.pool, dataset.id).await?;
+
+    let response = PaginatedResponse {
+        total_count,
+        items: datapoints,
+        any_in_project: total_count > 0,
+    };
+
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/app-server/src/api/v1/datasets.rs
+++ b/app-server/src/api/v1/datasets.rs
@@ -9,8 +9,8 @@ use crate::{
 #[derive(Deserialize)]
 pub struct GetDatapointsRequestParams {
     name: String,
-    limit: usize,
-    offset: usize,
+    limit: i64,
+    offset: i64,
 }
 
 #[get("/datasets/datapoints")]
@@ -29,13 +29,8 @@ async fn get_datapoints(
         return Ok(HttpResponse::NotFound().body(format!("dataset {} not found", &query.name)));
     };
 
-    let datapoints = datapoints::get_datapoints(
-        &db.pool,
-        dataset.id,
-        query.limit as i64,
-        query.offset as i64,
-    )
-    .await?;
+    let datapoints =
+        datapoints::get_datapoints(&db.pool, dataset.id, query.limit, query.offset).await?;
 
     let total_count = datapoints::count_datapoints(&db.pool, dataset.id).await?;
 

--- a/app-server/src/api/v1/mod.rs
+++ b/app-server/src/api/v1/mod.rs
@@ -1,3 +1,4 @@
+pub mod datasets;
 pub mod evaluations;
 pub mod metrics;
 pub mod pipelines;

--- a/app-server/src/db/datasets.rs
+++ b/app-server/src/db/datasets.rs
@@ -113,7 +113,7 @@ pub async fn update_index_column(
 
 pub async fn get_dataset_by_name(
     pool: &PgPool,
-    name: &String,
+    name: &str,
     project_id: Uuid,
 ) -> Result<Option<Dataset>> {
     let dataset = sqlx::query_as::<_, Dataset>(

--- a/app-server/src/db/datasets.rs
+++ b/app-server/src/db/datasets.rs
@@ -110,3 +110,23 @@ pub async fn update_index_column(
 
     Ok(dataset)
 }
+
+pub async fn get_dataset_by_name(
+    pool: &PgPool,
+    name: &String,
+    project_id: Uuid,
+) -> Result<Option<Dataset>> {
+    let dataset = sqlx::query_as::<_, Dataset>(
+        "SELECT id, created_at, name, project_id, indexed_on
+        FROM datasets
+        WHERE name = $1 AND project_id = $2
+        ORDER BY created_at DESC
+        LIMIT 1",
+    )
+    .bind(name)
+    .bind(project_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(dataset)
+}

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -369,9 +369,10 @@ fn main() -> anyhow::Result<()> {
                                 .service(api::v1::pipelines::run_pipeline_graph)
                                 .service(api::v1::pipelines::ping_healthcheck)
                                 .service(api::v1::traces::get_events_for_session)
+                                .service(api::v1::traces::process_traces)
+                                .service(api::v1::datasets::get_datapoints)
                                 .service(api::v1::evaluations::create_evaluation)
                                 .service(api::v1::metrics::process_metrics)
-                                .service(api::v1::traces::process_traces)
                                 .app_data(PayloadConfig::new(10 * 1024 * 1024)),
                         )
                         // Scopes with generic auth

--- a/app-server/src/routes/datasets.rs
+++ b/app-server/src/routes/datasets.rs
@@ -46,7 +46,7 @@ async fn get_datasets(
     let datasets =
         datasets::get_datasets(&db.pool, project_id, limit, params.page_number as i64).await?;
 
-    let total_count = datasets::count_datasets(&db.pool, project_id).await?;
+    let total_count = datasets::count_datasets(&db.pool, project_id).await? as u64;
 
     let response = PaginatedResponse::<Dataset> {
         total_count,
@@ -307,7 +307,7 @@ async fn get_datapoints(
 
     let response = PaginatedResponse::<DatapointView> {
         items: datapoints,
-        total_count: total_entries as i64,
+        total_count: total_entries,
         any_in_project: true,
     };
 

--- a/app-server/src/routes/events.rs
+++ b/app-server/src/routes/events.rs
@@ -98,7 +98,7 @@ pub async fn get_events_by_template_id(
 
     let total_count =
         db::events::count_events_by_template_id(&db.pool, &template_id, &date_range, &filters)
-            .await?;
+            .await? as u64;
     let any_in_project = if total_count > 0 {
         true
     } else {

--- a/app-server/src/routes/mod.rs
+++ b/app-server/src/routes/mod.rs
@@ -49,7 +49,7 @@ pub struct PaginatedGetQueryParams {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PaginatedResponse<T> {
-    pub total_count: i64,
+    pub total_count: u64,
     pub items: Vec<T>,
     /// returns true if there are any items of type `T` in the project.
     /// This is useful because `total_count` only counts items that match the filter.

--- a/app-server/src/routes/traces.rs
+++ b/app-server/src/routes/traces.rs
@@ -64,7 +64,7 @@ pub async fn get_traces(
             text_search_filter,
         )
         .await
-        .unwrap_or(0);
+        .unwrap_or(0) as u64;
         let any_in_project = if total_count == 0 {
             db::trace::count_all_traces_in_project(&db.pool, project_id)
                 .await
@@ -249,7 +249,8 @@ pub async fn get_sessions(
     let sessions =
         db::trace::get_sessions(&db.pool, project_id, limit, offset, &filters, date_range).await?;
 
-    let total_count = db::trace::count_sessions(&db.pool, project_id, &filters, date_range).await?;
+    let total_count =
+        db::trace::count_sessions(&db.pool, project_id, &filters, date_range).await? as u64;
     let any_in_project = if total_count == 0 {
         db::trace::count_all_sessions_in_project(&db.pool, project_id).await? > 0
     } else {


### PR DESCRIPTION
This is required to run evaluations in client-side SDKs that pull from a dataset hosted on Laminar
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add API endpoint to fetch datapoints from datasets, update response struct, and register new service and module.
> 
>   - **API Addition**:
>     - Add `get_datapoints` function in `datasets.rs` to fetch datapoints using `name`, `limit`, and `offset`.
>     - Register `get_datapoints` service in `main.rs`.
>   - **Database**:
>     - Add `get_dataset_by_name` function in `datasets.rs` to retrieve datasets by name and project ID.
>   - **Response Struct**:
>     - Change `total_count` type from `i64` to `u64` in `PaginatedResponse` in `routes/mod.rs` and other affected files.
>   - **Module Registration**:
>     - Add `datasets` module to `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 2de827c80e899effb4138d43704d37a5371c00be. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->