### PR TITLE
minor fix to correctly export spans to datasets

### DIFF
--- a/frontend/components/traces/export-spans-dialog.tsx
+++ b/frontend/components/traces/export-spans-dialog.tsx
@@ -39,8 +39,8 @@ export default function ExportSpansDialog({ span }: ExportSpansDialogProps) {
 
   const { toast } = useToast();
 
-  const [data, setData] = useState(span.input);
-  const [target, setTarget] = useState(span.output);
+  const [data, setData] = useState(toJsonObject(span.input, 'input'));
+  const [target, setTarget] = useState(toJsonObject(span.output, 'output'));
   const [isDataValid, setIsDataValid] = useState(true);
   const [isTargetValid, setIsTargetValid] = useState(true);
 
@@ -161,11 +161,7 @@ export default function ExportSpansDialog({ span }: ExportSpansDialogProps) {
                   className="max-h-[500px]"
                   editable
                   defaultMode={'json'}
-                  value={JSON.stringify(
-                    toJsonObject(span.input, 'input'),
-                    null,
-                    2
-                  )}
+                  value={JSON.stringify(data, null, 2)}
                   onChange={handleDataChange}
                 />
                 {!isDataValid && (
@@ -178,11 +174,7 @@ export default function ExportSpansDialog({ span }: ExportSpansDialogProps) {
                   className="max-h-[500px]"
                   editable
                   defaultMode={'json'}
-                  value={JSON.stringify(
-                    toJsonObject(span.output, 'output'),
-                    null,
-                    2
-                  )}
+                  value={JSON.stringify(target, null, 2)}
                   onChange={handleTargetChange}
                 />
                 {!isTargetValid && (
@@ -195,11 +187,7 @@ export default function ExportSpansDialog({ span }: ExportSpansDialogProps) {
                   className="max-h-[500px]"
                   editable
                   defaultMode={'json'}
-                  value={JSON.stringify(
-                    toJsonObject(metadata, 'metadata'),
-                    null,
-                    2
-                  )}
+                  value={JSON.stringify(metadata, null, 2)}
                   onChange={handleMetadataChange}
                 />
                 {!isMetadataValid && (


### PR DESCRIPTION
Spans were exported to datasets into the `data` field despite having `data`, `target`, and `metadata` keys. This was because `target` was only visually converted to a JSON object, but remained a string in the state. This commit addresses that
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes JSON export issue in `ExportSpansDialog` by ensuring `data` and `target` are correctly initialized as JSON objects.
> 
>   - **Behavior**:
>     - Fixes issue where `data` and `target` were not correctly exported as JSON objects in `ExportSpansDialog`.
>     - Initializes `data` and `target` using `toJsonObject()` to ensure proper JSON conversion.
>   - **Code Simplification**:
>     - Simplifies JSON stringification in `Formatter` by using `data`, `target`, and `metadata` state variables directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for c27ecd913b6b4b9edcb6b0b8dd9e5303279e44b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->