### PR TITLE
treat more spans as llm spans

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -141,7 +141,12 @@ impl SpanAttributes {
             serde_json::from_value::<SpanType>(span_type.clone()).unwrap_or_default()
         } else {
             // quick hack until we figure how to set span type on auto-instrumentation
-            if self.attributes.contains_key(GEN_AI_SYSTEM) {
+            if self.attributes.contains_key(GEN_AI_SYSTEM)
+                || self
+                    .attributes
+                    .iter()
+                    .any(|(k, _)| k.starts_with("gen_ai.") || k.starts_with("llm."))
+            {
                 SpanType::LLM
             } else {
                 SpanType::DEFAULT


### PR DESCRIPTION
openllmetry seems not to set `gen_ai.system` on OpenAI assistant spans, so our checks don't treat the span as an llm span. While we/traceloop fixes openllmetry loosen our checks a bit.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Loosen span type checks in `span_type()` in `spans.rs` to classify spans as LLM if attributes start with `gen_ai.` or `llm.`.
> 
>   - **Behavior**:
>     - Loosen span type checks in `span_type()` in `spans.rs` to classify spans as LLM if attributes start with `gen_ai.` or `llm.`.
>     - Addresses issue where `gen_ai.system` is not set on OpenAI assistant spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for f6537abf4de9e8e00785a73b60522c0099715158. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->