### PR TITLE
add prompt as input to the span around generateText

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -375,6 +375,16 @@ impl Span {
                 );
             }
         }
+
+        // Vercel AI SDK wraps "raw" LLM spans in an additional `ai.generateText` span.
+        // Which is not really an LLM span, but it has the prompt in its attributes.
+        // Set the input to the prompt.
+        if let Some(serde_json::Value::String(s)) = attributes.get("ai.prompt") {
+            span.input = Some(
+                serde_json::from_str::<Value>(s).unwrap_or(serde_json::Value::String(s.clone())),
+            );
+        }
+
         // If an LLM span is sent manually, we prefer `lmnr.span.input` and `lmnr.span.output`
         // attributes over gen_ai/vercel/LiteLLM attributes.
         // Therefore this block is outside and after the LLM span type check.


### PR DESCRIPTION
Records the input of the wrapper span around ai.generateText
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `Span::from_otel_span()` in `spans.rs` now sets `span.input` from `ai.prompt` attribute to handle Vercel AI SDK's span wrapping.
> 
>   - **Behavior**:
>     - In `spans.rs`, `Span::from_otel_span()` now sets `span.input` from `ai.prompt` attribute if present.
>     - This handles Vercel AI SDK's `ai.generateText` span wrapping, which includes the prompt in its attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 619896c7d167e759ad020fdc11a5052abda35ede. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->