### PR TITLE
allow indexing datasets, expose semantic search as API

### DIFF
--- a/app-server/src/api/v1/mod.rs
+++ b/app-server/src/api/v1/mod.rs
@@ -2,4 +2,5 @@ pub mod datasets;
 pub mod evaluations;
 pub mod metrics;
 pub mod pipelines;
+pub mod semantic_search;
 pub mod traces;

--- a/app-server/src/api/v1/semantic_search.rs
+++ b/app-server/src/api/v1/semantic_search.rs
@@ -1,0 +1,84 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use actix_web::{post, web, HttpResponse};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::db::project_api_keys::ProjectApiKey;
+use crate::features::{is_feature_enabled, Feature};
+use crate::routes::types::ResponseResult;
+use crate::semantic_search::SemanticSearch;
+
+const DEFAULT_LIMIT: u32 = 10;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SemanticSearchRequest {
+    query: String,
+    dataset_id: Uuid,
+    #[serde(default)]
+    limit: Option<u32>,
+    #[serde(default)]
+    threshold: f32,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SemanticSearchResult {
+    dataset_id: Uuid,
+    score: f32,
+    data: HashMap<String, String>,
+    content: String,
+}
+
+#[derive(Serialize)]
+struct SemanticSearchResponse {
+    results: Vec<SemanticSearchResult>,
+}
+
+#[post("/semantic-search")]
+pub async fn semantic_search(
+    params: web::Json<SemanticSearchRequest>,
+    project_api_key: ProjectApiKey,
+    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+) -> ResponseResult {
+    if !is_feature_enabled(Feature::FullBuild) {
+        let error = "Semantic search is not enabled. Please enable full build";
+        return Ok(HttpResponse::NotImplemented().body(error));
+    }
+
+    let project_id = project_api_key.project_id;
+    let semantic_search = semantic_search.into_inner();
+    let params = params.into_inner();
+
+    let dataset_id = params.dataset_id;
+
+    let payloads = vec![HashMap::from([(
+        "datasource_id".to_string(),
+        dataset_id.to_string(),
+    )])];
+
+    let query_res = semantic_search
+        .query(
+            &project_id.to_string(),
+            params.query,
+            params.limit.unwrap_or(DEFAULT_LIMIT),
+            params.threshold,
+            payloads,
+        )
+        .await?;
+
+    let results = query_res
+        .results
+        .iter()
+        .map(|result| SemanticSearchResult {
+            dataset_id,
+            score: result.score,
+            data: result.data.clone(),
+            content: result.content.clone(),
+        })
+        .collect();
+
+    Ok(HttpResponse::Ok().json(SemanticSearchResponse { results }))
+}

--- a/app-server/src/datasets/mod.rs
+++ b/app-server/src/datasets/mod.rs
@@ -1,11 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use uuid::Uuid;
-
-use crate::{pipeline::nodes::NodeInput, semantic_search::SemanticSearch};
 
 pub mod datapoints;
 pub mod utils;
@@ -14,38 +10,10 @@ pub mod utils;
 #[serde(rename_all = "camelCase")]
 pub struct Dataset {
     pub id: Uuid,
+    #[serde(skip_deserializing)]
     pub created_at: DateTime<Utc>,
     pub name: String,
     pub project_id: Uuid,
     #[serde(default)]
     pub indexed_on: Option<String>,
-}
-
-impl Dataset {
-    pub async fn index_new_points(
-        &self,
-        datapoints: Vec<datapoints::Datapoint>,
-        semantic_search: Arc<dyn SemanticSearch>,
-        collection_name: String,
-        new_index_column: Option<String>,
-    ) -> anyhow::Result<()> {
-        if let Some(index_column) = &new_index_column {
-            let indexable_datapoints = datapoints.iter().filter(|datapoint| {
-                serde_json::from_value::<HashMap<String, NodeInput>>(datapoint.data.clone())
-                    .is_ok_and(|data| data.contains_key(index_column))
-            });
-
-            let vector_db_datapoints = indexable_datapoints
-                .clone()
-                .map(|datapoint| datapoint.into_vector_db_datapoint(index_column))
-                .collect::<Vec<_>>();
-
-            if !vector_db_datapoints.is_empty() {
-                semantic_search
-                    .index(vector_db_datapoints, collection_name)
-                    .await?;
-            }
-        }
-        Ok(())
-    }
 }

--- a/app-server/src/datasets/utils.rs
+++ b/app-server/src/datasets/utils.rs
@@ -1,9 +1,11 @@
-use std::result::Result;
+use std::{collections::HashMap, result::Result, sync::Arc};
 
-use crate::routes::error::Error;
+use crate::{pipeline::nodes::NodeInput, routes::error::Error, semantic_search::SemanticSearch};
 use actix_multipart::Multipart;
 use anyhow::Context;
 use futures_util::StreamExt;
+
+use super::datapoints::Datapoint;
 
 pub async fn read_multipart_file(mut payload: Multipart) -> Result<(String, bool, Vec<u8>), Error> {
     let mut filename = String::new();
@@ -39,4 +41,30 @@ pub async fn read_multipart_file(mut payload: Multipart) -> Result<(String, bool
     }
 
     Ok((filename, is_unstructured_file, bytes))
+}
+
+pub async fn index_new_points(
+    datapoints: Vec<Datapoint>,
+    semantic_search: Arc<dyn SemanticSearch>,
+    collection_name: String,
+    new_index_column: Option<String>,
+) -> anyhow::Result<()> {
+    if let Some(index_column) = &new_index_column {
+        let indexable_datapoints = datapoints.iter().filter(|datapoint| {
+            serde_json::from_value::<HashMap<String, NodeInput>>(datapoint.data.clone())
+                .is_ok_and(|data| data.contains_key(index_column))
+        });
+
+        let vector_db_datapoints = indexable_datapoints
+            .clone()
+            .map(|datapoint| datapoint.into_vector_db_datapoint(index_column))
+            .collect::<Vec<_>>();
+
+        if !vector_db_datapoints.is_empty() {
+            semantic_search
+                .index(vector_db_datapoints, collection_name)
+                .await?;
+        }
+    }
+    Ok(())
 }

--- a/app-server/src/db/datapoints.rs
+++ b/app-server/src/db/datapoints.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Value;
@@ -74,7 +74,7 @@ pub async fn insert_raw_data(
 
 pub async fn get_all_datapoints(pool: &PgPool, dataset_id: Uuid) -> Result<Vec<Datapoint>> {
     let datapoints = sqlx::query_as::<_, Datapoint>(
-        "SELECT id, dataset_id, data, target
+        "SELECT id, dataset_id, data, target, metadata
         FROM dataset_datapoints
         WHERE dataset_id = $1
         ORDER BY
@@ -111,37 +111,6 @@ pub async fn get_datapoints(
     .await?;
 
     Ok(datapoints)
-}
-
-pub async fn update_datapoint(
-    pool: &PgPool,
-    datapoint_id: &Uuid,
-    data: &Value,
-    target: &Value,
-    metadata: &Option<Value>,
-) -> Result<Datapoint> {
-    let datapoint = sqlx::query_as::<_, Datapoint>(
-        "UPDATE dataset_datapoints SET data = $2, target = $3, metadata = $4
-        WHERE id = $1
-        RETURNING id, dataset_id, data, target, metadata",
-    )
-    .bind(datapoint_id)
-    .bind(data)
-    .bind(target)
-    .bind(metadata)
-    .fetch_optional(pool)
-    .await?;
-
-    datapoint.context(anyhow::anyhow!("Failed to find datapoint by id"))
-}
-
-pub async fn delete_datapoints(pool: &PgPool, datapoint_ids: &Vec<Uuid>) -> Result<()> {
-    sqlx::query("DELETE FROM dataset_datapoints WHERE id in (SELECT * FROM UNNEST($1::uuid[]))")
-        .bind(datapoint_ids)
-        .execute(pool)
-        .await?;
-
-    Ok(())
 }
 
 #[derive(FromRow)]

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -404,6 +404,7 @@ fn main() -> anyhow::Result<()> {
                                 .service(api::v1::datasets::get_datapoints)
                                 .service(api::v1::evaluations::create_evaluation)
                                 .service(api::v1::metrics::process_metrics)
+                                .service(api::v1::semantic_search::semantic_search)
                                 .app_data(PayloadConfig::new(10 * 1024 * 1024)),
                         )
                         // Scopes with generic auth
@@ -493,10 +494,10 @@ fn main() -> anyhow::Result<()> {
                                         )
                                         .service(routes::datasets::delete_dataset)
                                         .service(routes::datasets::upload_datapoint_file)
-                                        .service(routes::datasets::create_datapoints)
+                                        .service(routes::datasets::create_datapoint_embeddings)
                                         .service(routes::datasets::get_datapoints)
-                                        .service(routes::datasets::update_datapoint_data)
-                                        .service(routes::datasets::delete_datapoints)
+                                        .service(routes::datasets::update_datapoint_embeddings)
+                                        .service(routes::datasets::delete_datapoint_embeddings)
                                         .service(routes::datasets::delete_all_datapoints)
                                         .service(routes::datasets::index_dataset)
                                         .service(routes::traces::get_traces)

--- a/app-server/src/pipeline/nodes/semantic_search_utils.rs
+++ b/app-server/src/pipeline/nodes/semantic_search_utils.rs
@@ -38,6 +38,7 @@ pub(super) fn render_query_res_point(
 ) -> String {
     let mut data = res_point.data.clone();
     data.insert("relevance_index".to_string(), relevance_index.to_string());
+    data.insert("score".to_string(), res_point.score.to_string());
     let inputs: HashMap<String, NodeInput> = data.into_iter().map(|(k, v)| (k, v.into())).collect();
     render_template(template, &inputs)
 }

--- a/app-server/src/routes/datasets.rs
+++ b/app-server/src/routes/datasets.rs
@@ -7,13 +7,17 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::{
-    datasets::{datapoints, utils::read_multipart_file},
+    datasets::{
+        datapoints::{self, Datapoint},
+        utils::{index_new_points, read_multipart_file},
+    },
     db::{self, datapoints::DatapointView, datasets, DB},
     routes::{PaginatedGetQueryParams, PaginatedResponse, ResponseResult},
     semantic_search::SemanticSearch,
 };
 
 const DEFAULT_PAGE_SIZE: usize = 50;
+const BATCH_SIZE: usize = 50;
 
 #[delete("datasets/{dataset_id}")]
 async fn delete_dataset(
@@ -69,90 +73,95 @@ async fn upload_datapoint_file(
         datapoints::insert_datapoints_from_file(&bytes, &filename, dataset_id, db.clone()).await?;
 
     if indexed_on.is_some() {
-        dataset
-            .index_new_points(
-                datapoints.clone(),
-                semantic_search.as_ref().clone(),
-                project_id.to_string(),
-                indexed_on,
-            )
-            .await?;
+        index_new_points(
+            datapoints.clone(),
+            semantic_search.as_ref().clone(),
+            project_id.to_string(),
+            indexed_on,
+        )
+        .await?;
     }
 
     Ok(HttpResponse::Ok().json(datapoints))
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CreateDatapointsRequest {
     datapoints: Vec<serde_json::Value>,
+    indexed_on: String,
 }
 
 #[post("datasets/{dataset_id}/datapoints")]
-async fn create_datapoints(
+async fn create_datapoint_embeddings(
     path: web::Path<(Uuid, Uuid)>,
-    db: web::Data<DB>,
     req: web::Json<CreateDatapointsRequest>,
     semantic_search: web::Data<Arc<dyn SemanticSearch>>,
 ) -> ResponseResult {
     let (project_id, dataset_id) = path.into_inner();
-    let input_datapoints = req.into_inner().datapoints;
+    let req = req.into_inner();
+    let indexed_on = req.indexed_on;
+    let input_datapoints = req.datapoints;
 
-    let dataset = db::datasets::get_dataset(&db.pool, project_id, dataset_id).await?;
+    let datapoints = input_datapoints
+        .iter()
+        .filter_map(|value| Datapoint::try_from_raw_value(dataset_id.to_owned(), value))
+        .collect::<Vec<_>>();
 
-    let datapoints =
-        db::datapoints::insert_raw_data(&db.pool, &dataset_id, &input_datapoints).await?;
-
-    if dataset.indexed_on.is_some() {
-        dataset
-            .index_new_points(
-                datapoints.clone(),
-                semantic_search.as_ref().clone(),
-                project_id.to_string(),
-                dataset.indexed_on.clone(),
-            )
-            .await?;
-    }
+    index_new_points(
+        datapoints.clone(),
+        semantic_search.as_ref().clone(),
+        project_id.to_string(),
+        Some(indexed_on),
+    )
+    .await?;
 
     Ok(HttpResponse::Ok().json(datapoints))
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct UpdateDatapointRequest {
     data: Value,
-    target: Value,
+    target: Option<Value>,
     metadata: Option<Value>,
+    indexed_on: String,
 }
 
 #[post("datasets/{dataset_id}/datapoints/{datapoint_id}")]
-async fn update_datapoint_data(
+async fn update_datapoint_embeddings(
     path: web::Path<(Uuid, Uuid, Uuid)>,
-    db: web::Data<DB>,
     req: web::Json<UpdateDatapointRequest>,
     semantic_search: web::Data<Arc<dyn SemanticSearch>>,
 ) -> ResponseResult {
     let (project_id, dataset_id, datapoint_id) = path.into_inner();
     let req = req.into_inner();
 
-    let updated_datapoint = db::datapoints::update_datapoint(
-        &db.pool,
-        &datapoint_id,
-        &req.data,
-        &req.target,
-        &req.metadata,
+    semantic_search
+        .delete_embeddings(
+            &project_id.to_string(),
+            vec![HashMap::from([(
+                "id".to_string(),
+                datapoint_id.to_string(),
+            )])],
+        )
+        .await?;
+
+    let updated_datapoint = Datapoint {
+        id: datapoint_id,
+        dataset_id,
+        data: req.data,
+        target: req.target,
+        metadata: req.metadata,
+    };
+
+    index_new_points(
+        vec![updated_datapoint.clone()],
+        semantic_search.as_ref().clone(),
+        project_id.to_string(),
+        Some(req.indexed_on),
     )
     .await?;
-
-    let dataset = db::datasets::get_dataset(&db.pool, project_id, dataset_id).await?;
-    if dataset.indexed_on.is_some() {
-        dataset
-            .index_new_points(
-                vec![updated_datapoint.clone()],
-                semantic_search.as_ref().clone(),
-                project_id.to_string(),
-                dataset.indexed_on.clone(),
-            )
-            .await?;
-    }
 
     Ok(HttpResponse::Ok().json(updated_datapoint))
 }
@@ -163,23 +172,25 @@ pub struct DeleteDatapointRequest {
 }
 
 #[delete("datasets/{dataset_id}/datapoints")]
-async fn delete_datapoints(
+async fn delete_datapoint_embeddings(
     path: web::Path<(Uuid, Uuid)>,
-    db: web::Data<DB>,
     req: web::Json<DeleteDatapointRequest>,
     semantic_search: web::Data<Arc<dyn SemanticSearch>>,
 ) -> ResponseResult {
-    let (project_id, _dataset_id) = path.into_inner();
+    let (project_id, dataset_id) = path.into_inner();
     let datapoint_ids = req.into_inner().ids;
-
-    db::datapoints::delete_datapoints(&db.pool, &datapoint_ids).await?;
 
     semantic_search
         .delete_embeddings(
             &project_id.to_string(),
             datapoint_ids
                 .iter()
-                .map(|id| HashMap::from([("id".to_string(), id.to_string())]))
+                .map(|id| {
+                    HashMap::from([
+                        ("id".to_string(), id.to_string()),
+                        ("datasource_id".to_string(), dataset_id.to_string()),
+                    ])
+                })
                 .collect::<Vec<_>>(),
         )
         .await?;
@@ -252,8 +263,8 @@ async fn index_dataset(
         return Ok(HttpResponse::Ok().json(dataset));
     }
 
-    // TODO: batch process this in pages
     let datapoints = db::datapoints::get_all_datapoints(&db.pool, dataset_id).await?;
+
     // First, delete old embeddings
     if dataset.indexed_on.is_some() {
         semantic_search
@@ -266,17 +277,17 @@ async fn index_dataset(
             )
             .await?;
     }
-
-    // Then, index all embeddings
-    if index_column.is_some() {
-        dataset
-            .index_new_points(
-                datapoints.clone(),
+    for batch in datapoints.chunks(BATCH_SIZE) {
+        // Then, index all embeddings
+        if index_column.is_some() {
+            index_new_points(
+                batch.to_vec(),
                 semantic_search.as_ref().clone(),
                 project_id.to_string(),
                 index_column.clone(),
             )
             .await?;
+        }
     }
 
     let dataset =

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,6 +1,7 @@
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=next_secret_abc
 BACKEND_URL=http://localhost:8000
+SEMANTIC_SEARCH_URL=http://localhost:8080
 NEXT_OTEL_FETCH_DISABLED=1
 SHARED_SECRET_TOKEN=some_secret
 

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -3,6 +3,10 @@
     "next/core-web-vitals",
     "prettier"
   ],
+  "ignorePatterns": [
+    "lib/semantic-search/generated/**/*.js",
+    "lib/semantic-search/generated/**/*.mjs"
+  ],
   "rules": {
     "indent": [
       "error",

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -3,10 +3,6 @@
     "next/core-web-vitals",
     "prettier"
   ],
-  "ignorePatterns": [
-    "lib/semantic-search/generated/**/*.js",
-    "lib/semantic-search/generated/**/*.mjs"
-  ],
   "rules": {
     "indent": [
       "error",

--- a/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/route.ts
+++ b/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/route.ts
@@ -125,9 +125,6 @@ export async function DELETE(
   const datapointIds = searchParams.get('datapointIds')?.split(',');
   const indexedOn = searchParams.get('indexedOn');
 
-  console.log('indexedOn', indexedOn);
-  console.log('datapointIds', datapointIds);
-
   if (!datapointIds) {
     return new Response('At least one Datapoint ID is required', { status: 400 });
   }

--- a/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/route.ts
+++ b/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/route.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray } from 'drizzle-orm';
-import { datapointToSpan, datasetDatapoints } from '@/lib/db/migrations/schema';
+import { datapointToSpan, datasetDatapoints, datasets } from '@/lib/db/migrations/schema';
 
 import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db/drizzle';
@@ -44,8 +44,6 @@ export async function POST(
   const projectId = params.projectId;
   const datasetId = params.datasetId;
 
-
-
   const body = await req.json();
 
   // Validate request body
@@ -81,6 +79,34 @@ export async function POST(
     ).returning();
   }
 
+  const dataset = await db.query.datasets.findFirst({
+    where: and(eq(datasets.id, datasetId), eq(datasets.projectId, projectId)),
+  });
+
+  if (dataset?.indexedOn != null && res.length > 0) {
+    const session = await getServerSession(authOptions);
+    const user = session!.user;
+    await fetcher(
+      `/projects/${projectId}/datasets/${datasetId}/datapoints`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${user.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          datapoints: res.map((datapoint) => ({
+            id: datapoint.id,
+            data: datapoint.data,
+            target: datapoint.target,
+            metadata: datapoint.metadata,
+          })),
+          indexedOn: dataset?.indexedOn
+        })
+      }
+    );
+  }
+
   if (res.length === 0) {
     return new Response('Error creating datasetDatapoints', { status: 500 });
   }
@@ -95,10 +121,12 @@ export async function DELETE(
   const projectId = params.projectId;
   const datasetId = params.datasetId;
 
-
-
   const { searchParams } = new URL(req.url);
   const datapointIds = searchParams.get('datapointIds')?.split(',');
+  const indexedOn = searchParams.get('indexedOn');
+
+  console.log('indexedOn', indexedOn);
+  console.log('datapointIds', datapointIds);
 
   if (!datapointIds) {
     return new Response('At least one Datapoint ID is required', { status: 400 });
@@ -112,6 +140,22 @@ export async function DELETE(
           eq(datasetDatapoints.datasetId, datasetId)
         )
       );
+
+    if (indexedOn != null) {
+      const session = await getServerSession(authOptions);
+      const user = session!.user;
+      await fetcher(
+        `/projects/${projectId}/datasets/${datasetId}/datapoints`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${user.apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ ids: datapointIds })
+        }
+      );
+    }
 
     return new Response('datasetDatapoints deleted successfully', { status: 200 });
   } catch (error) {

--- a/frontend/components/dataset/dataset-panel.tsx
+++ b/frontend/components/dataset/dataset-panel.tsx
@@ -5,7 +5,7 @@ import { Button } from '../ui/button';
 import { Datapoint } from '@/lib/dataset/types';
 import Formatter from '../ui/formatter';
 import { Label } from '../ui/label';
-import Mono from '../ui/mono';
+import MonoWithCopy from '../ui/mono-with-copy';
 import { ScrollArea } from '../ui/scroll-area';
 import { Skeleton } from '../ui/skeleton';
 import { useProjectContext } from '@/contexts/project-context';
@@ -13,6 +13,7 @@ import { useToast } from '@/lib/hooks/use-toast';
 
 interface DatasetPanelProps {
   datasetId: string;
+  indexedOn: string | null;
   datapoint: Datapoint;
   onClose: () => void;
 }
@@ -21,6 +22,7 @@ const AUTO_SAVE_TIMEOUT_MS = 750;
 
 export default function DatasetPanel({
   datasetId,
+  indexedOn,
   datapoint,
   onClose,
 }: DatasetPanelProps) {
@@ -58,7 +60,8 @@ export default function DatasetPanel({
         body: JSON.stringify({
           data: newData,
           target: newTarget,
-          metadata: newMetadata
+          metadata: newMetadata,
+          indexedOn
         })
       }
     );
@@ -107,7 +110,7 @@ export default function DatasetPanel({
           <ChevronsRight />
         </Button>
         <div>Row</div>
-        <Mono className="text-secondary-foreground mt-0.5">{datapoint.id}</Mono>
+        <MonoWithCopy className="text-secondary-foreground mt-0.5">{datapoint.id}</MonoWithCopy>
         {saving && <div className='flex text-secondary-foreground text-sm'>
           <Loader2 className="animate-spin h-4 w-4 mr-2 mt-0.5" />
           Saving

--- a/frontend/components/dataset/index-dataset-dialog.tsx
+++ b/frontend/components/dataset/index-dataset-dialog.tsx
@@ -6,15 +6,17 @@ import {
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog';
-import { Loader2, NotepadText } from 'lucide-react';
 import React, { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import { Dataset } from '@/lib/dataset/types';
 import { Input } from '../ui/input';
 import { Label } from '@/components/ui/label';
+import Link from 'next/link';
+import { Loader2 } from 'lucide-react';
 import { useProjectContext } from '@/contexts/project-context';
-import { useToast } from '../../lib/hooks/use-toast';
+import { useToast } from '@/lib/hooks/use-toast';
 
 interface IndexDatasetDialogProps {
   datasetId: string;
@@ -43,7 +45,7 @@ export default function IndexDatasetDialog({
       `/api/projects/${projectId}/datasets/${datasetId}/index`,
       {
         method: 'POST',
-        body: JSON.stringify({ indexColumn: selectedIndexKey }),
+        body: JSON.stringify({ indexColumn: selectedIndexKey !== '' ? selectedIndexKey : null }),
         cache: 'no-cache'
       }
     );
@@ -71,21 +73,35 @@ export default function IndexDatasetDialog({
   return (
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline" className="h-7 ml-4">
-          <NotepadText className="w-4 mr-1 text-gray-500" />
-          Index
-        </Button>
+        {defaultDataset.indexedOn ? (
+          <div
+            className={cn(
+              'text-sm text-secondary-foreground cursor-pointer rounded border py-0.5 px-2',
+              'border-primary bg-primary/10 text-primary'
+            )}
+          >
+            Indexed on {`'${defaultDataset.indexedOn}'`} key
+          </div>
+        ) : (
+          <Button variant="outline">Not indexed</Button>
+        )}
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>Index dataset</DialogTitle>
         </DialogHeader>
         <Label>
-          Type the key to index this dataset on for semantic search.
+          Type the key from datapoint {'"'}data{'"'} to index this dataset.
         </Label>
-        <Label className="text-sm text-slate-400">
-          {'New datapoints are indexed automatically. ' +
-            'Only datapoints with this key in data" will be indexed.'}
+        <Label className="text-sm text-secondary-foreground">
+          New datapoints are indexed automatically.{' '}
+          <Link
+            className="text-primary"
+            href="https://docs.lmnr.ai/datasets/indexing"
+            target="_blank"
+          >
+            Learn more
+          </Link>
         </Label>
         <Input
           defaultValue={defaultDataset?.indexedOn ?? ''}
@@ -96,14 +112,13 @@ export default function IndexDatasetDialog({
             className="my-4"
             disabled={
               isLoading ||
-              !selectedIndexKey ||
               selectedIndexKey === defaultDataset.indexedOn
             }
             onClick={async () => await indexDataset()}
             handleEnter
           >
             {isLoading && <Loader2 className="animate-spin h-4 w-4 mr-2" />}
-            Index
+            {selectedIndexKey === '' ? 'Unindex' : 'Index'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/components/dataset/manual-add-datapoint-dialog.tsx
+++ b/frontend/components/dataset/manual-add-datapoint-dialog.tsx
@@ -106,7 +106,7 @@ export default function ManualAddDatapointDialog({
         </div>
         {!isValidJson() && (
           <div className="text-red-500">
-            Please enter a valid JSON map with a &dquote;data&dquote; field
+            Please enter a valid JSON map that has a {'"'}data{'"'} key
           </div>
         )}
         <DialogFooter className="mt-4">

--- a/frontend/components/event/event-view.tsx
+++ b/frontend/components/event/event-view.tsx
@@ -6,6 +6,7 @@ import { Event } from '@/lib/events/types';
 import Formatter from '../ui/formatter';
 import { Label } from '../ui/label';
 import Mono from '../ui/mono';
+import MonoWithCopy from '../ui/mono-with-copy';
 import { ScrollArea } from '../ui/scroll-area';
 import { Span } from '@/lib/traces/types';
 import { useProjectContext } from '@/contexts/project-context';
@@ -34,7 +35,7 @@ export default function EventView({ onClose, event }: EventViewProps) {
             <ChevronsRight />
           </Button>
           <div>Event</div>
-          <Mono className="text-secondary-foreground">{event.id}</Mono>
+          <MonoWithCopy>{event.id}</MonoWithCopy>
         </div>
         <div className="flex-grow flex-col flex space-y-2 p-4">
           <div className="flex justify-between">

--- a/frontend/components/pipeline/nodes/semantic-search-node.tsx
+++ b/frontend/components/pipeline/nodes/semantic-search-node.tsx
@@ -2,8 +2,9 @@ import { Database, X } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
-  DialogHeader,
+  DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog';
 import { memo, useState } from 'react';
@@ -14,8 +15,10 @@ import DatasetSelect from '@/components/ui/dataset-select';
 import DefaultTextarea from '@/components/ui/default-textarea';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import Link from 'next/link';
 import { type SemanticSearchNode } from '@/lib/flow/types';
 import { Slider } from '@/components/ui/slider';
+import { useProjectContext } from '@/contexts/project-context';
 import useStore from '@/lib/flow/store';
 
 const SemanticSearchNodeComponent = ({
@@ -25,6 +28,7 @@ const SemanticSearchNodeComponent = ({
 }) => {
   const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const { projectId } = useProjectContext();
 
   const id = data.id;
   const updateNodeData = useStore((state) => state.updateNodeData);
@@ -90,15 +94,16 @@ const SemanticSearchNodeComponent = ({
               className="mt-2"
               onClick={() => setDialogOpen(true)}
             >
-              Add datasource
+              Add dataset
             </Button>
           </DialogTrigger>
           <DialogContent className="md:max-w-[400px]">
-            <DialogHeader>
-              <h1 className="text-lg font-semibold">New datasource</h1>
-            </DialogHeader>
-            <Label>Dataset</Label>
+            <DialogTitle>New dataset</DialogTitle>
+            <DialogDescription>
+              Select dataset. Only indexed datasets are shown.
+            </DialogDescription>
             <DatasetSelect
+              onlyShowIndexed
               onDatasetChange={(dataset) => {
                 setSelectedDataset(dataset);
               }}
@@ -126,9 +131,15 @@ const SemanticSearchNodeComponent = ({
               className="mt-2 flex h-10 items-center space-x-2 rounded bg-secondary p-2 border group"
             >
               <Database size={14} />
-              <Label className="truncate">{(dataset as Dataset).name}</Label>
+              <Label className="truncate">
+                <Link href={`/project/${projectId}/datasets/${dataset.id}`}>{dataset.name}</Link>
+              </Label>
+              <Label className="text-xs text-muted-foreground">
+                indexed on {`'${dataset.indexedOn}'`}
+              </Label>
               <div className="flex-grow"></div>
-              <button
+              <Button
+                variant={'ghost'}
                 className="hidden group-hover:block"
                 onClick={() => {
                   updateNodeData(id, {
@@ -137,7 +148,7 @@ const SemanticSearchNodeComponent = ({
                 }}
               >
                 <X size={14} />
-              </button>
+              </Button>
             </div>
           ))}
         </div>

--- a/frontend/components/pipeline/pipeline-history.tsx
+++ b/frontend/components/pipeline/pipeline-history.tsx
@@ -76,9 +76,11 @@ export default function PipelineHistory({
   //   if (!selectedRunTrace) {
   //     return;
   //   }
-  //   fetch(`/api/projects/${projectId}/traces/trace/${selectedRunTrace?.runId}`).then((res) => res.json()).then((data) => {
-  //     setFullTrace(data)
-  //   })
+  //   fetch(`/api/projects/${projectId}/traces/trace/${selectedRunTrace?.runId}`)
+  //     .then((res) => res.json())
+  //     .then((data) => {
+  //       setFullTrace(data)
+  //     })
   // }, [selectedRunTrace])
 
   // useEffect(() => {

--- a/frontend/components/pipeline/pipeline-outputs.tsx
+++ b/frontend/components/pipeline/pipeline-outputs.tsx
@@ -306,6 +306,7 @@ export default function PipelineOutputs({
 
     runId.current = v4();
     setRunTrace(undefined);
+    console.log(JSON.stringify(graph.toObject(), null, 2));
 
     const response = await fetch(
       `/api/projects/${projectId}/pipelines/run/graph`,

--- a/frontend/components/pipeline/pipeline-trace.tsx
+++ b/frontend/components/pipeline/pipeline-trace.tsx
@@ -53,7 +53,8 @@ export default function PipelineTrace({}: PipelineTraceProps) {
               let inputNodes
 
               if (mode === PipelineExecutionMode.Node && focusedNodeId) {
-                inputNodes = Array.from(getRunGraph().nodes.values()).filter(node => node.type === NodeType.INPUT) as InputNode[];
+                inputNodes = Array.from(getRunGraph().nodes.values())
+                  .filter(node => node.type === NodeType.INPUT) as InputNode[];
               } else {
                 // Private pipelines will only come here if they are not in Unit test mode
                 // Public pipelines don't have Unit test mode and will always come here

--- a/frontend/components/pipeline/pipeline.tsx
+++ b/frontend/components/pipeline/pipeline.tsx
@@ -440,7 +440,8 @@ export default function Pipeline({ pipeline, isSupabaseEnabled }: PipelineProps)
   useEffect(() => {
     if (!selectedPipelineVersion) return;
 
-    // The node may be focused, but if we're not in Node execution mode, we're still working with whole pipeline's inputs.
+    // The node may be focused, but if we're not in Node execution mode,
+    // we're still working with whole pipeline's inputs.
     let storeFocusedNodeId =
       mode === PipelineExecutionMode.Node ? focusedNodeId : null;
     setStoredInputs(selectedPipelineVersion.id!, storeFocusedNodeId, allInputs);

--- a/frontend/components/pipelines/create-pipeline-dialog.tsx
+++ b/frontend/components/pipelines/create-pipeline-dialog.tsx
@@ -64,7 +64,8 @@ export function CreatePipelineDialog({ onUpdate }: CreatePipelineDialogProps) {
     });
 
     if (res.status !== 200) {
-      // Just a generic error message, since most likely the error has happened because the pipeline with the same name already exists.
+      // Just a generic error message, since most likely the error
+      // has happened because the pipeline with the same name already exists.
       toast({
         title: 'Error creating pipeline',
         description: 'Pipeline name must be unique in the project',

--- a/frontend/components/pipelines/update-pipeline-dialog.tsx
+++ b/frontend/components/pipelines/update-pipeline-dialog.tsx
@@ -74,10 +74,9 @@ export function UpdatePipelineDialog({
         </DialogTrigger>
         <DialogContent
           className="sm:max-w-[425px]"
-          aria-description="Edit pipeline"
         >
           <DialogHeader>
-            <DialogTitle>Edit pipeline {oldPipeline.name}</DialogTitle>
+            <DialogTitle>Rename pipeline</DialogTitle>
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <Label>Name</Label>

--- a/frontend/components/queue/queue.tsx
+++ b/frontend/components/queue/queue.tsx
@@ -14,6 +14,7 @@ import Header from '../ui/header';
 import { isChatMessageList } from '@/lib/flow/utils';
 import { Label } from '../ui/label';
 import { Labels } from './labels';
+import MonoWithCopy from "../ui/mono-with-copy";
 import { ScrollArea } from '../ui/scroll-area';
 import { Switch } from '../ui/switch';
 import { useProjectContext } from '@/contexts/project-context';
@@ -103,7 +104,12 @@ export default function Queue({ queue }: QueueProps) {
                 <ScrollArea className="flex overflow-auto w-full mt-0">
                   <div className="flex flex-col max-h-0">
                     <div className="flex flex-col p-4 gap-4">
-                      <Label className="text-xs text-secondary-foreground font-mono">Span id {data.span.spanId}</Label>
+                      <div className="flex items-center space-x-2">
+                        <Label className="text-xs text-secondary-foreground font-mono">Span id</Label>
+                        <MonoWithCopy className="text-secondary-foreground">
+                          {data.span.spanId.replace(/^00000000-0000-0000-/g, '')}
+                        </MonoWithCopy>
+                      </div>
                       <div className="w-full h-full">
                         <div className="pb-2 font-medium text-lg">Input</div>
                         {isChatMessageList(data.span.input) ? (

--- a/frontend/components/traces/chat-message-list-tab.tsx
+++ b/frontend/components/traces/chat-message-list-tab.tsx
@@ -23,11 +23,11 @@ interface ContentPartImageProps {
 }
 
 function ContentPartImage({ b64_data }: ContentPartImageProps) {
-  return <img className="" src={`data:image/png;base64,${b64_data}`} />;
+  return <img src={`data:image/png;base64,${b64_data}`} alt="span image" />;
 }
 
 function ContentPartImageUrl(url: string) {
-  return <img src={url} />;
+  return <img src={url} alt="span image" />;
 }
 
 interface ContentPartsProps {

--- a/frontend/components/traces/trace-view.tsx
+++ b/frontend/components/traces/trace-view.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import { Button } from '../ui/button';
 import { ChevronsRight } from 'lucide-react';
-import Mono from '../ui/mono';
+import MonoWithCopy from '../ui/mono-with-copy';
 import { Skeleton } from '../ui/skeleton';
 import { Span } from '@/lib/traces/types';
 import { SpanCard } from './span-card';
@@ -150,7 +150,7 @@ export default function TraceView({ traceId, onClose }: TraceViewProps) {
           <ChevronsRight />
         </Button>
         <div>Trace</div>
-        <Mono className="text-secondary-foreground">{traceId}</Mono>
+        <MonoWithCopy className="text-secondary-foreground">{traceId}</MonoWithCopy>
         <div className="flex-grow" />
         <div>
           {selectedSpan && (

--- a/frontend/components/ui/dataset-select.tsx
+++ b/frontend/components/ui/dataset-select.tsx
@@ -14,11 +14,13 @@ import { useProjectContext } from '@/contexts/project-context';
 interface DatasetSelectProps {
   onDatasetChange: (dataset: Dataset) => void;
   selectedDatasetId?: string;
+  onlyShowIndexed?: boolean;
 }
 
 export default function DatasetSelect({
   onDatasetChange,
-  selectedDatasetId
+  selectedDatasetId,
+  onlyShowIndexed
 }: DatasetSelectProps) {
   const { projectId } = useProjectContext();
   const [datasets, setDatasets] = useState<Dataset[]>([]);
@@ -27,7 +29,7 @@ export default function DatasetSelect({
     fetch(`/api/projects/${projectId}/datasets`)
       .then((res) => res.json())
       .then((datasets: PaginatedResponse<Dataset>) => {
-        setDatasets(datasets.items);
+        setDatasets(onlyShowIndexed ? datasets.items.filter(dataset => dataset.indexedOn != null) : datasets.items);
       });
   }, []);
 

--- a/frontend/components/ui/mono-with-copy.tsx
+++ b/frontend/components/ui/mono-with-copy.tsx
@@ -1,0 +1,27 @@
+import { Copy } from 'lucide-react';
+import CopyToClipboard from './copy-to-clipboard';
+import Mono from '@/components/ui/mono';
+
+interface MonoWithCopyProps {
+  children: React.ReactNode;
+  className?: string;
+  copySize?: number;
+}
+
+export default function MonoWithCopy({
+  children,
+  className,
+  copySize
+}: MonoWithCopyProps) {
+  return (
+    <div className="flex items-center group space-x-2">
+      <Mono className={className}>{children}</Mono>
+      <CopyToClipboard
+        text={children as string}
+        className="hidden group-hover:block max-h-4"
+      >
+        <Copy size={copySize ?? 16} />
+      </CopyToClipboard>
+    </div>
+  );
+}

--- a/frontend/components/ui/mono-with-copy.tsx
+++ b/frontend/components/ui/mono-with-copy.tsx
@@ -17,7 +17,7 @@ export default function MonoWithCopy({
     <div className="flex items-center group space-x-2">
       <Mono className={className}>{children}</Mono>
       <CopyToClipboard
-        text={children as string}
+        text={String(children)}
         className="hidden group-hover:block max-h-4"
       >
         <Copy size={copySize ?? 16} />

--- a/frontend/lib/clickhouse/evaluation-scores.ts
+++ b/frontend/lib/clickhouse/evaluation-scores.ts
@@ -1,7 +1,8 @@
 import { addTimeRangeToQuery, AggregationFunction, aggregationFunctionToCh, TimeRange } from "./utils";
+import { Feature, isFeatureEnabled } from "../features/features";
+
 import { ClickHouseClient } from "@clickhouse/client";
 import { EvaluationTimeProgression } from "../evaluation/types";
-import { Feature, isFeatureEnabled } from "../features/features";
 
 export const getEvaluationTimeProgression = async (
   clickhouseClient: ClickHouseClient,

--- a/frontend/lib/clickhouse/spans.ts
+++ b/frontend/lib/clickhouse/spans.ts
@@ -1,4 +1,3 @@
-import { ClickHouseClient } from "@clickhouse/client";
 import {
   addTimeRangeToQuery,
   AggregationFunction,
@@ -8,8 +7,10 @@ import {
   groupByTimeRelativeStatement,
   TimeRange
 } from "./utils";
-import { GroupByInterval, truncateTimeMap } from "./modifiers";
 import { Feature, isFeatureEnabled } from "../features/features";
+import { GroupByInterval, truncateTimeMap } from "./modifiers";
+
+import { ClickHouseClient } from "@clickhouse/client";
 
 export enum SpanMetricGroupBy {
   Model = 'model',

--- a/frontend/lib/clickhouse/utils.ts
+++ b/frontend/lib/clickhouse/utils.ts
@@ -1,5 +1,6 @@
-import { ClickHouseClient } from "@clickhouse/client";
 import { chStepMap, GroupByInterval, intervalMap, truncateTimeMap } from "./modifiers";
+
+import { ClickHouseClient } from "@clickhouse/client";
 
 interface TimeBounds {
   minTime: number;

--- a/frontend/lib/semantic-cache/types.ts
+++ b/frontend/lib/semantic-cache/types.ts
@@ -1,6 +1,0 @@
-export type SemanticCacheConfig = {
-  semanticCacheEnabled: boolean;
-  semanticCacheDatasetId: string | null;
-  semanticSimilarityThreshold: number | null;
-  semanticCacheDataKey: string | null;
-};

--- a/frontend/lib/traces/utils.ts
+++ b/frontend/lib/traces/utils.ts
@@ -1,5 +1,5 @@
-import { SpanMetricGroupBy } from '../clickhouse/spans';
 import { DatatableFilter } from '../types';
+import { SpanMetricGroupBy } from '../clickhouse/spans';
 import { SpanType } from './types';
 
 export const SPAN_TYPE_TO_COLOR = {

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,10 +1,10 @@
 import * as Y from 'yjs';
-import { GroupByInterval } from './clickhouse/modifiers';
 
 import { ChatMessageContentPart, DatatableFilter } from './types';
 import { type ClassValue, clsx } from 'clsx';
 import { InputVariable, PipelineVisibility } from './pipeline/types';
 
+import { GroupByInterval } from './clickhouse/modifiers';
 import { twMerge } from 'tailwind-merge';
 
 export const TIME_MILLISECONDS_FORMAT = 'timeMilliseconds';


### PR DESCRIPTION
- Expose semantic search as an API
- Revive dataset indexing logic
   - app-server now is a proxy to semantic search indexing jobs
   - frontend does the rest directly with DB via drizzle
- add a `MonoWithCopy` component that allows copying various UUIDs to clipboard 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce semantic search API and dataset indexing logic, with frontend updates for UUID copying and dataset management.
> 
>   - **Backend**:
>     - Add `semantic_search` module in `app-server/src/api/v1/mod.rs` and implement `semantic_search` API in `app-server/src/api/v1/semantic_search.rs`.
>     - Revive dataset indexing logic in `app-server/src/datasets/utils.rs` and `app-server/src/routes/datasets.rs`.
>     - Modify `Datapoint` structure in `app-server/src/datasets/datapoints.rs` to support UUIDs from raw data.
>   - **Frontend**:
>     - Add `MonoWithCopy` component in `frontend/components/ui/mono-with-copy.tsx` for copying UUIDs.
>     - Update dataset management in `frontend/components/dataset/dataset.tsx` and `frontend/components/dataset/dataset-panel.tsx` to support new indexing logic.
>     - Enhance semantic search node in `frontend/components/pipeline/nodes/semantic-search-node.tsx` to only show indexed datasets.
>   - **Configuration**:
>     - Add `SEMANTIC_SEARCH_URL` to `frontend/.env.local.example` for semantic search service configuration.
>   - **Miscellaneous**:
>     - Update ESLint configuration in `frontend/.eslintrc.json` to ignore generated semantic search files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d62c6fb18a1318a8d924186065051edf2c028528. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->