### PR TITLE
Easier contribution experience for frontend-only changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,22 +26,24 @@ Don't get overwhelmed by the number of docker-compose files. Here's a quick over
 - `docker-compose.yml` is the simplest one that spins up frontend, app-server, and postgres. Good for quickstarts.
 - `docker-compose-full.yml` is the one you want to use for running the full stack locally. This is the best 
 for self-hosting.
+- `docker-compose-local-dev-full.yml` full file for local development. To be used when you make changes
+  to the backend. It will only run the dependency services (postgres, qdrant, clickhouse, rabbitmq).
+  You will need to run `cargo r`, `pnpm run dev`, and `python server.py` manually.
 - `docker-compose-local-dev.yml` is the one you want to use for local development. It will only
-  run the dependency services (postgres, qdrant, clickhouse, rabbitmq). You will need to run
-  `cargo r`, `pnpm run dev`, and `python server.py` manually.
+  run postgres and app-server. Good for frontend changes.
 - `docker-compose-local-build.yml` will build the services from the source and run them in production mode. This is good for self-hosting with your own changes,
 or for testing the changes after developing on your own and before opening a PR.
 
-| Service | docker-compose.yml | docker-compose-full.yml | docker-compose-local-dev.yml | docker-compose-local-build.yml |
-|---------|-------------------|------------------------|----------------------------|------------------------------|
-| postgres | ✅ | ✅ | ✅ | ✅ |
-| qdrant | ❌ | ✅ | ✅ | ✅ |
-| clickhouse | ❌ | ✅ | ✅ | ✅ |
-| rabbitmq | ❌ | ✅ | ✅ | ✅ |
-| app-server | ℹ️ | ✅ | 💻 | 🔧 |
-| frontend | ℹ️ | ✅ | 💻 | 🔧 |
-| semantic-search-service | ❌ | ✅ |  💻 | 🔧 |
-| python-executor | ❌ | ✅ | 💻 | 🔧 |
+| Service | docker-compose.yml | docker-compose-full.yml | docker-compose-local-dev-full.yml | docker-compose-local-dev.yml | docker-compose-local-build.yml |
+|---------|-------------------|------------------------|------------------------------|----------------------------|------------------------------|
+| postgres | ✅ | ✅ | ✅ | ✅ | ✅ |
+| qdrant | ❌ | ✅ | ✅ | ❌ | ✅ |
+| clickhouse | ❌ | ✅ | ✅ | ❌ | ✅ |
+| rabbitmq | ❌ | ✅ | ✅ | ❌ | ✅ |
+| app-server | ℹ️ | ✅ | 💻 | ℹ️ | 🔧 | 
+| frontend | ℹ️ | ✅ | 💻 | 💻 | 🔧 |
+| semantic-search-service | ❌ | ✅ | 💻 | ❌ | 🔧 |
+| python-executor | ❌ | ✅ | 💻 | ❌ | 🔧 |
 
 - ✅ – service present, image is pulled from a container registry.
 - 🔧 – service present, image is built from the source. This may take a while.
@@ -50,10 +52,39 @@ or for testing the changes after developing on your own and before opening a PR.
 - ❌ – service not present.
 
 
-## Running Laminar locally
+## Running Laminar locally for development
 
-If you want to test your local changes, you can run code separately in
-development mode.
+Use this guide if you are changing frontend code only.
+For making backend changes or changes across the full stack,
+see [Advanced] section below.
+
+### 0. Configure environment variables
+
+```sh
+cd frontend
+cp .env.local.example .env.local
+```
+
+### 1. Spin up app-server and postgres
+
+```sh
+docker compose -f docker-compose-local-dev.yml up
+```
+
+### 2. Run frontend in development mode
+
+```sh
+cd frontend
+pnpm run dev
+```
+
+Next.js is hot-reloadable in development mode, so any changes you make will be reflected
+immediately.
+
+## [Advanced] Running full stack locally for development
+
+This guide is for when you are changing backend code, or when you want to run the full stack
+locally for development. If you only want to change frontend code, see the section above.
 
 ### 0. Configure environment variables
 
