### PR TITLE
add feature of auto filter when clicking on property

### DIFF
--- a/frontend/components/traces/sessions-table.tsx
+++ b/frontend/components/traces/sessions-table.tsx
@@ -188,7 +188,7 @@ export default function SessionsTable({ onRowClick }: SessionsTableProps) {
             event.stopPropagation();
             handleAddFilter('id', row.getValue());
           }}
-          className="cursor-pointer underline underline-offset-2 decoration-dotted text-primary hover:decoration-solid"
+          className="cursor-pointer hover:underline"
         >
           {/* <Mono className='text-xs'>{row.getValue()}</Mono> */}
         </div>

--- a/frontend/components/traces/spans-table.tsx
+++ b/frontend/components/traces/spans-table.tsx
@@ -231,7 +231,7 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
             event.stopPropagation();
             handleAddFilter('span_type', row.getValue());
           }}
-          className="cursor-pointer flex space-x-2 items-center underline underline-offset-2 decoration-dotted text-primary hover:decoration-solid"
+          className="cursor-pointer flex space-x-2 items-center hover:underline"
         >
           <SpanTypeIcon className='z-10' spanType={row.getValue()} />
           <div className='flex text-sm'>{row.getValue() === 'DEFAULT' ? 'SPAN' : row.getValue()}</div>
@@ -245,7 +245,7 @@ export default function SpansTable({ onRowClick }: SpansTableProps) {
             event.stopPropagation();
             handleAddFilter('name', row.getValue());
           }}
-          className="cursor-pointer underline underline-offset-2 decoration-dotted text-primary hover:decoration-solid"
+          className="cursor-pointer hover:underline"
         >
           {row.getValue()}
         </div>

--- a/frontend/components/traces/traces-table.tsx
+++ b/frontend/components/traces/traces-table.tsx
@@ -215,8 +215,11 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
       id: 'top_span_type',
       cell: (row) => (
         <div
-          onClick={() =>handleAddFilter('top_span_type',row.getValue())}
-          className="cursor-pointer flex space-x-2 items-center underline underline-offset-2 decoration-dotted text-primary hover:decoration-solid"
+        onClick={(event) => {
+          event.stopPropagation();
+          handleAddFilter('span_type', row.getValue());
+        }}
+          className="cursor-pointer flex space-x-2 items-center hover:underline"
         >
           <SpanTypeIcon className='z-10' spanType={row.getValue()} />
           <div className='flex text-sm'>{row.getValue() === 'DEFAULT' ? 'SPAN' : row.getValue()}</div>
@@ -228,9 +231,9 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
         <div
           onClick={(event) => {
             event.stopPropagation();
-            handleAddFilter('top_span_name', row.getValue());
+            handleAddFilter('name', row.getValue());
           }}
-          className="cursor-pointer underline underline-offset-2 decoration-dotted text-primary hover:decoration-solid"
+          className="cursor-pointer hover:underline"
         >
           {row.getValue()}
         </div>

--- a/frontend/components/traces/traces-table.tsx
+++ b/frontend/components/traces/traces-table.tsx
@@ -215,10 +215,10 @@ export default function TracesTable({ onRowClick }: TracesTableProps) {
       id: 'top_span_type',
       cell: (row) => (
         <div
-        onClick={(event) => {
-          event.stopPropagation();
-          handleAddFilter('span_type', row.getValue());
-        }}
+          onClick={(event) => {
+            event.stopPropagation();
+            handleAddFilter('span_type', row.getValue());
+          }}
           className="cursor-pointer flex space-x-2 items-center hover:underline"
         >
           <SpanTypeIcon className='z-10' spanType={row.getValue()} />

--- a/frontend/components/ui/datatable-filter.tsx
+++ b/frontend/components/ui/datatable-filter.tsx
@@ -71,9 +71,8 @@ export default function DataTableFilter({
   useEffect(() => {
     if (activeFilters.length > 0) {
       setFilters(activeFilters);
-      handleApplyFilters();
     }
-  }, [activeFilters,pathName, router, searchParams]);
+  }, [activeFilters]);
 
   const isFilterFilled = (filter: DatatableFilter): boolean => filter.value.length > 0;
 


### PR DESCRIPTION
This PR implements the Auto Filter feature, enabling users to apply filters automatically when clicking on cells in the Trace , Span and Session Tab.

#192
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add auto-filter feature to `sessions-table.tsx`, `spans-table.tsx`, and `traces-table.tsx` enabling filter application by clicking on table cells.
> 
>   - **Behavior**:
>     - Auto-filter feature added to `sessions-table.tsx`, `spans-table.tsx`, and `traces-table.tsx` allowing users to apply filters by clicking on table cells.
>     - Filters are applied to columns like `id`, `span_type`, `name`, `top_span_type`, and `top_span_name`.
>   - **Functions**:
>     - `handleAddFilter` and `handleUpdateFilters` functions added to manage filter state in `sessions-table.tsx`, `spans-table.tsx`, and `traces-table.tsx`.
>   - **UI Components**:
>     - `DataTableFilter` in `datatable-filter.tsx` updated to handle active filters and apply them to URL search parameters.
>     - `handleApplyFilters` function in `datatable-filter.tsx` updates URL with new filters and resets pagination.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 9f6142caa67d574b569bc627c6c3924376e2d0d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->