### PR TITLE
Various qdrant fixes

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -376,7 +376,6 @@ fn main() -> anyhow::Result<()> {
                                 semantic_search.clone(),
                                 rabbitmq_connection.clone(),
                                 clickhouse.clone(),
-                                chunker_runner.clone(),
                                 storage.clone(),
                             ));
                         }

--- a/app-server/src/projects/mod.rs
+++ b/app-server/src/projects/mod.rs
@@ -50,15 +50,5 @@ pub async fn create_project(
         }
     }
 
-    semantic_search
-        .create_collection(project.id.to_string(), false)
-        .await?;
-    log::info!("Created new index collection for project: {}", project.id);
-
-    semantic_search
-        .create_collection(format!("spans-{}", project.id), true)
-        .await?;
-    log::info!("Created new spans collection for project: {}", project.id);
-
     Ok(project)
 }

--- a/app-server/src/traces/index.rs
+++ b/app-server/src/traces/index.rs
@@ -5,19 +5,12 @@ use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
 use crate::{
-    chunk::{
-        character_split::CharacterSplitParams,
-        runner::{ChunkParams, ChunkerRunner, ChunkerType},
-    },
     db::spans::Span,
     semantic_search::{semantic_search_grpc::index_request::Datapoint, SemanticSearch},
 };
 
 use super::span_attributes::SPAN_PATH;
 
-const CHARACTER_SPLITTER_CHUNK_SIZE: u32 = 512;
-// Since this indexing is for sparse vectors, we can use a smaller stride
-const CHARACTER_SPLITTER_STRIDE: u32 = 32;
 const DATASOURCE_ID: &str = "spans";
 
 /// internal enum to choose which span field to index
