### PR TITLE
improve edit datapoint experience

### DIFF
--- a/frontend/components/dataset/dataset.tsx
+++ b/frontend/components/dataset/dataset.tsx
@@ -154,12 +154,14 @@ export default function Dataset({ dataset }: DatasetProps) {
           onDelete={deleteDatapoints}
           totalDatapointsCount={totalCount}
           useAll={allDatapointsAcrossPagesSelected} /> */}
-        <AddDatapointsDialog datasetId={dataset.id} onUpdate={router.refresh} />
-        <ManualAddDatapoint datasetId={dataset.id} onUpdate={router.refresh} />
+        <AddDatapointsDialog datasetId={dataset.id}
+          onUpdate={getDatapoints}
+        />
+        <ManualAddDatapoint datasetId={dataset.id} onUpdate={getDatapoints} />
         <IndexDatasetDialog
           datasetId={dataset.id}
           defaultDataset={dataset}
-          onUpdate={router.refresh}
+          onUpdate={getDatapoints}
         />
       </div>
       <div className="flex-grow">
@@ -208,7 +210,8 @@ export default function Dataset({ dataset }: DatasetProps) {
               <DatasetPanel
                 datasetId={dataset.id}
                 datapoint={expandedDatapoint}
-                onClose={() => {
+                onClose={(madeChanges: boolean) => {
+                  madeChanges && getDatapoints();
                   setExpandedDatapoint(null);
                 }}
               />

--- a/frontend/components/onboarding/create-first-workspace-and-project.tsx
+++ b/frontend/components/onboarding/create-first-workspace-and-project.tsx
@@ -27,6 +27,8 @@ export default function CreateFirstWorkspaceAndProject({
   const handleButtonClick = async () => {
     setIsLoading(true);
 
+    // TODO: Handle errors
+
     const res = await fetch('/api/workspaces', {
       method: 'POST',
       body: JSON.stringify({
@@ -37,11 +39,11 @@ export default function CreateFirstWorkspaceAndProject({
 
     const newWorkspace = (await res.json()) as WorkspaceWithProjects;
 
-    setIsLoading(false);
-
     // As we want user to start from traces page, redirect to it
     // Expect the workspace to contain exactly one created project
     router.push(`/project/${newWorkspace.projects[0].id}/traces`);
+    // We don't need to set isLoading to false, as we are redirecting.
+    // Redirect itself takes some time, so we need the button to be disabled
   };
 
   return (

--- a/frontend/components/projects/workspace-create-dialog.tsx
+++ b/frontend/components/projects/workspace-create-dialog.tsx
@@ -68,7 +68,7 @@ export default function WorkspaceCreateDialog({
           <Button
             onClick={createNewWorkspace}
             handleEnter={true}
-            disabled={!newWorkspaceName}
+            disabled={!newWorkspaceName || isCreatingWorkspace}
           >
             {isCreatingWorkspace && (
               <Loader className="mr-2 animate-spin" size={16} />

--- a/frontend/components/ui/formatter.tsx
+++ b/frontend/components/ui/formatter.tsx
@@ -13,6 +13,7 @@ import { Sheet, SheetClose, SheetContent, SheetTrigger } from './sheet';
 import { Button } from './button';
 import { Expand, Maximize, Minimize, X } from 'lucide-react';
 import { ScrollArea } from './scroll-area';
+import { DialogTitle } from './dialog';
 
 interface OutputFormatterProps {
   value: string;
@@ -91,6 +92,7 @@ export default function Formatter({
               </Button>
             </SheetTrigger>
             <SheetContent side="right" className="flex flex-col gap-0 min-w-[50vw]">
+              <DialogTitle className='hidden'></DialogTitle>
               <div className="flex-none border-b h-12 items-center flex p-4 justify-between">
                 <div className="flex justify-start">
                   <Select


### PR DESCRIPTION
- State of the sheet and smaller formatter are synchronized for datapoint view
- Auto-save changes to datapoints as long as they are valid JSON
- Refetch the datapoints table properly on change by re-querying instead of `router.refresh()`
- Disable the "continue" button completely in the onboarding screen, because the screen redirects
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances datapoint editing experience with auto-save, UI improvements, and better data fetching in `DatasetPanel` and related components.
> 
>   - **Behavior**:
>     - Auto-save functionality added to `DatasetPanel` for datapoint edits, saving every 750ms if JSON is valid.
>     - `onClose` callback in `DatasetPanel` now indicates if changes were made.
>     - Replaces `router.refresh()` with `getDatapoints()` in `dataset.tsx` to refetch data.
>     - Disables "continue" button in onboarding screen to prevent premature navigation.
>   - **UI Components**:
>     - Adds loading spinner to indicate saving state in `DatasetPanel`.
>     - Updates `Formatter` to synchronize with sheet state.
>     - Disables button in `WorkspaceCreateDialog` when workspace name is empty or creation is in progress.
>   - **Misc**:
>     - Comments out unused `deepEqual` function in `dataset-panel.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for ed5d3ebf3c6cb20c3502aa8996a1c62200ff23fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->