### PR TITLE
add keyword search into span view

### DIFF
--- a/frontend/app/api/projects/[projectId]/spans/route.ts
+++ b/frontend/app/api/projects/[projectId]/spans/route.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, getTableColumns, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, getTableColumns, inArray, or, sql } from 'drizzle-orm';
 import { FilterDef, filtersToSql } from '@/lib/db/modifiers';
 import { getDateRangeFilters, paginatedGet } from '@/lib/db/utils';
 import { labelClasses, labels, spans, traces } from '@/lib/db/migrations/schema';
@@ -49,6 +49,14 @@ export async function GET(
           ))
       );
     });
+
+  const textSearch = req.nextUrl.searchParams.get("search");
+  const textSearchFilters = textSearch ? [
+    or(
+      sql`input::text LIKE ${`%${textSearch}%`}::text`,
+      sql`output::text LIKE ${`%${textSearch}%`}::text`
+    )!
+  ] : [];
 
   urlParamFilters = urlParamFilters
     // labels are handled separately above
@@ -103,7 +111,7 @@ export async function GET(
     sql`project_id = ${projectId}`
   ];
 
-  const filters = getDateRangeFilters(startTime, endTime, pastHours).concat(sqlFilters, labelFilters);
+  const filters = getDateRangeFilters(startTime, endTime, pastHours).concat(sqlFilters, labelFilters, textSearchFilters);
   // don't query input and output, only query previews
   const { input, output, ...columns } = getTableColumns(spans);
 

--- a/frontend/components/traces/spans-table.tsx
+++ b/frontend/components/traces/spans-table.tsx
@@ -19,6 +19,7 @@ import Mono from '../ui/mono';
 import { PaginatedResponse } from '@/lib/types';
 import { Span } from '@/lib/traces/types';
 import SpanTypeIcon from './span-type-icon';
+import TextSearchFilter from '../ui/text-search-filter';
 import { useProjectContext } from '@/contexts/project-context';
 
 interface SpansTableProps {
@@ -370,7 +371,7 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
       totalItemsCount={totalCount}
       enableRowSelection
     >
-      {/* <TextSearchFilter /> */}
+      <TextSearchFilter />
       <DataTableFilter
         possibleFilters={filterColumns}
       />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add keyword search functionality to span view, enabling filtering by input and output fields.
> 
>   - **Backend**:
>     - Add `textSearchFilters` in `route.ts` to filter spans by `input` and `output` fields using a keyword search.
>     - Modify `filters` to include `textSearchFilters` in `route.ts`.
>   - **Frontend**:
>     - Add `TextSearchFilter` component to `spans-table.tsx` to allow users to input search keywords.
>     - Update `getSpans` function in `spans-table.tsx` to include `search` parameter in API requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 8579183fe807b287b6ec37064348a7538d4425ef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->