@@ -30,50 +23,28 @@ pub async fn index_span(
     span: &Span,
     semantic_search: Arc<dyn SemanticSearch>,
     collection_name: &String,
-    chunker_runner: Arc<ChunkerRunner>,
 ) -> Result<()> {
     let input_content = get_indexable_content(span, IndexField::Input);
     let output_content = get_indexable_content(span, IndexField::Output);
     if input_content.is_none() && output_content.is_none() {
         return Ok(());
     }
-    let input_chunks = chunk(chunker_runner.clone(), input_content)?;
-    let output_chunks = chunk(chunker_runner.clone(), output_content)?;
 
-    let mut points = input_chunks
-        .iter()
-        .map(|chunk| create_datapoint(span, chunk.to_string(), "input"))
-        .collect::<Vec<_>>();
+    let mut points = Vec::new();
 
-    let output_points = output_chunks
-        .iter()
-        .map(|chunk| create_datapoint(span, chunk.to_string(), "output"))
-        .collect::<Vec<_>>();
+    if let Some(input_content) = input_content {
+        points.push(create_datapoint(span, input_content, "input"));
+    }
 
-    points.extend(output_points);
+    if let Some(output_content) = output_content {
+        points.push(create_datapoint(span, output_content, "output"));
+    }
 
     semantic_search
         .index(points, collection_name.to_owned(), true)
         .await?;
 
     Ok(())
-}
-
-fn chunk(chunker_runner: Arc<ChunkerRunner>, content: Option<String>) -> Result<Vec<String>> {
-    let chunks = content
-        .map(|content| {
-            chunker_runner.chunk(
-                &ChunkerType::CharacterSplit,
-                &content,
-                &ChunkParams::CharacterSplit(CharacterSplitParams {
-                    chunk_size: CHARACTER_SPLITTER_CHUNK_SIZE,
-                    stride: CHARACTER_SPLITTER_STRIDE,
-                }),
-            )
-        })
-        .transpose()?
-        .unwrap_or_default();
-    Ok(chunks)
 }
 
 fn create_datapoint(span: &Span, content: String, field_type: &str) -> Datapoint {

--- a/frontend/app/api/workspaces/route.ts
+++ b/frontend/app/api/workspaces/route.ts
@@ -1,19 +1,64 @@
+import { desc, eq, sql } from 'drizzle-orm';
 import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth';
 
 import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/db/drizzle';
+import { apiKeys, membersOfWorkspaces, projects, subscriptionTiers, workspaces } from '@/lib/db/migrations/schema';
 import { fetcher } from '@/lib/utils';
 
 export async function GET(req: NextRequest): Promise<Response> {
   const session = await getServerSession(authOptions);
-  const user = session!.user;
 
-  return await fetcher('/workspaces?' + req.nextUrl.searchParams.toString(), {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${user.apiKey}`
-    }
+  if (!session?.user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  const apiKey = session.user.apiKey;
+  const userId = await db
+    .select({ id: apiKeys.userId })
+    .from(apiKeys)
+    .where(eq(apiKeys.apiKey, apiKey))
+    .execute()
+    .then((res) => res[0].id);
+
+  const results = await db
+    .select({
+      id: workspaces.id,
+      name: workspaces.name,
+      tierName: subscriptionTiers.name,
+      isFreeTier: sql`${workspaces.tierId} = 1`,
+    })
+    .from(workspaces)
+    .innerJoin(membersOfWorkspaces, eq(workspaces.id, membersOfWorkspaces.workspaceId))
+    .innerJoin(subscriptionTiers, eq(workspaces.tierId, subscriptionTiers.id))
+    .where(eq(membersOfWorkspaces.userId, userId))
+    .orderBy(desc(workspaces.createdAt));
+
+  // Fetch projects for each workspace
+  const workspacesWithProjects = await Promise.all(
+    results.map(async (workspace) => {
+      const prjs = await db
+        .select({
+          id: projects.id,
+          name: projects.name,
+          workspaceId: projects.workspaceId,
+        })
+        .from(projects)
+        .where(eq(projects.workspaceId, workspace.id));
+
+      return {
+        ...workspace,
+        projects: prjs,
+      };
+    })
+  );
+
+  return new Response(JSON.stringify(workspacesWithProjects), {
+    headers: { 'Content-Type': 'application/json' }
   });
 }
 

--- a/frontend/components/projects/project-card.tsx
+++ b/frontend/components/projects/project-card.tsx
@@ -1,7 +1,6 @@
 import { ChevronRightIcon } from 'lucide-react';
 import Link from 'next/link';
 
-import { Card } from '@/components/ui/card';
 import { Project } from '@/lib/workspaces/types';
 
 interface ProjectCardProps {
@@ -11,15 +10,15 @@ interface ProjectCardProps {
 export default function ProjectCard({ project }: ProjectCardProps) {
   return (
     <Link href={`/project/${project.id}/traces`} key={project.id}>
-      <Card className="hover:bg-secondary w-96 h-44 rounded-md bg-secondary/40 transition-all duration-200">
-        <div className="p-4 space-y-1">
+      <div className="hover:bg-secondary w-96 h-44 rounded-md bg-secondary/40 transition-all duration-100">
+        <div className="p-4 flex flex-col gap-2">
           <div className="flex items-center justify-between">
-            <h4 className="font-medium truncate max-w-50">{project.name}</h4>
+            <p className="text-lg font-medium">{project.name}</p>
             <ChevronRightIcon className="w-4 text-secondary-foreground" />
           </div>
-          <p className="text-gray-600 font-mono text-[10px]">{project.id}</p>
+          <p className="text-muted-foreground font-mono text-xs">{project.id}</p>
         </div>
-      </Card>
+      </div>
     </Link>
   );
 }

--- a/frontend/components/traces/chat-message-list-tab.tsx
+++ b/frontend/components/traces/chat-message-list-tab.tsx
@@ -32,7 +32,10 @@ function ContentPartImage({ b64_data }: ContentPartImageProps) {
 }
 
 function ContentPartImageUrl({ url }: { url: string }) {
-  return <img src={`${url}?payloadType=image`} alt="span image" />;
+  // if url is a relative path, add ?payloadType=image to the end of the url
+  // because it implies that we stored the image in S3
+  if (url.startsWith('/')) url += '?payloadType=image';
+  return <img src={url} alt="span image" />;
 }
 
 function ContentPartDocumentUrl({ url }: { url: string }) {

--- a/frontend/components/traces/span-card.tsx
+++ b/frontend/components/traces/span-card.tsx
@@ -44,7 +44,7 @@ export function SpanCard({
 
   useEffect(() => {
     if (ref.current) {
-      setSegmentHeight(ref.current.getBoundingClientRect().y - parentY);
+      setSegmentHeight(Math.max(0, ref.current.getBoundingClientRect().y - parentY));
     }
   }, [parentY, collapsedSpans]);
 
@@ -109,7 +109,7 @@ export function SpanCard({
           )}
           {hasChildren && (
             <button
-              className="z-40 p-1 hover:bg-muted transition-all text-muted-foreground rounded-sm"
+              className="z-30 p-1 hover:bg-muted transition-all text-muted-foreground rounded-sm"
               onClick={(e) => {
                 e.stopPropagation();
                 onToggleCollapse?.(span.spanId);

--- a/frontend/components/traces/trace-view.tsx
+++ b/frontend/components/traces/trace-view.tsx
@@ -230,7 +230,7 @@ export default function TraceView({ traceId, onClose }: TraceViewProps) {
                               {topLevelSpans.map((span, index) => (
                                 <div key={index} className="pl-6 relative">
                                   <SpanCard
-                                    parentY={0}
+                                    parentY={traceTreePanel.current?.getBoundingClientRect().y || 0}
                                     span={span}
                                     childSpans={childSpans}
                                     depth={1}

--- a/frontend/components/ui/formatter.tsx
+++ b/frontend/components/ui/formatter.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronUp, Copy, Maximize, Minimize } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import YAML from 'yaml';
 
 import { cn } from '@/lib/utils';
@@ -39,6 +39,7 @@ export default function Formatter({
   presetKey = null
 }: OutputFormatterProps) {
 
+  const [renderedValue, setRenderedValue] = useState(value);
   const [mode, setMode] = useState(() => {
     if (presetKey) {
       const savedMode = localStorage.getItem(`formatter-mode-${presetKey}`);
@@ -56,11 +57,17 @@ export default function Formatter({
     }
   };
 
+  useEffect(() => {
+    console.log(`value: ${value}, mode: ${mode}`);
+    console.log(`renderedValue: ${renderText(value)}`);
+    setRenderedValue(renderText(value));
+  }, [value, mode]);
+
   const renderText = (value: string) => {
-    // if mode is YAML try to parse it as YAML
+
     if (mode === 'yaml') {
       try {
-        const yamlFormatted = YAML.stringify(JSON.parse(value));
+        const yamlFormatted = YAML.stringify(YAML.parse(value));
         return yamlFormatted;
       } catch (e) {
         return value;
@@ -133,7 +140,7 @@ export default function Formatter({
           <div className="flex items-center gap-1">
             <CopyToClipboardButton
               className='h-7 w-7'
-              text={renderText(value)}
+              text={renderedValue}
             >
               <Copy className="h-3.5 w-3.5" />
             </CopyToClipboardButton>
@@ -173,7 +180,7 @@ export default function Formatter({
                   <div className="flex items-center gap-1">
                     <CopyToClipboardButton
                       className='h-7 w-7'
-                      text={renderText(value)}
+                      text={renderedValue}
                     >
                       <Copy className="h-3.5 w-3.5" />
                     </CopyToClipboardButton>
@@ -222,12 +229,12 @@ export default function Formatter({
         <div className="flex-grow flex overflow-auto w-full">
           {mode === 'custom' ? (
             <CustomRenderer
-              data={renderText(value)}
+              data={renderedValue}
               presetKey={presetKey}
             />
           ) : (
             <CodeEditor
-              value={renderText(value)}
+              value={renderedValue}
               editable={editable}
               language={mode}
               onChange={(v) => {

--- a/frontend/components/workspace/workspace-usage.tsx
+++ b/frontend/components/workspace/workspace-usage.tsx
@@ -74,14 +74,14 @@ export default function WorkspaceUsage({
       <div className="flex flex-col space-y-1">
         {workspaceStats.tierName === 'Pro' && (
           <p className="text-secondary-foreground text-sm mb-2">
-            Pro tier comes with 50K spans included per month. <br />
+            Pro tier comes with 100K spans included per month. <br />
             If you exceed this limit, you will be charged for overages.
           </p>
         )}
         {
           workspaceStats.tierName === 'Free' && (
             <p className="text-secondary-foreground text-sm mb-2">
-              Free tier comes with 10K spans included per month. <br />
+              Free tier comes with 50K spans included per month. <br />
               If you exceed this limit, you won{"'"}t be able to send <br />
               any more spans during current billing cycle.
             </p>
@@ -96,16 +96,11 @@ export default function WorkspaceUsage({
               <div className="flex-grow">
                 {spansThisMonth} / {spansLimit}
               </div>
-              {/* <div className=""> All time {workspaceStats.totalSpans} </div> */}
             </div>
           </>
         ) : (
           <div className="flex flex-row space-x-2 ">
             <div className="flex-grow">{spansThisMonth} </div>
-            {/* <div className="text-sm text-secondary-foreground">
-              {' '}
-              All time {workspaceStats.totalSpans}{' '}
-            </div> */}
           </div>
         )}
       </div>

--- a/frontend/lib/workspaces/types.ts
+++ b/frontend/lib/workspaces/types.ts
@@ -2,6 +2,8 @@ export type Project = {
   id: string;
   name: string;
   workspaceId: string;
+  numSpans: number;
+  numEvaluations: number;
 };
 
 export interface WorkspaceUser {

--- a/semantic-search-service/Cargo.lock
+++ b/semantic-search-service/Cargo.lock
@@ -1260,19 +1260,22 @@ dependencies = [
 
 [[package]]
 name = "qdrant-client"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbff72d38eac3860f5888f02d4688690de6cdc77c901112d3b0788694afc1d37"
+checksum = "9b585625d1ef06478e97fe8d7170a3f32a1cba5dbf986ff136095a85a0ec3d91"
 dependencies = [
  "anyhow",
  "derive_builder",
+ "futures",
  "futures-util",
  "prost",
  "prost-types",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
  "tonic",
 ]
 
@@ -1638,6 +1641,12 @@ dependencies = [
  "tonic-build",
  "uuid",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"

--- a/semantic-search-service/Cargo.toml
+++ b/semantic-search-service/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
+edition = "2021"
 name = "semantic-search-service"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 anyhow = "1"
+bm25 = "2.2.0"
+chrono = {version = "0.4.39", features = ["serde"]}
+dotenv = "0.15.0"
 enum_dispatch = "0.3.12"
 env_logger = "0.10.0"
-tonic = "0.12.3"
-prost = "0.13"
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
-tokio-stream = { version = "0.1", features = ["net"] }
 futures = "0.3"
-qdrant-client = "1.12.1"
-rayon = "1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
-serde = "1"
-simsimd = "3.9.0"
-serde_json = "1.0.105"
-log = "0.4.20"
-dotenv = "0.15.0"
-uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics"] }
-bm25 = "2.2.0"
 indexmap = "2.7.0"
-chrono = { version = "0.4.39", features = ["serde"] }
+log = "0.4.20"
+prost = "0.13"
 prost-types = "0.13.4"
+qdrant-client = "1.13"
+rayon = "1"
+reqwest = {version = "0.12", default-features = false, features = ["rustls-tls", "json"]}
+serde = "1"
+serde_json = "1.0.105"
+simsimd = "3.9.0"
+tokio = {version = "1.24", features = ["macros", "rt-multi-thread"]}
+tokio-stream = {version = "0.1", features = ["net"]}
+tonic = "0.12.3"
+uuid = {version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics"]}
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/semantic-search-service/src/embeddings/bm25.rs
+++ b/semantic-search-service/src/embeddings/bm25.rs
@@ -5,10 +5,7 @@ use indexmap::IndexMap;
 
 use super::{Embed, Embedding};
 
-// This has to be tuned together with CHARACTER_SPLITTER_CHUNK_SIZE
-// or any other chunking method. At the time of writing this,
-// chunk size is 512 characters, which is approximately 150 words.
-const DOCUMENT_LENGTH_TOKENS: f32 = 150.0;
+const DOCUMENT_LENGTH_TOKENS: f32 = 1024.0;
 
 pub struct Bm25 {
     embedder: Embedder,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR removes `chunker_runner`, updates `qdrant-client` to `1.13.0`, and refines backend and frontend logic for projects, spans, and workspaces.
> 
>   - **Backend Changes**:
>     - Removed `chunker_runner` from `main.rs`, `consumer.rs`, and `index.rs`.
>     - Removed `create_collection` calls in `create_project()` in `mod.rs`.
>     - Updated `qdrant-client` to version `1.13.0` in `Cargo.toml` and `Cargo.lock`.
>     - Modified `index_span()` in `index.rs` to directly use content without chunking.
>     - Adjusted `Bm25` document length in `bm25.rs` to `1024.0`.
>   - **Frontend Changes**:
>     - Updated `GET` in `route.ts` to fetch workspaces and projects directly from the database.
>     - Modified `ProjectCard` in `project-card.tsx` to remove `Card` component.
>     - Adjusted image URL handling in `chat-message-list-tab.tsx`.
>     - Fixed span height calculation in `SpanCard` in `span-card.tsx`.
>     - Updated `TraceView` in `trace-view.tsx` to handle span selection and timeline width.
>     - Enhanced `Formatter` in `formatter.tsx` to handle YAML and JSON modes more robustly.
>     - Updated workspace usage text in `workspace-usage.tsx`.
>   - **Miscellaneous**:
>     - Added `semver` dependency in `Cargo.toml` and `Cargo.lock`.
>     - Minor UI adjustments and bug fixes across various frontend components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 472e023be02f1f48e38d79dd0d652a452baf6b8a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->