### PR TITLE
fix a few errors in datapoint page

### DIFF
--- a/frontend/components/dataset/dataset-panel.tsx
+++ b/frontend/components/dataset/dataset-panel.tsx
@@ -34,12 +34,12 @@ export default function DatasetPanel({
     swrFetcher
   );
   // datapoint is DatasetDatapoint, i.e. result of one execution on a data point
-  const [newData, setNewData] = useState<Record<string, any> | null>(datapoint?.data);
+  const [newData, setNewData] = useState<Record<string, any> | null>(datapoint?.data ?? null);
   const [newTarget, setNewTarget] = useState<Record<string, any> | null>(
-    datapoint?.target
+    datapoint?.target ?? null
   );
   const [newMetadata, setNewMetadata] = useState<Record<string, any>>(
-    datapoint?.metadata || {}
+    datapoint?.metadata ?? {}
   );
   const [isValidJsonData, setIsValidJsonData] = useState(true);
   const [isValidJsonTarget, setIsValidJsonTarget] = useState(true);
@@ -102,6 +102,8 @@ export default function DatasetPanel({
     setNewTarget(datapoint.target);
     setNewMetadata(datapoint.metadata);
   }, [datapoint]);
+
+  console.log(newTarget);
 
   return isLoading ? (<div className='p-4 space-y-2 h-full w-full'>
     <Skeleton className="h-8" />

--- a/frontend/components/dataset/dataset-panel.tsx
+++ b/frontend/components/dataset/dataset-panel.tsx
@@ -103,8 +103,6 @@ export default function DatasetPanel({
     setNewMetadata(datapoint.metadata);
   }, [datapoint]);
 
-  console.log(newTarget);
-
   return isLoading ? (<div className='p-4 space-y-2 h-full w-full'>
     <Skeleton className="h-8" />
     <Skeleton className="h-8" />

--- a/frontend/components/dataset/manual-add-datapoint-dialog.tsx
+++ b/frontend/components/dataset/manual-add-datapoint-dialog.tsx
@@ -37,12 +37,13 @@ export default function ManualAddDatapointDialog({
   const isValidJson = useCallback(() => {
     try {
       const parsed = JSON.parse(data);
-      if (!parsed.data) {
+      if (parsed.data === undefined) {
         return false;
       }
-      if (parsed.metadata) {
-        isValidJsonObject(parsed.metadata);
+      if (parsed.metadata !== undefined && !isValidJsonObject(parsed.metadata)) {
+        return false;
       }
+      return true;
     } catch (e) {
       return false;
     }
@@ -109,11 +110,11 @@ export default function ManualAddDatapointDialog({
         </DialogHeader>
         <span>{'Fill in datapoint in JSON format.'}</span>
         <div className="border rounded-md max-h-[300px] overflow-y-auto">
-          <CodeEditor value={data} onChange={setData} language="json" />
+          <CodeEditor value={data} onChange={setData} language="json" editable />
         </div>
         {!isValidJson() && (
           <div className="text-red-500">
-            Please enter a valid JSON map that has a {'"'}data{'"'} key
+            Please enter a valid JSON map that has a {'"'}data{'"'} key.
           </div>
         )}
         <DialogFooter className="mt-4">

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -400,7 +400,7 @@ export const isGroupByIntervalAvailable = (
 
 export const toFixedIfFloat = (value: number) => (value % 1 === 0 ? value : parseFloat(`${value}`)?.toFixed(3));
 
-export const isValidJsonObject = (value: any) => value !== null && typeof value === "object" && !Array.isArray(value);
+export const isValidJsonObject = (value: any): boolean => value !== null && typeof value === "object" && !Array.isArray(value);
 
 export const formatSecondsToMinutesAndSeconds = (seconds: number) => {
   const mins = Math.floor(seconds / 60);


### PR DESCRIPTION
- default undefined data to null, so formatter doesn't fail
- for old datasets we try to first delete the points, but some collections disappeared when we used qdrant, so not fail if collection doesn't exist
- Fix add data dialog, purely faulty logic there
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix data handling and error management issues in datapoint page, including defaulting undefined data to null and handling missing collections gracefully.
> 
>   - **Behavior**:
>     - Default undefined data to `null` in `dataset-panel.tsx` to prevent formatter failures.
>     - In `mod.rs`, handle missing collections gracefully by not failing if a collection does not exist during deletion.
>     - Fix logic in `manual-add-datapoint-dialog.tsx` to ensure valid JSON data is required.
>   - **Functions**:
>     - Update `isValidJsonObject` in `utils.ts` to include a return type.
>   - **UI**:
>     - Make `CodeEditor` editable in `manual-add-datapoint-dialog.tsx`.
>     - Update error message in `manual-add-datapoint-dialog.tsx` to specify JSON map requirement.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 1930added66a4a7644dc90b5c9c5a2fe8d9eec1a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->