### PR TITLE
make lq columns and evals page panels resizable

### DIFF
--- a/frontend/components/evaluations/evaluations.tsx
+++ b/frontend/components/evaluations/evaluations.tsx
@@ -30,6 +30,7 @@ import {
 } from '../ui/dialog';
 import Header from '../ui/header';
 import Mono from '../ui/mono';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '../ui/resizable';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import EvaluationsGroupsBar from './evaluations-groups-bar';
 import ProgressionChart from './progression-chart';
@@ -147,49 +148,54 @@ export default function Evaluations() {
               </Select>
             </div>
           </div>
-          <ProgressionChart className="h-64 flex-none px-2" aggregationFunction={aggregationFunction} />
-          <div className="flex-grow">
-            <DataTable
-              enableRowSelection={true}
-              columns={columns}
-              data={evaluations}
-              onRowClick={(row) => {
-                router.push(`/project/${projectId}/evaluations/${row.original.id}`);
-              }}
-              getRowId={(row: Evaluation) => row.id}
-              paginated
-              manualPagination
-              selectionPanel={(selectedRowIds) => (
-                <div className="flex flex-col space-y-2">
-                  <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-                    <DialogTrigger asChild>
-                      <Button variant="ghost">
-                        <Trash2 size={12} />
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent>
-                      <DialogHeader>
-                        <DialogTitle>Delete Evaluations</DialogTitle>
-                        <DialogDescription>
-                          Are you sure you want to delete {selectedRowIds.length} evaluation(s)?
-                          This action cannot be undone.
-                        </DialogDescription>
-                      </DialogHeader>
-                      <DialogFooter>
-                        <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)} disabled={isDeleting}>
-                          Cancel
+          <ResizablePanelGroup direction="vertical">
+            <ResizablePanel className="flex-none px-2" minSize={15} defaultSize={20}>
+              <ProgressionChart className="h-full flex-none px-2" aggregationFunction={aggregationFunction} />
+            </ResizablePanel>
+            <ResizableHandle className="z-50" />
+            <ResizablePanel className="flex-grow" minSize={30}>
+              <DataTable
+                enableRowSelection={true}
+                columns={columns}
+                data={evaluations}
+                onRowClick={(row) => {
+                  router.push(`/project/${projectId}/evaluations/${row.original.id}`);
+                }}
+                getRowId={(row: Evaluation) => row.id}
+                paginated
+                manualPagination
+                selectionPanel={(selectedRowIds) => (
+                  <div className="flex flex-col space-y-2">
+                    <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+                      <DialogTrigger asChild>
+                        <Button variant="ghost">
+                          <Trash2 size={12} />
                         </Button>
-                        <Button onClick={() => handleDeleteEvaluations(selectedRowIds)} disabled={isDeleting}>
-                          {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                          Delete
-                        </Button>
-                      </DialogFooter>
-                    </DialogContent>
-                  </Dialog>
-                </div>
-              )}
-            />
-          </div>
+                      </DialogTrigger>
+                      <DialogContent>
+                        <DialogHeader>
+                          <DialogTitle>Delete Evaluations</DialogTitle>
+                          <DialogDescription>
+                            Are you sure you want to delete {selectedRowIds.length} evaluation(s)?
+                            This action cannot be undone.
+                          </DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                          <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)} disabled={isDeleting}>
+                            Cancel
+                          </Button>
+                          <Button onClick={() => handleDeleteEvaluations(selectedRowIds)} disabled={isDeleting}>
+                            {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            Delete
+                          </Button>
+                        </DialogFooter>
+                      </DialogContent>
+                    </Dialog>
+                  </div>
+                )}
+              />
+            </ResizablePanel>
+          </ResizablePanelGroup>
         </div>
       </div>
     </div>

