### PR TITLE
upload langchain b64 images to S3

### DIFF
--- a/app-server/src/language_model/chat_message.rs
+++ b/app-server/src/language_model/chat_message.rs
@@ -271,7 +271,6 @@ impl ChatMessageContentPart {
                 // https://github.com/traceloop/openllmetry/issues/2516
                 let pattern = Regex::new(r"^data:image/[a-zA-z]+;base64,.*$").unwrap();
                 if pattern.is_match(&image_url.url) {
-                    println!("Caught LangChain base64 image url");
                     let base64_data = image_url.url.split(',').last().unwrap();
                     let data = crate::storage::base64_to_bytes(base64_data)?;
                     let key = crate::storage::create_key(project_id, &None);


### PR DESCRIPTION
https://python.langchain.com/docs/how_to/multimodal_inputs/

This is a WIP, because
- [X] we upload images that are registered with the LLM spans themselves (i.e. ChatOpenAI.chat)
- [ ] the immediate parent span (`RunnableParallel<raw>` for the example I tested with) and the root span (`RunnableSequence`) also have the base64 payload in the attribute we parse as input, as part of stringified JSON. Ideally, we should replace that with link or at least remove that too, in order to reduce load on our DB
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds functionality to upload base64 encoded images in `ChatMessageContentPart::ImageUrl` to S3 and replace the URL with the S3 link.
> 
>   - **Behavior**:
>     - `ChatMessageContentPart::ImageUrl` now checks if the URL is a base64 encoded image using a regex pattern.
>     - If base64, uploads image to S3 and replaces URL with S3 link in `store_media()`.
>   - **Functions**:
>     - Updates `store_media()` in `chat_message.rs` to handle base64 image URLs.
>   - **Dependencies**:
>     - Adds `regex` crate for pattern matching base64 image URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3637364a9758c118edbbb94dc34c8527e94a6ae8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->