### PR TITLE
skip saving traces when specified so with attributes

### DIFF
--- a/app-server/src/traces/producer.rs
+++ b/app-server/src/traces/producer.rs
@@ -36,6 +36,10 @@ pub async fn push_spans_to_queue(
                 for otel_span in scope_span.spans {
                     let mut span = Span::from_otel_span(otel_span.clone());
 
+                    if !span.should_save() {
+                        continue;
+                    }
+
                     let span_usage = super::utils::get_llm_usage_for_span(
                         &mut span.get_attributes(),
                         db.clone(),
@@ -92,6 +96,10 @@ pub async fn push_spans_to_queue(
                     } else {
                         log::warn!("Unknown event type: {}", event_type);
                     }
+                }
+
+                if !span.should_save() {
+                    continue;
                 }
 
                 let rabbitmq_span_message = RabbitMqSpanMessage {


### PR DESCRIPTION
Add an attribute `lmnr.internal.tracing_level` that can be one of `off`, `meta_only`, and `all` that controls whether to save inputs and outputs for spans or to skip spans altogether
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `lmnr.internal.tracing_level` attribute to control span saving behavior in `producer.rs` and `spans.rs`.
> 
>   - **Behavior**:
>     - Introduces `lmnr.internal.tracing_level` attribute to control span saving.
>     - `TracingLevel` enum with values `Off`, `MetaOnly`, `All`.
>     - `Span::should_save()` checks `tracing_level` to skip saving spans if `Off`.
>     - If `MetaOnly`, `Span::from_otel_span()` sets `input` and `output` to `None`.
>   - **Functions**:
>     - `Span::should_save()` in `spans.rs`.
>     - `SpanAttributes::tracing_level()` in `spans.rs`.
>   - **Files**:
>     - Updates in `producer.rs` to skip spans based on `should_save()`.
>     - Updates in `spans.rs` to handle `tracing_level`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 864a992b54551fd9e437ddd8a097d76b46da1e71. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->