### PR TITLE
write manual inputs and outputs on LLM spans

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -333,20 +333,19 @@ impl Span {
                     false,
                 );
             }
-        } else {
-            if let Some(serde_json::Value::String(s)) = attributes.get(INPUT_ATTRIBUTE_NAME) {
-                span.input = Some(
-                    serde_json::from_str::<Value>(s)
-                        .unwrap_or(serde_json::Value::String(s.clone())),
-                );
-            }
-
-            if let Some(serde_json::Value::String(s)) = attributes.get(OUTPUT_ATTRIBUTE_NAME) {
-                span.output = Some(
-                    serde_json::from_str::<Value>(s)
-                        .unwrap_or(serde_json::Value::String(s.clone())),
-                );
-            }
+        }
+        // If an LLM span is sent manually, we prefer `lmnr.span.input` and `lmnr.span.output`
+        // attributes over gen_ai/vercel/LiteLLM attributes.
+        // Therefore this block is outside and after the LLM span type check.
+        if let Some(serde_json::Value::String(s)) = attributes.get(INPUT_ATTRIBUTE_NAME) {
+            span.input = Some(
+                serde_json::from_str::<Value>(s).unwrap_or(serde_json::Value::String(s.clone())),
+            );
+        }
+        if let Some(serde_json::Value::String(s)) = attributes.get(OUTPUT_ATTRIBUTE_NAME) {
+            span.output = Some(
+                serde_json::from_str::<Value>(s).unwrap_or(serde_json::Value::String(s.clone())),
+            );
         }
 
         // Traceloop hard-codes these attributes to LangChain auto-instrumented spans.


### PR DESCRIPTION
Write LLM span inputs and outputs if they were set manually  as `lmnr.span.input` and `lmnr.span.output`. This gets higher priority then openllmetry/ai-sdk/litellm attributes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prioritize manually set `lmnr.span.input` and `lmnr.span.output` over other attributes in `Span::from_otel_span()`.
> 
>   - **Behavior**:
>     - Prioritize manually set `lmnr.span.input` and `lmnr.span.output` attributes over `gen_ai`, `vercel`, and `LiteLLM` attributes in `Span::from_otel_span()`.
>   - **Misc**:
>     - Adjusted logic in `spans.rs` to ensure manual attributes are checked after LLM span type determination.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for f2145da6f1e0c993c4b258764e68f7621e7155fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->