### PR TITLE
add migrations for the updated spans table with project id

### DIFF
--- a/frontend/lib/db/migrations/0002_cold_romulus.sql
+++ b/frontend/lib/db/migrations/0002_cold_romulus.sql
@@ -2,8 +2,8 @@ CREATE TABLE IF NOT EXISTS "labeling_queue_data" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"queue_id" uuid DEFAULT gen_random_uuid() NOT NULL,
-	"data" jsonb NOT NULL,
-	"action" jsonb NOT NULL
+	"action" jsonb NOT NULL,
+	"span_id" uuid NOT NULL
 );
 --> statement-breakpoint
 ALTER TABLE "dataset_datapoints" ALTER COLUMN "target" DROP NOT NULL;--> statement-breakpoint

--- a/frontend/lib/db/migrations/0003_cultured_tinkerer.sql
+++ b/frontend/lib/db/migrations/0003_cultured_tinkerer.sql
@@ -1,0 +1,29 @@
+ALTER TABLE "labels" DROP CONSTRAINT "trace_tags_span_id_fkey";
+--> statement-breakpoint
+/* 
+    [SOLVED]
+    Unfortunately in current drizzle-kit version we can't automatically get name for primary key.
+    We are working on making it available!
+
+    Meanwhile you can:
+        1. Check pk name in your database, by running
+            SELECT constraint_name FROM information_schema.table_constraints
+            WHERE table_schema = 'public'
+                AND table_name = 'spans'
+                AND constraint_type = 'PRIMARY KEY';
+        2. Uncomment code below and paste pk name manually
+        
+    Hope to release this update as soon as possible
+*/
+
+ALTER TABLE "spans" DROP CONSTRAINT "spans_pkey";--> statement-breakpoint
+ALTER TABLE "spans" ADD COLUMN "project_id" uuid NOT NULL;--> statement-breakpoint
+ALTER TABLE "spans" ADD CONSTRAINT "spans_pkey" PRIMARY KEY("span_id","project_id");--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "spans" ADD CONSTRAINT "spans_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE no action ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "spans_project_id_idx" ON "spans" USING btree ("project_id");--> statement-breakpoint
+ALTER TABLE "spans" ADD CONSTRAINT "unique_span_id_project_id" UNIQUE("span_id","project_id");

--- a/frontend/lib/db/migrations/meta/0003_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0003_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "326ba2ca-6925-4d69-8416-1a7691a8bcfd",
-  "prevId": "a7f4ca0c-430b-49f5-93d4-09d1ab968dac",
+  "id": "2bfae944-3896-4b39-b7e0-d1103db2d9d1",
+  "prevId": "326ba2ca-6925-4d69-8416-1a7691a8bcfd",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -901,19 +901,6 @@
       },
       "indexes": {},
       "foreignKeys": {
-        "trace_tags_span_id_fkey": {
-          "name": "trace_tags_span_id_fkey",
-          "tableFrom": "labels",
-          "tableTo": "spans",
-          "columnsFrom": [
-            "span_id"
-          ],
-          "columnsTo": [
-            "span_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        },
         "trace_tags_type_id_fkey": {
           "name": "trace_tags_type_id_fkey",
           "tableFrom": "labels",
@@ -1557,7 +1544,7 @@
         "span_id": {
           "name": "span_id",
           "type": "uuid",
-          "primaryKey": true,
+          "primaryKey": false,
           "notNull": true
         },
         "created_at": {
@@ -1639,6 +1626,12 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
         }
       },
       "indexes": {
@@ -1649,6 +1642,21 @@
               "expression": "(attributes -> 'lmnr.span.path'::text)",
               "asc": true,
               "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_project_id_idx": {
+          "name": "spans_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
               "nulls": "last"
             }
           ],
@@ -1707,10 +1715,40 @@
           ],
           "onDelete": "cascade",
           "onUpdate": "cascade"
+        },
+        "spans_project_id_fkey": {
+          "name": "spans_project_id_fkey",
+          "tableFrom": "spans",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
         }
       },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
