### PR TITLE
minor fixes to react render

### DIFF
--- a/frontend/components/evaluations/evaluations-groups-bar.tsx
+++ b/frontend/components/evaluations/evaluations-groups-bar.tsx
@@ -3,6 +3,7 @@ import ClientTimestampFormatter from "../client-timestamp-formatter";
 import { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "../ui/datatable";
 import { swrFetcher } from "@/lib/utils";
+import { useEffect } from "react";
 import { useProjectContext } from "@/contexts/project-context";
 import useSWR from "swr";
 
@@ -17,9 +18,11 @@ export default function EvaluationsGroupsBar() {
     swrFetcher,
   );
 
-  if (groups && groups.length > 0 && !searchParams.get('groupId')) {
-    router.push(`/project/${projectId}/evaluations?groupId=${groups[0].groupId}`);
-  }
+  useEffect(() => {
+    if (groups && groups.length > 0 && !searchParams.get('groupId')) {
+      router.replace(`/project/${projectId}/evaluations?groupId=${groups[0].groupId}`);
+    }
+  }, [groups, searchParams, router, projectId]);
 
   const columns: ColumnDef<{ groupId: string, lastEvaluationCreatedAt: string }>[] = [
     {

--- a/frontend/components/ui/mono-with-copy.tsx
+++ b/frontend/components/ui/mono-with-copy.tsx
@@ -17,7 +17,8 @@ export default function MonoWithCopy({
     <div className="flex items-center group space-x-2">
       <Mono className={className}>{children}</Mono>
       <CopyToClipboard
-        text={String(children)}
+        // this is intentional, so that this fails if the children is not a string
+        text={children as string}
         className="hidden group-hover:block max-h-4"
       >
         <Copy size={copySize ?? 16} />


### PR DESCRIPTION
1. Update route using `useEffect` because on some loads there was a warning about setting state while rendering
2. Force type cast instead of convert so that we don't use Mono like it is not intended. This is hacky, but better than silently stringifying internal react.