### PR TITLE
fix double conversion date in chart tooltip too

### DIFF
--- a/frontend/components/dashboard/span-stat-chart.tsx
+++ b/frontend/components/dashboard/span-stat-chart.tsx
@@ -13,6 +13,7 @@ import { AggregationFunction } from '@/lib/clickhouse/utils';
 import {
   cn,
   formatTimestamp,
+  formatTimestampFromSeconds,
   formatTimestampFromSecondsWithInterval,
   formatTimestampWithInterval,
 } from '@/lib/utils';
@@ -298,7 +299,9 @@ export function DefaultLineChart({
             <ChartTooltipContent
               labelKey={xAxisKey}
               labelFormatter={(_, p) =>
-                formatTimestamp(`${p[0].payload[xAxisKey]}Z`)
+                numericTimestamp
+                  ? formatTimestampFromSeconds(p[0].payload[xAxisKey])
+                  : formatTimestamp(`${p[0].payload[xAxisKey]}Z`)
               }
             />
           }


### PR DESCRIPTION
follow up to https://github.com/lmnr-ai/lmnr/pull/308
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes double date conversion in `DefaultLineChart` tooltip by correctly formatting numeric timestamps.
> 
>   - **Behavior**:
>     - Fixes double conversion of date in chart tooltip in `DefaultLineChart`.
>     - Uses `formatTimestampFromSeconds` if `numericTimestamp` is true, otherwise uses `formatTimestamp`.
>   - **Functions**:
>     - Modifies `labelFormatter` in `ChartTooltipContent` within `DefaultLineChart` to handle numeric timestamps correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for e0c4d654e77e1afa5f02426edfa82eb26aa216d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->