### PR TITLE
query all spans with project_id

### DIFF
--- a/app-server/src/db/spans.rs
+++ b/app-server/src/db/spans.rs
@@ -128,12 +128,14 @@ pub async fn record_span(pool: &PgPool, span: &Span, project_id: &Uuid) -> Resul
 pub async fn get_trace_spans(
     pool: &PgPool,
     trace_id: Uuid,
+    project_id: Uuid,
     search: Option<String>,
 ) -> Result<Vec<Span>> {
     let mut query = sqlx::QueryBuilder::<Postgres>::new(
         "WITH span_events AS (
             SELECT
                 events.span_id,
+                event_templates.project_id,
                 jsonb_agg(
                     jsonb_build_object(
                         'id', events.id,
@@ -147,10 +149,11 @@ pub async fn get_trace_spans(
                 ) AS events
             FROM events
             JOIN event_templates ON events.template_id = event_templates.id
-            GROUP BY events.span_id
+            GROUP BY events.span_id, event_templates.project_id
         ),
         span_labels AS (
             SELECT labels.span_id,
+            label_classes.project_id,
             jsonb_agg(
                 jsonb_build_object(
                     'id', labels.id,
@@ -168,7 +171,7 @@ pub async fn get_trace_spans(
             ) AS labels
             FROM labels
             JOIN label_classes ON labels.class_id = label_classes.id
-            GROUP BY labels.span_id
+            GROUP BY labels.span_id, label_classes.project_id
         ),
         spans_info AS (
             SELECT
@@ -186,11 +189,13 @@ pub async fn get_trace_spans(
                 COALESCE(span_events.events, '[]'::jsonb) AS events,
                 COALESCE(span_labels.labels, '[]'::jsonb) AS labels
             FROM spans
-            LEFT JOIN span_events ON spans.span_id = span_events.span_id
-            LEFT JOIN span_labels ON spans.span_id = span_labels.span_id
+            LEFT JOIN span_events ON spans.span_id = span_events.span_id AND span_events.project_id = spans.project_id
+            LEFT JOIN span_labels ON spans.span_id = span_labels.span_id AND span_labels.project_id = spans.project_id
             WHERE spans.trace_id = ",
     );
     query.push_bind(trace_id);
+    query.push(" AND spans.project_id = ");
+    query.push_bind(project_id);
     query.push(
         ")
         SELECT * FROM spans_info WHERE 1=1
@@ -216,7 +221,7 @@ pub async fn get_trace_spans(
     Ok(spans)
 }
 
-pub async fn get_span(pool: &PgPool, id: Uuid) -> Result<Span> {
+pub async fn get_span(pool: &PgPool, id: Uuid, project_id: Uuid) -> Result<Span> {
     let span = sqlx::query_as::<_, Span>(
         "SELECT
             span_id,
@@ -233,9 +238,10 @@ pub async fn get_span(pool: &PgPool, id: Uuid) -> Result<Span> {
             '[]'::jsonb as events,
             '[]'::jsonb as labels
         FROM spans
-        WHERE span_id = $1",
+        WHERE span_id = $1 AND project_id = $2",
     )
     .bind(id)
+    .bind(project_id)
     .fetch_one(pool)
     .await?;
 

--- a/app-server/src/db/trace.rs
+++ b/app-server/src/db/trace.rs
@@ -220,8 +220,10 @@ fn add_traces_info_expression(
                 trace_id
             FROM spans
             WHERE parent_span_id IS NULL
+            AND project_id = 
             ",
     );
+    query.push_bind(project_id);
     add_date_range_to_query(
         query,
         date_range,

--- a/app-server/src/routes/traces.rs
+++ b/app-server/src/routes/traces.rs
@@ -112,12 +112,12 @@ pub async fn get_single_trace(
     db: web::Data<DB>,
     query_params: web::Query<GetTraceParams>,
 ) -> ResponseResult {
-    let (_project_id, trace_id) = params.into_inner();
+    let (project_id, trace_id) = params.into_inner();
     let search = query_params.search.clone();
 
     let trace = db::trace::get_single_trace(&db.pool, trace_id).await?;
 
-    let span_previews = db::spans::get_trace_spans(&db.pool, trace_id, search).await?;
+    let span_previews = db::spans::get_trace_spans(&db.pool, trace_id, project_id, search).await?;
 
     let trace_with_spans = TraceWithSpanPreviews {
         trace,
@@ -137,9 +137,9 @@ struct SpanWithEvents {
 
 #[get("spans/{span_id}")]
 pub async fn get_single_span(params: web::Path<(Uuid, Uuid)>, db: web::Data<DB>) -> ResponseResult {
-    let (_project_id, span_id) = params.into_inner();
+    let (project_id, span_id) = params.into_inner();
 
-    let span = db::spans::get_span(&db.pool, span_id).await?;
+    let span = db::spans::get_span(&db.pool, span_id, project_id).await?;
     let events = db::events::get_events_for_span(&db.pool, span_id).await?;
 
     let span_with_events = SpanWithEvents { span, events };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `project_id` filtering to span and trace queries in `spans.rs`, `trace.rs`, and `traces.rs` to ensure project-specific data retrieval.
> 
>   - **Behavior**:
>     - Add `project_id` parameter to `get_trace_spans()` and `get_span()` in `spans.rs` to filter spans by project.
>     - Modify `get_single_trace()` and `get_single_span()` in `traces.rs` to pass `project_id` to span retrieval functions.
>   - **Queries**:
>     - Update SQL queries in `spans.rs` and `trace.rs` to include `project_id` in `WHERE` clauses for filtering.
>     - Ensure `project_id` is used in joins and conditions in `spans.rs` and `trace.rs`.
>   - **Misc**:
>     - Adjust `add_traces_info_expression()` in `trace.rs` to bind `project_id` in query construction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 42d0a8a9ca0ee76b90fe95986e0d6d3a909c9344. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->