### PR TITLE
feat: change FE port to 5667

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker compose up -d
 ```
 
 This will spin up a lightweight version of the stack with Postgres, app-server, and frontend. This is good for a quickstart 
-or for lightweight usage. You can access the UI at http://localhost:3000 in your browser.
+or for lightweight usage. You can access the UI at http://localhost:5667 in your browser.
 
 For production environment, we recommend using our [managed platform](https://www.lmnr.ai/projects) or `docker compose -f docker-compose-full.yml up -d`. 
 

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -114,7 +114,7 @@ services:
   frontend:
     image: ghcr.io/lmnr-ai/frontend
     ports:
-      - "3000:3000"
+      - "5667:5667"
     pull_policy: always
     depends_on:
       postgres:
@@ -122,13 +122,13 @@ services:
       clickhouse:
         condition: service_started
     environment:
-      - PORT=3000
+      - PORT=5667
       - BACKEND_URL=http://app-server:8000
       - SHARED_SECRET_TOKEN=${SHARED_SECRET_TOKEN}
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-      - NEXTAUTH_URL=http://localhost:3000
+      - NEXTAUTH_URL=http://localhost:5667
       - NEXTAUTH_SECRET=some_secret
-      - NEXT_PUBLIC_URL=http://localhost:3000
+      - NEXT_PUBLIC_URL=http://localhost:5667
       - ENVIRONMENT=FULL
       - CLICKHOUSE_URL=http://clickhouse:8123
       - CLICKHOUSE_USER=${CLICKHOUSE_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,18 +27,18 @@ services:
     image: ghcr.io/lmnr-ai/frontend
     pull_policy: always
     ports:
-      - "3000:3000"
+      - "5667:5667"
     depends_on:
       postgres:
         condition: service_healthy
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-      PORT: 3000
+      PORT: 5667
       BACKEND_URL: http://app-server:8000
       SHARED_SECRET_TOKEN: ${SHARED_SECRET_TOKEN}
-      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_URL: http://localhost:5667
       NEXTAUTH_SECRET: some_secret
-      NEXT_PUBLIC_URL: http://localhost:3000
+      NEXT_PUBLIC_URL: http://localhost:5667
       ENVIRONMENT: LITE # this disables runtime dependency on clickhouse
 
   app-server:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change frontend port from 3000 to 5667 in `docker-compose-full.yml` and `docker-compose.yml`.
> 
>   - **Ports**:
>     - Change frontend port from `3000` to `5667` in `docker-compose-full.yml` and `docker-compose.yml`.
>   - **Environment Variables**:
>     - Update `PORT`, `NEXTAUTH_URL`, and `NEXT_PUBLIC_URL` to use port `5667` in both `docker-compose-full.yml` and `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 27ec73f6397250ac33bbd28638c712c57e3b872c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->