### PR TITLE
do not limit eval time progression graph to 7d

### DIFF
--- a/frontend/app/api/projects/[projectId]/evaluation-groups/[groupId]/progression/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluation-groups/[groupId]/progression/route.ts
@@ -16,7 +16,7 @@ export const GET = async (request: NextRequest, { params }: { params: { projectI
     const endDate = new Date(request.nextUrl.searchParams.get('endDate') ?? '');
     timeRange = { start: startDate, end: endDate };
   } else {
-    timeRange = { pastHours: 168 };
+    timeRange = { pastHours: 'all' };
   }
 
   const aggregationFunction = (request.nextUrl.searchParams.get('aggregate') ?? 'AVG') as AggregationFunction;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default time range in `route.ts` from 7 days to unlimited for evaluation time progression data.
> 
>   - **Behavior**:
>     - Change default `timeRange` in `GET` function in `route.ts` from 7 days (`pastHours: 168`) to unlimited (`pastHours: 'all'`).
>     - Affects evaluation time progression data retrieval when no specific time range is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 91b740cf1ed1bf78b5c7a02e1e745bd7f640e09a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->