### PR TITLE
Replaced all Loader to Loader2

### DIFF
--- a/frontend/components/dataset/dataset-panel.tsx
+++ b/frontend/components/dataset/dataset-panel.tsx
@@ -1,5 +1,5 @@
 import { useProjectContext } from '@/contexts/project-context';
-import { ChevronsRight, Loader, Loader2 } from 'lucide-react';
+import { ChevronsRight, Loader2 } from 'lucide-react';
 import { Skeleton } from '../ui/skeleton';
 import { Label } from '../ui/label';
 import { ScrollArea } from '../ui/scroll-area';

--- a/frontend/components/dataset/dataset-upload.tsx
+++ b/frontend/components/dataset/dataset-upload.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { uploadFile } from '@/lib/dataset/utils';
 import { useToast } from '@/lib/hooks/use-toast';
-import { Loader } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 interface DatasetUploadProps {
   datasetId: string;
@@ -31,7 +31,7 @@ export default function DatasetUpload({
           className="mt-4 w-32"
           onClick={() => hiddenInput.current?.click()}
         >
-          {isLoading && <Loader className="animate-spin h-4 w-4 mr-2" />}
+          {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
           Select file
         </Button>
         <input

--- a/frontend/components/dataset/delete-datapoints-dialog.tsx
+++ b/frontend/components/dataset/delete-datapoints-dialog.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { useState } from 'react';
-import { Loader } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 export interface DeleteDatapointsDialogProps {
   selectedDatapointIds: string[];
@@ -64,7 +64,7 @@ export default function DeleteDatapointsDialog({
               setOpen(false);
             }}
           >
-            {isLoading && <Loader className="animate-spin h-4 w-4 mr-2" />}
+            {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
             Delete
           </Button>
         </DialogFooter>

--- a/frontend/components/dataset/index-dataset-dialog.tsx
+++ b/frontend/components/dataset/index-dataset-dialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog';
-import { Loader, NotepadText } from 'lucide-react';
+import { Loader2, NotepadText } from 'lucide-react';
 import { useProjectContext } from '@/contexts/project-context';
 import { Label } from '@/components/ui/label';
 import { Input } from '../ui/input';
@@ -102,7 +102,7 @@ export default function IndexDatasetDialog({
             onClick={async () => await indexDataset()}
             handleEnter
           >
-            {isLoading && <Loader className="animate-spin h-4 w-4 mr-2" />}
+            {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
             Index
           </Button>
         </DialogFooter>

--- a/frontend/components/dataset/manual-add-datapoint-dialog.tsx
+++ b/frontend/components/dataset/manual-add-datapoint-dialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogTrigger
 } from '../ui/dialog';
 import { Button } from '../ui/button';
-import { Loader } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import CodeEditor from '../ui/code-editor';
 
 const DEFAULT_DATA = '{\n  "data": {},\n  "target": {}\n}';
@@ -99,7 +99,7 @@ export default function ManualAddDatapointDialog({
             disabled={isLoading}
             onClick={async () => await addDatapoint()}
           >
-            {isLoading && <Loader className="animate-spin h-4 w-4 mr-2" />}
+            {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
             Add datapoint
           </Button>
         </DialogFooter>

--- a/frontend/components/dataset/unstructured-file-upload.tsx
+++ b/frontend/components/dataset/unstructured-file-upload.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { uploadFile } from '@/lib/dataset/utils';
 import { useToast } from '@/lib/hooks/use-toast';
-import { Loader } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 interface UnstructuredFileUploadProps {
   datasetId: string;
@@ -37,7 +37,7 @@ export default function UnstructuredFileUpload({
           className="mt-4 w-32"
           onClick={() => hiddenInput.current?.click()}
         >
-          {isLoading && <Loader className="animate-spin h-4 w-4 mr-2" />}
+          {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
           Select file
         </Button>
         <input

--- a/frontend/components/datasets/create-dataset-dialog.tsx
+++ b/frontend/components/datasets/create-dataset-dialog.tsx
@@ -9,7 +9,7 @@ import {
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Loader, Plus } from 'lucide-react';
+import { Loader2, Plus } from 'lucide-react';
 import { cn, fetcher } from '@/lib/utils';
 import { useState } from 'react';
 import { useProjectContext } from '@/contexts/project-context';
@@ -82,7 +82,7 @@ export default function CreateDatasetDialog({}: CreateDatasetDialogProps) {
               disabled={!newDatasetName || isLoading}
               handleEnter
             >
-              <Loader
+              <Loader2
                 className={cn(
                   'mr-2 hidden',
                   isLoading ? 'animate-spin block' : ''

--- a/frontend/components/datasets/datasets.tsx
+++ b/frontend/components/datasets/datasets.tsx
@@ -7,7 +7,7 @@ import { swrFetcher } from '@/lib/utils';
 
 import { useProjectContext } from '@/contexts/project-context';
 import { useRouter } from 'next/navigation';
-import { Loader, Loader2, MoreVertical, Trash2 } from 'lucide-react';
+import { Loader2, MoreVertical, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ColumnDef } from '@tanstack/react-table';
 import { Dataset } from '@/lib/dataset/types';

--- a/frontend/components/datasets/update-dataset-dialog.tsx
+++ b/frontend/components/datasets/update-dataset-dialog.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Loader, Pencil } from 'lucide-react';
+import { Loader2, Pencil } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
 import { DropdownMenuItem } from '../ui/dropdown-menu';
@@ -75,7 +75,7 @@ export default function UpdateDatasetDialog({
               }}
               disabled={!dataset || isLoading}
             >
-              <Loader
+              <Loader2
                 className={cn(
                   'mr-2 hidden',
                   isLoading ? 'animate-spin block' : ''

--- a/frontend/components/evaluations/create-evaluation-dialog.tsx
+++ b/frontend/components/evaluations/create-evaluation-dialog.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Info, Loader, Plus } from 'lucide-react';
+import { Info, Loader2, Plus } from 'lucide-react';
 import { cn, getLocalDevSessions, getLocalEnvVars } from '@/lib/utils';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -190,7 +190,7 @@ export default function CreateEvaluationDialog() {
               onClick={createNewEvaluation}
               disabled={!isEvaluationComplete() || isLoading}
             >
-              <Loader
+              <Loader2
                 className={cn(
                   'mr-2 hidden',
                   isLoading ? 'animate-spin block' : ''

--- a/frontend/components/event/edit-event-template-dialog.tsx
+++ b/frontend/components/event/edit-event-template-dialog.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Loader } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -105,7 +105,7 @@ export default function EditEventTemplateDialog({
           </div>
           <DialogFooter>
             <Button onClick={updateEvent} disabled={isLoading || !isReady()}>
-              <Loader
+              <Loader2
                 className={cn(
                   'mr-2 hidden',
                   isLoading ? 'animate-spin block' : ''

--- a/frontend/components/events/create-event-template-dialog.tsx
+++ b/frontend/components/events/create-event-template-dialog.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Loader } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -97,7 +97,7 @@ export default function CreateEventTemplateDialog() {
           </div>
           <DialogFooter>
             <Button onClick={createNewEvent} disabled={isLoading || !isReady()}>
-              <Loader
+              <Loader2
                 className={cn(
                   'mr-2 hidden',
                   isLoading ? 'animate-spin block' : ''

--- a/frontend/components/pipeline/commit-button.tsx
+++ b/frontend/components/pipeline/commit-button.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
-import { Loader, PlusCircle } from 'lucide-react';
+import { Loader2, PlusCircle } from 'lucide-react';
 import { PipelineVersionInfo } from '@/lib/pipeline/types';
 import { useProjectContext } from '@/contexts/project-context';
 import useStore from '@/lib/flow/store';
@@ -120,7 +120,7 @@ export default function CommitButton({
             handleEnter={true}
             onClick={commitPipelineVersion}
           >
-            {isLoading && <Loader className="animate-spin h-4 w-4 mr-2" />}
+            {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
             Commit
           </Button>
         </DialogFooter>

--- a/frontend/components/pipeline/delete-version-button.tsx
+++ b/frontend/components/pipeline/delete-version-button.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState } from 'react';
 import { ProjectContext } from '@/contexts/project-context';
-import { Loader, MoreVertical, Trash2 } from 'lucide-react';
+import { Loader2, MoreVertical, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -100,7 +100,7 @@ export default function DeletePipelineVersionButton({
               disabled={deleteVersionInputText != selectedPipelineVersion.name}
               onClick={deletePipelineVersion}
             >
-              <Loader
+              <Loader2
                 className={cn(
                   'mr-2 hidden',
                   isDeleting ? 'animate-spin block' : ''

--- a/frontend/components/pipeline/deploy-button.tsx
+++ b/frontend/components/pipeline/deploy-button.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
-import { Loader, Rocket } from 'lucide-react';
+import { Loader2, Rocket } from 'lucide-react';
 import { PipelineVersionInfo } from '@/lib/pipeline/types';
 import { useProjectContext } from '@/contexts/project-context';
 import EndpointSelect from '../ui/endpoint-select';
@@ -178,7 +178,7 @@ export default function DeployButton({
             }
             onClick={deployPipelineVersion}
           >
-            {isDeploying && <Loader className="animate-spin h-4 w-4 mr-2" />}
+            {isDeploying && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
             Deploy
           </Button>
         </DialogFooter>

--- a/frontend/components/pipeline/fork-button.tsx
+++ b/frontend/components/pipeline/fork-button.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
-import { Loader, GitFork } from 'lucide-react';
+import { Loader2, GitFork } from 'lucide-react';
 import { PipelineVersionInfo } from '@/lib/pipeline/types';
 import { useRouter } from 'next/navigation';
 import { useProjectContext } from '@/contexts/project-context';
@@ -109,7 +109,7 @@ export default function ForkButton({
             handleEnter={true}
             onClick={forkPipelineVersion}
           >
-            {isLoading && <Loader className="animate-spin h-4 w-4 mr-2" />}
+            {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
             Fork
           </Button>
         </DialogFooter>

--- a/frontend/components/pipeline/overwrite-workshop-button.tsx
+++ b/frontend/components/pipeline/overwrite-workshop-button.tsx
@@ -11,7 +11,7 @@ import {
   DialogTrigger
 } from '@/components/ui/dialog';
 import { Label } from '../ui/label';
-import { Loader, Pencil, ShieldQuestion } from 'lucide-react';
+import { Loader2, Pencil, ShieldQuestion } from 'lucide-react';
 import { PipelineVersionInfo } from '@/lib/pipeline/types';
 import { useProjectContext } from '@/contexts/project-context';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -93,7 +93,7 @@ export default function OverwriteWorkshopButton({
             Cancel
           </Button>
           <Button handleEnter={true} onClick={overwriteWorkshopVersion}>
-            {isLoading && <Loader className="animate-spin h-4 w-4 mr-2" />}
+            {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
             Overwrite
           </Button>
         </DialogFooter>

--- a/frontend/components/pipeline/stream-trace.tsx
+++ b/frontend/components/pipeline/stream-trace.tsx
@@ -14,7 +14,7 @@ import {
   Clock3,
   Coins,
   FastForward,
-  Loader,
+  Loader2,
   Play
 } from 'lucide-react';
 import { StreamMessage } from './pipeline-outputs';
@@ -334,7 +334,7 @@ function StreamTraceCard({
         </div>
         {showSpinner && (
           <div>
-            <Loader
+            <Loader2
               className="text-secondary-foreground animate-spin"
               size={12}
             />

--- a/frontend/components/pipeline/target-version.tsx
+++ b/frontend/components/pipeline/target-version.tsx
@@ -11,7 +11,7 @@ import {
   DialogTrigger
 } from '@/components/ui/dialog';
 import { Label } from '../ui/label';
-import { Loader, Pencil, ShieldQuestion } from 'lucide-react';
+import { Loader2, Pencil, ShieldQuestion } from 'lucide-react';
 import { PipelineVersionInfo } from '@/lib/pipeline/types';
 import { useProjectContext } from '@/contexts/project-context';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -93,7 +93,7 @@ export default function SetTargetVersionButton({
             Cancel
           </Button>
           <Button handleEnter={true} onClick={overwriteWorkshopVersion}>
-            {isLoading && <Loader className="animate-spin h-4 w-4 mr-2" />}
+            {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
             Confirm
           </Button>
         </DialogFooter>

--- a/frontend/components/pipelines/create-pipeline-dialog.tsx
+++ b/frontend/components/pipelines/create-pipeline-dialog.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input';
 import { useEffect, useState } from 'react';
 import { useProjectContext } from '@/contexts/project-context';
 import { useRouter } from 'next/navigation';
-import { Loader, Plus } from 'lucide-react';
+import { Loader2, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TemplateInfo } from '@/lib/pipeline/types';
 import { Skeleton } from '../ui/skeleton';
@@ -141,7 +141,7 @@ export function CreatePipelineDialog({ onUpdate }: CreatePipelineDialogProps) {
             handleEnter={true}
             disabled={selectedTemplateId === undefined || isLoading}
           >
-            <Loader
+            <Loader2
               className={cn(
                 'mr-2 hidden',
                 isLoading ? 'animate-spin block' : ''

--- a/frontend/components/pipelines/update-pipeline-dialog.tsx
+++ b/frontend/components/pipelines/update-pipeline-dialog.tsx
@@ -13,7 +13,7 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { useState } from 'react';
 import { useProjectContext } from '@/contexts/project-context';
-import { Loader, Pencil, Plus } from 'lucide-react';
+import { Loader2, Pencil, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Pipeline } from '@/lib/pipeline/types';
 import { DropdownMenuItem } from '../ui/dropdown-menu';
@@ -98,7 +98,7 @@ export function UpdatePipelineDialog({
               disabled={!pipeline.name || isLoading}
               handleEnter
             >
-              <Loader
+              <Loader2
                 className={cn(
                   'mr-2 hidden',
                   isLoading ? 'animate-spin block' : ''

--- a/frontend/components/projects/project-create-dialog.tsx
+++ b/frontend/components/projects/project-create-dialog.tsx
@@ -17,7 +17,7 @@ import {
   SelectItem
 } from '@/components/ui/select';
 import { Button } from '../ui/button';
-import { Loader, Plus } from 'lucide-react';
+import { Loader2, Plus } from 'lucide-react';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
 import { useToast } from '@/lib/hooks/use-toast';
@@ -114,7 +114,7 @@ export default function ProjectCreateDialog({
             disabled={newProjectWorkspaceId === undefined || !newProjectName}
           >
             {isCreatingProject && (
-              <Loader className="mr-2 animate-spin" size={16} />
+              <Loader2 className="mr-2 animate-spin" size={16} />
             )}
             Create
           </Button>

--- a/frontend/components/projects/workspace-create-dialog.tsx
+++ b/frontend/components/projects/workspace-create-dialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogTrigger
 } from '@/components/ui/dialog';
 import { Button } from '../ui/button';
-import { Loader, Plus } from 'lucide-react';
+import { Loader2, Plus } from 'lucide-react';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
 
@@ -71,7 +71,7 @@ export default function WorkspaceCreateDialog({
             disabled={!newWorkspaceName || isCreatingWorkspace}
           >
             {isCreatingWorkspace && (
-              <Loader className="mr-2 animate-spin" size={16} />
+              <Loader2 className="mr-2 animate-spin" size={16} />
             )}
             Create
           </Button>

--- a/frontend/components/settings/delete-project.tsx
+++ b/frontend/components/settings/delete-project.tsx
@@ -13,7 +13,7 @@ import { Label } from '../ui/label';
 import { Input } from '../ui/input';
 import { useState } from 'react';
 import { useProjectContext } from '@/contexts/project-context';
-import { Loader, Trash, Trash2 } from 'lucide-react';
+import { Loader2, Trash, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface DeleteProjectProps { }
@@ -82,7 +82,7 @@ export default function DeleteProject({ }: DeleteProjectProps) {
                 onClick={deleteProject}
                 handleEnter={true}
               >
-                <Loader
+                <Loader2
                   className={cn(
                     'mr-2 hidden',
                     isLoading ? 'animate-spin block' : ''

--- a/frontend/components/settings/revoke-dialog.tsx
+++ b/frontend/components/settings/revoke-dialog.tsx
@@ -9,7 +9,7 @@ import {
 } from '../ui/dialog';
 import { useState } from 'react';
 import { Button } from '../ui/button';
-import { Loader, Trash2 } from 'lucide-react';
+import { Loader2, Trash2 } from 'lucide-react';
 import { Label } from '../ui/label';
 import { cn } from '@/lib/utils';
 
@@ -50,7 +50,7 @@ export default function RevokeDialog({
               setIsOpen(false);
             }}
           >
-            <Loader
+            <Loader2
               className={cn(
                 'mr-2 hidden',
                 isLoading ? 'animate-spin block' : ''

--- a/frontend/components/traces/export-spans-dialog.tsx
+++ b/frontend/components/traces/export-spans-dialog.tsx
@@ -11,7 +11,7 @@ import { Button } from '../ui/button';
 import DatasetSelect from '../ui/dataset-select';
 import { Span } from '@/lib/traces/types';
 import { Label } from '../ui/label';
-import { Database, Loader } from 'lucide-react';
+import { Database, Loader2 } from 'lucide-react';
 import { cn, isJsonStringAValidObject } from '@/lib/utils';
 import { useToast } from '@/lib/hooks/use-toast';
 import { Dataset } from '@/lib/dataset/types';
@@ -136,7 +136,7 @@ export default function ExportSpansDialog({ span }: ExportSpansDialogProps) {
                   !isTargetValid
                 }
               >
-                <Loader
+                <Loader2
                   className={cn(
                     'mr-2 hidden',
                     isLoading ? 'animate-spin block' : ''

--- a/frontend/components/traces/log-export-dialog.tsx
+++ b/frontend/components/traces/log-export-dialog.tsx
@@ -13,7 +13,7 @@ import { Label } from '../ui/label';
 import DatasetSelect from '../ui/dataset-select';
 import { cn, getFilterFromUrlParams } from '@/lib/utils';
 import { useSearchParams } from 'next/navigation';
-import { Loader } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import {
   Tooltip,
   TooltipContent,
@@ -125,7 +125,7 @@ export default function LogExportDialog({
             }}
             handleEnter
           >
-            <Loader
+            <Loader2
               className={cn(
                 'mr-2 hidden',
                 isLoading ? 'animate-spin block' : ''

--- a/frontend/components/ui/pipeline-select.tsx
+++ b/frontend/components/ui/pipeline-select.tsx
@@ -10,7 +10,7 @@ import {
 import { useEffect, useState } from 'react';
 import { Pipeline, PipelineVersion } from '@/lib/pipeline/types';
 import { useProjectContext } from '@/contexts/project-context';
-import { GitBranch, GitCommitVertical, Loader, Radio } from 'lucide-react';
+import { GitBranch, GitCommitVertical, Loader2, Radio } from 'lucide-react';
 
 interface PipelineSelectProps {
   onPipelineChange?: (pipeline: Pipeline) => void;
@@ -148,7 +148,7 @@ export default function PipelineSelect({
               className="flex justify-center"
               disabled={true}
             >
-              <Loader className="animate-spin block" size={16} />
+              <Loader2 className="animate-spin block" size={16} />
             </SelectItem>
           ) : (
             pipelines!.map((pipeline) => (
@@ -189,7 +189,7 @@ export default function PipelineSelect({
               className="flex justify-center"
               disabled={true}
             >
-              <Loader className="animate-spin block" size={16} />
+              <Loader2 className="animate-spin block" size={16} />
             </SelectItem>
           </SelectContent>
         ) : (

--- a/frontend/components/workspace/workspace-users.tsx
+++ b/frontend/components/workspace/workspace-users.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog';
-import { Loader, Plus } from 'lucide-react';
+import { Loader2, Plus } from 'lucide-react';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
 import { useCallback, useState } from 'react';
@@ -146,7 +146,7 @@ export default function WorkspaceUsers({
                       Add
                     </Button>
                     {isAddUserLoading && (
-                      <Loader className="animate-spin h-4 w-4 mr-2" />
+                      <Loader2 className="animate-spin h-4 w-4 mr-2" />
                     )}
                   </DialogFooter>
                 </DialogContent>


### PR DESCRIPTION
This PR solves issue #128 
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `Loader` with `Loader2` in loading indicators across multiple UI components for a consistent visual appearance.
> 
>   - **UI Components**:
>     - Replaces `Loader` with `Loader2` in loading indicators across various components such as `dataset-panel.tsx`, `dataset-upload.tsx`, and `delete-datapoints-dialog.tsx`.
>     - Affects components in `pipeline`, `projects`, `settings`, `traces`, and `workspace` directories.
>   - **Behavior**:
>     - Visual change in loading indicators, using `Loader2` for a consistent look.
>   - **Misc**:
>     - Updates import statements to remove `Loader` and include `Loader2` from `lucide-react`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for b5c2a4c6b08c0caff7cca7bc4c40ab9e738505f9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->