@@ -68,7 +99,7 @@ cp frontend/.env.local.example frontend/.env.local
 ### 1. Spin up dependency containers
 
 ```sh
-docker compose -f docker-compose-local-dev.yml up
+docker compose -f docker-compose-local-dev-full.yml up
 ```
 
 This will spin up postgres, qdrant, clickhouse, and RabbitMQ.

--- a/docker-compose-local-dev-full.yml
+++ b/docker-compose-local-dev-full.yml
@@ -1,0 +1,73 @@
+# This compose definition does not build Laminar images, it is intended for local development.
+# This file is meant to be used with running the Laminar services manually from each service's directory.
+# Refer to CONTRIBUTING.md for more information on how to run the services locally.
+name: lmnr
+
+services:
+  qdrant:
+    image: qdrant/qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - type: volume
+        source: qdrant-data
+        target: /data
+    
+  rabbitmq:
+    image: rabbitmq
+    ports:
+      - "5672:5672"
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 7s
+      timeout: 5s
+      retries: 3
+
+  clickhouse:
+    build:
+      context: ./clickhouse
+    container_name: clickhouse
+    hostname: clickhouse
+    ports:
+      - "8123:8123"
+    volumes:
+      - type: volume
+        source: clickhouse-data
+        target: /var/lib/clickhouse/
+      - type: volume
+        source: clickhouse-logs
+        target: /var/log/clickhouse-server/
+    cap_add:
+      - SYS_NICE
+      - NET_ADMIN
+      - IPC_LOCK
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
+  postgres:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  qdrant-data:
+  clickhouse-data:
+  clickhouse-logs:
+  postgres-data:

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -1,55 +1,13 @@
-# This compose definition does not build Laminar images, it is intended for local development.
-# This file is meant to be used with running the Laminar services manually from each service's directory.
-# Refer to CONTRIBUTING.md for more information on how to run the services locally.
+# This compose file is a lightweight version of docker-compose-local-dev-full.yml.
+# It is intended to be used for local development on frontend only.
+# It does not include ClickHouse,
+# Qdrant, Semantic Search, Python executor, and RabbitMQ.
+# It only includes postgres, and app-server.
+# Run frontend manually with `ENVIRONMENT=LITE pnpm run dev`.
+
 name: lmnr
 
 services:
-  qdrant:
-    image: qdrant/qdrant
-    ports:
-      - "6333:6333"
-      - "6334:6334"
-    volumes:
-      - type: volume
-        source: qdrant-data
-        target: /data
-    
-  rabbitmq:
-    image: rabbitmq
-    ports:
-      - "5672:5672"
-    environment:
-      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER}
-      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
-    healthcheck:
-      test: rabbitmq-diagnostics -q ping
-      interval: 7s
-      timeout: 5s
-      retries: 3
-
-  clickhouse:
-    build:
-      context: ./clickhouse
-    container_name: clickhouse
-    hostname: clickhouse
-    ports:
-      - "8123:8123"
-    volumes:
-      - type: volume
-        source: clickhouse-data
-        target: /var/lib/clickhouse/
-      - type: volume
-        source: clickhouse-logs
-        target: /var/log/clickhouse-server/
-    cap_add:
-      - SYS_NICE
-      - NET_ADMIN
-      - IPC_LOCK
-    ulimits:
-      nofile:
-        soft: 262144
-        hard: 262144
-
   postgres:
     image: postgres:16
     ports:
@@ -66,8 +24,21 @@ services:
       timeout: 5s
       retries: 5
 
+  app-server:
+    image: ghcr.io/lmnr-ai/app-server
+    pull_policy: always
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PORT: 8000
+      GRPC_PORT: 8001
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      SHARED_SECRET_TOKEN: ${SHARED_SECRET_TOKEN}
+      ENVIRONMENT: LITE # this disables runtime dependency on clickhouse, rabbitmq, semantic search, and python executor
+
 volumes:
