### PR TITLE
remove text search index

### DIFF
--- a/app-server/src/db/spans.rs
+++ b/app-server/src/db/spans.rs
@@ -203,11 +203,7 @@ pub async fn get_trace_spans(
             .push(" OR name::TEXT ILIKE ")
             .push_bind(format!("%{search}%"))
             .push(" OR attributes::TEXT ILIKE ")
-            .push_bind(format!("%{search}%"))
-            .push(" OR to_tsvector('english', input::text || ' ' || output::text)")
-            .push(" @@ plainto_tsquery(")
-            .push_bind(search)
-            .push("))");
+            .push_bind(format!("%{search}%"));
     }
 
     query.push(" ORDER BY start_time ASC");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove text search index from `get_trace_spans()` in `spans.rs`, using only `ILIKE` for search.
> 
>   - **Behavior**:
>     - Removed text search index using `to_tsvector` and `plainto_tsquery` from `get_trace_spans()` in `spans.rs`.
>     - Search now only uses `ILIKE` for `input`, `output`, `name`, and `attributes` fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 2be9caba697fa0ee3bdb0132ed6a1ea8f51af875. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->