### PR TITLE
make target optional in evals (default to json null)

### DIFF
--- a/app-server/src/evaluations/utils.rs
+++ b/app-server/src/evaluations/utils.rs
@@ -17,6 +17,7 @@ pub struct HumanEvaluator {
 #[serde(rename_all = "camelCase")]
 pub struct EvaluationDatapointResult {
     pub data: Value,
+    #[serde(default)]
     pub target: Value,
     pub executor_output: Option<Value>,
     #[serde(default)]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `target` field in `EvaluationDatapointResult` optional, defaulting to JSON null if not provided.
> 
>   - **Behavior**:
>     - Make `target` field in `EvaluationDatapointResult` optional by adding `#[serde(default)]`, defaulting to JSON null if not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 542acc9e82b11a93ff316c560cad27913f2c03db. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->