-  qdrant-data:
-  clickhouse-data:
-  clickhouse-logs:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       NEXTAUTH_URL: http://localhost:3000
       NEXTAUTH_SECRET: some_secret
       NEXT_PUBLIC_URL: http://localhost:3000
-      ENVIRONMENT: LITE # this disables runtime reliance on clickhouse
+      ENVIRONMENT: LITE # this disables runtime dependency on clickhouse
 
   app-server:
     image: ghcr.io/lmnr-ai/app-server
@@ -55,7 +55,7 @@ services:
       GRPC_PORT: 8001
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       SHARED_SECRET_TOKEN: ${SHARED_SECRET_TOKEN}
-      ENVIRONMENT: LITE # this disables runtime reliance on clickhouse, rabbitmq, semantic search, and python executor
+      ENVIRONMENT: LITE # this disables runtime dependency on clickhouse, rabbitmq, semantic search, and python executor
 
 volumes:
   postgres-data:

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,27 +1,27 @@
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=next_secret_abc
+BACKEND_URL=http://localhost:8000
+NEXT_OTEL_FETCH_DISABLED=1
+SHARED_SECRET_TOKEN=some_secret
 
+# these must match what you have in your docker-compose-local-dev.yml for postgres
+# postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@{host}:5432/${POSTGRES_DB}
+DATABASE_URL="postgres://postgres:postgres_passwordabc@localhost:5432/postgres"
+
+# replace with FULL if you are testing with a full stack
+# ENVIRONMENT=FULL
+ENVIRONMENT=LITE # this disables runtime dependency on clickhouse
+
+# for realtime
+SUPABASE_JWT_SECRET=
+# for auth
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
-
 AUTH_GOOGLE_ID=
 AUTH_GOOGLE_SECRET=
 
-BACKEND_URL=
-
-SUPABASE_JWT_SECRET=
-
-NEXT_OTEL_FETCH_DISABLED=1
-SHARED_SECRET_TOKEN=some_secret
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres_passwordabc
-POSTGRES_DB=postgres
-DATABASE_URL="postgres://postgres:postgres_passwordabc@localhost:5432/postgres"
-BASE_URL=http://localhost:8000
-
-
+# for s3
 AWS_REGION=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
-
-ENVIRONMENT=FULL
+S3_IMGS_BUCKET=

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,5 +1,5 @@
-NEXTAUTH_URL=
-NEXTAUTH_SECRET=
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=next_secret_abc
 
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
@@ -13,6 +13,12 @@ SUPABASE_JWT_SECRET=
 
 NEXT_OTEL_FETCH_DISABLED=1
 SHARED_SECRET_TOKEN=some_secret
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres_passwordabc
+POSTGRES_DB=postgres
+DATABASE_URL="postgres://postgres:postgres_passwordabc@localhost:5432/postgres"
+BASE_URL=http://localhost:8000
+
 
 AWS_REGION=
 AWS_ACCESS_KEY_ID=


### PR DESCRIPTION
This PR moves old `docker-compose-local-dev.yml` to `docker-compose-local-dev-full.yml` and introduces the new `docker-compose-local-dev.yml`. The idea is that you use this thin file if you want to contribute to the frontend only.

Changes:
- New thin local dev docker compose
- Explanation of that in CONTRIBUTING.md
- Add missing env vars to `.env.local.example` in the frontend and re-order them for clearer understanding and grouping.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce a new lightweight Docker Compose file for frontend-only development and update documentation and environment variables accordingly.
> 
>   - **Docker Compose Changes**:
>     - Rename `docker-compose-local-dev.yml` to `docker-compose-local-dev-full.yml`.
>     - Introduce new `docker-compose-local-dev.yml` for frontend-only development, including only `postgres` and `app-server`.
>   - **Documentation**:
>     - Update `CONTRIBUTING.md` to explain the new `docker-compose-local-dev.yml` and its usage for frontend development.
>   - **Environment Variables**:
>     - Add missing environment variables to `frontend/.env.local.example` and reorder for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 10a9146c7f20a7330b105d4fe744a6dc27222884. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->