### PR TITLE
fix API query datapoints does not truncate

### DIFF
--- a/app-server/src/api/v1/datasets.rs
+++ b/app-server/src/api/v1/datasets.rs
@@ -30,7 +30,7 @@ async fn get_datapoints(
     };
 
     let datapoints =
-        datapoints::get_datapoints(&db.pool, dataset.id, query.limit, query.offset).await?;
+        datapoints::get_full_datapoints(&db.pool, dataset.id, query.limit, query.offset).await?;
 
     let total_count = datapoints::count_datapoints(&db.pool, dataset.id).await?;
 

--- a/app-server/src/db/datapoints.rs
+++ b/app-server/src/db/datapoints.rs
@@ -88,7 +88,38 @@ pub async fn get_all_datapoints(pool: &PgPool, dataset_id: Uuid) -> Result<Vec<D
     Ok(datapoints)
 }
 
-pub async fn get_datapoints(
+pub async fn get_full_datapoints(
+    pool: &PgPool,
+    dataset_id: Uuid,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<Datapoint>> {
+    let datapoints = sqlx::query_as::<_, Datapoint>(
+        "SELECT
+            id,
+            dataset_id,
+            data,
+            target,
+            metadata,
+            created_at
+        FROM dataset_datapoints
+        WHERE dataset_id = $1
+        ORDER BY
+            created_at ASC,
+            index_in_batch ASC NULLS FIRST
+        LIMIT $2
+        OFFSET $3",
+    )
+    .bind(dataset_id)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(datapoints)
+}
+
+pub async fn get_datapoint_previews(
     pool: &PgPool,
     dataset_id: Uuid,
     limit: i64,

--- a/app-server/src/routes/datasets.rs
+++ b/app-server/src/routes/datasets.rs
@@ -232,7 +232,8 @@ async fn get_datapoints(
     let (_project_id, dataset_id) = path.into_inner();
     let limit = query_params.page_size.unwrap_or(DEFAULT_PAGE_SIZE) as i64;
     let offset = limit * (query_params.page_number) as i64;
-    let datapoints = db::datapoints::get_datapoints(&db.pool, dataset_id, limit, offset).await?;
+    let datapoints =
+        db::datapoints::get_datapoint_previews(&db.pool, dataset_id, limit, offset).await?;
     let total_entries = db::datapoints::count_datapoints(&db.pool, dataset_id).await?;
 
     let response = PaginatedResponse::<DatapointView> {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes API query datapoints truncation by renaming and adding functions for full and preview datapoint fetching.
> 
>   - **Behavior**:
>     - Fixes API query datapoints not truncating by renaming `get_datapoints` to `get_full_datapoints` in `datasets.rs` and `datapoints.rs`.
>     - Introduces `get_datapoint_previews` in `datapoints.rs` for fetching truncated datapoint previews.
>   - **Routes**:
>     - Updates `get_datapoints` route in `routes/datasets.rs` to use `get_datapoint_previews` for fetching datapoint previews.
>   - **Functions**:
>     - Renames `get_datapoints` to `get_full_datapoints` in `datapoints.rs`.
>     - Adds `get_datapoint_previews` in `datapoints.rs` to fetch truncated data and target fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for e7793f402d6eb8ce2bc7fdb2731659f7add4d088. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->