### PR TITLE
redirect to onboarding if no workspaces yet

### DIFF
--- a/frontend/components/projects/projects.tsx
+++ b/frontend/components/projects/projects.tsx
@@ -9,6 +9,7 @@ import WorkspaceCreateDialog from './workspace-create-dialog';
 import useSWR from 'swr';
 import { swrFetcher } from '@/lib/utils';
 import { Skeleton } from '../ui/skeleton';
+import { useRouter } from 'next/navigation';
 
 interface ProjectsProps {
   isWorkspaceEnabled: boolean;
@@ -19,6 +20,11 @@ export default function Projects({ isWorkspaceEnabled }: ProjectsProps) {
     '/api/workspaces',
     swrFetcher
   );
+
+  const router = useRouter();
+  if (data !== undefined && data.length === 0) {
+    router.push('/onboarding');
+  }
 
   return (
     <>

--- a/frontend/components/projects/projects.tsx
+++ b/frontend/components/projects/projects.tsx
@@ -22,8 +22,8 @@ export default function Projects({ isWorkspaceEnabled }: ProjectsProps) {
   );
 
   const router = useRouter();
-  if (data !== undefined && data.length === 0) {
-    router.push('/onboarding');
+  if (!isLoading && data !== undefined && data.length === 0) {
+    router.replace('/onboarding');
   }
 
   return (


### PR DESCRIPTION
Sometimes, onboarding flow breaks for people (e.g. signed in, then signed in from a different browser) and it is extremely difficult to figure out how to get started. This change redirects to onboarding if the user has 0 workspaces.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Redirects to onboarding in `Projects` component if no workspaces are found using `useRouter`.
> 
>   - **Behavior**:
>     - Redirects to `/onboarding` if `data` is defined and empty in `Projects` component.
>   - **Routing**:
>     - Uses `useRouter` from `next/navigation` to handle redirection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 33a3965783bc2ad6177b21dbcee99e9e6f250751. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->