### PR TITLE
query table evaluation_results with timestamp

### DIFF
--- a/frontend/app/api/projects/[projectId]/queues/[queueId]/remove/route.ts
+++ b/frontend/app/api/projects/[projectId]/queues/[queueId]/remove/route.ts
@@ -7,6 +7,8 @@ import { Feature } from '@/lib/features/features';
 import { clickhouseClient } from '@/lib/clickhouse/client';
 import { z } from 'zod';
 
+const NANOS_PER_MILLISECOND = 1_000_000;
+
 const removeQueueItemSchema = z.object({
   id: z.string(),
   spanId: z.string(),
@@ -77,7 +79,7 @@ export async function POST(request: Request, { params }: { params: { projectId: 
       if (matchingEvaluations.length > 0) {
         const evaluation = matchingEvaluations[0].evaluations;
         await clickhouseClient.insert({
-          table: 'old_evaluation_scores',
+          table: 'evaluation_scores',
           format: 'JSONEachRow',
           values: evaluationValues.map(value => ({
             project_id: params.projectId,
@@ -86,6 +88,7 @@ export async function POST(request: Request, { params }: { params: { projectId: 
             result_id: resultId,
             name: value.name,
             value: value.score,
+            timestamp: new Date().getTime() * NANOS_PER_MILLISECOND
           }))
         });
       }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update evaluation score handling by renaming table and adding timestamp serialization in `evaluation_scores.rs` and `route.ts`.
> 
>   - **Database Changes**:
>     - Change table name from `old_evaluation_scores` to `evaluation_scores` in `evaluation_scores.rs` and `route.ts`.
>     - Add `serialize_timestamp` function in `evaluation_scores.rs` to serialize `timestamp` as nanoseconds.
>   - **Functionality**:
>     - Update `insert_evaluation_scores`, `get_average_evaluation_score`, `get_evaluation_score_buckets_based_on_bounds`, and `get_global_evaluation_scores_bounds` to use `evaluation_scores` table.
>     - Modify `POST` function in `route.ts` to insert into `evaluation_scores` with nanosecond `timestamp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 749dcc22f8420a07fe0cbd872e907c737e59c6b1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->