### PR TITLE
return true on the backend for any traces in project

### DIFF
--- a/app-server/src/db/trace.rs
+++ b/app-server/src/db/trace.rs
@@ -507,22 +507,6 @@ pub async fn count_traces(
     Ok(count)
 }
 
-/// `count_traces` with filters adds a lot of information to the query and joins on the events (in order to filter)
-/// This function is a simpler version of `count_traces` that only counts the traces without any additional information
-/// and is more efficient.
-pub async fn count_all_traces_in_project(pool: &PgPool, project_id: Uuid) -> Result<i64> {
-    let count = sqlx::query_as::<_, TotalCount>(
-        "SELECT COUNT(*) as total_count
-        FROM traces
-        WHERE project_id = $1",
-    )
-    .bind(project_id)
-    .fetch_one(pool)
-    .await?;
-
-    Ok(count.total_count)
-}
-
 pub async fn get_single_trace(pool: &PgPool, id: Uuid) -> Result<Trace> {
     let trace = sqlx::query_as::<_, Trace>(
         "SELECT

--- a/app-server/src/routes/traces.rs
+++ b/app-server/src/routes/traces.rs
@@ -65,14 +65,9 @@ pub async fn get_traces(
         )
         .await
         .unwrap_or(0) as u64;
-        let any_in_project = if total_count == 0 {
-            db::trace::count_all_traces_in_project(&db.pool, project_id)
-                .await
-                .unwrap_or(1)
-                > 0
-        } else {
-            true
-        };
+        // this is checked in the frontend, and we temporarily return true here,
+        // while we migrate other `PaginatedGet` queries to drizzle
+        let any_in_project = true;
         (total_count, any_in_project)
     });
 

--- a/frontend/app/project/[projectId]/traces/page.tsx
+++ b/frontend/app/project/[projectId]/traces/page.tsx
@@ -16,15 +16,10 @@ export default async function TracesPage({
   params: { projectId: string };
 }) {
   const projectId = params.projectId;
-  const anyInProject = await db.$count(
-    spans,
-    inArray(
-      spans.traceId,
-      db.select({ traceId: traces.id })
-        .from(traces)
-        .where(eq(traces.projectId, projectId))
-    )) > 0;
-  if (!anyInProject) {
+  const anyInProject = await db.query.spans.findFirst({
+    where: eq(spans.projectId, projectId)
+  });
+  if (anyInProject === undefined) {
     return <TracesPagePlaceholder />;
   }
   return (


### PR DESCRIPTION
+ also simplify the next/drizzle query for this
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplify trace existence check by always returning true on the backend and optimizing frontend logic.
> 
>   - **Backend Changes**:
>     - In `traces.rs`, always return `true` for `any_in_project` in `get_traces()`.
>     - Remove `count_all_traces_in_project()` from `trace.rs`.
>   - **Frontend Changes**:
>     - Simplify trace existence check in `page.tsx` by using `db.query.spans.findFirst()` instead of counting spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for bc8e8d897e1c010bca1433329f2045f741b86da7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->