### PR TITLE
feat: add items count column to datasets list

### DIFF
--- a/app-server/src/db/datasets.rs
+++ b/app-server/src/db/datasets.rs
@@ -64,3 +64,40 @@ pub async fn get_dataset_by_name(
 
     Ok(dataset)
 }
+
+pub async fn get_datasets_with_counts(
+    pool: &PgPool,
+    project_id: Uuid,
+    limit: i64,
+    offset: i64,
+) -> Result<(Vec<(Dataset, i64)>, i64)> {
+    let datasets = sqlx::query_as::<_, (Dataset, i64)>(
+        "WITH dataset_counts AS (
+            SELECT d.id, COUNT(dp.id) as count
+            FROM datasets d
+            LEFT JOIN datapoints dp ON d.id = dp.dataset_id
+            WHERE d.project_id = $1
+            GROUP BY d.id
+        )
+        SELECT d.id, d.created_at, d.name, d.project_id, d.indexed_on, COALESCE(dc.count, 0)
+        FROM datasets d
+        LEFT JOIN dataset_counts dc ON d.id = dc.id
+        WHERE d.project_id = $1
+        ORDER BY d.created_at DESC
+        LIMIT $2 OFFSET $3",
+    )
+    .bind(project_id)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+
+    let total_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM datasets WHERE project_id = $1",
+    )
+    .bind(project_id)
+    .fetch_one(pool)
+    .await?;
+
+    Ok((datasets, total_count))
+}

--- a/app-server/src/routes/datasets.rs
+++ b/app-server/src/routes/datasets.rs
@@ -244,7 +244,7 @@ async fn get_datapoints(
     Ok(HttpResponse::Ok().json(response))
 }
 
-#[get("datasets")]
+#[get("projects/{project_id}/datasets")]
 async fn get_datasets(
     db: web::Data<DB>,
     path: web::Path<Uuid>,

--- a/frontend/components/datasets/datasets.tsx
+++ b/frontend/components/datasets/datasets.tsx
@@ -84,6 +84,11 @@ export default function Datasets() {
       size: 300
     },
     {
+      header: 'Items',
+      accessorKey: 'itemsCount',
+      size: 100,
+    },
+    {
       header: 'Created at',
       accessorKey: 'createdAt',
       cell: (row) => (

--- a/frontend/lib/dataset/types.ts
+++ b/frontend/lib/dataset/types.ts
@@ -3,6 +3,7 @@ export interface Dataset {
   createdAt?: string;
   name: string;
   indexedOn: string | null;
+  itemsCount: number;
 }
 
 export interface Datapoint {


### PR DESCRIPTION
- Added SQL query to count datapoints per dataset
- Added items count to dataset API response
- Added Items column to datasets table in UI
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add item count column to datasets list by updating backend and frontend components.
> 
>   - **Backend**:
>     - Added `get_datasets_with_counts()` in `datasets.rs` to fetch datasets with item counts.
>     - Updated `get_datasets()` in `datasets.rs` to use `get_datasets_with_counts()`.
>     - Modified `get_datasets()` in `routes/datasets.rs` to include `itemsCount` in API response.
>   - **Frontend**:
>     - Added `itemsCount` to `Dataset` interface in `types.ts`.
>     - Added "Items" column to datasets table in `datasets.tsx` to display item counts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d63d167e9579368d3dc563e6650337d87f1694ae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->