### PR TITLE
add AI SDK metadata to the trace level

### DIFF
--- a/app-server/src/traces/span_attributes.rs
+++ b/app-server/src/traces/span_attributes.rs
@@ -25,7 +25,7 @@ pub const GEN_AI_INPUT_COST: &str = "gen_ai.usage.input_cost";
 pub const GEN_AI_OUTPUT_COST: &str = "gen_ai.usage.output_cost";
 
 // Custom lmnr attributes
-pub const ASSOCIATION_PROPERTIES_PREFIX: &str = "lmnr.association.properties.";
+pub const ASSOCIATION_PROPERTIES_PREFIX: &str = "lmnr.association.properties";
 pub const SPAN_TYPE: &str = "lmnr.span.type";
 pub const SPAN_PATH: &str = "lmnr.span.path";
 pub const LLM_NODE_RENDERED_PROMPT: &str = "lmnr.span.prompt";


### PR DESCRIPTION
+ remove the input messages from the attributes themselves, similar to what we do for regular OpenLLMetry input output attributes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extend `SpanAttributes` metadata with AI SDK telemetry metadata and remove `ai.prompt.messages` from attributes.
> 
>   - **Behavior**:
>     - Extend `metadata()` in `SpanAttributes` to include AI SDK telemetry metadata.
>     - Remove `ai.prompt.messages` from attributes in `should_keep_attribute()`.
>   - **Refactoring**:
>     - Refactor `get_flattened_association_properties()` to use `get_flattened_properties()` in `spans.rs`.
>   - **Constants**:
>     - Remove trailing dot from `ASSOCIATION_PROPERTIES_PREFIX`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7cb7b38511aeff90d7d0460245259a61cae7a3ca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->