### PR TITLE
temporarily rename the CH table to old_evaluation_results

### DIFF
--- a/app-server/src/api/v1/evaluations.rs
+++ b/app-server/src/api/v1/evaluations.rs
@@ -1,4 +1,5 @@
 use actix_web::{post, web, HttpResponse};
+use chrono::Utc;
 use serde::Deserialize;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -84,6 +85,7 @@ async fn create_evaluation(
         project_id,
         group_id,
         evaluation.id,
+        Utc::now(),
     );
 
     let ch_task = tokio::spawn(insert_evaluation_scores(

--- a/frontend/app/api/projects/[projectId]/queues/[queueId]/remove/route.ts
+++ b/frontend/app/api/projects/[projectId]/queues/[queueId]/remove/route.ts
@@ -77,7 +77,7 @@ export async function POST(request: Request, { params }: { params: { projectId: 
       if (matchingEvaluations.length > 0) {
         const evaluation = matchingEvaluations[0].evaluations;
         await clickhouseClient.insert({
-          table: 'evaluation_scores',
+          table: 'old_evaluation_scores',
           format: 'JSONEachRow',
           values: evaluationValues.map(value => ({
             project_id: params.projectId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename ClickHouse table to `old_evaluation_scores` and add timestamp to `EvaluationScore` struct, affecting multiple functions and queries.
> 
>   - **Database Changes**:
>     - Rename ClickHouse table from `evaluation_scores` to `old_evaluation_scores` in `insert_evaluation_scores()`, `get_average_evaluation_score()`, `get_evaluation_score_buckets_based_on_bounds()`, and `get_global_evaluation_scores_bounds()` in `evaluation_scores.rs`.
>     - Update table name in `route.ts` for ClickHouse insert operation.
>   - **Struct Changes**:
>     - Add `timestamp` field to `EvaluationScore` in `evaluation_scores.rs`, skipped during serialization.
>   - **Function Changes**:
>     - Pass current timestamp to `EvaluationScore::from_evaluation_datapoint_results()` in `create_evaluation()` in `evaluations.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3355d379b737303c47e7262854d02000ad0e0752. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->