### PR TITLE
fix generate object

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -384,6 +384,13 @@ impl Span {
 
                 if let Some(serde_json::Value::String(s)) = attributes.get("ai.response.text") {
                     span.output = Some(serde_json::Value::String(s.clone()));
+                } else if let Some(serde_json::Value::String(s)) =
+                    attributes.get("ai.response.object")
+                {
+                    span.output = Some(
+                        serde_json::from_str::<Value>(s)
+                            .unwrap_or(serde_json::Value::String(s.clone())),
+                    );
                 }
             } else if attributes
                 .get("SpanAttributes.LLM_PROMPTS.0.content")
@@ -414,6 +421,10 @@ impl Span {
             );
         }
         if let Some(serde_json::Value::String(s)) = attributes.get("ai.response.text") {
+            span.output = Some(
+                serde_json::from_str::<Value>(s).unwrap_or(serde_json::Value::String(s.clone())),
+            );
+        } else if let Some(serde_json::Value::String(s)) = attributes.get("ai.response.object") {
             span.output = Some(
                 serde_json::from_str::<Value>(s).unwrap_or(serde_json::Value::String(s.clone())),
             );


### PR DESCRIPTION
Also write generate object output to span
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `span.output` in `Span` class to handle `ai.response.object` attribute by parsing it as JSON or using it as a string.
> 
>   - **Behavior**:
>     - Update `span.output` in `Span` class in `spans.rs` to handle `ai.response.object` attribute.
>     - If `ai.response.object` is a string, attempt to parse as JSON, fallback to string if parsing fails.
>   - **Implementation**:
>     - Changes made in two places within `impl Span` block in `spans.rs`.
>     - Similar logic applied as for `ai.response.text`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 436b7eaab41bc5d5948b00b62437b42ecdd97226. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->