### PR TITLE
fix: double conversion to date caused invalid date

### DIFF
--- a/frontend/components/dashboard/span-stat-chart.tsx
+++ b/frontend/components/dashboard/span-stat-chart.tsx
@@ -13,6 +13,7 @@ import { AggregationFunction } from '@/lib/clickhouse/utils';
 import {
   cn,
   formatTimestamp,
+  formatTimestampFromSecondsWithInterval,
   formatTimestampWithInterval,
 } from '@/lib/utils';
 
@@ -156,7 +157,8 @@ interface ChartProps {
   keys: Set<string>,
   xAxisKey: string,
   chartConfig: ChartConfig,
-  groupByInterval: GroupByInterval
+  groupByInterval: GroupByInterval,
+  numericTimestamp?: boolean
 }
 
 function StackedBarChart({
@@ -238,7 +240,8 @@ export function DefaultLineChart({
   keys,
   xAxisKey,
   chartConfig,
-  groupByInterval
+  groupByInterval,
+  numericTimestamp
 }: ChartProps) {
   const dataMax = useMemo(() => Math.max(...data.map((d) => Object.entries(d)
     .filter(([key]) => key !== xAxisKey)
@@ -270,12 +273,15 @@ export function DefaultLineChart({
           type="category"
           domain={['dataMin', 'dataMax']}
           tickLine={false}
-          tickFormatter={(value) =>
-            formatTimestampWithInterval(
+          tickFormatter={(value) => {
+            if (numericTimestamp) {
+              return formatTimestampFromSecondsWithInterval(value, groupByInterval ?? 'hour');
+            }
+            return formatTimestampWithInterval(
               value,
               groupByInterval ?? 'hour'
-            )
-          }
+            );
+          }}
           axisLine={false}
           tickMargin={8}
           dataKey={xAxisKey}

--- a/frontend/components/dashboard/trace-stat-chart.tsx
+++ b/frontend/components/dashboard/trace-stat-chart.tsx
@@ -7,7 +7,6 @@ import { GroupByInterval } from '@/lib/clickhouse/modifiers';
 import { TraceMetricDatapoint } from '@/lib/traces/types';
 import {
   cn,
-  formatTimestampFromSeconds,
   toFixedIfFloat,
 } from '@/lib/utils';
 
@@ -107,12 +106,13 @@ export function TraceStatChart({
           <DefaultLineChart
             data={data?.map((d) => ({
               "value": d.value,
-              "timestamp": formatTimestampFromSeconds(d.time)
+              "timestamp": d.time
             })) ?? []}
             xAxisKey="timestamp"
             chartConfig={chartConfig}
             groupByInterval={defaultGroupByInterval as GroupByInterval}
             keys={new Set(["value"])}
+            numericTimestamp={true}
           />
         )}
       </div>


### PR DESCRIPTION
Add a flag to render numeric timestamp to fix the dashboard
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes double date conversion in charts by adding `numericTimestamp` flag to handle numeric timestamps correctly.
> 
>   - **Behavior**:
>     - Adds `numericTimestamp` flag to `ChartProps` in `span-stat-chart.tsx` and `trace-stat-chart.tsx` to handle numeric timestamps.
>     - Updates `tickFormatter` in `DefaultLineChart` to use `formatTimestampFromSecondsWithInterval` when `numericTimestamp` is true.
>   - **Functions**:
>     - Modifies `DefaultLineChart` in `span-stat-chart.tsx` to support `numericTimestamp` for correct timestamp formatting.
>     - Removes `formatTimestampFromSeconds` from `trace-stat-chart.tsx` as it's no longer needed.
>   - **Misc**:
>     - Minor refactoring in `trace-stat-chart.tsx` to pass `numericTimestamp` to `DefaultLineChart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 48a2e71a22f8fc6397922d2b9c881f76d672acf4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->