### PR TITLE
fix ace is not defined error

### DIFF
--- a/frontend/components/ui/ide.tsx
+++ b/frontend/components/ui/ide.tsx
@@ -1,3 +1,4 @@
+import 'ace-builds/src-noconflict/ace';
 import 'ace-builds/src-noconflict/ext-beautify';
 import 'ace-builds/src-noconflict/ext-language_tools';
 import 'ace-builds/src-noconflict/mode-handlebars';


### PR DESCRIPTION
The import was likely lost during recent eslint changes, and this breaks any pipeline pages
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-adds missing `ace` import in `ide.tsx` to fix "ace is not defined" error on pipeline pages.
> 
>   - **Bug Fix**:
>     - Re-adds import for `ace` in `ide.tsx` to fix "ace is not defined" error affecting pipeline pages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 48f010d36e620fb94a3712ca5ac12768c1ef8ef7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->