### PR TITLE
Queue spanid

### DIFF
--- a/app-server/src/db/labeling_queues.rs
+++ b/app-server/src/db/labeling_queues.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use serde_json::Value;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -40,12 +39,12 @@ pub async fn push_to_labeling_queue(
         sqlx::query(
             "INSERT INTO labeling_queue_data (
             queue_id,
-            data,
+            span_id,
             action
         ) VALUES ($1, $2, $3)",
         )
         .bind(queue_id)
-        .bind(item.data.clone())
+        .bind(item.span_id)
         .bind(item.action.clone())
         .execute(pool)
         .await?;

--- a/frontend/app/api/projects/[projectId]/evaluations/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/route.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/db/drizzle';
 import { evaluations } from '@/lib/db/schema';
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 import { isCurrentUserMemberOfProject, paginatedGet } from '@/lib/db/utils';
 import { Evaluation } from '@/lib/evaluation/types';
 
@@ -14,20 +14,10 @@ export async function GET(
     return new Response(JSON.stringify({ error: "User is not a member of the project" }), { status: 403 });
   }
 
-  const baseQuery = db.$with(
-    "base"
-  ).as(
-    db
-      .select()
-      .from(evaluations)
-  );
-
   const result = await paginatedGet<any, Evaluation>({
     table: evaluations,
-    baseFilters: [eq(sql`project_id`, projectId)],
-    filters: [],
-    baseQuery,
-    orderBy: desc(sql`created_at`),
+    filters: [eq(evaluations.projectId, projectId)],
+    orderBy: desc(evaluations.createdAt),
   });
 
   return Response.json(result);

--- a/frontend/app/api/projects/[projectId]/spans/route.ts
+++ b/frontend/app/api/projects/[projectId]/spans/route.ts
@@ -55,9 +55,14 @@ export async function GET(
     return filter;
   });
 
