### PR TITLE
fix traces http endpoint and publish workflow

### DIFF
--- a/.github/workflows/build-app-server-binary.yml
+++ b/.github/workflows/build-app-server-binary.yml
@@ -1,11 +1,8 @@
-name: Build & publish lmnr images
+name: Build & publish app-server binary
 on:
-  push:
-    branches:
-      - test-action
-  # release:
-  #   types:
-  #     - published
+  release:
+    types:
+      - published
 
 jobs:
   build-and-upload:
@@ -44,12 +41,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const response = await github.rest.repos.getLatestRelease({
+            const response = await github.rest.repos.listReleases({
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            core.setOutput('upload_url', response.data.upload_url);
-            core.setOutput('release_id', response.data.id);
+            if (response.data.length === 0) {
+              core.setFailed('No releases found');
+              return;
+            }
+            const latest_release = response.data.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+            core.setOutput('upload_url', latest_release.upload_url);
+            core.setOutput('release_id', latest_release.id);
 
       - name: Delete existing assets
         uses: actions/github-script@v7


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes GitHub Actions workflow to trigger on releases and updates `process_traces` to use `Arc` for message queue.
> 
>   - **GitHub Actions Workflow**:
>     - Renamed workflow to "Build & publish app-server binary" in `build-app-server-binary.yml`.
>     - Changed trigger from `push` to `release` events.
>     - Updated script to handle cases with no releases and sort releases by creation date.
>   - **`process_traces` Function**:
>     - Changed `spans_message_queue` to use `Arc` for thread-safe reference counting in `traces.rs`.
>     - Updated `spans_message_queue` handling to clone the reference for use.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 785f982c9f3c80bb8be04398301c04b25bbca1c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->