### PR TITLE
batch insert labeling q items, ignore non-existent qs

### DIFF
--- a/app-server/src/db/labeling_queues.rs
+++ b/app-server/src/db/labeling_queues.rs
@@ -38,15 +38,13 @@ pub async fn push_to_labeling_queue(
         .iter()
         .map(|item| item.action.clone())
         .collect::<Vec<_>>();
-    let created_at_vec = items
-        .iter()
-        .map(|_| {
-            // Postgres precision is in microseconds, so we sleep for 1 microsecond
-            // to ensure that the timestamps are different
-            std::thread::sleep(std::time::Duration::from_micros(1));
-            Utc::now()
-        })
-        .collect::<Vec<_>>();
+    let mut created_at_vec = Vec::with_capacity(items.len());
+    for _ in items {
+        // Postgres precision is in microseconds, so we sleep for 1 microsecond
+        // to ensure that the timestamps are different
+        tokio::time::sleep(tokio::time::Duration::from_micros(1)).await;
+        created_at_vec.push(Utc::now());
+    }
 
     sqlx::query(
         "INSERT INTO labeling_queue_items (

--- a/app-server/src/db/labeling_queues.rs
+++ b/app-server/src/db/labeling_queues.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use chrono::Utc;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -7,21 +8,21 @@ use crate::evaluations::utils::LabelingQueueEntry;
 #[derive(sqlx::FromRow)]
 pub struct LabelingQueue {
     pub id: Uuid,
-    pub name: String,
-    pub project_id: Uuid,
+    // pub name: String,
+    // pub project_id: Uuid,
 }
 
 pub async fn get_labeling_queue_by_name(
     pool: &PgPool,
     name: &str,
     project_id: &Uuid,
-) -> Result<LabelingQueue> {
+) -> Result<Option<LabelingQueue>> {
     let queue = sqlx::query_as::<_, LabelingQueue>(
-        "SELECT id, name, project_id FROM labeling_queues WHERE name = $1 AND project_id = $2",
+        "SELECT id FROM labeling_queues WHERE name = $1 AND project_id = $2",
     )
     .bind(name)
     .bind(project_id)
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await?;
 
     Ok(queue)
@@ -32,22 +33,35 @@ pub async fn push_to_labeling_queue(
     queue_id: &Uuid,
     items: &Vec<LabelingQueueEntry>,
 ) -> Result<()> {
-    // we insert one row at a time to
-    // 1. avoid the risk of a failed insert corrupting the batch
-    // 2. sort on created_at
-    for item in items {
-        sqlx::query(
-            "INSERT INTO labeling_queue_items (
+    let span_ids = items.iter().map(|item| item.span_id).collect::<Vec<_>>();
+    let actions = items
+        .iter()
+        .map(|item| item.action.clone())
+        .collect::<Vec<_>>();
+    let created_at_vec = items
+        .iter()
+        .map(|_| {
+            // Postgres precision is in microseconds, so we sleep for 1 microsecond
+            // to ensure that the start times are different
+            std::thread::sleep(std::time::Duration::from_micros(1));
+            Utc::now()
+        })
+        .collect::<Vec<_>>();
+
+    sqlx::query(
+        "INSERT INTO labeling_queue_items (
             queue_id,
             span_id,
-            action
-        ) VALUES ($1, $2, $3)",
-        )
-        .bind(queue_id)
-        .bind(item.span_id)
-        .bind(item.action.clone())
-        .execute(pool)
-        .await?;
-    }
+            action,
+            created_at
+        ) SELECT $1, UNNEST($2), UNNEST($3), UNNEST($4)",
+    )
+    .bind(queue_id)
+    .bind(span_ids)
+    .bind(actions)
+    .bind(created_at_vec)
+    .execute(pool)
+    .await?;
+
     Ok(())
 }

--- a/app-server/src/db/labeling_queues.rs
+++ b/app-server/src/db/labeling_queues.rs
@@ -42,7 +42,7 @@ pub async fn push_to_labeling_queue(
         .iter()
         .map(|_| {
             // Postgres precision is in microseconds, so we sleep for 1 microsecond
-            // to ensure that the start times are different
+            // to ensure that the timestamps are different
             std::thread::sleep(std::time::Duration::from_micros(1));
             Utc::now()
         })


### PR DESCRIPTION
- Batch insert labeling queue items
- Do not fail the entire evaluation request if some of the labeling queues not found
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Batch insert labeling queue items and handle non-existent queues gracefully in evaluation requests.
> 
>   - **Behavior**:
>     - Batch insert of labeling queue items in `push_to_labeling_queue()` in `labeling_queues.rs` using `UNNEST` for `span_id`, `action`, and `created_at`.
>     - `datapoints_to_labeling_queues()` in `utils.rs` now skips datapoints with non-existent queues instead of failing.
>   - **Functions**:
>     - `get_labeling_queue_by_name()` in `labeling_queues.rs` returns `Option<LabelingQueue>` to handle non-existent queues.
>   - **Misc**:
>     - Removed unused fields `name` and `project_id` from `LabelingQueue` struct in `labeling_queues.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d3742e7160eb427a7b99ce70d33df08629799f77. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->