### PR TITLE
[1/3] record project_id in spans table

### DIFF
--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -124,7 +124,7 @@ pub async fn record_span_to_db(
         );
     }
 
-    db::spans::record_span(&db.pool, &span).await?;
+    db::spans::record_span(&db.pool, &span, project_id).await?;
 
     Ok(())
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `project_id` to `record_span` in `spans.rs` and update SQL to handle conflicts with `(span_id, project_id)`.
> 
>   - **Behavior**:
>     - Add `project_id` parameter to `record_span` in `spans.rs` to record `project_id` in the `spans` table.
>     - Update conflict resolution in SQL to use `(span_id, project_id)`.
>   - **Function Calls**:
>     - Update `record_span_to_db` in `utils.rs` to pass `project_id` to `record_span`.
>   - **SQL Changes**:
>     - Modify `INSERT INTO spans` statement to include `project_id`.
>     - Change `ON CONFLICT` clause to `(span_id, project_id)` in `spans.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d3cf4f1994c8d9411e79357d8b1ae6848d3d5159. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->