### PR TITLE
disable all clickhouse queries for non-full builds

### DIFF
--- a/app-server/src/ch/evaluation_scores.rs
+++ b/app-server/src/ch/evaluation_scores.rs
@@ -4,7 +4,10 @@ use clickhouse::Row;
 use serde::{Deserialize, Serialize, Serializer};
 use uuid::Uuid;
 
-use crate::evaluations::utils::EvaluationDatapointResult;
+use crate::{
+    evaluations::utils::EvaluationDatapointResult,
+    features::{is_feature_enabled, Feature},
+};
 
 use super::utils::chrono_to_nanoseconds;
 
@@ -72,6 +75,10 @@ pub async fn insert_evaluation_scores(
     evaluation_scores: Vec<EvaluationScore>,
 ) -> Result<()> {
     if evaluation_scores.is_empty() {
+        return Ok(());
+    }
+
+    if !is_feature_enabled(Feature::FullBuild) {
         return Ok(());
     }
 

--- a/app-server/src/ch/events.rs
+++ b/app-server/src/ch/events.rs
@@ -128,9 +128,6 @@ pub async fn get_total_event_count_metrics_relative(
     template_id: Uuid,
     past_hours: i64,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let ch_round_time = group_by_interval.to_ch_truncate_time();
 
     let query_string = format!(
@@ -166,9 +163,6 @@ pub async fn get_total_event_count_metrics_absolute(
     start_time: DateTime<Utc>,
     end_time: DateTime<Utc>,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let ch_round_time = group_by_interval.to_ch_truncate_time();
     let ch_start_time = start_time.timestamp();
     let ch_end_time = end_time.timestamp();

--- a/app-server/src/ch/events.rs
+++ b/app-server/src/ch/events.rs
@@ -5,7 +5,10 @@ use serde::Serialize;
 use serde_repr::Serialize_repr;
 use uuid::Uuid;
 
-use crate::db::{self, event_templates::EventTemplate};
+use crate::{
+    db::{self, event_templates::EventTemplate},
+    features::{is_feature_enabled, Feature},
+};
 
 use super::{
     modifiers::GroupByInterval,
@@ -87,6 +90,9 @@ impl CHEvent {
 }
 
 pub async fn insert_events(clickhouse: clickhouse::Client, events: Vec<CHEvent>) -> Result<()> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(());
+    }
     if events.is_empty() {
         return Ok(());
     }
@@ -122,6 +128,9 @@ pub async fn get_total_event_count_metrics_relative(
     template_id: Uuid,
     past_hours: i64,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let ch_round_time = group_by_interval.to_ch_truncate_time();
 
     let query_string = format!(
@@ -157,6 +166,9 @@ pub async fn get_total_event_count_metrics_absolute(
     start_time: DateTime<Utc>,
     end_time: DateTime<Utc>,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let ch_round_time = group_by_interval.to_ch_truncate_time();
     let ch_start_time = start_time.timestamp();
     let ch_end_time = end_time.timestamp();

--- a/app-server/src/ch/labels.rs
+++ b/app-server/src/ch/labels.rs
@@ -4,7 +4,10 @@ use clickhouse::Row;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::db::labels::LabelSource;
+use crate::{
+    db::labels::LabelSource,
+    features::{is_feature_enabled, Feature},
+};
 
 use super::utils::chrono_to_nanoseconds;
 
@@ -73,6 +76,10 @@ pub async fn insert_label(
     value: f64,
     span_id: Uuid,
 ) -> Result<()> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(());
+    }
+
     let label = CHLabel::new(
         project_id,
         class_id,
@@ -113,6 +120,9 @@ pub async fn delete_label(
     span_id: Uuid,
     id: Uuid,
 ) -> Result<()> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(());
+    }
     // Note, this does not immediately physically delete the data.
     // https://clickhouse.com/docs/en/sql-reference/statements/delete
     client

--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::{
     db::spans::{Span, SpanType},
+    features::{is_feature_enabled, Feature},
     traces::spans::SpanUsage,
 };
 
@@ -94,6 +95,9 @@ impl CHSpan {
 }
 
 pub async fn insert_span(clickhouse: clickhouse::Client, span: &CHSpan) -> Result<()> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(());
+    }
     let ch_insert = clickhouse.insert("spans");
     match ch_insert {
         Ok(mut ch_insert) => {
@@ -121,6 +125,9 @@ pub async fn get_total_trace_count_metrics_relative(
     project_id: Uuid,
     past_hours: i64,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let query = span_metric_query_relative(
         &clickhouse,
         project_id,
@@ -142,6 +149,9 @@ pub async fn get_total_trace_count_metrics_absolute(
     start_time: DateTime<Utc>,
     end_time: DateTime<Utc>,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let query = span_metric_query_absolute(
         &clickhouse,
         project_id,
@@ -164,6 +174,9 @@ pub async fn get_trace_latency_seconds_metrics_relative(
     past_hours: i64,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<f64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let query = span_metric_query_relative(
         &clickhouse,
         project_id,
@@ -186,6 +199,9 @@ pub async fn get_trace_latency_seconds_metrics_absolute(
     end_time: DateTime<Utc>,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<f64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let query = span_metric_query_absolute(
         &clickhouse,
         project_id,
@@ -208,6 +224,9 @@ pub async fn get_total_token_count_metrics_relative(
     past_hours: i64,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let query = span_metric_query_relative(
         &clickhouse,
         project_id,
@@ -230,6 +249,9 @@ pub async fn get_total_token_count_metrics_absolute(
     end_time: DateTime<Utc>,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let query = span_metric_query_absolute(
         &clickhouse,
         project_id,
@@ -252,6 +274,9 @@ pub async fn get_cost_usd_metrics_relative(
     past_hours: i64,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<f64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let query = span_metric_query_relative(
         &clickhouse,
         project_id,
@@ -274,6 +299,9 @@ pub async fn get_cost_usd_metrics_absolute(
     end_time: DateTime<Utc>,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<f64>>> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(Vec::new());
+    }
     let query = span_metric_query_absolute(
         &clickhouse,
         project_id,

--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -125,9 +125,6 @@ pub async fn get_total_trace_count_metrics_relative(
     project_id: Uuid,
     past_hours: i64,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let query = span_metric_query_relative(
         &clickhouse,
         project_id,
@@ -149,9 +146,6 @@ pub async fn get_total_trace_count_metrics_absolute(
     start_time: DateTime<Utc>,
     end_time: DateTime<Utc>,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let query = span_metric_query_absolute(
         &clickhouse,
         project_id,
@@ -174,9 +168,6 @@ pub async fn get_trace_latency_seconds_metrics_relative(
     past_hours: i64,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<f64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let query = span_metric_query_relative(
         &clickhouse,
         project_id,
@@ -199,9 +190,6 @@ pub async fn get_trace_latency_seconds_metrics_absolute(
     end_time: DateTime<Utc>,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<f64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let query = span_metric_query_absolute(
         &clickhouse,
         project_id,
@@ -224,9 +212,6 @@ pub async fn get_total_token_count_metrics_relative(
     past_hours: i64,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let query = span_metric_query_relative(
         &clickhouse,
         project_id,
@@ -249,9 +234,6 @@ pub async fn get_total_token_count_metrics_absolute(
     end_time: DateTime<Utc>,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<i64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let query = span_metric_query_absolute(
         &clickhouse,
         project_id,
@@ -274,9 +256,6 @@ pub async fn get_cost_usd_metrics_relative(
     past_hours: i64,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<f64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let query = span_metric_query_relative(
         &clickhouse,
         project_id,
@@ -299,9 +278,6 @@ pub async fn get_cost_usd_metrics_absolute(
     end_time: DateTime<Utc>,
     aggregation: Aggregation,
 ) -> Result<Vec<MetricTimeValue<f64>>> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        return Ok(Vec::new());
-    }
     let query = span_metric_query_absolute(
         &clickhouse,
         project_id,

--- a/app-server/src/routes/events.rs
+++ b/app-server/src/routes/events.rs
@@ -3,13 +3,14 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::{
-    ch::{self, utils::get_bounds, Aggregation},
+    ch::{self, utils::get_bounds, Aggregation, MetricTimeValue},
     db::{
         self,
         events::EventWithTemplateName,
         modifiers::{AbsoluteDateInterval, DateRange, Filter, RelativeDateInterval},
         DB,
     },
+    features::{is_feature_enabled, Feature},
     routes::{PaginatedGetQueryParams, PaginatedResponse, DEFAULT_PAGE_SIZE},
 };
 
@@ -174,6 +175,9 @@ pub async fn get_events_metrics(
     } else {
         defaulted_range
     };
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(HttpResponse::Ok().json(Vec::<MetricTimeValue<i64>>::new()));
+    }
 
     match range {
         DateRange::Relative(interval) => {

--- a/app-server/src/routes/traces.rs
+++ b/app-server/src/routes/traces.rs
@@ -1,6 +1,8 @@
 use super::{GetMetricsQueryParams, ResponseResult};
 use super::{PaginatedGetQueryParams, PaginatedResponse, DEFAULT_PAGE_SIZE};
 use crate::ch::utils::get_bounds;
+use crate::ch::MetricTimeValue;
+use crate::features::{is_feature_enabled, Feature};
 use crate::{
     ch::{self, modifiers::GroupByInterval, Aggregation},
     db::{
@@ -183,6 +185,10 @@ pub async fn get_traces_metrics(
             .unwrap_or(DateRange::Relative(RelativeDateInterval {
                 past_hours: "all".to_string(),
             }));
+
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(HttpResponse::Ok().json(Vec::<MetricTimeValue<f64>>::new()));
+    }
 
     match defaulted_range {
         DateRange::Relative(interval) => {

--- a/frontend/lib/clickhouse/evaluation-scores.ts
+++ b/frontend/lib/clickhouse/evaluation-scores.ts
@@ -2,6 +2,8 @@ import { ClickHouseClient } from "@clickhouse/client";
 import { AggregationFunction, TimeRange, addTimeRangeToQuery, aggregationFunctionToCh } from "./utils";
 import { EvaluationTimeProgression } from "../evaluation/types";
 import { BucketRow } from "../types";
+import { Feature } from "../features/features";
+import { isFeatureEnabled } from "../features/features";
 
 const DEFAULT_BUCKET_COUNT = 10;
 const DEFAULT_LOWER_BOUND = 0;
@@ -13,6 +15,9 @@ export const getEvaluationTimeProgression = async (
   timeRange: TimeRange,
   aggregationFunction: AggregationFunction,
 ): Promise<EvaluationTimeProgression[]> => {
+  if (!isFeatureEnabled(Feature.FULL_BUILD)) {
+    return [];
+  }
   const query = `WITH base AS (
   SELECT
     evaluation_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Disable ClickHouse queries for non-full builds by adding feature flag checks in multiple files and functions.
> 
>   - **Behavior**:
>     - Disable ClickHouse queries if `Feature::FullBuild` is not enabled in `evaluation_scores.rs`, `events.rs`, `labels.rs`, `spans.rs`, and `evaluation-scores.ts`.
>     - Affected functions include `insert_evaluation_scores`, `insert_events`, `insert_label`, `insert_span`, and various metric retrieval functions.
>   - **Files**:
>     - `evaluation_scores.rs`: Added feature flag check in `insert_evaluation_scores`.
>     - `events.rs`: Added feature flag check in `insert_events` and metric functions.
>     - `labels.rs`: Added feature flag check in `insert_label` and `delete_label`.
>     - `spans.rs`: Added feature flag check in `insert_span` and metric functions.
>     - `evaluation-scores.ts`: Added feature flag check in `getEvaluationTimeProgression`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for dea16b19dabea0377f5f3f34f41d23128226fcf5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->