### PR TITLE
increase payload limit for api /v1 to 200MB

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -404,7 +404,7 @@ fn main() -> anyhow::Result<()> {
                                 .service(api::v1::evaluations::create_evaluation)
                                 .service(api::v1::metrics::process_metrics)
                                 .service(api::v1::semantic_search::semantic_search)
-                                .app_data(PayloadConfig::new(10 * 1024 * 1024)),
+                                .app_data(PayloadConfig::new(200 * 1024 * 1024)),
                         )
                         // Scopes with generic auth
                         .service(


### PR DESCRIPTION
Some people load large payloads in evals, this is a quick fix
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase payload limit for `/v1` API scope to 200MB in `main.rs`.
> 
>   - **Behavior**:
>     - Increase payload limit for `/v1` API scope from 10MB to 200MB in `main.rs`.
>   - **Misc**:
>     - This change is a quick fix to support larger payloads in evaluations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 2e5f42466cc2430ed23804a9a4f58b60f8132424. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->