### PR TITLE
fix python online eval

### DIFF
--- a/app-server/src/traces/evaluators.rs
+++ b/app-server/src/traces/evaluators.rs
@@ -84,7 +84,17 @@ pub async fn run_evaluator(
 
     let (value, reasoning) = match serde_json::from_str::<EvaluatorResult>(&output_str) {
         Ok(EvaluatorResult::LLM(llm_output)) => (llm_output.value, llm_output.reasoning),
-        Ok(EvaluatorResult::Code(code)) => (code, String::new()),
+        Ok(EvaluatorResult::Code(code)) => {
+            // QUICK FIX
+            // python return True or False but we parse it into JSON as true/false
+            let mut code = code.clone();
+            if code == "true".to_string() {
+                code = "True".to_string();
+            } else if code == "false".to_string() {
+                code = "False".to_string();
+            }
+            (code, String::new())
+        }
         Err(_) => (output_str, String::new()),
     };
 

--- a/frontend/components/evaluator/evaluator-editor.tsx
+++ b/frontend/components/evaluator/evaluator-editor.tsx
@@ -106,7 +106,16 @@ export function EvaluatorEditor({
 
     const res = await response.json();
 
-    setOutput(res['outputs']['output']['value']);
+    let value = res['outputs']['output']['value'];
+
+    // python return True or False but we parse it into JSON as true/false
+    if (value === 'true') {
+      value = 'True';
+    } else if (value === 'false') {
+      value = 'False';
+    }
+
+    setOutput(value);
   };
 
   const runEval = async () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes boolean parsing issue by converting 'true'/'false' to 'True'/'False' in backend and frontend components, and renames a function for clarity.
> 
>   - **Behavior**:
>     - Fixes boolean parsing in `run_evaluator()` in `evaluators.rs` by converting 'true'/'false' to 'True'/'False'.
>     - Updates `EvaluatorEditor` and `AddLabelInstance` in `evaluator-editor.tsx` and `add-label-popover.tsx` to handle 'true'/'false' conversion.
>   - **Misc**:
>     - Renames `evaluatorType()` to `getEvaluatorType()` in `add-label-popover.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for f10ced6a4656f623a4224f7552456c87fd5feaf5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->