### PR TITLE
[beta] add button for csv export from evals

### DIFF
--- a/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/download/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/download/route.ts
@@ -1,0 +1,79 @@
+import { db } from '@/lib/db/drizzle';
+import { isCurrentUserMemberOfProject } from '@/lib/db/utils';
+import { asc, and, eq } from 'drizzle-orm';
+import { evaluationResults, evaluations } from '@/lib/db/migrations/schema';
+import { evaluationScores } from '@/lib/db/migrations/schema';
+import { sql } from 'drizzle-orm';
+import { json2csv } from 'json-2-csv';
+
+export async function GET(
+  req: Request,
+  {
+    params
+  }: {
+    params: { projectId: string; evaluationId: string; };
+  }
+): Promise<Response> {
+  if (!(await isCurrentUserMemberOfProject(params.projectId))) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const projectId = params.projectId;
+  const evaluationId = params.evaluationId;
+
+  const subQueryScoreCte = db.$with('scores').as(
+    db
+      .select({
+        resultId: evaluationScores.resultId,
+        cteScores: sql`jsonb_object_agg(${evaluationScores.name}, ${evaluationScores.score})`.as('cte_scores')
+      })
+      .from(evaluationScores)
+      .groupBy(evaluationScores.resultId)
+  );
+
+  const results: Record<string, any>[] = await db
+    .with(subQueryScoreCte)
+    .select({
+      id: evaluationResults.id,
+      createdAt: evaluationResults.createdAt,
+      data: evaluationResults.data,
+      target: evaluationResults.target,
+      executorOutput: evaluationResults.executorOutput,
+      scores: subQueryScoreCte.cteScores,
+    })
+    .from(evaluationResults)
+    .leftJoin(
+      subQueryScoreCte,
+      eq(evaluationResults.id, subQueryScoreCte.resultId)
+    )
+    .innerJoin(
+      evaluations,
+      and(
+        eq(evaluationResults.evaluationId, evaluations.id),
+        eq(evaluations.projectId, projectId)
+      )
+    )
+    .where(eq(evaluationResults.evaluationId, evaluationId))
+    .orderBy(
+      asc(evaluationResults.createdAt),
+      asc(evaluationResults.indexInBatch)
+    );
+
+  const flattenedResults = results.map(result => ({
+    ...result,
+    ...result.scores
+  }));
+  const csv = await json2csv(flattenedResults, {
+    emptyFieldValue: '',
+    expandNestedObjects: false // we only expand the scores object manually
+  });
+  const contentType = 'text/csv';
+  const filename = `evaluation-results-${evaluationId}.csv`;
+  const headers = new Headers();
+  headers.set('Content-Type', contentType);
+  headers.set('Content-Disposition', `attachment; filename="${filename}"`);
+
+  return new Response(csv, {
+    headers
+  });
+}

--- a/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/download/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/download/route.ts
@@ -59,10 +59,13 @@ export async function GET(
       asc(evaluationResults.indexInBatch)
     );
 
-  const flattenedResults = results.map(result => ({
-    ...result,
-    ...result.scores
-  }));
+  const flattenedResults = results.map(result => {
+    const { scores, ...rest } = result;
+    return {
+      ...rest,
+      ...scores
+    };
+  });
   const csv = await json2csv(flattenedResults, {
     emptyFieldValue: '',
     expandNestedObjects: false // we only expand the scores object manually

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "i": "^0.3.7",
     "js-base64": "^3.7.7",
     "js-tiktoken": "^1.0.15",
+    "json-2-csv": "^5.5.6",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.323.0",
     "next": "14.2.15",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       js-tiktoken:
         specifier: ^1.0.15
         version: 1.0.15
+      json-2-csv:
+        specifier: ^5.5.6
+        version: 5.5.6
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -3250,6 +3253,10 @@ packages:
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
 
+  deeks@3.1.0:
+    resolution: {integrity: sha512-e7oWH1LzIdv/prMQ7pmlDlaVoL64glqzvNgkgQNgyec9ORPHrT2jaOqMtRyqJuwWjtfb6v+2rk9pmaHj+F137A==}
+    engines: {node: '>= 16'}
+
   deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
     engines: {node: '>= 0.4'}
@@ -3298,6 +3305,10 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  doc-path@4.1.1:
+    resolution: {integrity: sha512-h1ErTglQAVv2gCnOpD3sFS6uolDbOKHDU1BZq+Kl3npPqroU3dYL42lUgMfd5UimlwtRgp7C9dLGwqQ5D2HYgQ==}
+    engines: {node: '>=16'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -4224,6 +4235,10 @@ packages:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-2-csv@5.5.6:
+    resolution: {integrity: sha512-N673XbJgHwUq9JreKpk530jSywPF/rEAQ08dV99QQpkluP/4HTwshpoP9hmDz26iSFqu7eNAPgyJfu/77HvPGA==}
+    engines: {node: '>= 16'}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -9201,6 +9216,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deeks@3.1.0: {}
+
   deep-equal@2.2.3:
     dependencies:
       array-buffer-byte-length: 1.0.1
@@ -9259,6 +9276,8 @@ snapshots:
   diff-match-patch@1.0.5: {}
 
   dlv@1.1.3: {}
+
+  doc-path@4.1.1: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -10321,6 +10340,11 @@ snapshots:
       argparse: 2.0.1
 
   jsesc@3.0.2: {}
+
+  json-2-csv@5.5.6:
+    dependencies:
+      deeks: 3.1.0
+      doc-path: 4.1.1
 
   json-buffer@3.0.1: {}
 


### PR DESCRIPTION
First quick go at downloading evaluations as CSV.

The button looks like this, but we should probably style it additionally.

![Screenshot 2024-11-06 at 00 10 28](https://github.com/user-attachments/assets/083318af-3529-4ea8-ab21-ffea637d71a0)


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds CSV export for evaluation results with a new API endpoint and UI button, using `json-2-csv`.
> 
>   - **API**:
>     - New `GET` endpoint in `route.ts` for CSV download of evaluation results.
>     - Validates user project membership before allowing download.
>     - Converts evaluation results to CSV using `json-2-csv`.
>   - **UI**:
>     - Adds "Download CSV" button in `evaluation.tsx`.
>     - Implements download logic with error handling and loading state.
>   - **Dependencies**:
>     - Adds `json-2-csv` to `package.json` for CSV conversion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for bda6d691be8e9cc47cc59da94e6383cf2aa6c912. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->