### PR TITLE
truncate data in datapoints and eval-datapoints

### DIFF
--- a/app-server/src/db/datapoints.rs
+++ b/app-server/src/db/datapoints.rs
@@ -13,8 +13,8 @@ pub struct DatapointView {
     id: Uuid,
     created_at: DateTime<Utc>,
     dataset_id: Uuid,
-    data: Value,
-    target: Option<Value>,
+    data: String,
+    target: Option<String>,
     metadata: Option<Value>,
 }
 
@@ -95,7 +95,13 @@ pub async fn get_datapoints(
     offset: i64,
 ) -> Result<Vec<DatapointView>> {
     let datapoints = sqlx::query_as::<_, DatapointView>(
-        "SELECT id, dataset_id, data, target, metadata, created_at
+        "SELECT
+            id,
+            dataset_id,
+            SUBSTRING(data::text, 0, 100) as data,
+            SUBSTRING(target::text, 0, 100) as target,
+            metadata,
+            created_at
         FROM dataset_datapoints
         WHERE dataset_id = $1
         ORDER BY

--- a/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/[datapointId]/route.ts
+++ b/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/[datapointId]/route.ts
@@ -7,6 +7,26 @@ import { db } from '@/lib/db/drizzle';
 import { datasetDatapoints } from '@/lib/db/migrations/schema';
 import { fetcher } from '@/lib/utils';
 
+export async function GET(
+  req: Request,
+  {
+    params
+  }: { params: { projectId: string; datasetId: string; datapointId: string } }
+) {
+  const datapoint = await db.query.datasetDatapoints.findFirst({
+    where: and(
+      eq(datasetDatapoints.id, params.datapointId),
+      eq(datasetDatapoints.datasetId, params.datasetId)
+    )
+  });
+
+  if (!datapoint) {
+    return new Response('Datapoint not found', { status: 404 });
+  }
+
+  return new Response(JSON.stringify(datapoint), { status: 200 });
+}
+
 export async function POST(
   req: Request,
   {

--- a/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/route.ts
@@ -3,7 +3,7 @@ import { and, asc, eq, sql } from 'drizzle-orm';
 import { db } from '@/lib/db/drizzle';
 import {
   evaluationResults,
-  evaluations,evaluationScores
+  evaluations, evaluationScores
 } from '@/lib/db/migrations/schema';
 
 export async function GET(
@@ -39,11 +39,10 @@ export async function GET(
       id: evaluationResults.id,
       createdAt: evaluationResults.createdAt,
       evaluationId: evaluationResults.evaluationId,
-      data: evaluationResults.data,
-      target: evaluationResults.target,
+      data: sql<string>`SUBSTRING(${evaluationResults.data}::text, 0, 100)`.as('data'),
+      target: sql<string>`SUBSTRING(${evaluationResults.target}::text, 0, 100)`.as('target'),
       executorOutput: evaluationResults.executorOutput,
       scores: subQueryScoreCte.cteScores,
-      traceId: evaluationResults.traceId
     })
     .from(evaluationResults)
     .leftJoin(

--- a/frontend/app/project/[projectId]/evaluations/[evaluationId]/page.tsx
+++ b/frontend/app/project/[projectId]/evaluations/[evaluationId]/page.tsx
@@ -6,7 +6,7 @@ import Evaluation from '@/components/evaluation/evaluation';
 import { db } from '@/lib/db/drizzle';
 import {
   evaluationResults,
-  evaluations,evaluationScores
+  evaluations, evaluationScores
 } from '@/lib/db/migrations/schema';
 import { EvaluationResultsInfo } from '@/lib/evaluation/types';
 
@@ -70,8 +70,8 @@ async function getEvaluationInfo(
       id: evaluationResults.id,
       createdAt: evaluationResults.createdAt,
       evaluationId: evaluationResults.evaluationId,
-      data: evaluationResults.data,
-      target: evaluationResults.target,
+      data: sql<string>`SUBSTRING(${evaluationResults.data}::text, 0, 100)`.as('data'),
+      target: sql<string>`SUBSTRING(${evaluationResults.target}::text, 0, 100)`.as('target'),
       executorOutput: evaluationResults.executorOutput,
       scores: subQueryScoreCte.cteScores,
       traceId: evaluationResults.traceId

--- a/frontend/components/dataset/dataset-panel.tsx
+++ b/frontend/components/dataset/dataset-panel.tsx
@@ -103,11 +103,15 @@ export default function DatasetPanel({
     setNewMetadata(datapoint.metadata);
   }, [datapoint]);
 
-  return isLoading ? (<div>Loading...</div>) : (
+  return isLoading ? (<div className='p-4 space-y-2 h-full w-full'>
+    <Skeleton className="h-8" />
+    <Skeleton className="h-8" />
+    <Skeleton className="h-8" />
+  </div>) : (
     <div className="flex flex-col h-full w-full">
       <div className="h-12 flex flex-none space-x-2 px-3 items-center border-b">
         <Button
-          variant={'ghost'}
+          variant='ghost'
           className="px-1"
           onClick={async () => {
             await saveChanges();

--- a/frontend/components/dataset/dataset.tsx
+++ b/frontend/components/dataset/dataset.tsx
@@ -267,7 +267,7 @@ export default function Dataset({ dataset }: DatasetProps) {
             <div className="w-full h-full flex">
               <DatasetPanel
                 datasetId={dataset.id}
-                datapoint={selectedDatapoint}
+                datapointId={selectedDatapoint.id}
                 onClose={() => {
                   handleDatapointSelect(null);
                   mutate();

--- a/frontend/lib/evaluation/types.ts
+++ b/frontend/lib/evaluation/types.ts
@@ -24,9 +24,9 @@ export type EvaluationDatapointPreview = {
   evaluationId: string;
   createdAt: string;
   scores?: Record<string, any>;
-  data: Record<string, any>;
-  target: Record<string, any>;
-  executorOutput: Record<string, any>;
+  data: any;
+  target: any;
+  executorOutput: any;
   traceId: string;
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Truncate `data` and `target` fields to 100 characters in both backend and frontend for consistent data handling.
> 
>   - **Backend Changes**:
>     - Truncate `data` and `target` fields to 100 characters in `get_datapoints()` in `datapoints.rs`.
>     - Change `data` and `target` types from `Value` to `String` in `DatapointView` in `datapoints.rs`.
>   - **Frontend API Changes**:
>     - Truncate `data` and `target` fields to 100 characters in `GET` requests in `route.ts` for evaluations.
>   - **Frontend Component Changes**:
>     - Use `useSWR` to fetch datapoint data in `dataset-panel.tsx`.
>     - Update `DatasetPanel` to handle `datapointId` instead of full `datapoint` object in `dataset.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 0a41982ca8e16ee46fa883a38bcfdbfa9fd3620a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->