### PR TITLE
disable chunking spans

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -376,7 +376,6 @@ fn main() -> anyhow::Result<()> {
                                 semantic_search.clone(),
                                 rabbitmq_connection.clone(),
                                 clickhouse.clone(),
-                                chunker_runner.clone(),
                                 storage.clone(),
                             ));
                         }

--- a/app-server/src/traces/index.rs
+++ b/app-server/src/traces/index.rs
@@ -5,19 +5,12 @@ use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
 use crate::{
-    chunk::{
-        character_split::CharacterSplitParams,
-        runner::{ChunkParams, ChunkerRunner, ChunkerType},
-    },
     db::spans::Span,
     semantic_search::{semantic_search_grpc::index_request::Datapoint, SemanticSearch},
 };
 
 use super::span_attributes::SPAN_PATH;
 
-const CHARACTER_SPLITTER_CHUNK_SIZE: u32 = 512;
-// Since this indexing is for sparse vectors, we can use a smaller stride
-const CHARACTER_SPLITTER_STRIDE: u32 = 32;
 const DATASOURCE_ID: &str = "spans";
 
 /// internal enum to choose which span field to index
@@ -30,50 +23,28 @@ pub async fn index_span(
     span: &Span,
     semantic_search: Arc<dyn SemanticSearch>,
     collection_name: &String,
-    chunker_runner: Arc<ChunkerRunner>,
 ) -> Result<()> {
     let input_content = get_indexable_content(span, IndexField::Input);
     let output_content = get_indexable_content(span, IndexField::Output);
     if input_content.is_none() && output_content.is_none() {
         return Ok(());
     }
-    let input_chunks = chunk(chunker_runner.clone(), input_content)?;
-    let output_chunks = chunk(chunker_runner.clone(), output_content)?;
 
-    let mut points = input_chunks
-        .iter()
-        .map(|chunk| create_datapoint(span, chunk.to_string(), "input"))
-        .collect::<Vec<_>>();
+    let mut points = Vec::new();
 
-    let output_points = output_chunks
-        .iter()
-        .map(|chunk| create_datapoint(span, chunk.to_string(), "output"))
-        .collect::<Vec<_>>();
+    if let Some(input_content) = input_content {
+        points.push(create_datapoint(span, input_content, "input"));
+    }
 
-    points.extend(output_points);
+    if let Some(output_content) = output_content {
+        points.push(create_datapoint(span, output_content, "output"));
+    }
 
     semantic_search
         .index(points, collection_name.to_owned(), true)
         .await?;
 
     Ok(())
-}
-
-fn chunk(chunker_runner: Arc<ChunkerRunner>, content: Option<String>) -> Result<Vec<String>> {
-    let chunks = content
-        .map(|content| {
-            chunker_runner.chunk(
-                &ChunkerType::CharacterSplit,
-                &content,
-                &ChunkParams::CharacterSplit(CharacterSplitParams {
-                    chunk_size: CHARACTER_SPLITTER_CHUNK_SIZE,
-                    stride: CHARACTER_SPLITTER_STRIDE,
-                }),
-            )
-        })
-        .transpose()?
-        .unwrap_or_default();
-    Ok(chunks)
 }
 
 fn create_datapoint(span: &Span, content: String, field_type: &str) -> Datapoint {

--- a/semantic-search-service/src/embeddings/bm25.rs
+++ b/semantic-search-service/src/embeddings/bm25.rs
@@ -5,10 +5,7 @@ use indexmap::IndexMap;
 
 use super::{Embed, Embedding};
 
-// This has to be tuned together with CHARACTER_SPLITTER_CHUNK_SIZE
-// or any other chunking method. At the time of writing this,
-// chunk size is 512 characters, which is approximately 150 words.
-const DOCUMENT_LENGTH_TOKENS: f32 = 150.0;
+const DOCUMENT_LENGTH_TOKENS: f32 = 1024.0;
 
 pub struct Bm25 {
     embedder: Embedder,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove chunking spans functionality and update BM25 document length tokens.
> 
>   - **Behavior**:
>     - Removed `chunker_runner` from `process_queue_spans()` and `inner_process_queue_spans()` in `consumer.rs`.
>     - Removed chunking logic from `index_span()` in `index.rs`.
>     - Updated `DOCUMENT_LENGTH_TOKENS` in `bm25.rs` from 150.0 to 1024.0.
>   - **Code Cleanup**:
>     - Removed `chunk` module import from `consumer.rs` and `index.rs`.
>     - Removed `chunk()` function from `index.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 9aad5f2546f5980a92fdd60508bcb2292b430ff1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->