### PR TITLE
add bedrock anthropic prices as anthropic

### DIFF
--- a/frontend/lib/db/seed.json
+++ b/frontend/lib/db/seed.json
@@ -2381,6 +2381,80 @@
         "additional_prices": {}
       },
       {
+        "id": "64ac4ea2-e503-4775-ae64-c536cc28aa0d",
+        "created_at": "2024-12-03 22:51:39.444574+00",
+        "updated_at": "2024-12-03 22:51:39.444574+00",
+        "provider": "anthropic",
+        "model": "claude-3-5-haiku-20241022-v1:0",
+        "input_price_per_million": "1",
+        "output_price_per_million": "5",
+        "input_cached_price_per_million": "",
+        "additional_prices": {}
+      },
+      {
+        "id": "31496f84-c7bb-4283-8330-5cd5032cb363",
+        "created_at": "2024-12-03 22:51:39.444574+00",
+        "updated_at": "2024-12-03 22:51:39.444574+00",
+        "provider": "anthropic",
+        "model": "claude-3-5-sonnet-20240620-v1:0",
+        "input_price_per_million": "3",
+        "output_price_per_million": "15",
+        "input_cached_price_per_million": "0.3",
+        "additional_prices": {
+          "input_caching_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "1ae55a6f-b852-439b-b50e-fc4db324f143",
+        "created_at": "2024-12-03 22:51:39.444574+00",
+        "updated_at": "2024-12-03 22:51:39.444574+00",
+        "provider": "anthropic",
+        "model": "claude-3-5-sonnet-20241022-v2:0",
+        "input_price_per_million": "3",
+        "output_price_per_million": "15",
+        "input_cached_price_per_million": "0.3",
+        "additional_prices": {
+          "input_caching_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "2621499c-70dc-4426-a1d3-7257691deff5",
+        "created_at": "2024-12-03 22:51:39.444574+00",
+        "updated_at": "2024-12-03 22:51:39.444574+00",
+        "provider": "anthropic",
+        "model": "claude-3-haiku-20240307-v1:0",
+        "input_price_per_million": "0.25",
+        "output_price_per_million": "1.25",
+        "input_cached_price_per_million": "0.03",
+        "additional_prices": {
+          "input_caching_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "fa414f72-b29a-4b24-bb30-acc10ba0c341",
+        "created_at": "2024-12-03 22:51:39.444574+00",
+        "updated_at": "2024-12-03 22:51:39.444574+00",
+        "provider": "anthropic",
+        "model": "claude-3-opus-20240229-v1:0",
+        "input_price_per_million": "15",
+        "output_price_per_million": "75",
+        "input_cached_price_per_million": "1.5",
+        "additional_prices": {
+          "input_caching_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "dd46cc51-83c3-421d-91d4-0f3f3c9c3d03",
+        "created_at": "2024-12-03 22:51:39.444574+00",
+        "updated_at": "2024-12-03 22:51:39.444574+00",
+        "provider": "anthropic",
+        "model": "claude-3-sonnet-20240229-v1:0",
+        "input_price_per_million": "3",
+        "output_price_per_million": "15",
+        "input_cached_price_per_million": "",
+        "additional_prices": {}
+      },
+      {
         "id": "1427ff14-26d4-4723-92d9-dbfd939b1ea3",
         "created_at": "2024-10-16 18:18:03.452359+00",
         "updated_at": "2024-10-16 18:18:03.452359+00",

--- a/frontend/lib/db/seed.json
+++ b/frontend/lib/db/seed.json
@@ -2386,9 +2386,9 @@
         "updated_at": "2024-12-03 22:51:39.444574+00",
         "provider": "anthropic",
         "model": "claude-3-5-haiku-20241022-v1:0",
-        "input_price_per_million": "1",
-        "output_price_per_million": "5",
-        "input_cached_price_per_million": "",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": null,
         "additional_prices": {}
       },
       {
@@ -2397,9 +2397,9 @@
         "updated_at": "2024-12-03 22:51:39.444574+00",
         "provider": "anthropic",
         "model": "claude-3-5-sonnet-20240620-v1:0",
-        "input_price_per_million": "3",
-        "output_price_per_million": "15",
-        "input_cached_price_per_million": "0.3",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
         "additional_prices": {
           "input_caching_write_price_per_million": 3.75
         }
@@ -2410,9 +2410,9 @@
         "updated_at": "2024-12-03 22:51:39.444574+00",
         "provider": "anthropic",
         "model": "claude-3-5-sonnet-20241022-v2:0",
-        "input_price_per_million": "3",
-        "output_price_per_million": "15",
-        "input_cached_price_per_million": "0.3",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
         "additional_prices": {
           "input_caching_write_price_per_million": 3.75
         }
@@ -2423,9 +2423,9 @@
         "updated_at": "2024-12-03 22:51:39.444574+00",
         "provider": "anthropic",
         "model": "claude-3-haiku-20240307-v1:0",
-        "input_price_per_million": "0.25",
-        "output_price_per_million": "1.25",
-        "input_cached_price_per_million": "0.03",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
         "additional_prices": {
           "input_caching_write_price_per_million": 0.3
         }
@@ -2436,9 +2436,9 @@
         "updated_at": "2024-12-03 22:51:39.444574+00",
         "provider": "anthropic",
         "model": "claude-3-opus-20240229-v1:0",
-        "input_price_per_million": "15",
-        "output_price_per_million": "75",
-        "input_cached_price_per_million": "1.5",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
         "additional_prices": {
           "input_caching_write_price_per_million": 18.75
         }
@@ -2449,9 +2449,9 @@
         "updated_at": "2024-12-03 22:51:39.444574+00",
         "provider": "anthropic",
         "model": "claude-3-sonnet-20240229-v1:0",
-        "input_price_per_million": "3",
-        "output_price_per_million": "15",
-        "input_cached_price_per_million": "",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
         "additional_prices": {}
       },
       {


### PR DESCRIPTION
OpenLLMetry sends `gen_ai.system` as `anthropic` when calling bedrock anthropic, so duplicate the prices as anthropic as well in the DB
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Added 7 new `anthropic` entries to `llm_prices` in `seed.json`, duplicating `bedrock-anthropic` prices for consistency.
> 
>   - **Database Changes**:
>     - Added 7 new entries to `llm_prices` in `seed.json` for `anthropic` provider.
>     - Models include `claude-3-5-haiku-20241022-v1:0`, `claude-3-5-sonnet-20240620-v1:0`, `claude-3-5-sonnet-20241022-v2:0`, `claude-3-haiku-20240307-v1:0`, `claude-3-opus-20240229-v1:0`, and `claude-3-sonnet-20240229-v1:0`.
>     - Prices are duplicated from `bedrock-anthropic` entries for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 6232c9794f67c81b4e1b9458104e2d95ef4e9d86. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->