### PR TITLE
filter out eval traces in the traces page

### DIFF
--- a/frontend/app/api/projects/[projectId]/traces/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/route.ts
@@ -92,6 +92,7 @@ export async function GET(
     ).where(
       and(
         eq(traces.projectId, projectId),
+        eq(traces.traceType, 'DEFAULT'),
         isNotNull(traces.startTime),
         isNotNull(traces.endTime),
         ...getDateRangeFilters(startTime, endTime, pastHours)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Filters out non-'DEFAULT' trace types in the `GET` function of `route.ts`.
> 
>   - **Behavior**:
>     - Filters out traces with `traceType` not equal to 'DEFAULT' in `GET` function in `route.ts`.
>     - Ensures only 'DEFAULT' traces are retrieved for the specified project and date range.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for bf61e59989a8bb54a8ae7edc86d3f6a70247fe66. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->