### PR TITLE
upgrade qdrant to 1.13

### DIFF
--- a/semantic-search-service/Cargo.lock
+++ b/semantic-search-service/Cargo.lock
@@ -1260,19 +1260,22 @@ dependencies = [
 
 [[package]]
 name = "qdrant-client"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbff72d38eac3860f5888f02d4688690de6cdc77c901112d3b0788694afc1d37"
+checksum = "9b585625d1ef06478e97fe8d7170a3f32a1cba5dbf986ff136095a85a0ec3d91"
 dependencies = [
  "anyhow",
  "derive_builder",
+ "futures",
  "futures-util",
  "prost",
  "prost-types",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
  "tonic",
 ]
 
@@ -1638,6 +1641,12 @@ dependencies = [
  "tonic-build",
  "uuid",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"

--- a/semantic-search-service/Cargo.toml
+++ b/semantic-search-service/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
+edition = "2021"
 name = "semantic-search-service"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 anyhow = "1"
+bm25 = "2.2.0"
+chrono = {version = "0.4.39", features = ["serde"]}
+dotenv = "0.15.0"
 enum_dispatch = "0.3.12"
 env_logger = "0.10.0"
-tonic = "0.12.3"
-prost = "0.13"
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
-tokio-stream = { version = "0.1", features = ["net"] }
 futures = "0.3"
-qdrant-client = "1.12.1"
-rayon = "1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
-serde = "1"
-simsimd = "3.9.0"
-serde_json = "1.0.105"
-log = "0.4.20"
-dotenv = "0.15.0"
-uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics"] }
-bm25 = "2.2.0"
 indexmap = "2.7.0"
-chrono = { version = "0.4.39", features = ["serde"] }
+log = "0.4.20"
+prost = "0.13"
 prost-types = "0.13.4"
+qdrant-client = "1.13"
+rayon = "1"
+reqwest = {version = "0.12", default-features = false, features = ["rustls-tls", "json"]}
+serde = "1"
+serde_json = "1.0.105"
+simsimd = "3.9.0"
+tokio = {version = "1.24", features = ["macros", "rt-multi-thread"]}
+tokio-stream = {version = "0.1", features = ["net"]}
+tonic = "0.12.3"
+uuid = {version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics"]}
 
 [build-dependencies]
 tonic-build = "0.12.3"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Upgrade `qdrant-client` to 1.13.0 and update vector handling in `mod.rs` to use `InnerVector` enum.
> 
>   - **Dependencies**:
>     - Upgrade `qdrant-client` from version 1.12.1 to 1.13.0 in `Cargo.toml` and `Cargo.lock`.
>     - Add `semver` and `tokio` as dependencies in `Cargo.lock`.
>   - **Code Changes**:
>     - Update vector handling in `mod.rs` to use `InnerVector` enum for `DenseVector` and `SparseVector`.
>     - Modify `index` function in `mod.rs` to accommodate new vector structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 585ce19b44b71626849a35bffe9afd3cf3e68b4f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->