### PR TITLE
disable all clickhouse queries for non-full builds (#213)

### DIFF
--- a/app-server/src/ch/evaluation_scores.rs
+++ b/app-server/src/ch/evaluation_scores.rs
@@ -4,7 +4,10 @@ use clickhouse::Row;
 use serde::{Deserialize, Serialize, Serializer};
 use uuid::Uuid;
 
-use crate::evaluations::utils::EvaluationDatapointResult;
+use crate::{
+    evaluations::utils::EvaluationDatapointResult,
+    features::{is_feature_enabled, Feature},
+};
 
 use super::utils::chrono_to_nanoseconds;
 
@@ -72,6 +75,10 @@ pub async fn insert_evaluation_scores(
     evaluation_scores: Vec<EvaluationScore>,
 ) -> Result<()> {
     if evaluation_scores.is_empty() {
+        return Ok(());
+    }
+
+    if !is_feature_enabled(Feature::FullBuild) {
         return Ok(());
     }
 

--- a/app-server/src/ch/events.rs
+++ b/app-server/src/ch/events.rs
@@ -5,7 +5,10 @@ use serde::Serialize;
 use serde_repr::Serialize_repr;
 use uuid::Uuid;
 
-use crate::db::{self, event_templates::EventTemplate};
+use crate::{
+    db::{self, event_templates::EventTemplate},
+    features::{is_feature_enabled, Feature},
+};
 
 use super::{
     modifiers::GroupByInterval,
@@ -87,6 +90,9 @@ impl CHEvent {
 }
 
 pub async fn insert_events(clickhouse: clickhouse::Client, events: Vec<CHEvent>) -> Result<()> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(());
+    }
     if events.is_empty() {
         return Ok(());
     }

--- a/app-server/src/ch/labels.rs
+++ b/app-server/src/ch/labels.rs
@@ -4,7 +4,10 @@ use clickhouse::Row;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::db::labels::LabelSource;
+use crate::{
+    db::labels::LabelSource,
+    features::{is_feature_enabled, Feature},
+};
 
 use super::utils::chrono_to_nanoseconds;
 
@@ -73,6 +76,10 @@ pub async fn insert_label(
     value: f64,
     span_id: Uuid,
 ) -> Result<()> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(());
+    }
+
     let label = CHLabel::new(
         project_id,
         class_id,
@@ -113,6 +120,9 @@ pub async fn delete_label(
     span_id: Uuid,
     id: Uuid,
 ) -> Result<()> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(());
+    }
     // Note, this does not immediately physically delete the data.
     // https://clickhouse.com/docs/en/sql-reference/statements/delete
     client

--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::{
     db::spans::{Span, SpanType},
+    features::{is_feature_enabled, Feature},
     traces::spans::SpanUsage,
 };
 
@@ -94,6 +95,9 @@ impl CHSpan {
 }
 
 pub async fn insert_span(clickhouse: clickhouse::Client, span: &CHSpan) -> Result<()> {
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(());
+    }
     let ch_insert = clickhouse.insert("spans");
     match ch_insert {
         Ok(mut ch_insert) => {

--- a/app-server/src/routes/events.rs
+++ b/app-server/src/routes/events.rs
@@ -3,13 +3,14 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::{
-    ch::{self, utils::get_bounds, Aggregation},
+    ch::{self, utils::get_bounds, Aggregation, MetricTimeValue},
     db::{
         self,
         events::EventWithTemplateName,
         modifiers::{AbsoluteDateInterval, DateRange, Filter, RelativeDateInterval},
         DB,
     },
+    features::{is_feature_enabled, Feature},
     routes::{PaginatedGetQueryParams, PaginatedResponse, DEFAULT_PAGE_SIZE},
 };
 
@@ -174,6 +175,9 @@ pub async fn get_events_metrics(
     } else {
         defaulted_range
     };
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(HttpResponse::Ok().json(Vec::<MetricTimeValue<i64>>::new()));
+    }
 
     match range {
         DateRange::Relative(interval) => {

--- a/app-server/src/routes/traces.rs
+++ b/app-server/src/routes/traces.rs
@@ -1,6 +1,8 @@
 use super::{GetMetricsQueryParams, ResponseResult};
 use super::{PaginatedGetQueryParams, PaginatedResponse, DEFAULT_PAGE_SIZE};
 use crate::ch::utils::get_bounds;
+use crate::ch::MetricTimeValue;
+use crate::features::{is_feature_enabled, Feature};
 use crate::{
     ch::{self, modifiers::GroupByInterval, Aggregation},
     db::{
@@ -183,6 +185,10 @@ pub async fn get_traces_metrics(
             .unwrap_or(DateRange::Relative(RelativeDateInterval {
                 past_hours: "all".to_string(),
             }));
+
+    if !is_feature_enabled(Feature::FullBuild) {
+        return Ok(HttpResponse::Ok().json(Vec::<MetricTimeValue<f64>>::new()));
+    }
 
     match defaulted_range {
         DateRange::Relative(interval) => {

--- a/frontend/lib/clickhouse/evaluation-scores.ts
+++ b/frontend/lib/clickhouse/evaluation-scores.ts
@@ -2,6 +2,8 @@ import { ClickHouseClient } from "@clickhouse/client";
 import { AggregationFunction, TimeRange, addTimeRangeToQuery, aggregationFunctionToCh } from "./utils";
 import { EvaluationTimeProgression } from "../evaluation/types";
 import { BucketRow } from "../types";
+import { Feature } from "../features/features";
+import { isFeatureEnabled } from "../features/features";
 
 const DEFAULT_BUCKET_COUNT = 10;
 const DEFAULT_LOWER_BOUND = 0;
@@ -13,6 +15,9 @@ export const getEvaluationTimeProgression = async (
   timeRange: TimeRange,
   aggregationFunction: AggregationFunction,
 ): Promise<EvaluationTimeProgression[]> => {
+  if (!isFeatureEnabled(Feature.FULL_BUILD)) {
+    return [];
+  }
   const query = `WITH base AS (
   SELECT
     evaluation_id,


### PR DESCRIPTION
* disable all clickhouse queries for non-full builds
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable ClickHouse queries for non-full builds by checking `Feature::FullBuild` across multiple modules.
> 
>   - **Behavior**:
>     - Disable ClickHouse queries for non-full builds by checking `Feature::FullBuild` in `insert_evaluation_scores()`, `insert_events()`, `insert_label()`, `delete_label()`, `insert_span()`, `get_events_metrics()`, and `get_traces_metrics()`.
>     - Return early with empty results or success when `Feature::FullBuild` is not enabled.
>   - **Files Affected**:
>     - `evaluation_scores.rs`, `events.rs`, `labels.rs`, `spans.rs` in `app-server/src/ch/`
>     - `events.rs`, `traces.rs` in `app-server/src/routes/`
>     - `evaluation-scores.ts` in `frontend/lib/clickhouse/`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7b14a7acde31984593e21a0762f6f0397dfac253. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->