### PR TITLE
fix: race with useSWR on updateScoreNames

### DIFF
--- a/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/route.ts
@@ -44,7 +44,8 @@ export async function GET(
       target: sql<string>`SUBSTRING(${evaluationResults.target}::text, 0, 100)`.as('target'),
       executorOutput: evaluationResults.executorOutput,
       scores: subQueryScoreCte.cteScores,
-      index: evaluationResults.index
+      index: evaluationResults.index,
+      traceId: evaluationResults.traceId
     })
     .from(evaluationResults)
     .leftJoin(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix race condition in `Evaluation` component by updating score names post data load and add `traceId` to API response.
> 
>   - **Behavior**:
>     - Fix race condition in `Evaluation` component by updating score names after data load.
>     - Add `traceId` to API response in `route.ts`.
>   - **State Management**:
>     - Rename `scoreColumns` to `scoreNames` in `evaluation.tsx`.
>     - Update `updateScoreColumns` to handle score names and columns correctly.
>   - **UI**:
>     - Adjust column setup in `evaluation.tsx` to include score names dynamically.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 8d9f3df2e7e17cd3c2137f90579689bd846afc03. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->