### PR TITLE
implement message queue as a trait

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -82,12 +82,14 @@ fn tonic_error_to_io_error(err: tonic::transport::Error) -> io::Error {
 }
 
 fn main() -> anyhow::Result<()> {
+    // == Crypto utils ==
     sodiumoxide::init().expect("failed to initialize sodiumoxide");
 
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Failed to install rustls crypto provider");
 
+    // == General configuration ==
     dotenv::dotenv().ok();
 
     let general_runtime =
@@ -109,6 +111,8 @@ fn main() -> anyhow::Result<()> {
         .unwrap();
     let grpc_address = format!("0.0.0.0:{}", grpc_port).parse().unwrap();
 
+    // == Stuff that is needed both for HTTP and gRPC servers ==
+    // === 1. Caches ===
     let mut caches: HashMap<TypeId, Arc<dyn CacheTrait>> = HashMap::new();
     let auth_cache: Arc<MokaCache<String, User>> = Arc::new(MokaCache::new(DEFAULT_CACHE_SIZE));
     caches.insert(TypeId::of::<User>(), auth_cache);
@@ -133,6 +137,7 @@ fn main() -> anyhow::Result<()> {
 
     let cache = Arc::new(Cache::new(caches));
 
+    // === 2. Database ===
     let db_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
 
     let mut pool = None;
@@ -151,37 +156,9 @@ fn main() -> anyhow::Result<()> {
         );
     });
     let pool = pool.unwrap();
-
     let db = Arc::new(db::DB::new(pool));
 
-    let mut chunkers = HashMap::new();
-    let character_split_chunker = CharacterSplitChunker {};
-    chunkers.insert(
-        ChunkerType::CharacterSplit,
-        Chunker::CharacterSplit(character_split_chunker),
-    );
-    let chunker_runner = Arc::new(ChunkerRunner::new(chunkers));
-
-    let interrupt_senders = Arc::new(DashMap::<Uuid, mpsc::Sender<GraphInterruptMessage>>::new());
-
-    let clickhouse_url = env::var("CLICKHOUSE_URL").expect("CLICKHOUSE_URL must be set");
-    let clickhouse_user = env::var("CLICKHOUSE_USER").expect("CLICKHOUSE_USER must be set");
-    let clickhouse_password = env::var("CLICKHOUSE_PASSWORD");
-    let client = clickhouse::Client::default()
-        .with_url(clickhouse_url)
-        .with_user(clickhouse_user)
-        .with_database("default")
-        .with_option("async_insert", "1")
-        .with_option("wait_for_async_insert", "0");
-
-    let clickhouse = match clickhouse_password {
-        Ok(password) => client.with_password(password),
-        _ => {
-            log::warn!("CLICKHOUSE_PASSWORD not set, using without password");
-            client
-        }
-    };
-
+    // === 3. Spans message queue ===
     let spans_message_queue: Arc<dyn mq::MessageQueue<api::v1::traces::RabbitMqSpanMessage>> =
         if is_feature_enabled(Feature::FullBuild) {
             let rabbitmq_url = env::var("RABBITMQ_URL").expect("RABBITMQ_URL must be set");
@@ -191,129 +168,69 @@ fn main() -> anyhow::Result<()> {
             Arc::new(mq::tokio_mpsc::TokioMpscQueue::new())
         };
 
-    let mut aws_sdk_config = None;
-    runtime_handle.block_on(async {
-        aws_sdk_config = Some(
-            aws_config::defaults(BehaviorVersion::latest())
-                .region(aws_config::Region::new(
-                    env::var("AWS_REGION").unwrap_or("us-east-1".to_string()),
-                ))
-                .load()
-                .await,
-        );
-    });
-    let aws_sdk_config = aws_sdk_config.unwrap();
-    let storage: Arc<dyn Storage> = if is_feature_enabled(Feature::Storage) {
-        let s3_client = aws_sdk_s3::Client::new(&aws_sdk_config);
-        let s3_storage = storage::s3::S3Storage::new(
-            s3_client,
-            env::var("S3_TRACE_PAYLOADS_BUCKET").expect("S3_TRACE_PAYLOADS_BUCKET must be set"),
-        );
-        Arc::new(s3_storage)
-    } else {
-        Arc::new(MockStorage {})
-    };
-
     let runtime_handle_for_http = runtime_handle.clone();
     let db_for_http = db.clone();
     let cache_for_http = cache.clone();
-    let mq_for_grpc = spans_message_queue.clone();
+    let spans_mq_for_http = spans_message_queue.clone();
 
-    let (semantic_search, pipeline_runner, language_model_runner) =
-        runtime_handle.block_on(async {
-            let semantic_search: Arc<dyn SemanticSearch> = if is_feature_enabled(Feature::FullBuild)
-            {
-                let semantic_search_url =
-                    env::var("SEMANTIC_SEARCH_URL").expect("SEMANTIC_SEARCH_URL must be set");
-
-                let semantic_search_client = Arc::new(
-                    SemanticSearchClient::connect(semantic_search_url)
-                        .await
-                        .unwrap(),
-                );
-                Arc::new(
-                    semantic_search::semantic_search_impl::SemanticSearchImpl::new(
-                        semantic_search_client,
-                    ),
-                )
-            } else {
-                Arc::new(semantic_search::mock::MockSemanticSearch {})
-            };
-
-            let code_executor: Arc<dyn CodeExecutor> = if is_feature_enabled(Feature::FullBuild) {
-                let code_executor_url =
-                    env::var("CODE_EXECUTOR_URL").expect("CODE_EXECUTOR_URL must be set");
-                let code_executor_client = Arc::new(
-                    CodeExecutorClient::connect(code_executor_url)
-                        .await
-                        .unwrap(),
-                );
-                Arc::new(code_executor::code_executor_impl::CodeExecutorImpl::new(
-                    code_executor_client,
-                ))
-            } else {
-                Arc::new(code_executor::mock::MockCodeExecutor {})
-            };
-
-            let client = reqwest::Client::new();
-            let anthropic = language_model::Anthropic::new(client.clone());
-            let openai = language_model::OpenAI::new(client.clone());
-            let openai_azure = language_model::OpenAIAzure::new(client.clone());
-            let gemini = language_model::Gemini::new(client.clone());
-            let groq = language_model::Groq::new(client.clone());
-            let mistral = language_model::Mistral::new(client.clone());
-
-            let mut language_models: HashMap<LanguageModelProviderName, LanguageModelProvider> =
-                HashMap::new();
-            language_models.insert(
-                LanguageModelProviderName::Anthropic,
-                LanguageModelProvider::Anthropic(anthropic),
-            );
-            language_models.insert(
-                LanguageModelProviderName::OpenAI,
-                LanguageModelProvider::OpenAI(openai),
-            );
-            language_models.insert(
-                LanguageModelProviderName::OpenAIAzure,
-                LanguageModelProvider::OpenAIAzure(openai_azure),
-            );
-            language_models.insert(
-                LanguageModelProviderName::Gemini,
-                LanguageModelProvider::Gemini(gemini),
-            );
-            language_models.insert(
-                LanguageModelProviderName::Groq,
-                LanguageModelProvider::Groq(groq),
-            );
-            language_models.insert(
-                LanguageModelProviderName::Mistral,
-                LanguageModelProvider::Mistral(mistral),
-            );
-            language_models.insert(
-                LanguageModelProviderName::Bedrock,
-                LanguageModelProvider::Bedrock(language_model::AnthropicBedrock::new(
-                    aws_sdk_bedrockruntime::Client::new(&aws_sdk_config),
-                )),
-            );
-            let language_model_runner =
-                Arc::new(language_model::LanguageModelRunner::new(language_models));
-
-            let pipeline_runner = Arc::new(pipeline::runner::PipelineRunner::new(
-                language_model_runner.clone(),
-                semantic_search.clone(),
-                spans_message_queue.clone(),
-                code_executor.clone(),
-                db_for_http.clone(),
-                cache_for_http.clone(),
-            ));
-
-            (semantic_search, pipeline_runner, language_model_runner)
-        });
-
+    // == HTTP server ==
     let http_server_handle = thread::Builder::new()
         .name("http".to_string())
         .spawn(move || {
             runtime_handle_for_http.block_on(async {
+                // == AWS config for S3 and Bedrock ==
+                let aws_sdk_config = aws_config::defaults(BehaviorVersion::latest())
+                    .region(aws_config::Region::new(
+                        env::var("AWS_REGION").unwrap_or("us-east-1".to_string()),
+                    ))
+                    .load()
+                    .await;
+
+                // == Storage ==
+                let storage: Arc<dyn Storage> = if is_feature_enabled(Feature::Storage) {
+                    let s3_client = aws_sdk_s3::Client::new(&aws_sdk_config);
+                    let s3_storage = storage::s3::S3Storage::new(
+                        s3_client,
+                        env::var("S3_TRACE_PAYLOADS_BUCKET")
+                            .expect("S3_TRACE_PAYLOADS_BUCKET must be set"),
+                    );
+                    Arc::new(s3_storage)
+                } else {
+                    Arc::new(MockStorage {})
+                };
+
+                // == Chunkers ==
+                // TODO: either add chunkers back to the datasets or remove them from code
+                let mut chunkers = HashMap::new();
+                let character_split_chunker = CharacterSplitChunker {};
+                chunkers.insert(
+                    ChunkerType::CharacterSplit,
+                    Chunker::CharacterSplit(character_split_chunker),
+                );
+                let chunker_runner = Arc::new(ChunkerRunner::new(chunkers));
+
+                // == Clickhouse ==
+                let clickhouse_url =
+                    env::var("CLICKHOUSE_URL").expect("CLICKHOUSE_URL must be set");
+                let clickhouse_user =
+                    env::var("CLICKHOUSE_USER").expect("CLICKHOUSE_USER must be set");
+                let clickhouse_password = env::var("CLICKHOUSE_PASSWORD");
+                let clickhouse_client = clickhouse::Client::default()
+                    .with_url(clickhouse_url)
+                    .with_user(clickhouse_user)
+                    .with_database("default")
+                    .with_option("async_insert", "1")
+                    .with_option("wait_for_async_insert", "0");
+
+                let clickhouse = match clickhouse_password {
+                    Ok(password) => clickhouse_client.with_password(password),
+                    _ => {
+                        log::warn!("CLICKHOUSE_PASSWORD not set, using without password");
+                        clickhouse_client
+                    }
+                };
+
+                // == Machine manager ==
                 let machine_manager: Arc<dyn MachineManager> =
                     if is_feature_enabled(Feature::MachineManager) {
                         let machine_manager_url_grpc = env::var("MACHINE_MANAGER_URL_GRPC")
@@ -328,7 +245,103 @@ fn main() -> anyhow::Result<()> {
                         Arc::new(machine_manager::MockMachineManager {})
                     };
 
+                // == Name generator ==
                 let name_generator = Arc::new(NameGenerator::new());
+
+                // == Interrupt senders for pipeline execution control ==
+                let interrupt_senders =
+                    Arc::new(DashMap::<Uuid, mpsc::Sender<GraphInterruptMessage>>::new());
+
+                // == Semantic search ==
+                let semantic_search: Arc<dyn SemanticSearch> =
+                    if is_feature_enabled(Feature::FullBuild) {
+                        let semantic_search_url = env::var("SEMANTIC_SEARCH_URL")
+                            .expect("SEMANTIC_SEARCH_URL must be set");
+
+                        let semantic_search_client = Arc::new(
+                            SemanticSearchClient::connect(semantic_search_url)
+                                .await
+                                .unwrap(),
+                        );
+                        Arc::new(
+                            semantic_search::semantic_search_impl::SemanticSearchImpl::new(
+                                semantic_search_client,
+                            ),
+                        )
+                    } else {
+                        Arc::new(semantic_search::mock::MockSemanticSearch {})
+                    };
+
+                // == Python executor ==
+                let code_executor: Arc<dyn CodeExecutor> = if is_feature_enabled(Feature::FullBuild)
+                {
+                    let code_executor_url =
+                        env::var("CODE_EXECUTOR_URL").expect("CODE_EXECUTOR_URL must be set");
+                    let code_executor_client = Arc::new(
+                        CodeExecutorClient::connect(code_executor_url)
+                            .await
+                            .unwrap(),
+                    );
+                    Arc::new(code_executor::code_executor_impl::CodeExecutorImpl::new(
+                        code_executor_client,
+                    ))
+                } else {
+                    Arc::new(code_executor::mock::MockCodeExecutor {})
+                };
+
+                // == Language models ==
+                let client = reqwest::Client::new();
+                let anthropic = language_model::Anthropic::new(client.clone());
+                let openai = language_model::OpenAI::new(client.clone());
+                let openai_azure = language_model::OpenAIAzure::new(client.clone());
+                let gemini = language_model::Gemini::new(client.clone());
+                let groq = language_model::Groq::new(client.clone());
+                let mistral = language_model::Mistral::new(client.clone());
+
+                let mut language_models: HashMap<LanguageModelProviderName, LanguageModelProvider> =
+                    HashMap::new();
+                language_models.insert(
+                    LanguageModelProviderName::Anthropic,
+                    LanguageModelProvider::Anthropic(anthropic),
+                );
+                language_models.insert(
+                    LanguageModelProviderName::OpenAI,
+                    LanguageModelProvider::OpenAI(openai),
+                );
+                language_models.insert(
+                    LanguageModelProviderName::OpenAIAzure,
+                    LanguageModelProvider::OpenAIAzure(openai_azure),
+                );
+                language_models.insert(
+                    LanguageModelProviderName::Gemini,
+                    LanguageModelProvider::Gemini(gemini),
+                );
+                language_models.insert(
+                    LanguageModelProviderName::Groq,
+                    LanguageModelProvider::Groq(groq),
+                );
+                language_models.insert(
+                    LanguageModelProviderName::Mistral,
+                    LanguageModelProvider::Mistral(mistral),
+                );
+                language_models.insert(
+                    LanguageModelProviderName::Bedrock,
+                    LanguageModelProvider::Bedrock(language_model::AnthropicBedrock::new(
+                        aws_sdk_bedrockruntime::Client::new(&aws_sdk_config),
+                    )),
+                );
+                let language_model_runner =
+                    Arc::new(language_model::LanguageModelRunner::new(language_models));
+
+                // == Pipeline runner ==
+                let pipeline_runner = Arc::new(pipeline::runner::PipelineRunner::new(
+                    language_model_runner.clone(),
+                    semantic_search.clone(),
+                    spans_mq_for_http.clone(),
+                    code_executor.clone(),
+                    db_for_http.clone(),
+                    cache_for_http.clone(),
+                ));
 
                 HttpServer::new(move || {
                     let auth = HttpAuthentication::bearer(auth::validator);
@@ -346,7 +359,7 @@ fn main() -> anyhow::Result<()> {
                             pipeline_runner.clone(),
                             db_for_http.clone(),
                             cache_for_http.clone(),
-                            spans_message_queue.clone(),
+                            spans_mq_for_http.clone(),
                             clickhouse.clone(),
                             storage.clone(),
                         ));
@@ -363,7 +376,7 @@ fn main() -> anyhow::Result<()> {
                         .app_data(web::Data::new(semantic_search.clone()))
                         .app_data(web::Data::new(interrupt_senders.clone()))
                         .app_data(web::Data::new(language_model_runner.clone()))
-                        .app_data(web::Data::new(spans_message_queue.clone()))
+                        .app_data(web::Data::new(spans_mq_for_http.clone()))
                         .app_data(web::Data::new(clickhouse.clone()))
                         .app_data(web::Data::new(name_generator.clone()))
                         .app_data(web::Data::new(semantic_search.clone()))
@@ -533,8 +546,11 @@ fn main() -> anyhow::Result<()> {
         .name("grpc".to_string())
         .spawn(move || {
             runtime_handle.block_on(async {
-                let process_traces_service =
-                    ProcessTracesService::new(db.clone(), cache.clone(), mq_for_grpc.clone());
+                let process_traces_service = ProcessTracesService::new(
+                    db.clone(),
+                    cache.clone(),
+                    spans_message_queue.clone(),
+                );
 
                 Server::builder()
                     .add_service(

--- a/app-server/src/mq/mod.rs
+++ b/app-server/src/mq/mod.rs
@@ -5,14 +5,14 @@ pub mod rabbit;
 pub mod tokio_mpsc;
 
 #[async_trait]
-pub trait MQReceiver<T>: Send + Sync {
-    async fn receive(&mut self) -> Option<anyhow::Result<Box<dyn MQDelivery<T>>>>
+pub trait MessageQueueReceiver<T>: Send + Sync {
+    async fn receive(&mut self) -> Option<anyhow::Result<Box<dyn MessageQueueDelivery<T>>>>
     where
         T: for<'de> Deserialize<'de> + Clone;
 }
 
 #[async_trait]
-pub trait MQDelivery<T>: Send + Sync {
+pub trait MessageQueueDelivery<T>: Send + Sync {
     async fn ack(&self) -> anyhow::Result<()>;
     fn data(&self) -> T
     where
@@ -31,5 +31,5 @@ where
         queue_name: &str,
         exchange: &str,
         routing_key: &str,
-    ) -> anyhow::Result<Box<dyn MQReceiver<T>>>;
+    ) -> anyhow::Result<Box<dyn MessageQueueReceiver<T>>>;
 }

--- a/app-server/src/mq/mod.rs
+++ b/app-server/src/mq/mod.rs
@@ -24,17 +24,12 @@ pub trait MessageQueue<T>: Send + Sync
 where
     T: for<'de> Deserialize<'de> + Serialize + Clone + Send + Sync + 'static,
 {
-    async fn publish(
-        &self,
-        message: &T,
-        exchange: Option<&str>,
-        routing_key: Option<&str>,
-    ) -> anyhow::Result<()>;
+    async fn publish(&self, message: &T, exchange: &str, routing_key: &str) -> anyhow::Result<()>;
 
     async fn get_receiver(
         &self,
-        queue_name: Option<&str>,
-        exchange: Option<&str>,
-        routing_key: Option<&str>,
+        queue_name: &str,
+        exchange: &str,
+        routing_key: &str,
     ) -> anyhow::Result<Box<dyn MQReceiver<T>>>;
 }

--- a/app-server/src/mq/mod.rs
+++ b/app-server/src/mq/mod.rs
@@ -1,0 +1,40 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+pub mod rabbit;
+pub mod tokio_mpsc;
+
+#[async_trait]
+pub trait MQReceiver<T>: Send + Sync {
+    async fn receive(&mut self) -> Option<anyhow::Result<Box<dyn MQDelivery<T>>>>
+    where
+        T: for<'de> Deserialize<'de> + Clone;
+}
+
+#[async_trait]
+pub trait MQDelivery<T>: Send + Sync {
+    async fn ack(&self) -> anyhow::Result<()>;
+    fn data(&self) -> T
+    where
+        T: for<'de> Deserialize<'de> + Clone;
+}
+
+#[async_trait]
+pub trait MessageQueue<T>: Send + Sync
+where
+    T: for<'de> Deserialize<'de> + Serialize + Clone + Send + Sync + 'static,
+{
+    async fn publish(
+        &self,
+        message: &T,
+        exchange: Option<&str>,
+        routing_key: Option<&str>,
+    ) -> anyhow::Result<()>;
+
+    async fn get_receiver(
+        &self,
+        queue_name: Option<&str>,
+        exchange: Option<&str>,
+        routing_key: Option<&str>,
+    ) -> anyhow::Result<Box<dyn MQReceiver<T>>>;
+}

--- a/app-server/src/mq/rabbit.rs
+++ b/app-server/src/mq/rabbit.rs
@@ -9,7 +9,7 @@ use lapin::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use super::{MQDelivery, MQReceiver, MessageQueue};
+use super::{MessageQueue, MessageQueueDelivery, MessageQueueReceiver};
 
 pub struct RabbitMQ {
     connection: Arc<Connection>,
@@ -25,7 +25,7 @@ struct RabbitMQDelivery<T> {
 }
 
 #[async_trait]
-impl<T> MQDelivery<T> for RabbitMQDelivery<T>
+impl<T> MessageQueueDelivery<T> for RabbitMQDelivery<T>
 where
     T: for<'de> Deserialize<'de> + Clone + Send + Sync,
 {
@@ -40,11 +40,11 @@ where
 }
 
 #[async_trait]
-impl<T> MQReceiver<T> for RabbitMQReceiver
+impl<T> MessageQueueReceiver<T> for RabbitMQReceiver
 where
     T: for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
 {
-    async fn receive(&mut self) -> Option<anyhow::Result<Box<dyn MQDelivery<T>>>> {
+    async fn receive(&mut self) -> Option<anyhow::Result<Box<dyn MessageQueueDelivery<T>>>> {
         if let Some(delivery) = self.consumer.next().await {
             let Ok(delivery) = delivery else {
                 return Some(Err(anyhow::anyhow!(
@@ -108,7 +108,7 @@ where
         queue_name: &str,
         exchange: &str,
         routing_key: &str,
-    ) -> anyhow::Result<Box<dyn MQReceiver<T>>>
+    ) -> anyhow::Result<Box<dyn MessageQueueReceiver<T>>>
     where
         T: for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
     {

--- a/app-server/src/mq/rabbit.rs
+++ b/app-server/src/mq/rabbit.rs
@@ -1,0 +1,175 @@
+use async_trait::async_trait;
+use futures::StreamExt;
+use lapin::{
+    message::Delivery,
+    options::{
+        BasicAckOptions, BasicConsumeOptions, BasicPublishOptions, ExchangeDeclareOptions,
+        QueueBindOptions, QueueDeclareOptions,
+    },
+    types::FieldTable,
+    BasicProperties, Connection, ConnectionProperties, Consumer, ExchangeKind,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use super::{MQDelivery, MQReceiver, MessageQueue};
+use crate::traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_QUEUE, OBSERVATIONS_ROUTING_KEY};
+
+pub struct RabbitMQ {
+    connection: Arc<Connection>,
+}
+
+struct RabbitMQReceiver {
+    consumer: Consumer,
+}
+
+struct RabbitMQDelivery<T> {
+    delivery: Delivery,
+    data: T,
+}
+
+#[async_trait]
+impl<T> MQDelivery<T> for RabbitMQDelivery<T>
+where
+    T: for<'de> Deserialize<'de> + Clone + Send + Sync,
+{
+    async fn ack(&self) -> anyhow::Result<()> {
+        self.delivery.ack(BasicAckOptions::default()).await?;
+        Ok(())
+    }
+
+    fn data(&self) -> T {
+        self.data.clone()
+    }
+}
+
+#[async_trait]
+impl<T> MQReceiver<T> for RabbitMQReceiver
+where
+    T: for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+{
+    async fn receive(&mut self) -> Option<anyhow::Result<Box<dyn MQDelivery<T>>>> {
+        if let Some(delivery) = self.consumer.next().await {
+            let Ok(delivery) = delivery else {
+                return Some(Err(anyhow::anyhow!(
+                    "Failed to get delivery from RabbitMQ."
+                )));
+            };
+
+            let Ok(payload) = String::from_utf8(delivery.data.clone()) else {
+                return Some(Err(anyhow::anyhow!(
+                    "Failed to parse delivery data as UTF-8."
+                )));
+            };
+
+            let payload = serde_json::from_str::<T>(&payload);
+            match payload {
+                Ok(payload) => Some(Ok(Box::new(RabbitMQDelivery {
+                    delivery,
+                    data: payload,
+                }))),
+                Err(e) => Some(Err(anyhow::anyhow!("Failed to deserialize payload: {}", e))),
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl RabbitMQ {
+    pub async fn create(url: &str) -> Self {
+        let connection = Connection::connect(url, ConnectionProperties::default())
+            .await
+            .unwrap();
+
+        // declare the exchange
+        let channel = connection.create_channel().await.unwrap();
+
+        channel
+            .exchange_declare(
+                OBSERVATIONS_EXCHANGE,
+                ExchangeKind::Fanout,
+                ExchangeDeclareOptions::default(),
+                FieldTable::default(),
+            )
+            .await
+            .unwrap();
+
+        channel
+            .queue_declare(
+                OBSERVATIONS_QUEUE,
+                QueueDeclareOptions::default(),
+                FieldTable::default(),
+            )
+            .await
+            .unwrap();
+
+        Self {
+            connection: Arc::new(connection),
+        }
+    }
+}
+
+#[async_trait]
+impl<T> MessageQueue<T> for RabbitMQ
+where
+    T: for<'de> Deserialize<'de> + Serialize + Clone + Send + Sync + 'static,
+{
+    async fn publish(
+        &self,
+        message: &T,
+        exchange: Option<&str>,
+        routing_key: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let payload = serde_json::to_string(message)?;
+        let payload = payload.as_bytes();
+
+        let channel = self.connection.create_channel().await?;
+
+        channel
+            .basic_publish(
+                exchange.unwrap_or(OBSERVATIONS_EXCHANGE),
+                routing_key.unwrap_or(OBSERVATIONS_ROUTING_KEY),
+                BasicPublishOptions::default(),
+                payload,
+                BasicProperties::default(),
+            )
+            .await?
+            .await?;
+
+        Ok(())
+    }
+
+    async fn get_receiver(
+        &self,
+        queue_name: Option<&str>,
+        exchange: Option<&str>,
+        routing_key: Option<&str>,
+    ) -> anyhow::Result<Box<dyn MQReceiver<T>>>
+    where
+        T: for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+    {
+        let channel = self.connection.create_channel().await?;
+
+        channel
+            .queue_bind(
+                queue_name.unwrap_or(OBSERVATIONS_QUEUE),
+                exchange.unwrap_or(OBSERVATIONS_EXCHANGE),
+                routing_key.unwrap_or(OBSERVATIONS_ROUTING_KEY),
+                QueueBindOptions::default(),
+                FieldTable::default(),
+            )
+            .await?;
+
+        let consumer = channel
+            .basic_consume(
+                queue_name.unwrap_or(OBSERVATIONS_QUEUE),
+                routing_key.unwrap_or(OBSERVATIONS_ROUTING_KEY),
+                BasicConsumeOptions::default(),
+                FieldTable::default(),
+            )
+            .await?;
+
+        Ok(Box::new(RabbitMQReceiver { consumer }))
+    }
+}

--- a/app-server/src/mq/tokio_mpsc.rs
+++ b/app-server/src/mq/tokio_mpsc.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::{MQDelivery, MQReceiver, MessageQueue};
+use crate::traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY};
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{
+    mpsc::{self, Receiver, Sender},
+    Mutex,
+};
+
+// TODO: Possibly think about how to generalize the inner type with any
+// `T: Clone + Serialize + Deserialize + Send + Sync`
+// instead of manually (de)serializing into `Vec<u8>`
+struct TokioMpscReceiver {
+    receiver: Receiver<Vec<u8>>,
+}
+
+struct TokioMpscDelivery<T> {
+    data: T,
+}
+
+#[async_trait]
+impl<T> MQDelivery<T> for TokioMpscDelivery<T>
+where
+    T: for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+{
+    async fn ack(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn data(&self) -> T
+    where
+        T: for<'de> Deserialize<'de> + Clone,
+    {
+        self.data.clone()
+    }
+}
+
+#[async_trait]
+impl<T> MQReceiver<T> for TokioMpscReceiver
+where
+    T: for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+{
+    async fn receive(&mut self) -> Option<anyhow::Result<Box<dyn MQDelivery<T>>>> {
+        let payload = self.receiver.recv().await;
+        match payload {
+            Some(payload) => {
+                let message = serde_json::from_slice(&payload);
+                match message {
+                    Ok(message) => Some(Ok(Box::new(TokioMpscDelivery { data: message }))),
+                    Err(e) => Some(Err(anyhow::anyhow!("Failed to deserialize payload: {}", e))),
+                }
+            }
+            None => None,
+        }
+    }
+}
+
+pub struct TokioMpscQueue {
+    senders: DashMap<String, Arc<Mutex<Vec<Sender<Vec<u8>>>>>>,
+}
+
+impl TokioMpscQueue {
+    pub fn new() -> Self {
+        Self {
+            senders: DashMap::new(),
+        }
+    }
+
+    fn key(&self, exchange: &str, routing_key: &str) -> String {
+        format!("{}:-:{}", exchange, routing_key)
+    }
+}
+
+#[async_trait]
+impl<T> MessageQueue<T> for TokioMpscQueue
+where
+    T: for<'de> Deserialize<'de> + Serialize + Clone + Send + Sync + 'static,
+{
+    async fn publish(
+        &self,
+        message: &T,
+        exchange: Option<&str>,
+        routing_key: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let exchange = exchange.unwrap_or(OBSERVATIONS_EXCHANGE);
+        let routing_key = routing_key.unwrap_or(OBSERVATIONS_ROUTING_KEY);
+        let key = self.key(exchange, routing_key);
+
+        let Some(senders) = self.senders.get(&key) else {
+            return Err(anyhow::anyhow!(
+                "Queue mapping for exchange `{}` and routing key `{}` not found",
+                exchange,
+                routing_key
+            ));
+        };
+
+        if senders.lock().await.is_empty() {
+            return Err(anyhow::anyhow!(
+                "No queues exist for exchange `{}` and routing key `{}`",
+                exchange,
+                routing_key
+            ));
+        }
+
+        // naive iteration to choose the least busy queue
+        let mut max_index = 0;
+        let mut max_capacity = 0;
+        for (index, sender) in senders.lock().await.iter().enumerate() {
+            if sender.capacity() > max_capacity {
+                max_capacity = sender.capacity();
+                max_index = index;
+            }
+        }
+
+        let payload = serde_json::to_vec(message)?;
+        senders.lock().await[max_index].send(payload).await?;
+
+        Ok(())
+    }
+
+    async fn get_receiver(
+        &self,
+        _queue_name: Option<&str>,
+        exchange: Option<&str>,
+        routing_key: Option<&str>,
+    ) -> anyhow::Result<Box<dyn MQReceiver<T>>> {
+        let exchange = exchange.unwrap_or(OBSERVATIONS_EXCHANGE);
+        let routing_key = routing_key.unwrap_or(OBSERVATIONS_ROUTING_KEY);
+        let key = self.key(exchange, routing_key);
+
+        let (sender, receiver) = mpsc::channel(100);
+        let tokio_mpsc_receiver = TokioMpscReceiver { receiver };
+        self.senders
+            .entry(key)
+            .or_default()
+            .lock()
+            .await
+            .push(sender);
+        Ok(Box::new(tokio_mpsc_receiver))
+    }
+}

--- a/app-server/src/pipeline/runner.rs
+++ b/app-server/src/pipeline/runner.rs
@@ -251,8 +251,8 @@ impl PipelineRunner {
         self.queue
             .publish(
                 &parent_span_mq_message,
-                Some(OBSERVATIONS_EXCHANGE),
-                Some(OBSERVATIONS_ROUTING_KEY),
+                OBSERVATIONS_EXCHANGE,
+                OBSERVATIONS_ROUTING_KEY,
             )
             .await?;
 
@@ -266,8 +266,8 @@ impl PipelineRunner {
             self.queue
                 .publish(
                     &message_span_mq_message,
-                    Some(OBSERVATIONS_EXCHANGE),
-                    Some(OBSERVATIONS_ROUTING_KEY),
+                    OBSERVATIONS_EXCHANGE,
+                    OBSERVATIONS_ROUTING_KEY,
                 )
                 .await?;
         }

--- a/app-server/src/pipeline/runner.rs
+++ b/app-server/src/pipeline/runner.rs
@@ -10,16 +10,12 @@ use crate::{
         DB,
     },
     engine::{engine::EngineOutput, Engine},
-    features::{is_feature_enabled, Feature},
+    mq::MessageQueue,
     routes::pipelines::GraphInterruptMessage,
-    traces::{
-        utils::{get_llm_usage_for_span, record_span_to_db},
-        OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY,
-    },
+    traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY},
 };
 use anyhow::Result;
 use itertools::Itertools;
-use lapin::{options::BasicPublishOptions, BasicProperties, Connection};
 use serde::Serialize;
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
@@ -99,7 +95,7 @@ impl Serialize for PipelineRunnerError {
 pub struct PipelineRunner {
     language_model: Arc<LanguageModelRunner>,
     semantic_search: Arc<dyn SemanticSearch>,
-    rabbitmq_connection: Option<Arc<Connection>>,
+    queue: Arc<dyn MessageQueue<RabbitMqSpanMessage>>,
     code_executor: Arc<dyn CodeExecutor>,
     db: Arc<DB>,
     cache: Arc<Cache>,
@@ -109,7 +105,7 @@ impl PipelineRunner {
     pub fn new(
         language_model: Arc<LanguageModelRunner>,
         semantic_search: Arc<dyn SemanticSearch>,
-        rabbitmq_connection: Option<Arc<Connection>>,
+        queue: Arc<dyn MessageQueue<RabbitMqSpanMessage>>,
         code_executor: Arc<dyn CodeExecutor>,
         db: Arc<DB>,
         cache: Arc<Cache>,
@@ -117,7 +113,7 @@ impl PipelineRunner {
         Self {
             language_model,
             semantic_search,
-            rabbitmq_connection,
+            queue,
             code_executor,
             db,
             cache,
@@ -232,7 +228,7 @@ impl PipelineRunner {
             _ => return Ok(()), // nothing to record
         };
         let run_stats = RunTraceStats::from_messages(&engine_output.messages);
-        let mut parent_span = Span::create_parent_span_in_run_trace(
+        let parent_span = Span::create_parent_span_in_run_trace(
             current_trace_and_span,
             &run_stats,
             pipeline_version_name,
@@ -252,66 +248,28 @@ impl PipelineRunner {
             events: vec![],
         };
 
-        if is_feature_enabled(Feature::FullBuild) {
-            // Safe to unwrap because we checked is_feature_enabled
-            let channel = self
-                .rabbitmq_connection
-                .as_ref()
-                .unwrap()
-                .create_channel()
-                .await?;
-            let payload = serde_json::to_string(&parent_span_mq_message)?;
-            let payload = payload.as_bytes();
-            channel
-                .basic_publish(
-                    OBSERVATIONS_EXCHANGE,
-                    OBSERVATIONS_ROUTING_KEY,
-                    BasicPublishOptions::default(),
-                    payload,
-                    BasicProperties::default(),
-                )
-                .await?
-                .await?;
-
-            for message_span in message_spans {
-                let message_mq_message = RabbitMqSpanMessage {
-                    project_id: *project_id,
-                    span: message_span,
-                    events: vec![],
-                };
-
-                let payload = serde_json::to_string(&message_mq_message)?;
-                let payload = payload.as_bytes();
-                channel
-                    .basic_publish(
-                        OBSERVATIONS_EXCHANGE,
-                        OBSERVATIONS_ROUTING_KEY,
-                        BasicPublishOptions::default(),
-                        payload,
-                        BasicProperties::default(),
-                    )
-                    .await?
-                    .await?;
-            }
-        } else {
-            let span_usage = get_llm_usage_for_span(
-                &mut parent_span.get_attributes(),
-                self.db.clone(),
-                self.cache.clone(),
+        self.queue
+            .publish(
+                &parent_span_mq_message,
+                Some(OBSERVATIONS_EXCHANGE),
+                Some(OBSERVATIONS_ROUTING_KEY),
             )
-            .await;
-            record_span_to_db(self.db.clone(), &span_usage, project_id, &mut parent_span).await?;
+            .await?;
 
-            for mut message_span in message_spans {
-                let span_usage = get_llm_usage_for_span(
-                    &mut message_span.get_attributes(),
-                    self.db.clone(),
-                    self.cache.clone(),
+        for message_span in message_spans {
+            let message_span_mq_message = RabbitMqSpanMessage {
+                project_id: *project_id,
+                span: message_span.clone(),
+                events: vec![],
+            };
+
+            self.queue
+                .publish(
+                    &message_span_mq_message,
+                    Some(OBSERVATIONS_EXCHANGE),
+                    Some(OBSERVATIONS_ROUTING_KEY),
                 )
-                .await;
-                record_span_to_db(self.db.clone(), &span_usage, project_id, &mut message_span)
-                    .await?;
-            }
+                .await?;
         }
 
         Ok(())

--- a/app-server/src/routes/pipelines.rs
+++ b/app-server/src/routes/pipelines.rs
@@ -130,7 +130,6 @@ async fn run_pipeline_graph(
 
             // Both successful and failed runs have trace
             if let Some(trace) = trace {
-                // TODO: record spans/traces if needed
                 let run_stats = RunTraceStats::from_messages(&trace.messages);
                 let run_trace = RunTrace {
                     run_id,

--- a/app-server/src/traces/consumer.rs
+++ b/app-server/src/traces/consumer.rs
@@ -56,9 +56,9 @@ async fn inner_process_queue_spans<S, Q>(
     // Safe to unwrap because we checked is_feature_enabled above
     let mut receiver = queue
         .get_receiver(
-            Some(OBSERVATIONS_QUEUE),
-            Some(OBSERVATIONS_EXCHANGE),
-            Some(OBSERVATIONS_ROUTING_KEY),
+            OBSERVATIONS_QUEUE,
+            OBSERVATIONS_EXCHANGE,
+            OBSERVATIONS_ROUTING_KEY,
         )
         .await
         .unwrap();

--- a/app-server/src/traces/consumer.rs
+++ b/app-server/src/traces/consumer.rs
@@ -3,9 +3,6 @@
 
 use std::sync::Arc;
 
-use futures::StreamExt;
-use lapin::{options::BasicConsumeOptions, options::*, types::FieldTable, Connection};
-
 use super::{
     process_label_classes, process_spans_and_events, OBSERVATIONS_EXCHANGE, OBSERVATIONS_QUEUE,
     OBSERVATIONS_ROUTING_KEY,
@@ -15,82 +12,66 @@ use crate::{
     cache::Cache,
     db::{spans::Span, DB},
     features::{is_feature_enabled, Feature},
+    mq::MessageQueue,
     pipeline::runner::PipelineRunner,
     storage::Storage,
 };
 
-pub async fn process_queue_spans<T: Storage + ?Sized>(
+pub async fn process_queue_spans<S, Q>(
     pipeline_runner: Arc<PipelineRunner>,
     db: Arc<DB>,
     cache: Arc<Cache>,
-    rabbitmq_connection: Option<Arc<Connection>>,
+    queue: Arc<Q>,
     clickhouse: clickhouse::Client,
-    storage: Arc<T>,
-) {
+    storage: Arc<S>,
+) where
+    S: Storage + ?Sized,
+    Q: MessageQueue<RabbitMqSpanMessage> + ?Sized,
+{
     loop {
         inner_process_queue_spans(
             pipeline_runner.clone(),
             db.clone(),
             cache.clone(),
-            rabbitmq_connection.clone(),
+            queue.clone(),
             clickhouse.clone(),
             storage.clone(),
         )
         .await;
-        log::warn!("Span listener exited. Creating a new RabbitMQ channel...");
+        log::warn!("Span listener exited. Rebinding queue conneciton...");
     }
 }
 
-async fn inner_process_queue_spans<T: Storage + ?Sized>(
+async fn inner_process_queue_spans<S, Q>(
     pipeline_runner: Arc<PipelineRunner>,
     db: Arc<DB>,
     cache: Arc<Cache>,
-    rabbitmq_connection: Option<Arc<Connection>>,
+    queue: Arc<Q>,
     clickhouse: clickhouse::Client,
-    storage: Arc<T>,
-) {
+    storage: Arc<S>,
+) where
+    S: Storage + ?Sized,
+    Q: MessageQueue<RabbitMqSpanMessage> + ?Sized,
+{
     // Safe to unwrap because we checked is_feature_enabled above
-    let channel = rabbitmq_connection.unwrap().create_channel().await.unwrap();
-
-    channel
-        .queue_bind(
-            OBSERVATIONS_QUEUE,
-            OBSERVATIONS_EXCHANGE,
-            OBSERVATIONS_ROUTING_KEY,
-            QueueBindOptions::default(),
-            FieldTable::default(),
+    let mut receiver = queue
+        .get_receiver(
+            Some(OBSERVATIONS_QUEUE),
+            Some(OBSERVATIONS_EXCHANGE),
+            Some(OBSERVATIONS_ROUTING_KEY),
         )
         .await
         .unwrap();
 
-    let mut consumer = channel
-        .basic_consume(
-            OBSERVATIONS_QUEUE,
-            OBSERVATIONS_ROUTING_KEY,
-            BasicConsumeOptions::default(),
-            FieldTable::default(),
-        )
-        .await
-        .unwrap();
+    log::info!("Started processing spans from queue");
 
-    log::info!("Started processing spans from RabbitMQ");
-
-    while let Some(delivery) = consumer.next().await {
-        let Ok(delivery) = delivery else {
-            log::error!("Failed to get delivery from RabbitMQ. Continuing...");
+    while let Some(delivery) = receiver.receive().await {
+        if let Err(e) = delivery {
+            log::error!("Failed to receive message from queue: {:?}", e);
             continue;
-        };
-
-        let Ok(payload) = String::from_utf8(delivery.data.clone()) else {
-            log::error!("Failed to parse delivery data as UTF-8. Continuing...");
-            continue;
-        };
-
-        let Ok(rabbitmq_span_message) = serde_json::from_str::<RabbitMqSpanMessage>(&payload)
-        else {
-            log::error!("Failed to parse delivery data as `RabbitMqSpanMessage`. Continuing...");
-            continue;
-        };
+        }
+        let delivery = delivery.unwrap();
+        let rabbitmq_span_message = delivery.data();
 
         if is_feature_enabled(Feature::UsageLimit) {
             match super::limits::update_workspace_limit_exceeded_by_project_id(
@@ -110,9 +91,9 @@ async fn inner_process_queue_spans<T: Storage + ?Sized>(
                 Ok(limits_exceeded) => {
                     if limits_exceeded.spans {
                         let _ = delivery
-                            .ack(BasicAckOptions::default())
+                            .ack()
                             .await
-                            .map_err(|e| log::error!("Failed to ack RabbitMQ delivery: {:?}", e));
+                            .map_err(|e| log::error!("Failed to ack MQ delivery: {:?}", e));
                         continue;
                     }
                 }
@@ -144,7 +125,7 @@ async fn inner_process_queue_spans<T: Storage + ?Sized>(
             db.clone(),
             clickhouse.clone(),
             cache.clone(),
-            Some(delivery),
+            delivery,
         )
         .await;
 
@@ -158,5 +139,5 @@ async fn inner_process_queue_spans<T: Storage + ?Sized>(
         .await;
     }
 
-    log::warn!("RabbitMQ closed connection. Shutting down span listener");
+    log::warn!("Queue closed connection. Shutting down span listener");
 }

--- a/app-server/src/traces/grpc_service.rs
+++ b/app-server/src/traces/grpc_service.rs
@@ -3,48 +3,42 @@ use std::sync::Arc;
 use sqlx::PgPool;
 
 use crate::{
-    api::utils::get_api_key_from_raw_value,
+    api::{utils::get_api_key_from_raw_value, v1::traces::RabbitMqSpanMessage},
     cache::Cache,
     db::{project_api_keys::ProjectApiKey, DB},
     features::{is_feature_enabled, Feature},
+    mq::MessageQueue,
     opentelemetry::opentelemetry::proto::collector::trace::v1::{
         trace_service_server::TraceService, ExportTraceServiceRequest, ExportTraceServiceResponse,
     },
-    pipeline::runner::PipelineRunner,
 };
-use lapin::Connection;
 use tonic::{Request, Response, Status};
 
 use super::{limits::get_workspace_limit_exceeded_by_project_id, producer::push_spans_to_queue};
 
-pub struct ProcessTracesService {
+pub struct ProcessTracesService<Q>
+where
+    Q: MessageQueue<RabbitMqSpanMessage> + ?Sized,
+{
     db: Arc<DB>,
     cache: Arc<Cache>,
-    rabbitmq_connection: Option<Arc<Connection>>,
-    clickhouse: clickhouse::Client,
-    pipeline_runner: Arc<PipelineRunner>,
+    queue: Arc<Q>,
 }
 
-impl ProcessTracesService {
-    pub fn new(
-        db: Arc<DB>,
-        cache: Arc<Cache>,
-        rabbitmq_connection: Option<Arc<Connection>>,
-        clickhouse: clickhouse::Client,
-        pipeline_runner: Arc<PipelineRunner>,
-    ) -> Self {
-        Self {
-            db,
-            cache,
-            rabbitmq_connection,
-            clickhouse,
-            pipeline_runner,
-        }
+impl<Q> ProcessTracesService<Q>
+where
+    Q: MessageQueue<RabbitMqSpanMessage> + ?Sized,
+{
+    pub fn new(db: Arc<DB>, cache: Arc<Cache>, queue: Arc<Q>) -> Self {
+        Self { db, cache, queue }
     }
 }
 
 #[tonic::async_trait]
-impl TraceService for ProcessTracesService {
+impl<Q> TraceService for ProcessTracesService<Q>
+where
+    Q: MessageQueue<RabbitMqSpanMessage> + Sync + Send + ?Sized + 'static,
+{
     async fn export(
         &self,
         request: Request<ExportTraceServiceRequest>,
@@ -73,20 +67,12 @@ impl TraceService for ProcessTracesService {
             }
         }
 
-        let response = push_spans_to_queue(
-            request,
-            project_id,
-            self.rabbitmq_connection.clone(),
-            self.db.clone(),
-            self.clickhouse.clone(),
-            self.cache.clone(),
-            self.pipeline_runner.clone(),
-        )
-        .await
-        .map_err(|e| {
-            log::error!("Failed to process traces: {:?}", e);
-            Status::internal("Failed to process traces")
-        })?;
+        let response = push_spans_to_queue(request, project_id, self.queue.clone())
+            .await
+            .map_err(|e| {
+                log::error!("Failed to process traces: {:?}", e);
+                Status::internal("Failed to process traces")
+            })?;
 
         Ok(Response::new(response))
     }

--- a/app-server/src/traces/mod.rs
+++ b/app-server/src/traces/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         events::Event, labels::get_registered_label_classes_for_path, spans::Span,
         stats::add_spans_and_events_to_project_usage_stats, DB,
     },
-    mq::MQDelivery,
+    mq::MessageQueueDelivery,
     pipeline::runner::PipelineRunner,
     traces::{
         evaluators::run_evaluator,
@@ -41,7 +41,7 @@ pub async fn process_spans_and_events<T>(
     db: Arc<DB>,
     clickhouse: clickhouse::Client,
     cache: Arc<Cache>,
-    delivery: Box<dyn MQDelivery<T>>,
+    delivery: Box<dyn MessageQueueDelivery<T>>,
 ) {
     let span_usage =
         get_llm_usage_for_span(&mut span.get_attributes(), db.clone(), cache.clone()).await;

--- a/app-server/src/traces/mod.rs
+++ b/app-server/src/traces/mod.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use lapin::{message::Delivery, options::BasicAckOptions};
 use uuid::Uuid;
 
 use crate::{
@@ -10,6 +9,7 @@ use crate::{
         events::Event, labels::get_registered_label_classes_for_path, spans::Span,
         stats::add_spans_and_events_to_project_usage_stats, DB,
     },
+    mq::MQDelivery,
     pipeline::runner::PipelineRunner,
     traces::{
         evaluators::run_evaluator,
@@ -34,26 +34,23 @@ pub const OBSERVATIONS_QUEUE: &str = "observations_queue";
 pub const OBSERVATIONS_EXCHANGE: &str = "observations_exchange";
 pub const OBSERVATIONS_ROUTING_KEY: &str = "observations_routing_key";
 
-pub async fn process_spans_and_events(
+pub async fn process_spans_and_events<T>(
     span: &mut Span,
     events: Vec<Event>,
     project_id: &Uuid,
     db: Arc<DB>,
     clickhouse: clickhouse::Client,
     cache: Arc<Cache>,
-    delivery: Option<Delivery>,
+    delivery: Box<dyn MQDelivery<T>>,
 ) {
     let span_usage =
         get_llm_usage_for_span(&mut span.get_attributes(), db.clone(), cache.clone()).await;
 
     match record_span_to_db(db.clone(), &span_usage, &project_id, span).await {
         Ok(_) => {
-            if let Some(delivery) = delivery {
-                let _ = delivery
-                    .ack(BasicAckOptions::default())
-                    .await
-                    .map_err(|e| log::error!("Failed to ack RabbitMQ delivery: {:?}", e));
-            }
+            let _ = delivery.ack().await.map_err(|e| {
+                log::error!("Failed to ack MQ delivery: {:?}", e);
+            });
         }
         Err(e) => {
             log::error!(

--- a/app-server/src/traces/producer.rs
+++ b/app-server/src/traces/producer.rs
@@ -59,8 +59,8 @@ where
                 queue
                     .publish(
                         &rabbitmq_span_message,
-                        Some(OBSERVATIONS_EXCHANGE),
-                        Some(OBSERVATIONS_ROUTING_KEY),
+                        OBSERVATIONS_EXCHANGE,
+                        OBSERVATIONS_ROUTING_KEY,
                     )
                     .await?;
             }

--- a/app-server/src/traces/producer.rs
+++ b/app-server/src/traces/producer.rs
@@ -4,80 +4,28 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use lapin::{options::BasicPublishOptions, BasicProperties, Connection};
 use uuid::Uuid;
 
 use crate::{
     api::v1::traces::RabbitMqSpanMessage,
-    cache::Cache,
-    db::{events::Event, spans::Span, DB},
-    features::{is_feature_enabled, Feature},
+    db::{events::Event, spans::Span},
+    mq::MessageQueue,
     opentelemetry::opentelemetry::proto::collector::trace::v1::{
         ExportTraceServiceRequest, ExportTraceServiceResponse,
     },
-    pipeline::runner::PipelineRunner,
 };
 
-use super::{
-    process_label_classes, process_spans_and_events, OBSERVATIONS_EXCHANGE,
-    OBSERVATIONS_ROUTING_KEY,
-};
+use super::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY};
 
 // TODO: Implement partial_success
-pub async fn push_spans_to_queue(
+pub async fn push_spans_to_queue<Q>(
     request: ExportTraceServiceRequest,
     project_id: Uuid,
-    rabbitmq_connection: Option<Arc<Connection>>,
-    db: Arc<DB>,
-    clickhouse: clickhouse::Client,
-    cache: Arc<Cache>,
-    pipeline_runner: Arc<PipelineRunner>,
-) -> Result<ExportTraceServiceResponse> {
-    if !is_feature_enabled(Feature::FullBuild) {
-        for resource_span in request.resource_spans {
-            for scope_span in resource_span.scope_spans {
-                for otel_span in scope_span.spans {
-                    let mut span = Span::from_otel_span(otel_span.clone());
-
-                    if !span.should_save() {
-                        continue;
-                    }
-
-                    let events = otel_span
-                        .events
-                        .into_iter()
-                        .map(|event| Event::from_otel(event, span.span_id, project_id))
-                        .collect::<Vec<Event>>();
-
-                    process_spans_and_events(
-                        &mut span,
-                        events,
-                        &project_id,
-                        db.clone(),
-                        clickhouse.clone(),
-                        cache.clone(),
-                        None,
-                    )
-                    .await;
-
-                    process_label_classes(
-                        &span,
-                        &project_id,
-                        db.clone(),
-                        clickhouse.clone(),
-                        pipeline_runner.clone(),
-                    )
-                    .await;
-                }
-            }
-        }
-        return Ok(ExportTraceServiceResponse {
-            partial_success: None,
-        });
-    }
-    // Safe to unwrap because we checked is_feature_enabled above
-    let channel = rabbitmq_connection.unwrap().create_channel().await?;
-
+    queue: Arc<Q>,
+) -> Result<ExportTraceServiceResponse>
+where
+    Q: MessageQueue<RabbitMqSpanMessage> + Send + Sync + ?Sized + 'static,
+{
     for resource_span in request.resource_spans {
         for scope_span in resource_span.scope_spans {
             for otel_span in scope_span.spans {
@@ -108,18 +56,12 @@ pub async fn push_spans_to_queue(
                     events,
                 };
 
-                let payload = serde_json::to_string(&rabbitmq_span_message).unwrap();
-                let payload = payload.as_bytes();
-
-                channel
-                    .basic_publish(
-                        OBSERVATIONS_EXCHANGE,
-                        OBSERVATIONS_ROUTING_KEY,
-                        BasicPublishOptions::default(),
-                        payload,
-                        BasicProperties::default(),
+                queue
+                    .publish(
+                        &rabbitmq_span_message,
+                        Some(OBSERVATIONS_EXCHANGE),
+                        Some(OBSERVATIONS_ROUTING_KEY),
                     )
-                    .await?
                     .await?;
             }
         }


### PR DESCRIPTION
This lets us:
1. Cleanup Environment lite code to use an in-memory queue
2. Use message queue elsewhere e.g. for batched clickhouse inserts
3. Extend the interface to implement a dead-letter exchange-queue

This is working: the only TODO is to make sure nothing is duplicated on the consumer and producer
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor message queue implementation to use a trait-based interface, supporting RabbitMQ and in-memory queues, affecting trace processing and pipeline execution.
> 
>   - **Message Queue Refactor**:
>     - Introduce `MessageQueue`, `MessageQueueReceiver`, and `MessageQueueDelivery` traits in `mq/mod.rs`.
>     - Implement `RabbitMQ` in `mq/rabbit.rs` and `TokioMpscQueue` in `mq/tokio_mpsc.rs` as `MessageQueue`.
>   - **Trace Processing**:
>     - Update `process_traces` in `traces.rs` to use `MessageQueue` for span processing.
>     - Modify `ProcessTracesService` in `grpc_service.rs` to use `MessageQueue`.
>   - **Pipeline Execution**:
>     - Refactor `PipelineRunner` in `runner.rs` to use `MessageQueue` for recording observations.
>   - **Main Application**:
>     - Update `main.rs` to initialize `MessageQueue` based on feature flags, supporting both RabbitMQ and in-memory queues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for f2a342066958085462de57f3afed672befda5a38. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->