### PR TITLE
add syntax highlighter to blog

### DIFF
--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -59,9 +59,10 @@ export default async function BlogPostPage({ params }: { params: { slug: string 
                 p: (props) => <p className="text-lg py-2" {...props} />,
                 a: (props) => <a className="text-primary underline" {...props} />,
                 blockquote: (props) => <blockquote className="border-l-2 border-primary pl-4 py-2" {...props} />,
-                pre: (props) => <PreHighlighter className="pl-4 py-4" {...props} />, // codeblock
-                code: (props) =>
-                  <span className="text-lg bg-secondary text-primary font-mono px-0.5" {...props} />, // inline code
+                // codeblock
+                pre: (props) => <PreHighlighter className="pl-4 py-4" {...props} />,
+                // inline code
+                code: (props) => <span className="text-lg bg-secondary text-primary font-mono px-0.5" {...props} />,
               }}
             />
           </div>

--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import MDHeading from "@/components/blog/md-heading";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import type { Metadata } from "next";
 import Footer from "@/components/landing/footer";
+import PreHighlighter from "@/components/blog/pre-highlighter";
 
 export const generateMetadata = async ({
   params,
@@ -55,8 +56,12 @@ export default async function BlogPostPage({ params }: { params: { slug: string 
                 h2: (props) => <MDHeading props={props} level={1} />,
                 h3: (props) => <MDHeading props={props} level={2} />,
                 h4: (props) => <MDHeading props={props} level={3} />,
-                p: (props) => <p className="text-lg py-1" {...props} />,
+                p: (props) => <p className="text-lg py-2" {...props} />,
                 a: (props) => <a className="text-primary underline" {...props} />,
+                blockquote: (props) => <blockquote className="border-l-2 border-primary pl-4 py-2" {...props} />,
+                pre: (props) => <PreHighlighter className="pl-4 py-4" {...props} />, // codeblock
+                code: (props) =>
+                  <span className="text-lg bg-secondary text-primary font-mono px-0.5" {...props} />, // inline code
               }}
             />
           </div>

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -27,13 +27,13 @@ export default async function BlogsPage() {
   const posts = getBlogPosts({ sortByDate: true });
   const session = await getServerSession(authOptions);
   return <>
-    <LandingHeader hasSession={session !== null && session !== undefined} />
-    <div className="mt-32 h-full flex justify-center pb-48">
-      <div className="grid grid-cols-1 gap-4 md:w-[1000px] w-full md:grid-cols-3">
+    <div className="h-full">
+      <LandingHeader hasSession={session !== null && session !== undefined} />
+      <div className="mt-32 pb-48 grid grid-cols-1 gap-4 md:w-[1000px] w-full md:grid-cols-3 mx-auto">
         {posts.map((post, index) => (
-          <Link href={`/blog/${post.slug}`} key={index}>
-            <Card key={index} className="overflow-hidden">
-              {post.data.image && <Image src={post.data.image} alt={post.data.title} width={400} height={400} className="object-cover mx-auto"/>}
+          <Link href={`/blog/${post.slug}`} key={index} className="">
+            <Card key={index} className="overflow-hidden h-[350px]">
+              {post.data.image && <Image src={post.data.image} alt={post.data.title} width={400} height={200} className="object-cover mx-auto"/>}
               <CardHeader>
                 <CardTitle>
                   {post.data.title}
@@ -48,7 +48,7 @@ export default async function BlogsPage() {
           </Link>
         ))}
       </div>
+      <Footer />
     </div>
-    <Footer />
   </>;
 }

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -31,7 +31,7 @@ export default async function BlogsPage() {
       <LandingHeader hasSession={session !== null && session !== undefined} />
       <div className="mt-32 pb-48 grid grid-cols-1 gap-4 md:w-[1000px] w-full md:grid-cols-3 mx-auto">
         {posts.map((post, index) => (
-          <Link href={`/blog/${post.slug}`} key={index} className="">
+          <Link href={`/blog/${post.slug}`} key={index}>
             <Card key={index} className="overflow-hidden h-[350px]">
               {post.data.image && <Image src={post.data.image} alt={post.data.title} width={400} height={200} className="object-cover mx-auto"/>}
               <CardHeader>

--- a/frontend/components/blog/pre-highlighter.tsx
+++ b/frontend/components/blog/pre-highlighter.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { cn } from "@/lib/utils";
+import CodeHighlighter from "@/components/ui/code-highlighter";
+import React from "react";
+
+interface PreHighlighterProps {
+  children?: React.ReactElement | React.ReactNode;
+  className?: string;
+}
+
+export default function PreHighlighter({ children, className }: PreHighlighterProps) {
+  if (!children || !React.isValidElement(children)) {
+    return null;
+  }
+  const code = children.props.children;
+  const language = children.props.className.split(" ").find((c: string) => c.startsWith("language-"))?.split("-")[1];
+  return <CodeHighlighter
+    code={code}
+    language={language}
+    className={cn("bg-secondary rounded-md", className)}
+    copyable
+  />;
+}

--- a/frontend/components/ui/code-highlighter.tsx
+++ b/frontend/components/ui/code-highlighter.tsx
@@ -1,3 +1,5 @@
+import { Button } from './button';
+import { CopyIcon } from 'lucide-react';
 import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import React from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -6,15 +8,26 @@ interface CodeProps {
   language?: string;
   code: string;
   className?: string;
+  copyable?: boolean;
 }
 
 export default function CodeHighlighter({
   language,
   code,
-  className
+  className,
+  copyable = false
 }: CodeProps) {
   return (
     <div className={className}>
+      <div className="relative">
+        <Button
+          onClick={() => navigator.clipboard.writeText(code)}
+          className="absolute right-2 top-2"
+          variant="ghost"
+        >
+          <CopyIcon className="w-4 h-4" />
+        </Button>
+      </div>
       <SyntaxHighlighter
         language={language}
         style={oneDark}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add syntax highlighting to blog posts using a new `PreHighlighter` component and update `CodeHighlighter` to include a copy button.
> 
>   - **Components**:
>     - Add `PreHighlighter` component in `pre-highlighter.tsx` to wrap code blocks with syntax highlighting.
>     - Update `CodeHighlighter` in `code-highlighter.tsx` to include a copy button for code blocks.
>   - **Pages**:
>     - Modify `BlogPostPage` in `page.tsx` to use `PreHighlighter` for `pre` elements and adjust styling for `p`, `blockquote`, and `code` elements.
>     - Adjust layout and image dimensions in `BlogsPage` in `page.tsx`.
>   - **Styling**:
>     - Update padding for paragraph elements and add styling for blockquote and inline code in `BlogPostPage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for caaa5bc7067f1b560d06c0cb77d4c9e8283f689d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->