### PR TITLE
fix docs URL in dashboard headers

### DIFF
--- a/frontend/components/ui/header.tsx
+++ b/frontend/components/ui/header.tsx
@@ -45,7 +45,7 @@ export default function Header({ path, children, className }: HeaderProps) {
       </div>
       <div className="flex space-x-2 pr-4">
         <Button variant={'ghost'}>
-          <a href="https://docs.lmnr.ai/introduction" target="_blank">
+          <a href="https://docs.lmnr.ai/" target="_blank">
             Docs
           </a>
         </Button>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update documentation URL in `Header` component to point to the correct homepage.
> 
>   - **Behavior**:
>     - Update documentation URL in `Header` component from `https://docs.lmnr.ai/introduction` to `https://docs.lmnr.ai/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 182ec4524a664f315a37017f12f37d7da1d66907. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->