### PR TITLE
fix evaluation scores graph

### DIFF
--- a/app-server/src/ch/evaluation_scores.rs
+++ b/app-server/src/ch/evaluation_scores.rs
@@ -217,7 +217,7 @@ SELECT
     SUM(CASE
         -- exclusive on upper bound to avoid counting the same value twice
         WHEN (value >= intervals.lower_bound AND value < intervals.upper_bound)
-            OR value = ? THEN 1
+            OR (value = ? AND intervals.interval_num = ?) THEN 1
         ELSE 0
     END) AS height
 FROM evaluation_scores
@@ -236,6 +236,7 @@ ORDER BY intervals.interval_num",
         .bind(lower_bound)
         .bind(step_size)
         .bind(upper_bound)
+        .bind(bucket_count)
         .bind(project_id)
         .bind(evaluation_id)
         .bind(name)


### PR DESCRIPTION
Previously all points that were strictly equal to the upper bound of the last bucket would be added to every bucket
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes SQL query in `evaluation_scores.rs` to correctly handle points equal to the upper bound of the last bucket in evaluation score buckets.
> 
>   - **Behavior**:
>     - Fixes SQL query in `get_evaluation_score_buckets_based_on_bounds()` in `evaluation_scores.rs` to correctly handle points equal to the upper bound of the last bucket.
>     - Adds additional binding for `bucket_count` to ensure correct bucket assignment.
>   - **Misc**:
>     - Updates SQL query logic to prevent double counting of values at bucket boundaries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 0d5b8b0b5a6ce21a011865abae3d6996f7495710. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->