### PR TITLE
don't join spans on count traces query

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -293,6 +293,7 @@ impl Span {
                 .get("SpanAttributes.LLM_PROMPTS.0.content")
                 .is_some()
             {
+                // handling the LiteLLM auto-instrumentation
                 let input_messages = input_chat_messages_from_prompt_content(
                     &attributes,
                     "SpanAttributes.LLM_PROMPTS",

--- a/frontend/components/traces/sessions-table.tsx
+++ b/frontend/components/traces/sessions-table.tsx
@@ -133,7 +133,8 @@ export default function SessionsTable({ onRowClick }: SessionsTableProps) {
             <span className="text-gray-500">Trace</span>
           </div>
         ),
-      id: 'type'
+      id: 'type',
+      size: 120
     },
     {
       accessorFn: (row) => (row.data.id === null ? '-' : row.data.id),
@@ -156,42 +157,50 @@ export default function SessionsTable({ onRowClick }: SessionsTableProps) {
 
         return (row.data as SessionPreview).duration.toFixed(3) + 's';
       },
-      header: 'Duration'
+      header: 'Duration',
+      size: 100,
     },
     {
       accessorFn: (row) => '$' + row.data.inputCost?.toFixed(5),
       header: 'Input cost',
-      id: 'input_cost'
+      id: 'input_cost',
+      size: 120,
     },
     {
       accessorFn: (row) => '$' + row.data.outputCost?.toFixed(5),
       header: 'Output cost',
-      id: 'output_cost'
+      id: 'output_cost',
+      size: 120,
     },
     {
       accessorFn: (row) => '$' + row.data.cost?.toFixed(5),
       header: 'Total cost',
-      id: 'cost'
+      id: 'cost',
+      size: 120,
     },
     {
       accessorFn: (row) => row.data.inputTokenCount,
-      header: 'Input token count',
-      id: 'input_token_count'
+      header: 'Input tokens',
+      id: 'input_token_count',
+      size: 120,
     },
     {
       accessorFn: (row) => row.data.outputTokenCount,
-      header: 'Output token count',
-      id: 'output_token_count'
+      header: 'Output tokens',
+      id: 'output_token_count',
+      size: 120,
     },
     {
       accessorFn: (row) => row.data.totalTokenCount,
-      header: 'Token count',
-      id: 'total_token_count'
+      header: 'Total tokens',
+      id: 'total_token_count',
+      size: 120,
     },
     {
       accessorFn: (row) => (row.data as SessionPreview).traceCount,
       header: 'Trace Count',
-      id: 'trace_count'
+      id: 'trace_count',
+      size: 120,
     }
   ];
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplify `count_traces` query in `trace.rs` by removing span joins and adjust `SessionsTable` UI in `sessions-table.tsx`.
> 
>   - **Database Query**:
>     - Modify `count_traces` in `trace.rs` to avoid joining spans, simplifying the query.
>     - Add `add_date_range_to_query` call in `count_traces` for date filtering.
>   - **Frontend**:
>     - Set column sizes in `SessionsTable` in `sessions-table.tsx`.
>     - Rename headers in `SessionsTable` for clarity (e.g., 'Token count' to 'Total tokens').
>   - **Misc**:
>     - Add comment in `spans.rs` for LiteLLM auto-instrumentation handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for c4f95ada0fe13642dfabd0194e3739ddb7bcf0e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->