--- a/frontend/components/evaluations/progression-chart.tsx
+++ b/frontend/components/evaluations/progression-chart.tsx
@@ -28,7 +28,7 @@ export default function ProgressionChart({
   const groupId = searchParams.get('groupId');
   const { projectId } = useProjectContext();
 
-  const { data, isLoading, error } = useSWR<EvaluationTimeProgression[]>(
+  const { data, error } = useSWR<EvaluationTimeProgression[]>(
     `/api/projects/${projectId}/evaluation-groups/${groupId}/progression?aggregate=${aggregationFunction}`,
     swrFetcher
   );
@@ -50,8 +50,7 @@ export default function ProgressionChart({
       timestamp,
       evaluationId,
       ...Object.fromEntries(names.map((name, index) => ([name, values[index]]))),
-    })) ?? [],
-  [data]
+    })) ?? [], [data]
   );
 
   const chartConfig = Object.fromEntries(Array.from(keys).map((key, index) => ([
@@ -67,14 +66,14 @@ export default function ProgressionChart({
     <div className={cn('w-full h-full', className)}>
       <ChartContainer
         config={chartConfig as ChartConfig}
-        className={cn('h-56', 'w-full')}
+        className={cn('h-5/6', 'w-full')}
       >
-        {isLoading || !data || error ? (
+        {!data || error ? (
           <div className="h-full w-full">
             <Skeleton className="h-full w-full" />
           </div>
         ) : <LineChart
-          margin={{ top: 10, right: 10, bottom: 0, left: -12 }}
+          margin={{ top: 10, right: 10, bottom: 5, left: -12 }}
           accessibilityLayer
           data={convertedScores}
         >
@@ -84,7 +83,8 @@ export default function ProgressionChart({
             dataKey="timestamp"
             tickLine={false}
             axisLine={false}
-            tickFormatter={(value: number) => formatTimestamp(`${value}Z`)}
+            // tickFormatter={(value: number) => formatTimestamp(`${value}Z`)}
+            tick={false}
             height={8}
             padding={{ left: horizontalPadding, right: horizontalPadding }}
           />
@@ -96,7 +96,12 @@ export default function ProgressionChart({
           />
           <ChartTooltip
             cursor={false}
-            content={<ChartTooltipContent hideLabel className="min-w-60" />}
+            content={
+              <ChartTooltipContent
+                className="min-w-60"
+                labelFormatter={(value) => formatTimestamp(`${value}Z`)}
+              />
+            }
           />
           {Array.from(keys).filter((key) => showScores.includes(key)).map((key) => (
             <Line

--- a/frontend/components/queue/queue.tsx
+++ b/frontend/components/queue/queue.tsx
@@ -16,6 +16,7 @@ import Formatter from '../ui/formatter';
 import Header from '../ui/header';
 import { Label } from '../ui/label';
 import MonoWithCopy from "../ui/mono-with-copy";
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../ui/resizable";
 import { ScrollArea } from '../ui/scroll-area';
 import { Switch } from '../ui/switch';
 import { Labels } from './labels';
@@ -98,8 +99,8 @@ export default function Queue({ queue }: QueueProps) {
         <Header path={`labeling queues/${queue.name}`} />
       </div>
       <div className="flex-1 flex">
-        <div className="flex-1 flex flex-col">
-          <div className="flex-1">
+        <ResizablePanelGroup direction="horizontal">
+          <ResizablePanel className="flex-1 flex" minSize={20} defaultSize={50}>
             {data?.span ? (
               <div className="flex h-full w-full">
                 <ScrollArea className="flex overflow-auto w-full mt-0">
@@ -140,104 +141,106 @@ export default function Queue({ queue }: QueueProps) {
                 No items in queue
               </div>
             )}
-          </div>
-        </div>
-        <div className="flex-1 flex border-l">
-          <div className="w-2/3 flex flex-col">
-            <div className="flex-none p-4 py-2 border-b text-secondary-foreground flex justify-between items-center">
-              {data && <span>Item {data?.position} of {data?.count}</span>}
-              <div></div>
-              <div className="flex items-center space-x-2">
-                <Button
-                  variant="outline"
-                  onClick={() => data?.queueData && next(data.queueData.createdAt, 'prev')}
-                  disabled={!data || data.position <= 1}
-                >
-                  <ArrowDown size={16} className="mr-2" />
-                  Prev
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => data?.queueData && next(data.queueData.createdAt, 'next')}
-                  disabled={!data || data.position >= (data.count || 0)}
-                >
-                  <ArrowUp size={16} className="mr-2" />
-                  Next
-                </Button>
-                <Button
-                  onClick={remove}
-                  disabled={isRemoving || !data}
-                >
-                  {isRemoving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  Complete
-                </Button>
+          </ResizablePanel>
+          <ResizableHandle withHandle className="z-50" />
+          <ResizablePanel className="flex-1 flex" minSize={20} defaultSize={33}>
+            <div className="w-full flex flex-col">
+              <div className="flex-none p-4 py-2 border-b text-secondary-foreground flex justify-between items-center">
+                {data && <span>Item {data?.position} of {data?.count}</span>}
+                <div></div>
+                <div className="flex items-center space-x-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => data?.queueData && next(data.queueData.createdAt, 'prev')}
+                    disabled={!data || data.position <= 1}
+                  >
+                    <ArrowDown size={16} className="mr-2" />
+                    Prev
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => data?.queueData && next(data.queueData.createdAt, 'next')}
+                    disabled={!data || data.position >= (data.count || 0)}
+                  >
+                    <ArrowUp size={16} className="mr-2" />
+                    Next
+                  </Button>
+                  <Button
+                    onClick={remove}
+                    disabled={isRemoving || !data}
+                  >
+                    {isRemoving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    Complete
+                  </Button>
+                </div>
               </div>
-            </div>
-            <div className="flex-1 p-4">
-              <Label className="text-sm text-secondary-foreground">Labels to be added to the span</Label>
-              <div className="mt-4 space-y-2">
-                {addedLabels.map((label, index) => (
-                  <div key={index} className="flex flex-col p-2 border border-foreground/10 bg-muted rounded gap-2">
-                    <div className="flex items-center gap-2 justify-between w-full">
-                      <span>
-                        {Object.entries(label.labelClass.valueMap).find(([key, value]) => value === label.value)?.[0]}
-                      </span>
+              <div className="flex-1 p-4">
+                <Label className="text-sm text-secondary-foreground">Labels to be added to the span</Label>
+                <div className="mt-4 space-y-2">
+                  {addedLabels.map((label, index) => (
+                    <div key={index} className="flex flex-col p-2 border border-foreground/10 bg-muted rounded gap-2">
+                      <div className="flex items-center gap-2 justify-between w-full">
+                        <span>
+                          {Object.entries(label.labelClass.valueMap).find(([key, value]) => value === label.value)?.[0]}
+                        </span>
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm text-muted-foreground">{label.labelClass.name}</span>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => removeLabel(index)}
+                            className="h-6 px-2"
+                          >
+                            <X size={14} />
+                          </Button>
+                        </div>
+                      </div>
                       <div className="flex items-center gap-2">
-                        <span className="text-sm text-muted-foreground">{label.labelClass.name}</span>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => removeLabel(index)}
-                          className="h-6 px-2"
-                        >
-                          <X size={14} />
-                        </Button>
+                        <DefaultTextarea
+                          className="w-full"
+                          placeholder="Reasoning (optional)"
+                          value={label.reasoning || ''}
+                          onChange={(e) => {
+                            setAddedLabels(
+                              prev =>
+                                prev.map(l =>
+                                  l.labelClass.id === label.labelClass.id
+                                    ? { ...l, reasoning: e.target.value }
+                                    : l
+                                )
+                            );
+                          }}
+                        />
                       </div>
                     </div>
-                    <div className="flex items-center gap-2">
-                      <DefaultTextarea
-                        className="w-full"
-                        placeholder="Reasoning (optional)"
-                        value={label.reasoning || ''}
-                        onChange={(e) => {
-                          setAddedLabels(
-                            prev =>
-                              prev.map(l =>
-                                l.labelClass.id === label.labelClass.id
-                                  ? { ...l, reasoning: e.target.value }
-                                  : l
-                              )
-                          );
-                        }}
-                      />
-                    </div>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
-            </div>
-            <div className="flex-none p-4 border-t">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="insert-dataset">Insert to dataset on complete</Label>
-                <Switch
-                  checked={insertOnComplete}
-                  onCheckedChange={setInsertOnComplete}
-                  id="insert-dataset"
-                />
-              </div>
-
-              {insertOnComplete && (
-                <div className="mt-4">
-                  <DatasetSelect
-                    selectedDatasetId={datasetId}
-                    onDatasetChange={(dataset) => {
-                      setDatasetId(dataset?.id || undefined);
-                    }}
+              <div className="flex-none p-4 border-t">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="insert-dataset">Insert to dataset on complete</Label>
+                  <Switch
+                    checked={insertOnComplete}
+                    onCheckedChange={setInsertOnComplete}
+                    id="insert-dataset"
                   />
                 </div>
-              )}
+
+                {insertOnComplete && (
+                  <div className="mt-4">
+                    <DatasetSelect
+                      selectedDatasetId={datasetId}
+                      onDatasetChange={(dataset) => {
+                        setDatasetId(dataset?.id || undefined);
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-          <div className="w-1/3 p-4 border-l">
+          </ResizablePanel>
+          <ResizableHandle withHandle className="z-50" />
+          <ResizablePanel className="w-1/3 p-4 border-l" minSize={10} defaultSize={17}>
             <Labels
               span={data?.span}
               onAddLabel={(value, labelClass) => {
@@ -249,8 +252,8 @@ export default function Queue({ queue }: QueueProps) {
                 }
               }}
             />
-          </div>
-        </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
       </div>
     </div>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make panels in evaluations and queue components resizable and improve progression chart display.
> 
>   - **UI Enhancements**:
>     - Introduced `ResizablePanel`, `ResizablePanelGroup`, and `ResizableHandle` in `evaluations.tsx` and `queue.tsx` to make panels resizable.
>     - Adjusted `ProgressionChart` in `progression-chart.tsx` to occupy more space (`h-5/6`) and removed `isLoading` check.
>   - **Chart Improvements**:
>     - Disabled `tickFormatter` and `tick` in `XAxis` of `ProgressionChart`.
>     - Updated `ChartTooltipContent` to use `labelFormatter` for timestamp formatting.
>   - **Miscellaneous**:
>     - Minor layout adjustments in `queue.tsx` for better panel distribution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 077c09ace6850ddf1c4dacf7b7666e827986290e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->