### PR TITLE
allow downloading datasets as JSON, minor refactor

### DIFF
--- a/frontend/app/api/projects/[projectId]/datasets/[datasetId]/download/route.ts
+++ b/frontend/app/api/projects/[projectId]/datasets/[datasetId]/download/route.ts
@@ -1,0 +1,53 @@
+import { db } from '@/lib/db/drizzle';
+import { isCurrentUserMemberOfProject } from '@/lib/db/utils';
+import { asc, and, eq } from 'drizzle-orm';
+import { datasetDatapoints, datasets, evaluationResults, evaluations } from '@/lib/db/migrations/schema';
+import { evaluationScores } from '@/lib/db/migrations/schema';
+import { sql } from 'drizzle-orm';
+
+export async function GET(
+  req: Request,
+  {
+    params
+  }: {
+    params: { projectId: string; datasetId: string; };
+  }
+): Promise<Response> {
+  if (!(await isCurrentUserMemberOfProject(params.projectId))) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const projectId = params.projectId;
+  const datasetId = params.datasetId;
+
+  const dataset = await db.query.datasets.findFirst({
+    where: and(
+      eq(datasets.id, datasetId),
+      eq(datasets.projectId, projectId)
+    )
+  });
+
+  if (!dataset) {
+    return Response.json({ error: 'Dataset not found' }, { status: 404 });
+  }
+
+  const datapoints = await db.query.datasetDatapoints.findMany({
+    where: eq(datasetDatapoints.datasetId, datasetId),
+    orderBy: [asc(datasetDatapoints.indexInBatch)],
+    columns: {
+      data: true,
+      target: true,
+      metadata: true
+    }
+  });
+
+  const contentType = 'application/json';
+  const filename = `${dataset.name.replace(/[^a-zA-Z0-9-_\.]/g, '_')}-${datasetId}.json`;
+  const headers = new Headers();
+  headers.set('Content-Type', contentType);
+  headers.set('Content-Disposition', `attachment; filename="${filename}"`);
+
+  return new Response(JSON.stringify(datapoints, null, 2), {
+    headers
+  });
+}

--- a/frontend/components/dataset/dataset.tsx
+++ b/frontend/components/dataset/dataset.tsx
@@ -20,6 +20,7 @@ import { swrFetcher } from '@/lib/utils';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '../ui/dialog';
 import { Loader2, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import DownloadButton from '../ui/download-button';
 
 interface DatasetProps {
   dataset: DatasetType;
@@ -131,6 +132,12 @@ export default function Dataset({ dataset }: DatasetProps) {
         <div className="flex-grow text-2xl font-medium">
           <h1>{dataset.name}</h1>
         </div>
+        <DownloadButton
+          uri={`/api/projects/${projectId}/datasets/${dataset.id}/download`}
+          fileFormat="JSON"
+          filenameFallback={`${dataset.name.replace(/[^a-zA-Z0-9-_\.]/g, '_')}-${dataset.id}.json`}
+          variant="outline"
+        />
         <AddDatapointsDialog datasetId={dataset.id} onUpdate={mutate} />
         <ManualAddDatapoint datasetId={dataset.id} onUpdate={mutate} />
       </div>

--- a/frontend/components/ui/download-button.tsx
+++ b/frontend/components/ui/download-button.tsx
@@ -1,0 +1,73 @@
+import { toast } from "@/lib/hooks/use-toast";
+import { Button } from "./button";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+
+const downloadFile = async (
+  uri: string,
+  fileFormat: string,
+  filenameFallback: string,
+) => {
+  try {
+    const response = await fetch(uri);
+
+    if (!response.ok) {
+      throw new Error('Download failed');
+    }
+
+    const contentDisposition = response.headers.get('Content-Disposition');
+    const filenameMatch = contentDisposition?.match(/filename="(.+)"/);
+    const filename = filenameMatch?.[1] || filenameFallback;
+
+    const blob = await response.blob();
+
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+
+    document.body.appendChild(link);
+    link.click();
+
+    // Cleanup
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  } catch (error) {
+    toast({
+      title: `Error downloading ${fileFormat}`,
+      variant: 'destructive'
+    });
+  }
+};
+
+interface DownloadButtonProps {
+  uri: string;
+  fileFormat: string;
+  filenameFallback: string;
+  variant?: 'default' | 'secondary' | 'destructive' | 'outline' | 'ghost';
+  className?: string;
+}
+
+export default function DownloadButton({
+  uri,
+  fileFormat,
+  filenameFallback,
+  variant = 'secondary',
+  className
+}: DownloadButtonProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  return (
+    <Button
+      variant={variant}
+      className={className}
+      onClick={async () => {
+        setIsDownloading(true);
+        await downloadFile(uri, fileFormat, filenameFallback);
+        setIsDownloading(false);
+      }}
+    >
+      {isDownloading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
+      Download {fileFormat}
+    </Button>
+  );
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add JSON dataset download feature and refactor download logic with a reusable `DownloadButton` component.
> 
>   - **New Feature**:
>     - Add `GET` endpoint in `route.ts` to download datasets as JSON, checking user authorization and dataset existence.
>   - **Components**:
>     - Add `DownloadButton` component in `download-button.tsx` for reusable download functionality.
>     - Replace existing download logic in `evaluation.tsx` with `DownloadButton` for CSV downloads.
>     - Add `DownloadButton` to `dataset.tsx` for JSON downloads.
>   - **Refactor**:
>     - Remove old CSV download logic from `evaluation.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for ac06b8033128e1e46a15a310494c0071e1476e39. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->