### PR TITLE
fetch dataset optionally from db to handle gracefully

### DIFF
--- a/app-server/src/db/datasets.rs
+++ b/app-server/src/db/datasets.rs
@@ -1,10 +1,14 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::datasets::Dataset;
 
-pub async fn get_dataset(pool: &PgPool, project_id: Uuid, dataset_id: Uuid) -> Result<Dataset> {
+pub async fn get_dataset(
+    pool: &PgPool,
+    project_id: Uuid,
+    dataset_id: Uuid,
+) -> Result<Option<Dataset>> {
     let dataset = sqlx::query_as::<_, Dataset>(
         "SELECT id, created_at, name, project_id, indexed_on FROM datasets WHERE id = $1 AND project_id = $2",
     )
@@ -12,8 +16,7 @@ pub async fn get_dataset(pool: &PgPool, project_id: Uuid, dataset_id: Uuid) -> R
     .bind(project_id)
     .fetch_optional(pool)
     .await?;
-
-    dataset.context("Dataset with such id and project_id not found")
+    Ok(dataset)
 }
 
 pub async fn delete_dataset(pool: &PgPool, dataset_id: Uuid) -> Result<()> {

--- a/app-server/src/routes/datasets.rs
+++ b/app-server/src/routes/datasets.rs
@@ -57,7 +57,9 @@ async fn upload_datapoint_file(
 
     let (filename, is_unstructured_file, bytes) = read_multipart_file(payload).await?;
 
-    let dataset = db::datasets::get_dataset(&db.pool, project_id, dataset_id).await?;
+    let Some(dataset) = db::datasets::get_dataset(&db.pool, project_id, dataset_id).await? else {
+        return Ok(HttpResponse::NotFound().body("Dataset not found"));
+    };
 
     let mut indexed_on = dataset.indexed_on.clone();
     if indexed_on.is_none() && is_unstructured_file {
@@ -257,7 +259,9 @@ async fn index_dataset(
 ) -> ResponseResult {
     let (project_id, dataset_id) = path.into_inner();
     let index_column = &request.index_column;
-    let dataset = db::datasets::get_dataset(&db.pool, project_id, dataset_id).await?;
+    let Some(dataset) = db::datasets::get_dataset(&db.pool, project_id, dataset_id).await? else {
+        return Ok(HttpResponse::NotFound().body("Dataset not found"));
+    };
 
     if &dataset.indexed_on == index_column {
         return Ok(HttpResponse::Ok().json(dataset));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve dataset fetching by returning 404 for non-existent datasets in `semantic_search`, `upload_datapoint_file`, and `index_dataset`.
> 
>   - **Behavior**:
>     - `semantic_search` in `semantic_search.rs` now checks if a dataset exists and returns 404 if not found.
>     - `upload_datapoint_file` and `index_dataset` in `routes/datasets.rs` now return 404 if dataset is not found.
>   - **Database**:
>     - `get_dataset` in `datasets.rs` now returns `Option<Dataset>` instead of throwing an error if not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3c7724fbe979c46e2ac2c070127278e7f11da961. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->