### PR TITLE
create migrations for labeling_queue_data with spans

### DIFF
--- a/frontend/lib/db/migrations/0002_cold_romulus.sql
+++ b/frontend/lib/db/migrations/0002_cold_romulus.sql
@@ -2,10 +2,11 @@ CREATE TABLE IF NOT EXISTS "labeling_queue_data" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"queue_id" uuid DEFAULT gen_random_uuid() NOT NULL,
-	"data" jsonb NOT NULL,
-	"action" jsonb NOT NULL
+	"action" jsonb NOT NULL,
+	"span_id" uuid NOT NULL
 );
 --> statement-breakpoint
+ALTER TABLE "dataset_datapoints" ALTER COLUMN "target" DROP NOT NULL;--> statement-breakpoint
 DO $$ BEGIN
  ALTER TABLE "labeling_queue_data" ADD CONSTRAINT "labelling_queue_data_queue_id_fkey" FOREIGN KEY ("queue_id") REFERENCES "public"."labeling_queues"("id") ON DELETE cascade ON UPDATE cascade;
 EXCEPTION

--- a/frontend/lib/db/migrations/meta/0002_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0002_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "b99ec153-af07-4417-8ff6-91708ead7b1d",
+  "id": "326ba2ca-6925-4d69-8416-1a7691a8bcfd",
   "prevId": "a7f4ca0c-430b-49f5-93d4-09d1ab968dac",
   "version": "7",
   "dialect": "postgresql",
@@ -95,7 +95,7 @@
           "name": "target",
           "type": "jsonb",
           "primaryKey": false,
-          "notNull": true,
+          "notNull": false,
           "default": "'{}'::jsonb"
         },
         "index_in_batch": {
@@ -742,15 +742,15 @@
           "notNull": true,
           "default": "gen_random_uuid()"
         },
-        "data": {
-          "name": "data",
+        "action": {
+          "name": "action",
           "type": "jsonb",
           "primaryKey": false,
           "notNull": true
         },
-        "action": {
-          "name": "action",
-          "type": "jsonb",
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         }

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -19,8 +19,8 @@
     {
       "idx": 2,
       "version": "7",
-      "when": 1730492567345,
-      "tag": "0002_motionless_dragon_lord",
+      "when": 1730608599324,
+      "tag": "0002_cold_romulus",
       "breakpoints": true
     }
   ]

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -307,7 +307,7 @@ export const datasetDatapoints = pgTable("dataset_datapoints", {
   createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   data: jsonb().notNull(),
   indexedOn: text("indexed_on"),
-  target: jsonb().default({}).notNull(),
+  target: jsonb().default({}),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
   indexInBatch: bigint("index_in_batch", { mode: "number" }),
   metadata: jsonb(),
@@ -339,8 +339,8 @@ export const labelingQueueData = pgTable("labeling_queue_data", {
   id: uuid().defaultRandom().primaryKey().notNull(),
   createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   queueId: uuid("queue_id").defaultRandom().notNull(),
-  data: jsonb().notNull(),
   action: jsonb().notNull(),
+  spanId: uuid("span_id").notNull(),
 },
 (table) => ({
   labellingQueueDataQueueIdFkey: foreignKey({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `span_id` to `labeling_queue_data` and make `target` nullable in `dataset_datapoints`, updating migrations and schema definitions.
> 
>   - **Database Schema Changes**:
>     - Add `span_id` column to `labeling_queue_data` table in `0002_cold_romulus.sql`.
>     - Make `target` column in `dataset_datapoints` nullable in `0002_cold_romulus.sql`.
>   - **Migration Files**:
>     - Rename `0002_motionless_dragon_lord.sql` to `0002_cold_romulus.sql`.
>     - Update `0002_snapshot.json` and `_journal.json` to reflect new migration.
>   - **Schema Definitions**:
>     - Update `labelingQueueData` and `datasetDatapoints` in `schema.ts` to match new schema.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7b811f09dffd336fbbf2e144d480c308e21f5c39. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->