+      "compositePrimaryKeys": {
+        "spans_pkey": {
+          "name": "spans_pkey",
+          "columns": [
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_span_id_project_id": {
+          "name": "unique_span_id_project_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
       "checkConstraints": {}
     },
     "public.subscription_tiers": {

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -19,8 +19,15 @@
     {
       "idx": 2,
       "version": "7",
-      "when": 1730581897701,
-      "tag": "0002_next_tusk",
+      "when": 1730608599324,
+      "tag": "0002_cold_romulus",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1730701646174,
+      "tag": "0003_cultured_tinkerer",
       "breakpoints": true
     }
   ]

--- a/frontend/lib/db/relations.ts
+++ b/frontend/lib/db/relations.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm/relations";
-import { pipelines, targetPipelineVersions, pipelineVersions, projects, traces, evaluations, evaluationResults, spans, eventTemplates, events, labelingQueues, providerApiKeys, workspaces, workspaceUsage, evaluationScores, labelClassesForPath, users, apiKeys, datasets, datasetDatapoints, labelingQueueData, membersOfWorkspaces, projectApiKeys, subscriptionTiers, userSubscriptionInfo, labels, labelClasses } from "./schema";
+import { pipelines, targetPipelineVersions, pipelineVersions, projects, traces, evaluations, evaluationResults, eventTemplates, events, labelingQueues, providerApiKeys, workspaces, workspaceUsage, evaluationScores, labelClassesForPath, users, apiKeys, datasets, datasetDatapoints, labelingQueueData, membersOfWorkspaces, projectApiKeys, subscriptionTiers, userSubscriptionInfo, labelClasses, labels, spans } from "./schema";
 
 export const targetPipelineVersionsRelations = relations(targetPipelineVersions, ({one}) => ({
   pipeline: one(pipelines, {
@@ -47,6 +47,7 @@ export const projectsRelations = relations(projects, ({one, many}) => ({
   }),
   projectApiKeys: many(projectApiKeys),
   labelClasses: many(labelClasses),
+  spans: many(spans),
 }));
 
 export const evaluationResultsRelations = relations(evaluationResults, ({one, many}) => ({
@@ -63,14 +64,6 @@ export const evaluationsRelations = relations(evaluations, ({one, many}) => ({
     fields: [evaluations.projectId],
     references: [projects.id]
   }),
-}));
-
-export const spansRelations = relations(spans, ({one, many}) => ({
-  trace: one(traces, {
-    fields: [spans.traceId],
-    references: [traces.id]
-  }),
-  labels: many(labels),
 }));
 
 export const eventsRelations = relations(events, ({one}) => ({
@@ -199,10 +192,6 @@ export const userSubscriptionInfoRelations = relations(userSubscriptionInfo, ({o
 }));
 
 export const labelsRelations = relations(labels, ({one}) => ({
-  span: one(spans, {
-    fields: [labels.spanId],
-    references: [spans.spanId]
-  }),
   labelClass: one(labelClasses, {
     fields: [labels.classId],
     references: [labelClasses.id]
@@ -213,6 +202,17 @@ export const labelClassesRelations = relations(labelClasses, ({one, many}) => ({
   labels: many(labels),
   project: one(projects, {
     fields: [labelClasses.projectId],
+    references: [projects.id]
+  }),
+}));
+
+export const spansRelations = relations(spans, ({one}) => ({
+  trace: one(traces, {
+    fields: [spans.traceId],
+    references: [traces.id]
+  }),
+  project: one(projects, {
+    fields: [spans.projectId],
     references: [projects.id]
   }),
 }));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR updates the `spans` table to include `project_id` as part of the primary key, modifies related constraints and indexes, and updates the `labeling_queue_data` table and related code to reflect these changes.
> 
>   - **Database Schema Changes**:
>     - Add `project_id` column to `spans` table, making it part of the primary key.
>     - Update `spans` table with new foreign key `spans_project_id_fkey` and index `spans_project_id_idx`.
>     - Add `span_id` column to `labeling_queue_data` table.
>   - **Migrations**:
>     - Rename `0002_next_tusk.sql` to `0002_cold_romulus.sql` and update to include `span_id` in `labeling_queue_data`.
>     - Add `0003_cultured_tinkerer.sql` to drop and recreate `spans_pkey` with `project_id`.
>   - **Metadata Updates**:
>     - Update `0002_snapshot.json` and `0003_snapshot.json` to reflect schema changes.
>     - Update `_journal.json` with new migration entries.
>   - **Code Updates**:
>     - Update `relations.ts` to include `project` relation in `spansRelations`.
>     - Update `schema.ts` to define new primary key and foreign key constraints for `spans`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for bb9b9f9cb1449a13db598abf81a9461876706806. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->