### PR TITLE
expect Authorization header as well

### DIFF
--- a/app-server/src/traces/grpc_service.rs
+++ b/app-server/src/traces/grpc_service.rs
@@ -93,7 +93,12 @@ async fn authenticate_request(
 }
 
 fn extract_bearer_token(metadata: &tonic::metadata::MetadataMap) -> anyhow::Result<String> {
-    if let Some(auth_header) = metadata.get("authorization") {
+    // Default OpenTelemetry gRPC exporter uses `"authorization"` with lowercase `a`,
+    // but users may use `"Authorization"` with uppercase `A` in custom exporters.
+    let header = metadata
+        .get("authorization")
+        .or(metadata.get("Authorization"));
+    if let Some(auth_header) = header {
         let auth_str = auth_header
             .to_str()
             .map_err(|_| Status::unauthenticated("Invalid token"))?;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `extract_bearer_token()` in `grpc_service.rs` now supports both lowercase and uppercase 'Authorization' headers for compatibility.
> 
>   - **Behavior**:
>     - `extract_bearer_token()` in `grpc_service.rs` now checks for both `"authorization"` and `"Authorization"` headers.
>     - Ensures compatibility with custom gRPC exporters using different header casing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 0673a8de15f5c725ca01624d6ce7adf0bd86f5a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->