### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
     - [x] Written in Rust 🦀
     - [x] Traces are sent via gRPC, ensuring the best performance and lowest overhead.
 - [x] Modern Open-Source stack
-    - [x] RabbitMQ for message queue, Postgres for data, Clickhouse for analytics. Qdrant for semantic similraity search and hybrid search.
+    - [x] RabbitMQ for message queue, Postgres for data, Clickhouse for analytics. Qdrant for semantic similarity search and hybrid search.
 - [x] Fast and beautiful dashboards for traces / evaluations / labels.
 <img width="1506" alt="traces-2" src="https://github.com/user-attachments/assets/14d6eec9-cd0e-4c3e-b601-3d64c4c0c875">
 


### PR DESCRIPTION
My eye caught this typo. So I opened this PR to quickly fix it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `README.md`, changing 'similraity' to 'similarity'.
> 
>   - Fix typo in `README.md`, changing 'similraity' to 'similarity'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for c2a0750c370ef36be3ae8c535cd629d945895891. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->