### PR TITLE
added backlink to dataset in spans

### DIFF
--- a/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/route.ts
+++ b/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/route.ts
@@ -3,9 +3,10 @@ import { authOptions } from '@/lib/auth';
 import { fetcher } from '@/lib/utils';
 import { NextRequest } from 'next/server';
 import { db } from '@/lib/db/drizzle';
-import { datasetDatapoints } from '@/lib/db/migrations/schema';
+import { datasetDatapoints, datapointToSpan } from '@/lib/db/migrations/schema';
 import { and, inArray, eq } from 'drizzle-orm';
 import { isCurrentUserMemberOfProject } from '@/lib/db/utils';
+import { z } from 'zod';
 
 export async function GET(
   req: NextRequest,
@@ -27,28 +28,66 @@ export async function GET(
   );
 }
 
+const CreateDatapointsSchema = z.object({
+  datapoints: z.array(z.object({
+    data: z.unknown(),
+    target: z.any().optional(),
+    metadata: z.record(z.any()).optional(),
+  })),
+  sourceSpanId: z.string().optional(),
+});
+
 export async function POST(
   req: Request,
   { params }: { params: { projectId: string; datasetId: string } }
 ): Promise<Response> {
   const projectId = params.projectId;
   const datasetId = params.datasetId;
-  const session = await getServerSession(authOptions);
-  const user = session!.user;
+
+  if (!(await isCurrentUserMemberOfProject(projectId))) {
+    return new Response(JSON.stringify({ error: "User is not a member of the project" }), { status: 403 });
+  }
 
   const body = await req.json();
 
-  return await fetcher(
-    `/projects/${projectId}/datasets/${datasetId}/datapoints`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${user.apiKey}`
-      },
-      body: JSON.stringify(body)
-    }
-  );
+  // Validate request body
+  const parseResult = CreateDatapointsSchema.required().safeParse(body);
+  if (!parseResult.success) {
+    return new Response(
+      JSON.stringify({
+        error: "Invalid request body",
+        details: parseResult.error.issues
+      }),
+      { status: 400 }
+    );
+  }
+
+  const { datapoints, sourceSpanId } = parseResult.data;
+
+  const res = await db.insert(datasetDatapoints).values(
+    datapoints.map((datapoint) => ({
+      ...datapoint,
+      data: datapoint.data,
+      createdAt: new Date().toUTCString(),
+      datasetId
+    }))
+  ).returning();
+
+  if (sourceSpanId && res.length > 0) {
+    await db.insert(datapointToSpan).values(
+      res.map((datapoint) => ({
+        spanId: sourceSpanId,
+        datapointId: datapoint.id,
+        projectId,
+      }))
+    ).returning();
+  }
+
+  if (res.length === 0) {
+    return new Response('Error creating datasetDatapoints', { status: 500 });
+  }
+
+  return new Response('datasetDatapoints created successfully', { status: 200 });
 }
 
 export async function DELETE(

--- a/frontend/app/api/projects/[projectId]/spans/[spanId]/datapoints/route.ts
+++ b/frontend/app/api/projects/[projectId]/spans/[spanId]/datapoints/route.ts
@@ -1,0 +1,37 @@
+import { db } from "@/lib/db/drizzle";
+import { datapointToSpan } from "@/lib/db/migrations/schema";
+import { isCurrentUserMemberOfProject } from "@/lib/db/utils";
+import { eq } from "drizzle-orm";
+
+
+export async function GET(
+  request: Request,
+  { params }: { params: { projectId: string; spanId: string } }
+) {
+
+  const { projectId, spanId } = params;
+
+  if (!(await isCurrentUserMemberOfProject(projectId))) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const datapoints = await db.query.datapointToSpan.findMany({
+    where: eq(datapointToSpan.spanId, spanId),
+    with: {
+      datasetDatapoint: {
+        with: {
+          dataset: true
+        }
+      }
+    },
+  });
+
+  // Flatten the structure
+  const flattenedDatapoints = datapoints.map(dp => ({
+    datapointId: dp.datasetDatapoint.id,
+    datasetId: dp.datasetDatapoint.dataset.id,
+    datasetName: dp.datasetDatapoint.dataset.name
+  }));
+
+  return Response.json(flattenedDatapoints);
+}

--- a/frontend/components/traces/export-spans-dialog.tsx
+++ b/frontend/components/traces/export-spans-dialog.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils';
 import { useToast } from '@/lib/hooks/use-toast';
 import { Dataset } from '@/lib/dataset/types';
 import Formatter from '../ui/formatter';
+import { eventEmitter } from '@/lib/event-emitter';
 
 interface ExportSpansDialogProps {
   span: Span;
@@ -88,7 +89,8 @@ export default function ExportSpansDialog({ span }: ExportSpansDialogProps) {
               target: target,
               metadata: metadata
             }
-          ]
+          ],
+          sourceSpanId: span.spanId
         })
       }
     );
@@ -100,6 +102,7 @@ export default function ExportSpansDialog({ span }: ExportSpansDialogProps) {
         variant: 'destructive'
       });
     } else {
+      eventEmitter.emit('mutateSpanDatapoints');
       toast({
         title: `Successfully exported span to dataset ${selectedDataset?.name}`
       });

--- a/frontend/components/traces/span-datasets.tsx
+++ b/frontend/components/traces/span-datasets.tsx
@@ -1,0 +1,93 @@
+import { useProjectContext } from '@/contexts/project-context';
+import { cn, swrFetcher } from '@/lib/utils';
+import useSWR from 'swr';
+import { useEffect } from 'react';
+
+import { eventEmitter } from '@/lib/event-emitter';
+import { Table, TableBody, TableCell, TableRow } from '../ui/table';
+import { Skeleton } from '../ui/skeleton';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '../ui/tooltip';
+import ClientTimestampFormatter from '../client-timestamp-formatter';
+import { Button } from '../ui/button';
+import { ArrowUpRight, Info, X } from 'lucide-react';
+import Link from 'next/link';
+
+interface SpanDatasetsProps {
+  spanId: string;
+}
+
+interface SpanDataset {
+  datasetName: string;
+  datasetId: string;
+  datapointId: string;
+}
+
+export default function SpanDatasets({ spanId }: SpanDatasetsProps) {
+  const { projectId } = useProjectContext();
+
+  const { data, isLoading, mutate } = useSWR<SpanDataset[]>(
+    `/api/projects/${projectId}/spans/${spanId}/datapoints`,
+    swrFetcher
+  );
+
+  useEffect(() => {
+    const handleDatapointAdded = () => {
+      mutate();
+    };
+    eventEmitter.on('mutateSpanDatapoints', handleDatapointAdded);
+
+    return () => {
+      eventEmitter.off('mutateSpanDatapoints', handleDatapointAdded);
+    };
+  }, [mutate]);
+
+  return (
+    <div className="flex flex-col pb-2">
+      <div className="pb-2 font-medium text-lg">Datasets</div>
+      <div className="border rounded bg-card">
+        {isLoading ? (
+          <div>
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : data && data.length > 0 ? (
+          <Table className="">
+            <TableBody className="text-base">
+              {data?.map((dataset: SpanDataset, index: number) => (
+                <TableRow
+                  key={dataset.datasetId}
+                  className={cn(
+                    'text-sm',
+                    index === data.length - 1 ? 'border-b-0' : ''
+                  )}
+                >
+                  <TableCell>
+                    <div className="flex">
+                      <div className="border-secondary-foreground/30 border p-0.5 px-3 bg-secondary rounded-full">
+                        {dataset.datasetName}
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell className="font-mono text-secondary-foreground">{dataset.datapointId}</TableCell>
+                  <TableCell>
+                    <Link href={`/project/${projectId}/datasets/${dataset.datasetId}?datapointId=${dataset.datapointId}`} target="_blank">
+                      <ArrowUpRight className="text-secondary-foreground" size={16} />
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <div className="p-2 text-secondary-foreground text-sm">
+            No labels
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/traces/span-view-span.tsx
+++ b/frontend/components/traces/span-view-span.tsx
@@ -4,6 +4,7 @@ import Formatter from '../ui/formatter';
 import ChatMessageListTab from './chat-message-list-tab';
 import { Span } from '@/lib/traces/types';
 import SpanLabels from './span-labels';
+import SpanDatasets from './span-datasets';
 
 interface SpanViewSpanProps {
   span: Span;
@@ -17,6 +18,7 @@ export function SpanViewSpan({ span }: SpanViewSpanProps) {
           <div>
             <div className="p-4 w-full h-full">
               <SpanLabels spanId={span.spanId} />
+              <SpanDatasets spanId={span.spanId} />
               <div className="pb-2 font-medium text-lg">Input</div>
               {isChatMessageList(span.input) ? (
                 <ChatMessageListTab messages={span.input} />

--- a/frontend/components/traces/spans-table.tsx
+++ b/frontend/components/traces/spans-table.tsx
@@ -120,9 +120,13 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
     searchParams.set('traceId', row.traceId!);
     searchParams.set('spanId', row.spanId);
     router.push(`${pathName}?${searchParams.toString()}`);
-    setSpanId(row.spanId);
     onRowClick?.(row.traceId);
   };
+
+  useEffect(() => {
+    setSpanId(searchParams.get('spanId') ?? null);
+  }, [searchParams]);
+
   const columns: ColumnDef<Span, any>[] = [
     {
       cell: (row) => <Mono>{row.getValue()}</Mono>,

--- a/frontend/components/traces/trace-view.tsx
+++ b/frontend/components/traces/trace-view.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { SpanCard } from './span-card';
-import { getDurationString } from '@/lib/flow/utils';
 import { ScrollArea, ScrollBar } from '../ui/scroll-area';
-import { Label } from '../ui/label';
-import { Span, TraceWithSpans } from '@/lib/traces/types';
-import { ChevronsRight, CircleDollarSign, Clock3, Coins } from 'lucide-react';
+import { Span } from '@/lib/traces/types';
+import { ChevronsRight } from 'lucide-react';
 import { SpanView } from './span-view';
 import Timeline from './timeline';
 import { cn, swrFetcher } from '@/lib/utils';
@@ -25,7 +23,6 @@ export default function TraceView({ traceId, onClose }: TraceViewProps) {
   const searchParams = new URLSearchParams(useSearchParams().toString());
   const router = useRouter();
   const pathName = usePathname();
-  const ref = useRef<HTMLDivElement>(null);
   const container = useRef<HTMLDivElement>(null);
   const traceTreePanel = useRef<HTMLDivElement>(null);
   const [containerHeight, setContainerHeight] = useState(0);
@@ -73,13 +70,23 @@ export default function TraceView({ traceId, onClose }: TraceViewProps) {
     setChildSpans(childSpans);
     setTopLevelSpans(topLevelSpans);
     setSpans(spans);
-    setSelectedSpan(
-      searchParams.get('spanId')
-        ? spans.find(
-          (span: Span) => span.spanId === searchParams.get('spanId')
-        ) || null
-        : null
-    );
+
+    // If there's only one span, select it automatically
+    if (spans.length === 1) {
+      const singleSpan = spans[0];
+      setSelectedSpan(singleSpan);
+      searchParams.set('spanId', singleSpan.spanId);
+      router.push(`${pathName}?${searchParams.toString()}`);
+    } else {
+      // Otherwise, use the spanId from URL if present
+      setSelectedSpan(
+        searchParams.get('spanId')
+          ? spans.find(
+            (span: Span) => span.spanId === searchParams.get('spanId')
+          ) || null
+          : null
+      );
+    }
   }, [trace]);
 
   useEffect(() => {

--- a/frontend/components/traces/traces-table.tsx
+++ b/frontend/components/traces/traces-table.tsx
@@ -137,9 +137,12 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
     searchParams.set('traceId', row.id!);
     searchParams.delete('spanId');
     onRowClick?.(row.id!);
-    setTraceId(row.id);
     router.push(`${pathName}?${searchParams.toString()}`);
   };
+
+  useEffect(() => {
+    setTraceId(searchParams.get('traceId') ?? null);
+  }, [searchParams]);
 
   const columns: ColumnDef<Trace, any>[] = [
     // {

--- a/frontend/components/ui/datatable.tsx
+++ b/frontend/components/ui/datatable.tsx
@@ -62,7 +62,6 @@ interface DataTableProps<TData> {
   // and manage that externally
   onSelectAllAcrossPages?: (selectAll: boolean) => void;
   children?: React.ReactNode;
-
   selectionPanel?: (selectedRowIds: string[]) => React.ReactNode;
 }
 
@@ -85,7 +84,7 @@ export function DataTable<TData>({
   onSelectedRowsChange,
   onSelectAllAcrossPages,
   children,
-  selectionPanel
+  selectionPanel,
 }: DataTableProps<TData>) {
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
   const [allRowsAcrossAllPagesSelected, setAllRowsAcrossAllPagesSelected] = useState(false);
@@ -195,6 +194,7 @@ export function DataTable<TData>({
         'flex min-w-full border-b',
         !!onRowClick && 'cursor-pointer',
         row.depth > 0 && 'bg-secondary/40',
+        focusedRowId === row.id && 'bg-secondary/50'
       )}
       key={row.id}
       data-state={row.getIsSelected() && 'selected'}
@@ -304,7 +304,7 @@ export function DataTable<TData>({
   return (
     <div className={cn('flex flex-col h-full border-t relative', className)}>
       {Object.keys(rowSelection).length > 0 && (
-        <div className="h-12 flex flex-none px-4 items-center border-primary border-[1.5px] rounded-lg absolute bottom-20 z-50 left-1/2 transform -translate-x-1/2">
+        <div className="bg-background h-12 flex flex-none px-4 items-center border-primary border-[1.5px] rounded-lg absolute bottom-20 z-50 left-1/2 transform -translate-x-1/2">
           <Label className="">
             {`${Object.keys(rowSelection).length} ${Object.keys(rowSelection).length === 1 ? 'row ' : 'rows '}`}
             selected

--- a/frontend/lib/db/migrations/0004_worthless_kitty_pryde.sql
+++ b/frontend/lib/db/migrations/0004_worthless_kitty_pryde.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS "datapoint_to_span" (
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"datapoint_id" uuid NOT NULL,
+	"span_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	CONSTRAINT "datapoint_to_span_pkey" PRIMARY KEY("datapoint_id","span_id","project_id")
+);
+--> statement-breakpoint
+ALTER TABLE "labeling_queue_items" DROP CONSTRAINT "labelling_queue_data_queue_id_fkey";
+--> statement-breakpoint
+ALTER TABLE "labels" ALTER COLUMN "value" SET NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "datapoint_to_span" ADD CONSTRAINT "datapoint_to_span_datapoint_id_fkey" FOREIGN KEY ("datapoint_id") REFERENCES "public"."dataset_datapoints"("id") ON DELETE cascade ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "datapoint_to_span" ADD CONSTRAINT "datapoint_to_span_span_id_project_id_fkey" FOREIGN KEY ("span_id","project_id") REFERENCES "public"."spans"("span_id","project_id") ON DELETE cascade ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "labeling_queue_items" ADD CONSTRAINT "labelling_queue_items_queue_id_fkey" FOREIGN KEY ("queue_id") REFERENCES "public"."labeling_queues"("id") ON DELETE cascade ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "evaluation_scores_result_id_idx" ON "evaluation_scores" USING hash ("result_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "spans_parent_span_id_project_id_start_time_end_time_idx" ON "spans" USING btree ("parent_span_id","project_id","start_time","end_time");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "spans_project_id_trace_id_start_time_idx" ON "spans" USING btree ("project_id","trace_id","start_time");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "spans_trace_id_start_time_idx" ON "spans" USING btree ("trace_id","start_time");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "traces_id_project_id_start_time_times_not_null_idx" ON "traces" USING btree ("id","project_id","start_time" DESC NULLS FIRST) WHERE ((start_time IS NOT NULL) AND (end_time IS NOT NULL));--> statement-breakpoint
+ALTER TABLE "evaluation_scores" ADD CONSTRAINT "evaluation_results_names_unique" UNIQUE("result_id","name");

--- a/frontend/lib/db/migrations/meta/0004_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,2689 @@
+{
+  "id": "c67dedc9-6a88-4e8e-8fb8-1990dfa64eee",
+  "prevId": "2bfae944-3896-4b39-b7e0-d1103db2d9d1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.datapoint_to_span": {
+      "name": "datapoint_to_span",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "datapoint_id": {
+          "name": "datapoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datapoint_to_span_datapoint_id_fkey": {
+          "name": "datapoint_to_span_datapoint_id_fkey",
+          "tableFrom": "datapoint_to_span",
+          "tableTo": "dataset_datapoints",
+          "columnsFrom": [
+            "datapoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "datapoint_to_span_span_id_project_id_fkey": {
+          "name": "datapoint_to_span_span_id_project_id_fkey",
+          "tableFrom": "datapoint_to_span",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "span_id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "datapoint_to_span_pkey": {
+          "name": "datapoint_to_span_pkey",
+          "columns": [
+            "datapoint_id",
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dataset_datapoints": {
+      "name": "dataset_datapoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_on": {
+          "name": "indexed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "index_in_batch": {
+          "name": "index_in_batch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dataset_datapoints_dataset_id_fkey": {
+          "name": "dataset_datapoints_dataset_id_fkey",
+          "tableFrom": "dataset_datapoints",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "indexed_on": {
+          "name": "indexed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "public_datasets_project_id_fkey": {
+          "name": "public_datasets_project_id_fkey",
+          "tableFrom": "datasets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "executor_output": {
+          "name": "executor_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_in_batch": {
+          "name": "index_in_batch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "evaluation_results_evaluation_id_idx": {
+          "name": "evaluation_results_evaluation_id_idx",
+          "columns": [
+            {
+              "expression": "evaluation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_evaluation_id_fkey1": {
+          "name": "evaluation_results_evaluation_id_fkey1",
+          "tableFrom": "evaluation_results",
+          "tableTo": "evaluations",
+          "columnsFrom": [
+            "evaluation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.evaluation_scores": {
+      "name": "evaluation_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "evaluation_scores_result_id_idx": {
+          "name": "evaluation_scores_result_id_idx",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_scores_result_id_fkey": {
+          "name": "evaluation_scores_result_id_fkey",
+          "tableFrom": "evaluation_scores",
+          "tableTo": "evaluation_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evaluation_results_names_unique": {
+          "name": "evaluation_results_names_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "result_id",
+            "name"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.evaluations": {
+      "name": "evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluations_project_id_fkey1": {
+          "name": "evaluations_project_id_fkey1",
+          "tableFrom": "evaluations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BOOLEAN'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_project_id_fkey": {
+          "name": "event_templates_project_id_fkey",
+          "tableFrom": "event_templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_name_project_id": {
+          "name": "unique_name_project_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "project_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "event_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_template_id_fkey": {
+          "name": "events_template_id_fkey",
+          "tableFrom": "events",
+          "tableTo": "event_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.label_classes": {
+      "name": "label_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_type": {
+          "name": "label_type",
+          "type": "label_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_map": {
+          "name": "value_map",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[false,true]'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluator_runnable_graph": {
+          "name": "evaluator_runnable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_version_id": {
+          "name": "pipeline_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_classes_project_id_fkey": {
+          "name": "label_classes_project_id_fkey",
+          "tableFrom": "label_classes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.label_classes_for_path": {
+      "name": "label_classes_for_path",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_class_id": {
+          "name": "label_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "autoeval_labels_project_id_fkey": {
+          "name": "autoeval_labels_project_id_fkey",
+          "tableFrom": "label_classes_for_path",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_project_id_path_label_class": {
+          "name": "unique_project_id_path_label_class",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "path",
+            "label_class_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.labeling_queue_items": {
+      "name": "labeling_queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labelling_queue_items_queue_id_fkey": {
+          "name": "labelling_queue_items_queue_id_fkey",
+          "tableFrom": "labeling_queue_items",
+          "tableTo": "labeling_queues",
+          "columnsFrom": [
+            "queue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.labeling_queues": {
+      "name": "labeling_queues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labeling_queues_project_id_fkey": {
+          "name": "labeling_queues_project_id_fkey",
+          "tableFrom": "labeling_queues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "label_source": {
+          "name": "label_source",
+          "type": "label_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "job_status": {
+          "name": "job_status",
+          "type": "label_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trace_tags_type_id_fkey": {
+          "name": "trace_tags_type_id_fkey",
+          "tableFrom": "labels",
+          "tableTo": "label_classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_span_id_class_id_user_id_key": {
+          "name": "labels_span_id_class_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "class_id",
+            "span_id",
+            "user_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.llm_prices": {
+      "name": "llm_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_price_per_million": {
+          "name": "input_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_price_per_million": {
+          "name": "output_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_cached_price_per_million": {
+          "name": "input_cached_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_prices": {
+          "name": "additional_prices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.members_of_workspaces": {
+      "name": "members_of_workspaces",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_role": {
+          "name": "member_role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        }
+      },
+      "indexes": {
+        "members_of_workspaces_user_id_idx": {
+          "name": "members_of_workspaces_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_of_workspaces_user_id_fkey": {
+          "name": "members_of_workspaces_user_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "public_members_of_workspaces_workspace_id_fkey": {
+          "name": "public_members_of_workspaces_workspace_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_of_workspaces_user_workspace_unique": {
+          "name": "members_of_workspaces_user_workspace_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.pipeline_templates": {
+      "name": "pipeline_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "runnable_graph": {
+          "name": "runnable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "displayable_graph": {
+          "name": "displayable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "number_of_nodes": {
+          "name": "number_of_nodes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "display_group": {
+          "name": "display_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'build'"
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.pipeline_versions": {
+      "name": "pipeline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayable_graph": {
+          "name": "displayable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runnable_graph": {
+          "name": "runnable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline_type": {
+          "name": "pipeline_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.pipelines": {
+      "name": "pipelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "python_requirements": {
+          "name": "python_requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "pipelines_name_project_id_idx": {
+          "name": "pipelines_name_project_id_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipelines_project_id_idx": {
+          "name": "pipelines_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipelines_project_id_fkey": {
+          "name": "pipelines_project_id_fkey",
+          "tableFrom": "pipelines",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_project_id_pipeline_name": {
+          "name": "unique_project_id_pipeline_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.project_api_keys": {
+      "name": "project_api_keys",
+      "schema": "",
+      "columns": {
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shorthand": {
+          "name": "shorthand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "public_project_api_keys_project_id_fkey": {
+          "name": "public_project_api_keys_project_id_fkey",
+          "tableFrom": "project_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_workspace_id_idx": {
+          "name": "projects_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_fkey": {
+          "name": "projects_workspace_id_fkey",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.provider_api_keys": {
+      "name": "provider_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hex": {
+          "name": "nonce_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_api_keys_project_id_fkey": {
+          "name": "provider_api_keys_project_id_fkey",
+          "tableFrom": "provider_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.spans": {
+      "name": "spans",
+      "schema": "",
+      "columns": {
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parent_span_id": {
+          "name": "parent_span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "span_type": {
+          "name": "span_type",
+          "type": "span_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_preview": {
+          "name": "input_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_preview": {
+          "name": "output_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "span_path_idx": {
+          "name": "span_path_idx",
+          "columns": [
+            {
+              "expression": "(attributes -> 'lmnr.span.path'::text)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_parent_span_id_project_id_start_time_end_time_idx": {
+          "name": "spans_parent_span_id_project_id_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "parent_span_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_project_id_idx": {
+          "name": "spans_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_project_id_trace_id_start_time_idx": {
+          "name": "spans_project_id_trace_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_start_time_end_time_idx": {
+          "name": "spans_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_trace_id_idx": {
+          "name": "spans_trace_id_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_trace_id_start_time_idx": {
+          "name": "spans_trace_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_spans_trace_id_fkey": {
+          "name": "new_spans_trace_id_fkey",
+          "tableFrom": "spans",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "spans_project_id_fkey": {
+          "name": "spans_project_id_fkey",
+          "tableFrom": "spans",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "spans_pkey": {
+          "name": "spans_pkey",
+          "columns": [
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_span_id_project_id": {
+          "name": "unique_span_id_project_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "subscription_tiers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_mib": {
+          "name": "storage_mib",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_retention_days": {
+          "name": "log_retention_days",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "members_per_workspace": {
+          "name": "members_per_workspace",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "num_workspaces": {
+          "name": "num_workspaces",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "events": {
+          "name": "events",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "spans": {
+          "name": "spans",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_span_price": {
+          "name": "extra_span_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_event_price": {
+          "name": "extra_event_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.target_pipeline_versions": {
+      "name": "target_pipeline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline_version_id": {
+          "name": "pipeline_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "target_pipeline_versions_pipeline_id_fkey": {
+          "name": "target_pipeline_versions_pipeline_id_fkey",
+          "tableFrom": "target_pipeline_versions",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "target_pipeline_versions_pipeline_version_id_fkey": {
+          "name": "target_pipeline_versions_pipeline_version_id_fkey",
+          "tableFrom": "target_pipeline_versions",
+          "tableTo": "pipeline_versions",
+          "columnsFrom": [
+            "pipeline_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pipeline_id": {
+          "name": "unique_pipeline_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pipeline_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.traces": {
+      "name": "traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_token_count": {
+          "name": "total_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trace_type": {
+          "name": "trace_type",
+          "type": "trace_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DEFAULT'"
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "input_cost": {
+          "name": "input_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_cost": {
+          "name": "output_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {
+        "traces_id_project_id_start_time_times_not_null_idx": {
+          "name": "traces_id_project_id_start_time_times_not_null_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "((start_time IS NOT NULL) AND (end_time IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_project_id_idx": {
+          "name": "traces_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_session_id_idx": {
+          "name": "traces_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_start_time_end_time_idx": {
+          "name": "traces_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_traces_project_id_fkey": {
+          "name": "new_traces_project_id_fkey",
+          "tableFrom": "traces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_subscription_info": {
+      "name": "user_subscription_info",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_subscription_info_stripe_customer_id_idx": {
+          "name": "user_subscription_info_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscription_info_fkey": {
+          "name": "user_subscription_info_fkey",
+          "tableFrom": "user_subscription_info",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.workspace_usage": {
+      "name": "workspace_usage",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "span_count": {
+          "name": "span_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "span_count_since_reset": {
+          "name": "span_count_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "prev_span_count": {
+          "name": "prev_span_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "event_count_since_reset": {
+          "name": "event_count_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "prev_event_count": {
+          "name": "prev_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "reset_time": {
+          "name": "reset_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reset_reason": {
+          "name": "reset_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signup'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_usage_workspace_id_fkey": {
+          "name": "user_usage_workspace_id_fkey",
+          "tableFrom": "workspace_usage",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_usage_workspace_id_key": {
+          "name": "user_usage_workspace_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "additional_seats": {
+          "name": "additional_seats",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_tier_id_fkey": {
+          "name": "workspaces_tier_id_fkey",
+          "tableFrom": "workspaces",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.event_source": {
+      "name": "event_source",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL",
+        "CODE"
+      ]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "BOOLEAN",
+        "STRING",
+        "NUMBER"
+      ]
+    },
+    "public.label_job_status": {
+      "name": "label_job_status",
+      "schema": "public",
+      "values": [
+        "RUNNING",
+        "DONE"
+      ]
+    },
+    "public.label_source": {
+      "name": "label_source",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO"
+      ]
+    },
+    "public.label_type": {
+      "name": "label_type",
+      "schema": "public",
+      "values": [
+        "BOOLEAN",
+        "CATEGORICAL"
+      ]
+    },
+    "public.span_type": {
+      "name": "span_type",
+      "schema": "public",
+      "values": [
+        "DEFAULT",
+        "LLM",
+        "PIPELINE",
+        "EXECUTOR",
+        "EVALUATOR",
+        "EVALUATION"
+      ]
+    },
+    "public.trace_type": {
+      "name": "trace_type",
+      "schema": "public",
+      "values": [
+        "DEFAULT",
+        "EVENT",
+        "EVALUATION"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1730701646174,
       "tag": "0003_cultured_tinkerer",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1731040951021,
+      "tag": "0004_worthless_kitty_pryde",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/db/migrations/relations.ts
+++ b/frontend/lib/db/migrations/relations.ts
@@ -1,7 +1,7 @@
 import { relations } from "drizzle-orm/relations";
-import { pipelines, targetPipelineVersions, pipelineVersions, projects, traces, evaluations, evaluationResults, eventTemplates, events, labelingQueues, providerApiKeys, workspaces, workspaceUsage, evaluationScores, labelClassesForPath, users, apiKeys, datasets, datasetDatapoints, labelingQueueItems, membersOfWorkspaces, projectApiKeys, subscriptionTiers, userSubscriptionInfo, labelClasses, labels, spans } from "./schema";
+import { pipelines, targetPipelineVersions, pipelineVersions, projects, traces, evaluations, evaluationResults, eventTemplates, events, labelingQueues, providerApiKeys, workspaces, workspaceUsage, evaluationScores, labelClassesForPath, users, apiKeys, datasets, datasetDatapoints, labelingQueueItems, membersOfWorkspaces, projectApiKeys, subscriptionTiers, userSubscriptionInfo, labelClasses, labels, datapointToSpan, spans } from "./schema";
 
-export const targetPipelineVersionsRelations = relations(targetPipelineVersions, ({ one }) => ({
+export const targetPipelineVersionsRelations = relations(targetPipelineVersions, ({one}) => ({
   pipeline: one(pipelines, {
     fields: [targetPipelineVersions.pipelineId],
     references: [pipelines.id]
@@ -12,7 +12,7 @@ export const targetPipelineVersionsRelations = relations(targetPipelineVersions,
   }),
 }));
 
-export const pipelinesRelations = relations(pipelines, ({ one, many }) => ({
+export const pipelinesRelations = relations(pipelines, ({one, many}) => ({
   targetPipelineVersions: many(targetPipelineVersions),
   project: one(projects, {
     fields: [pipelines.projectId],
@@ -20,11 +20,11 @@ export const pipelinesRelations = relations(pipelines, ({ one, many }) => ({
   }),
 }));
 
-export const pipelineVersionsRelations = relations(pipelineVersions, ({ many }) => ({
+export const pipelineVersionsRelations = relations(pipelineVersions, ({many}) => ({
   targetPipelineVersions: many(targetPipelineVersions),
 }));
 
-export const tracesRelations = relations(traces, ({ one, many }) => ({
+export const tracesRelations = relations(traces, ({one, many}) => ({
   project: one(projects, {
     fields: [traces.projectId],
     references: [projects.id]
@@ -32,7 +32,7 @@ export const tracesRelations = relations(traces, ({ one, many }) => ({
   spans: many(spans),
 }));
 
-export const projectsRelations = relations(projects, ({ one, many }) => ({
+export const projectsRelations = relations(projects, ({one, many}) => ({
   traces: many(traces),
   labelingQueues: many(labelingQueues),
   providerApiKeys: many(providerApiKeys),
@@ -50,7 +50,7 @@ export const projectsRelations = relations(projects, ({ one, many }) => ({
   spans: many(spans),
 }));
 
-export const evaluationResultsRelations = relations(evaluationResults, ({ one, many }) => ({
+export const evaluationResultsRelations = relations(evaluationResults, ({one, many}) => ({
   evaluation: one(evaluations, {
     fields: [evaluationResults.evaluationId],
     references: [evaluations.id]
@@ -58,7 +58,7 @@ export const evaluationResultsRelations = relations(evaluationResults, ({ one, m
   evaluationScores: many(evaluationScores),
 }));
 
-export const evaluationsRelations = relations(evaluations, ({ one, many }) => ({
+export const evaluationsRelations = relations(evaluations, ({one, many}) => ({
   evaluationResults: many(evaluationResults),
   project: one(projects, {
     fields: [evaluations.projectId],
@@ -66,14 +66,14 @@ export const evaluationsRelations = relations(evaluations, ({ one, many }) => ({
   }),
 }));
 
-export const eventsRelations = relations(events, ({ one }) => ({
+export const eventsRelations = relations(events, ({one}) => ({
   eventTemplate: one(eventTemplates, {
     fields: [events.templateId],
     references: [eventTemplates.id]
   }),
 }));
 
-export const eventTemplatesRelations = relations(eventTemplates, ({ one, many }) => ({
+export const eventTemplatesRelations = relations(eventTemplates, ({one, many}) => ({
   events: many(events),
   project: one(projects, {
     fields: [eventTemplates.projectId],
@@ -81,7 +81,7 @@ export const eventTemplatesRelations = relations(eventTemplates, ({ one, many })
   }),
 }));
 
-export const labelingQueuesRelations = relations(labelingQueues, ({ one, many }) => ({
+export const labelingQueuesRelations = relations(labelingQueues, ({one, many}) => ({
   project: one(projects, {
     fields: [labelingQueues.projectId],
     references: [projects.id]
@@ -89,21 +89,21 @@ export const labelingQueuesRelations = relations(labelingQueues, ({ one, many })
   labelingQueueItems: many(labelingQueueItems),
 }));
 
-export const providerApiKeysRelations = relations(providerApiKeys, ({ one }) => ({
+export const providerApiKeysRelations = relations(providerApiKeys, ({one}) => ({
   project: one(projects, {
     fields: [providerApiKeys.projectId],
     references: [projects.id]
   }),
 }));
 
-export const workspaceUsageRelations = relations(workspaceUsage, ({ one }) => ({
+export const workspaceUsageRelations = relations(workspaceUsage, ({one}) => ({
   workspace: one(workspaces, {
     fields: [workspaceUsage.workspaceId],
     references: [workspaces.id]
   }),
 }));
 
-export const workspacesRelations = relations(workspaces, ({ one, many }) => ({
+export const workspacesRelations = relations(workspaces, ({one, many}) => ({
   workspaceUsages: many(workspaceUsage),
   membersOfWorkspaces: many(membersOfWorkspaces),
   projects: many(projects),
@@ -113,41 +113,42 @@ export const workspacesRelations = relations(workspaces, ({ one, many }) => ({
   }),
 }));
 
-export const evaluationScoresRelations = relations(evaluationScores, ({ one }) => ({
+export const evaluationScoresRelations = relations(evaluationScores, ({one}) => ({
   evaluationResult: one(evaluationResults, {
     fields: [evaluationScores.resultId],
     references: [evaluationResults.id]
   }),
 }));
 
-export const labelClassesForPathRelations = relations(labelClassesForPath, ({ one }) => ({
+export const labelClassesForPathRelations = relations(labelClassesForPath, ({one}) => ({
   project: one(projects, {
     fields: [labelClassesForPath.projectId],
     references: [projects.id]
   }),
 }));
 
-export const apiKeysRelations = relations(apiKeys, ({ one }) => ({
+export const apiKeysRelations = relations(apiKeys, ({one}) => ({
   user: one(users, {
     fields: [apiKeys.userId],
     references: [users.id]
   }),
 }));
 
-export const usersRelations = relations(users, ({ many }) => ({
+export const usersRelations = relations(users, ({many}) => ({
   apiKeys: many(apiKeys),
   membersOfWorkspaces: many(membersOfWorkspaces),
   userSubscriptionInfos: many(userSubscriptionInfo),
 }));
 
-export const datasetDatapointsRelations = relations(datasetDatapoints, ({ one }) => ({
+export const datasetDatapointsRelations = relations(datasetDatapoints, ({one, many}) => ({
   dataset: one(datasets, {
     fields: [datasetDatapoints.datasetId],
     references: [datasets.id]
   }),
+  datapointToSpans: many(datapointToSpan),
 }));
 
-export const datasetsRelations = relations(datasets, ({ one, many }) => ({
+export const datasetsRelations = relations(datasets, ({one, many}) => ({
   datasetDatapoints: many(datasetDatapoints),
   project: one(projects, {
     fields: [datasets.projectId],
@@ -155,14 +156,14 @@ export const datasetsRelations = relations(datasets, ({ one, many }) => ({
   }),
 }));
 
-export const labelingQueueItemsRelations = relations(labelingQueueItems, ({ one }) => ({
+export const labelingQueueItemsRelations = relations(labelingQueueItems, ({one}) => ({
   labelingQueue: one(labelingQueues, {
     fields: [labelingQueueItems.queueId],
     references: [labelingQueues.id]
   }),
 }));
 
-export const membersOfWorkspacesRelations = relations(membersOfWorkspaces, ({ one }) => ({
+export const membersOfWorkspacesRelations = relations(membersOfWorkspaces, ({one}) => ({
   user: one(users, {
     fields: [membersOfWorkspaces.userId],
     references: [users.id]
@@ -173,32 +174,32 @@ export const membersOfWorkspacesRelations = relations(membersOfWorkspaces, ({ on
   }),
 }));
 
-export const projectApiKeysRelations = relations(projectApiKeys, ({ one }) => ({
+export const projectApiKeysRelations = relations(projectApiKeys, ({one}) => ({
   project: one(projects, {
     fields: [projectApiKeys.projectId],
     references: [projects.id]
   }),
 }));
 
-export const subscriptionTiersRelations = relations(subscriptionTiers, ({ many }) => ({
+export const subscriptionTiersRelations = relations(subscriptionTiers, ({many}) => ({
   workspaces: many(workspaces),
 }));
 
-export const userSubscriptionInfoRelations = relations(userSubscriptionInfo, ({ one }) => ({
+export const userSubscriptionInfoRelations = relations(userSubscriptionInfo, ({one}) => ({
   user: one(users, {
     fields: [userSubscriptionInfo.userId],
     references: [users.id]
   }),
 }));
 
-export const labelsRelations = relations(labels, ({ one }) => ({
+export const labelsRelations = relations(labels, ({one}) => ({
   labelClass: one(labelClasses, {
     fields: [labels.classId],
     references: [labelClasses.id]
   }),
 }));
 
-export const labelClassesRelations = relations(labelClasses, ({ one, many }) => ({
+export const labelClassesRelations = relations(labelClasses, ({one, many}) => ({
   labels: many(labels),
   project: one(projects, {
     fields: [labelClasses.projectId],
@@ -206,7 +207,19 @@ export const labelClassesRelations = relations(labelClasses, ({ one, many }) => 
   }),
 }));
 
-export const spansRelations = relations(spans, ({ one }) => ({
+export const datapointToSpanRelations = relations(datapointToSpan, ({one}) => ({
+  datasetDatapoint: one(datasetDatapoints, {
+    fields: [datapointToSpan.datapointId],
+    references: [datasetDatapoints.id]
+  }),
+  span: one(spans, {
+    fields: [datapointToSpan.spanId],
+    references: [spans.spanId]
+  }),
+}));
+
+export const spansRelations = relations(spans, ({one, many}) => ({
+  datapointToSpans: many(datapointToSpan),
   trace: one(traces, {
     fields: [spans.traceId],
     references: [traces.id]

--- a/frontend/lib/db/migrations/schema.ts
+++ b/frontend/lib/db/migrations/schema.ts
@@ -244,6 +244,7 @@ export const evaluationScores = pgTable("evaluation_scores", {
     foreignColumns: [evaluationResults.id],
     name: "evaluation_scores_result_id_fkey"
   }).onUpdate("cascade").onDelete("cascade"),
+  evaluationResultsNamesUnique: unique("evaluation_results_names_unique").on(table.resultId, table.name),
 }));
 
 export const labelClassesForPath = pgTable("label_classes_for_path", {
@@ -468,7 +469,7 @@ export const labels = pgTable("labels", {
   id: uuid().defaultRandom().primaryKey().notNull(),
   createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   classId: uuid("class_id").notNull(),
-  value: doublePrecision().default(sql`'0'`),
+  value: doublePrecision().default(sql`'0'`).notNull(),
   spanId: uuid("span_id").notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   userId: uuid("user_id").defaultRandom(),
@@ -502,6 +503,26 @@ export const labelClasses = pgTable("label_classes", {
     foreignColumns: [projects.id],
     name: "label_classes_project_id_fkey"
   }).onUpdate("cascade").onDelete("cascade"),
+}));
+
+export const datapointToSpan = pgTable("datapoint_to_span", {
+  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  datapointId: uuid("datapoint_id").notNull(),
+  spanId: uuid("span_id").notNull(),
+  projectId: uuid("project_id").notNull(),
+},
+(table) => ({
+  datapointToSpanDatapointIdFkey: foreignKey({
+    columns: [table.datapointId],
+    foreignColumns: [datasetDatapoints.id],
+    name: "datapoint_to_span_datapoint_id_fkey"
+  }).onUpdate("cascade").onDelete("cascade"),
+  datapointToSpanSpanIdProjectIdFkey: foreignKey({
+    columns: [table.spanId, table.projectId],
+    foreignColumns: [spans.spanId, spans.projectId],
+    name: "datapoint_to_span_span_id_project_id_fkey"
+  }).onUpdate("cascade").onDelete("cascade"),
+  datapointToSpanPkey: primaryKey({ columns: [table.datapointId, table.spanId, table.projectId], name: "datapoint_to_span_pkey"}),
 }));
 
 export const spans = pgTable("spans", {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR adds functionality to link datapoints to spans, updating the database schema, API, and frontend components accordingly.
> 
>   - **Database**:
>     - Add `datapoint_to_span` table with foreign keys to `dataset_datapoints` and `spans` in `0004_worthless_kitty_pryde.sql`.
>     - Update `relations.ts` and `schema.ts` to include `datapoint_to_span` relations.
>   - **API**:
>     - Update `route.ts` in `datapoints` to handle POST requests linking datapoints to spans.
>     - Add new route in `spans` to retrieve datapoints linked to a span.
>   - **Frontend**:
>     - Update `dataset.tsx` to handle datapoint selection and deletion.
>     - Add `span-datasets.tsx` to display datasets linked to a span.
>     - Update `export-spans-dialog.tsx` to include `sourceSpanId` when exporting spans to datasets.
>     - Modify `span-view-span.tsx` to include `SpanDatasets` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 1630c4f13e9cd95485c086eae26be657688d79e0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->