+  // TODO: this is repeated in the paginatedGet below. Deduplicate.
   const sqlFilters = filtersToSql(
     urlParamFilters,
-    [new RegExp(/^\(attributes\s*->>\s*'[a-zA-Z_\.]+'\)(?:::int8|::float8)?$/)]
+    [new RegExp(/^\(attributes\s*->>\s*'[a-zA-Z_\.]+'\)(?:::int8|::float8)?$/)],
+    {
+      latency: sql<number>`EXTRACT(EPOCH FROM (end_time - start_time))`,
+      path: sql<string>`attributes ->> 'lmnr.span.path'`,
+    }
   );
 
   const baseFilters = [
@@ -77,27 +82,17 @@ export async function GET(
   // don't query input and output, only query previews
   const { input, output, ...columns } = getTableColumns(spans);
 
-  const baseQuery = db.$with(
-    "base",
-  ).as(
-    db
-      .select({
-        ...columns,
-        latency: sql<number>`EXTRACT(EPOCH FROM (end_time - start_time))`.as("latency"),
-        path: sql<string>`attributes ->> 'lmnr.span.path'`.as("path"),
-      })
-      .from(spans)
-      .where(and(...baseFilters))
-  );
-
   const spanData = await paginatedGet<any, Span>({
     table: spans,
     pageNumber,
     pageSize,
-    baseFilters,
-    filters,
-    orderBy: desc(sql`start_time`),
-    baseQuery,
+    filters: baseFilters.concat(filters),
+    orderBy: desc(spans.startTime),
+    columns: {
+      ...columns,
+      latency: sql<number>`EXTRACT(EPOCH FROM (end_time - start_time))`.as("latency"),
+      path: sql<string>`attributes ->> 'lmnr.span.path'`.as("path"),
+    }
   });
 
   return new Response(JSON.stringify(spanData), { status: 200 });

--- a/frontend/app/project/[projectId]/evaluations/page.tsx
+++ b/frontend/app/project/[projectId]/evaluations/page.tsx
@@ -1,5 +1,9 @@
 import { Metadata } from 'next';
 import Evaluations from '@/components/evaluations/evaluations';
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db/drizzle';
+import { evaluations } from '@/lib/db/schema';
+import EvalsPagePlaceholder from '@/components/evaluations/page-placeholder';
 
 export const metadata: Metadata = {
   title: 'Evaluations'
@@ -10,5 +14,10 @@ export default async function EvaluationsPage({
 }: {
   params: { projectId: string };
 }) {
+  const projectId = params.projectId;
+  const anyInProject = await db.$count(evaluations, eq(evaluations.projectId, projectId)) > 0;
+  if (!anyInProject) {
+    return <EvalsPagePlaceholder />;
+  }
   return <Evaluations />;
 }

--- a/frontend/app/project/[projectId]/traces/page.tsx
+++ b/frontend/app/project/[projectId]/traces/page.tsx
@@ -1,12 +1,32 @@
 import TracesDashboard from '@/components/traces/traces';
 import { Metadata } from 'next';
 import Header from '@/components/ui/header';
+import { spans, traces } from '@/lib/db/schema';
+import { eq, inArray } from 'drizzle-orm';
+import { db } from '@/lib/db/drizzle';
+import TracesPagePlaceholder from '@/components/traces/page-placeholder';
 
 export const metadata: Metadata = {
   title: 'Traces'
 };
 
-export default async function TracesPage() {
+export default async function TracesPage({
+  params
+}: {
+  params: { projectId: string };
+}) {
+  const projectId = params.projectId;
+  const anyInProject = await db.$count(
+    spans,
+    inArray(
+      spans.traceId,
+      db.select({ traceId: traces.id })
+        .from(traces)
+        .where(eq(traces.projectId, projectId))
+    )) > 0;
+  if (!anyInProject) {
+    return <TracesPagePlaceholder />;
+  }
   return (
     <>
       <Header path={'traces'} className="border-b-0" />

--- a/frontend/components/evaluations/evaluations.tsx
+++ b/frontend/components/evaluations/evaluations.tsx
@@ -32,8 +32,11 @@ import { PaginatedResponse } from '@/lib/types';
 
 export default function Evaluations() {
   const { projectId } = useProjectContext();
-  const { data, mutate } = useSWR<PaginatedResponse<Evaluation>>(`/api/projects/${projectId}/evaluations`, swrFetcher);
-  const evaluations = data?.items ?? [];
+  const { data, mutate, isLoading } = useSWR<PaginatedResponse<Evaluation>>(
+    `/api/projects/${projectId}/evaluations`,
+    swrFetcher
+  );
+  const evaluations = data?.items;
 
   const router = useRouter();
   const posthog = usePostHog();
@@ -107,15 +110,6 @@ export default function Evaluations() {
     setIsDeleteDialogOpen(false);
   };
 
-  if (data?.anyInProject === false) {
-    return (
-      <div className="flex flex-col h-full">
-        <Header path="evaluations" />
-        <EvalsPagePlaceholder />
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col h-full">
       <Header path="evaluations" />
@@ -133,6 +127,8 @@ export default function Evaluations() {
             router.push(`/project/${projectId}/evaluations/${row.original.id}`);
           }}
           getRowId={(row: Evaluation) => row.id}
+          paginated
+          manualPagination
           selectionPanel={(selectedRowIds) => (
             <div className="flex flex-col space-y-2">
               <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>

--- a/frontend/components/evaluations/page-placeholder.tsx
+++ b/frontend/components/evaluations/page-placeholder.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import { useState } from 'react';
 import CodeHighlighter from '../ui/code-highlighter';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { PYTHON_INSTALL, TYPESCRIPT_INSTALL } from '@/lib/const';
 import { useProjectContext } from '@/contexts/project-context';
+import Header from '../ui/header';
 
 export default function EvalsPagePlaceholder() {
   const { projectId } = useProjectContext();
@@ -45,8 +48,9 @@ evaluate({
 `;
 
   return (
-    <div className="h-full w-full justify-center flex p-2">
-      <div className="flex flex-col">
+    <div className="h-full w-full flex flex-col">
+      <Header path="evaluations" />
+      <div className="flex flex-col justify-center items-center p-2">
         <div className="flex-col p-4 mb-32 space-y-4 w-[800px]">
           <h1 className="text-2xl font-semibold mb-4">Evaluations</h1>
           <h3 className="text-secondary-foreground/80 font-light">

--- a/frontend/components/event/event.tsx
+++ b/frontend/components/event/event.tsx
@@ -22,7 +22,7 @@ import DataTableFilter from '../ui/datatable-filter';
 import ClientTimestampFormatter from '../client-timestamp-formatter';
 import { Resizable } from 're-resizable';
 import EventView from './event-view';
-import { PaginatedResponse } from '@/lib/types';
+import { PaginatedGetResponseWithProjectPresenceFlag } from '@/lib/types';
 
 // TODO: add refresh button on realtime updates. See components/traces/traces-table-traces-view.tsx for an example.
 
@@ -35,7 +35,7 @@ const getEvents = async (
   pastHours: string | null,
   startDate: string | null | undefined,
   endDate: string | null | undefined
-): Promise<PaginatedResponse<Event>> => {
+): Promise<PaginatedGetResponseWithProjectPresenceFlag<Event>> => {
   let url = `/api/projects/${projectId}/event-templates/${templateId}/events?pageNumber=${pageNumber}&pageSize=${pageSize}`;
   if (pastHours !== null) {
     url += `&pastHours=${pastHours}`;
@@ -59,7 +59,7 @@ const getEvents = async (
     },
     cache: 'no-cache'
   });
-  return (await res.json()) as PaginatedResponse<Event>;
+  return (await res.json()) as PaginatedGetResponseWithProjectPresenceFlag<Event>;
 };
 
 interface EventProps {

--- a/frontend/components/traces/page-placeholder.tsx
+++ b/frontend/components/traces/page-placeholder.tsx
@@ -1,9 +1,12 @@
+'use client';
+
 import { useState } from 'react';
 import { useProjectContext } from '@/contexts/project-context';
 import CodeHighlighter from '../ui/code-highlighter';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { PYTHON_INSTALL, TYPESCRIPT_INSTALL } from '@/lib/const';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion';
+import Header from '../ui/header';
 
 
 export default function TracesPagePlaceholder() {
@@ -43,8 +46,9 @@ const function_to_trace =
 })`;
 
   return (
-    <div className="h-full w-full justify-center flex p-2">
-      <div className="flex flex-col">
+    <div className="h-full w-full flex flex-col">
+      <Header path={'traces'} />
+      <div className="flex flex-col justify-center items-center p-2">
         <div className="flex-col p-4 mb-32 space-y-4 w-[800px]">
           <h1 className="text-2xl font-semibold mb-4">Quickstart</h1>
           <h3 className="text-secondary-foreground/80 font-light">

--- a/frontend/components/traces/spans-table.tsx
+++ b/frontend/components/traces/spans-table.tsx
@@ -51,7 +51,6 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
   const textSearchFilter = searchParams.get('search');
   const [spans, setSpans] = useState<Span[] | undefined>(undefined);
   const [totalCount, setTotalCount] = useState<number>(0); // including the filtering
-  const [anyInProject, setAnyInProject] = useState<boolean>(true);
   const pageCount = Math.ceil(totalCount / pageSize);
   const [spanId, setSpanId] = useState<string | null>(
     searchParams.get('spanId') ?? null
@@ -103,7 +102,6 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
 
     setSpans(data.items);
     setTotalCount(data.totalCount);
-    setAnyInProject(data.anyInProject);
   };
   useEffect(() => {
     getSpans();

--- a/frontend/components/traces/traces-table.tsx
+++ b/frontend/components/traces/traces-table.tsx
@@ -7,7 +7,6 @@ import { ColumnDef } from '@tanstack/react-table';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useState, useEffect, useMemo } from 'react';
 import ClientTimestampFormatter from '../client-timestamp-formatter';
-import StatusLabel from '../ui/status-label';
 import TracesPagePlaceholder from './page-placeholder';
 import { EventTemplate } from '@/lib/events/types';
 import DateRangeFilter from '../ui/date-range-filter';
@@ -16,7 +15,7 @@ import DataTableFilter from '../ui/datatable-filter';
 import TextSearchFilter from '../ui/text-search-filter';
 import { Button } from '../ui/button';
 import { ArrowRight, RefreshCcw } from 'lucide-react';
-import { PaginatedResponse } from '@/lib/types';
+import { PaginatedGetResponseWithProjectPresenceFlag, PaginatedResponse } from '@/lib/types';
 import Mono from '../ui/mono';
 import useSWR from 'swr';
 import { swrFetcher } from '@/lib/utils';
@@ -113,7 +112,7 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
       }
     });
 
-    const data = (await res.json()) as PaginatedResponse<Trace>;
+    const data = (await res.json()) as PaginatedGetResponseWithProjectPresenceFlag<Trace>;
 
     setTraces(data.items);
     setTotalCount(data.totalCount);

--- a/frontend/lib/db/migrations/0002_cold_romulus.sql
+++ b/frontend/lib/db/migrations/0002_cold_romulus.sql
@@ -2,10 +2,11 @@ CREATE TABLE IF NOT EXISTS "labeling_queue_data" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"queue_id" uuid DEFAULT gen_random_uuid() NOT NULL,
-	"data" jsonb NOT NULL,
-	"action" jsonb NOT NULL
+	"action" jsonb NOT NULL,
+	"span_id" uuid NOT NULL
 );
 --> statement-breakpoint
+ALTER TABLE "dataset_datapoints" ALTER COLUMN "target" DROP NOT NULL;--> statement-breakpoint
 DO $$ BEGIN
  ALTER TABLE "labeling_queue_data" ADD CONSTRAINT "labelling_queue_data_queue_id_fkey" FOREIGN KEY ("queue_id") REFERENCES "public"."labeling_queues"("id") ON DELETE cascade ON UPDATE cascade;
 EXCEPTION

--- a/frontend/lib/db/migrations/meta/0002_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0002_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "b99ec153-af07-4417-8ff6-91708ead7b1d",
+  "id": "326ba2ca-6925-4d69-8416-1a7691a8bcfd",
   "prevId": "a7f4ca0c-430b-49f5-93d4-09d1ab968dac",
   "version": "7",
   "dialect": "postgresql",
@@ -95,7 +95,7 @@
           "name": "target",
           "type": "jsonb",
           "primaryKey": false,
-          "notNull": true,
+          "notNull": false,
           "default": "'{}'::jsonb"
         },
         "index_in_batch": {
@@ -742,15 +742,15 @@
           "notNull": true,
           "default": "gen_random_uuid()"
         },
-        "data": {
-          "name": "data",
+        "action": {
+          "name": "action",
           "type": "jsonb",
           "primaryKey": false,
           "notNull": true
         },
-        "action": {
-          "name": "action",
-          "type": "jsonb",
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         }

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -19,8 +19,8 @@
     {
       "idx": 2,
       "version": "7",
-      "when": 1730492567345,
-      "tag": "0002_motionless_dragon_lord",
+      "when": 1730608599324,
+      "tag": "0002_cold_romulus",
       "breakpoints": true
     }
   ]

--- a/frontend/lib/db/modifiers.ts
+++ b/frontend/lib/db/modifiers.ts
@@ -21,12 +21,18 @@ export type FilterDef = {
   value: string;
 }
 
-export const filtersToSql = (filters: FilterDef[], allowPatterns?: RegExp[]): SQL[] => {
+export const filtersToSql = (
+  filters: FilterDef[],
+  allowPatterns?: RegExp[],
+  additionalColumnDefinitions?: Record<string, SQL<any>>
+): SQL[] => {
   let result = [];
   for (const filter of filters) {
     if (filter.column && filter.operator && filter.value != null) {
       const operator = filterOperators[filter.operator] ?? eq;
-      if (validateSqlColumnName(filter.column, allowPatterns)) {
+      if (additionalColumnDefinitions && filter.column in additionalColumnDefinitions) {
+        result.push(operator(additionalColumnDefinitions[filter.column], filter.value));
+      } else if (validateSqlColumnName(filter.column, allowPatterns)) {
         result.push(operator(sql`${sql.raw(filter.column)}`, filter.value));
       }
     }

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -307,7 +307,7 @@ export const datasetDatapoints = pgTable("dataset_datapoints", {
   createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   data: jsonb().notNull(),
   indexedOn: text("indexed_on"),
-  target: jsonb().default({}).notNull(),
+  target: jsonb().default({}),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
   indexInBatch: bigint("index_in_batch", { mode: "number" }),
   metadata: jsonb(),
@@ -339,8 +339,8 @@ export const labelingQueueData = pgTable("labeling_queue_data", {
   id: uuid().defaultRandom().primaryKey().notNull(),
   createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   queueId: uuid("queue_id").defaultRandom().notNull(),
-  data: jsonb().notNull(),
   action: jsonb().notNull(),
+  spanId: uuid("span_id").notNull(),
 },
 (table) => ({
   labellingQueueDataQueueIdFkey: foreignKey({

--- a/frontend/lib/db/utils.ts
+++ b/frontend/lib/db/utils.ts
@@ -3,7 +3,7 @@ import { eq, and, gt, sql, lt, SQL, lte, ne, gte, BinaryOperator, getTableColumn
 import { membersOfWorkspaces, projects, users } from "./schema";
 import { getServerSession } from 'next-auth';
 import { authOptions } from "../auth";
-import { PgTableWithColumns, TableConfig } from "drizzle-orm/pg-core";
+import { PgColumn, PgTableWithColumns, SelectedFields, TableConfig } from "drizzle-orm/pg-core";
 import { PaginatedResponse } from "../types";
 
 export const isCurrentUserMemberOfProject = async (projectId: string) => {
@@ -67,59 +67,52 @@ export const getDateRangeFilters = (
 
 interface PaginatedGetParams<T extends TableConfig, R> {
   table: PgTableWithColumns<T>;
-  baseQuery: WithSubquery<string, any>;
   pageNumber?: number;
   pageSize?: number;
-  baseFilters: SQL[];
   filters: SQL[];
   orderBy: SQL;
+  /**
+   * If provided, only these columns will be selected.
+   * Useful to remove columns that are too heavy to query, or
+   * to add columns to compute query time, e.g. latency.
+   */
+  columns?: SelectedFields;
 }
 
-export const paginatedGet = async<T extends TableConfig, R> (
+export const paginatedGet = async<T extends TableConfig, R>(
   {
     table,
     pageNumber,
     pageSize,
-    baseFilters,
     filters,
     orderBy,
-    baseQuery,
+    columns,
   }: PaginatedGetParams<T, R>
 ): Promise<PaginatedResponse<R>> => {
-  const allFilters = baseFilters.concat(filters);
 
   const itemsQuery = pageNumber !== undefined && pageSize !== undefined
     ? db
-      .with(baseQuery)
-      .select()
-      .from(baseQuery)
-      .where(and(...allFilters))
+      .select(columns ?? getTableColumns(table))
+      .from(table)
+      .where(and(...filters))
       .orderBy(orderBy)
       .limit(pageSize).offset(pageNumber * pageSize)
     : db
-      .with(baseQuery)
-      .select()
-      .from(baseQuery)
-      .where(and(...allFilters))
+      .select(columns ?? getTableColumns(table))
+      .from(table)
+      .where(and(...filters))
       .orderBy(orderBy);
 
-  const countQueries = async () => {
-    const totalCount = await db
-      .with(baseQuery)
-      .select({ count: sql<number>`COUNT(*)` })
-      .from(baseQuery)
-      .where(and(...allFilters))
+  const countQuery = async () =>
+    db.select({ count: sql<number>`COUNT(*)` })
+      .from(table)
+      .where(and(...filters))
       .then(([{ count }]) => count);
-    const anyInProject = totalCount > 0
-      ? true
-      : await db.$count(table, and(...baseFilters)) > 0;
-    return { totalCount, anyInProject };
-  };
 
-  const [items, { totalCount, anyInProject }] = await Promise.all([
+  const [items, totalCount] = await Promise.all([
     itemsQuery,
-    countQueries(),
+    countQuery(),
   ]);
 
-  return { items: items as R[], totalCount, anyInProject };
+  return { items: items as R[], totalCount };
 };

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -43,5 +43,8 @@ export type DatatableFilter = {
 export type PaginatedResponse<T> = {
   items: T[];
   totalCount: number;
+};
+
+export type PaginatedGetResponseWithProjectPresenceFlag<T> = PaginatedResponse<T> & {
   anyInProject: boolean;
 };


### PR DESCRIPTION
Accept vec of HumanEvaluator objects from SDK instead of a record. Add executor span id to the request definition and write it to the updated labeling queue.

+ cherry-pick some frontend changes (migrations)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR updates the handling of span IDs in the labeling queue, modifies the data model to accept a vector of HumanEvaluator objects, and includes frontend and database schema changes.
> 
>   - **Behavior**:
>     - Accepts `Vec<HumanEvaluator>` instead of a `HashMap` in `EvaluationDatapointResult` in `utils.rs`.
>     - Adds `executor_span_id` to `EvaluationDatapointResult` in `utils.rs`.
>     - Updates `push_to_labeling_queue` in `labeling_queues.rs` to use `span_id` instead of `data`.
>   - **Database**:
>     - Adds `span_id` column to `labeling_queue_data` table in `0002_cold_romulus.sql`.
>     - Drops NOT NULL constraint from `target` column in `dataset_datapoints` table in `0002_cold_romulus.sql`.
>   - **Frontend**:
>     - Updates `paginatedGet` function in `utils.ts` to remove `baseQuery` and `baseFilters`.
>     - Modifies `GET` function in `evaluations/route.ts` to use updated `paginatedGet`.
>     - Updates `filtersToSql` in `modifiers.ts` to handle additional column definitions.
>     - Adds placeholder components for empty states in `evaluations/page.tsx` and `traces/page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for c63fd15a575d4f824967151017ce184ad83e2166. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->