### PR TITLE
add default AEAD key to .env

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,5 @@ RABBITMQ_DEFAULT_PASS=adminpasswd
 
 CLICKHOUSE_USER=default
 POSTGRES_PORT=5433
+# must be exactly 32 bytes (64 hex characters)
+AEAD_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -95,6 +95,7 @@ services:
       - CODE_EXECUTOR_URL=http://python-executor:8811
       - SHARED_SECRET_TOKEN=${SHARED_SECRET_TOKEN}
       - ENVIRONMENT=FULL
+      - AEAD_SECRET_KEY=${AEAD_SECRET_KEY}
   frontend:
     image: ghcr.io/lmnr-ai/frontend
     ports:

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -74,6 +74,9 @@ services:
 
   app-server:
     image: ghcr.io/lmnr-ai/app-server
+    ports:
+      - "8000:8000"
+      - "8001:8001"
     depends_on:
       semantic-search-service:
         condition: service_started

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -73,6 +73,9 @@ services:
     container_name: python-executor
 
   app-server:
+    ports:
+      - "8000:8000"
+      - "8001:8001"
     build:
       context: ./app-server
       args:

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -66,6 +66,7 @@ services:
       CLICKHOUSE_URL: http://clickhouse:8123
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       ENVIRONMENT: LITE # this disables runtime dependency on rabbitmq, semantic search, and python executor
+      AEAD_SECRET_KEY: ${AEAD_SECRET_KEY}
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,9 @@ services:
   app-server:
     image: ghcr.io/lmnr-ai/app-server
     pull_policy: always
+    ports:
+      - "8000:8000"
+      - "8001:8001"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       CLICKHOUSE_URL: http://clickhouse:8123
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       ENVIRONMENT: LITE # this disables runtime dependency on rabbitmq, semantic search, and python executor
+      AEAD_SECRET_KEY: ${AEAD_SECRET_KEY}
 
 volumes:
   postgres-data:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `AEAD_SECRET_KEY` environment variable and expose ports 8000 and 8001 for `app-server` in multiple Docker Compose files.
> 
>   - **Environment Variables**:
>     - Add `AEAD_SECRET_KEY` to `app-server` environment in `docker-compose-full.yml`, `docker-compose-local-dev.yml`, and `docker-compose.yml`.
>   - **Ports**:
>     - Expose ports `8000:8000` and `8001:8001` for `app-server` in `docker-compose-full.yml`, `docker-compose-local-build.yml`, and `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 1f570a4027fe14b06f6f2374ca8544e2309d10cd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->