### PR TITLE
write the output content to the parent span of aisdk

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -407,9 +407,14 @@ impl Span {
 
         // Vercel AI SDK wraps "raw" LLM spans in an additional `ai.generateText` span.
         // Which is not really an LLM span, but it has the prompt in its attributes.
-        // Set the input to the prompt.
+        // Set the input to the prompt and the output to the response.
         if let Some(serde_json::Value::String(s)) = attributes.get("ai.prompt") {
             span.input = Some(
+                serde_json::from_str::<Value>(s).unwrap_or(serde_json::Value::String(s.clone())),
+            );
+        }
+        if let Some(serde_json::Value::String(s)) = attributes.get("ai.response.text") {
+            span.output = Some(
                 serde_json::from_str::<Value>(s).unwrap_or(serde_json::Value::String(s.clone())),
             );
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `span.output` to `ai.response.text` in `spans.rs` for Vercel AI SDK spans.
> 
>   - **Behavior**:
>     - In `spans.rs`, set `span.output` to `ai.response.text` if present in attributes.
>     - Handles Vercel AI SDK spans by setting both `span.input` and `span.output` from `ai.prompt` and `ai.response.text` respectively.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for f4f6236d8fe28dede82bd8593a470a32bf8809e1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->