### PR TITLE
remove join with events on a traces table

### DIFF
--- a/app-server/src/routes/traces.rs
+++ b/app-server/src/routes/traces.rs
@@ -8,7 +8,7 @@ use crate::{
         events::EventWithTemplateName,
         modifiers::{DateRange, Filter, RelativeDateInterval},
         spans::Span,
-        trace::{Session, Trace, TraceWithParentSpanAndEvents},
+        trace::{Session, Trace, TraceWithTopSpan},
         DB,
     },
 };
@@ -82,7 +82,7 @@ pub async fn get_traces(
     let (total_count, any_in_project) =
         count_result.map_err(|e| anyhow::anyhow!("Failed to count traces: {:?}", e))?;
 
-    let response = PaginatedResponse::<TraceWithParentSpanAndEvents> {
+    let response = PaginatedResponse::<TraceWithTopSpan> {
         total_count,
         items: traces,
         any_in_project,


### PR DESCRIPTION
This join was redundant (we don't show events in the traces table any longer) and made the query work very slow randomly at only some time ranges. Now the query works fast for all of 1, 24, 168, and 720 past hours.

Note: this does not fix the query planner issue, it is still MUCH slower on 24 hours
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant join with events in traces table, improving query performance and updating related structs and routes.
> 
>   - **Behavior**:
>     - Removed redundant join with events in `get_traces()` and `count_traces()` in `trace.rs`, improving query performance.
>     - Query performance improved for 1, 24, 168, and 720 past hours.
>     - Does not fix query planner issue for 24-hour queries.
>   - **Structs**:
>     - Renamed `TraceWithParentSpanAndEvents` to `TraceWithTopSpan`.
>     - Removed `events` field from `TraceWithTopSpan`.
>   - **Routes**:
>     - Updated `get_traces()` in `traces.rs` to use `TraceWithTopSpan`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 9a1088cff31648031d22863a91fc0904bf7adfc9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->