### PR TITLE
overwrite span id when attribute set, query unique traces

### DIFF
--- a/app-server/src/db/trace.rs
+++ b/app-server/src/db/trace.rs
@@ -402,6 +402,7 @@ pub async fn get_traces(
     query.push(
         "
         SELECT
+            DISTINCT ON (start_time, id)
             id,
             start_time,
             end_time,
@@ -435,7 +436,7 @@ pub async fn get_traces(
     add_filters_to_traces_query(&mut query, &filters);
 
     query
-        .push(" ORDER BY start_time DESC OFFSET ")
+        .push(" ORDER BY start_time DESC, id OFFSET ")
         .push_bind(offset as i64)
         .push(" LIMIT ")
         .push_bind(limit as i64);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure unique trace results and allow parent span ID overriding based on attributes in `trace.rs` and `spans.rs`.
> 
>   - **Behavior**:
>     - In `get_traces()` in `trace.rs`, added `DISTINCT ON (start_time, id)` to ensure unique trace results.
>     - Modified `ORDER BY` clause in `get_traces()` to include `id` for consistent ordering.
>     - In `from_otel_span()` in `spans.rs`, set `parent_span_id` to `None` if `OVERRIDE_PARENT_SPAN_ATTRIBUTE_NAME` is `true`.
>   - **Constants**:
>     - Added `OVERRIDE_PARENT_SPAN_ATTRIBUTE_NAME` in `spans.rs` to manage parent span ID overriding.
>   - **Misc**:
>     - Updated `should_keep_attribute()` in `spans.rs` to exclude `OVERRIDE_PARENT_SPAN_ATTRIBUTE_NAME`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 5258fea7d5f4b3418fcc37b739df466f924ce8c9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->