### PR TITLE
fix some migrations

### DIFF
--- a/frontend/lib/db/migrations/0004_worthless_kitty_pryde.sql
+++ b/frontend/lib/db/migrations/0004_worthless_kitty_pryde.sql
@@ -6,8 +6,6 @@ CREATE TABLE IF NOT EXISTS "datapoint_to_span" (
 	CONSTRAINT "datapoint_to_span_pkey" PRIMARY KEY("datapoint_id","span_id","project_id")
 );
 --> statement-breakpoint
-ALTER TABLE "labeling_queue_items" DROP CONSTRAINT "labelling_queue_data_queue_id_fkey";
---> statement-breakpoint
 ALTER TABLE "labels" ALTER COLUMN "value" SET NOT NULL;--> statement-breakpoint
 DO $$ BEGIN
  ALTER TABLE "datapoint_to_span" ADD CONSTRAINT "datapoint_to_span_datapoint_id_fkey" FOREIGN KEY ("datapoint_id") REFERENCES "public"."dataset_datapoints"("id") ON DELETE cascade ON UPDATE cascade;

--- a/frontend/lib/db/migrations/meta/0002_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0002_snapshot.json
@@ -757,7 +757,7 @@
       },
       "indexes": {},
       "foreignKeys": {
-        "labeling_queue_items_queue_id_fkey": {
+        "labelling_queue_items_queue_id_fkey": {
           "name": "labelling_queue_items_queue_id_fkey",
           "tableFrom": "labeling_queue_items",
           "tableTo": "labeling_queues",

--- a/frontend/lib/db/migrations/meta/0002_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0002_snapshot.json
@@ -757,8 +757,8 @@
       },
       "indexes": {},
       "foreignKeys": {
-        "labelling_queue_data_queue_id_fkey": {
-          "name": "labelling_queue_data_queue_id_fkey",
+        "labeling_queue_items_queue_id_fkey": {
+          "name": "labelling_queue_items_queue_id_fkey",
           "tableFrom": "labeling_queue_items",
           "tableTo": "labeling_queues",
           "columnsFrom": [

--- a/frontend/lib/db/migrations/meta/0003_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0003_snapshot.json
@@ -758,7 +758,7 @@
       "indexes": {},
       "foreignKeys": {
         "labelling_queue_items_queue_id_fkey": {
-          "name": "llabelling_queue_items_queue_id_fkey",
+          "name": "labelling_queue_items_queue_id_fkey",
           "tableFrom": "labeling_queue_items",
           "tableTo": "labeling_queues",
           "columnsFrom": [

--- a/frontend/lib/db/migrations/meta/0003_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0003_snapshot.json
@@ -757,8 +757,8 @@
       },
       "indexes": {},
       "foreignKeys": {
-        "labelling_queue_data_queue_id_fkey": {
-          "name": "labelling_queue_data_queue_id_fkey",
+        "labelling_queue_items_queue_id_fkey": {
+          "name": "llabelling_queue_items_queue_id_fkey",
           "tableFrom": "labeling_queue_items",
           "tableTo": "labeling_queues",
           "columnsFrom": [


### PR DESCRIPTION
Remove some duplication in migration files that had arised from merge conflicts manual resolution
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes duplication and incorrect foreign key names in migration files to resolve merge conflict issues.
> 
>   - **Migrations**:
>     - Remove duplicate `ALTER TABLE` statement in `0004_worthless_kitty_pryde.sql`.
>     - Correct foreign key name from `labelling_queue_data_queue_id_fkey` to `labeling_queue_items_queue_id_fkey` in `0002_snapshot.json` and `0003_snapshot.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7f8acd45d50ba865d50cc375ca9406354192bd70. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->