### PR TITLE
fix raw openai images

### DIFF
--- a/frontend/components/traces/chat-message-list-tab.tsx
+++ b/frontend/components/traces/chat-message-list-tab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ChatMessage, ChatMessageContentPart } from '@/lib/types';
+import { ChatMessage, ChatMessageContentPart, OpenAIImageUrl } from '@/lib/types';
 import { isStringType } from '@/lib/utils';
 
 import DownloadButton from '../ui/download-button';
@@ -54,21 +54,33 @@ interface ContentPartsProps {
 }
 
 function ContentParts({ contentParts }: ContentPartsProps) {
+
+  const renderContentPart = (contentPart: ChatMessageContentPart) => {
+    switch (contentPart.type) {
+      case 'text':
+        return <ContentPartText text={contentPart.text} />;
+      case 'image':
+        return <ContentPartImage b64_data={contentPart.data} />;
+      case 'image_url':
+        // it means we managed to parse span input and properly store image in S3
+        if (contentPart.url) {
+          return <ContentPartImageUrl url={contentPart.url} />;
+        } else {
+          const openAIImageUrl = contentPart as any as OpenAIImageUrl;
+          return <img src={openAIImageUrl.image_url.url} alt="span image" className='w-full' />;
+        }
+      case 'document_url':
+        return <ContentPartDocumentUrl url={contentPart.url} />;
+      default:
+        return <div>Unknown content part</div>;
+    }
+  };
+
   return (
     <div className="flex flex-col space-y-2 w-full">
       {contentParts.map((contentPart, index) => (
         <div key={index} className="w-full">
-          {contentPart.type === 'text' ? (
-            <ContentPartText text={contentPart.text} />
-          ) : contentPart.type === 'image' ? (
-            <ContentPartImage b64_data={contentPart.data} />
-          ) : contentPart.type === 'image_url' ? (
-            <ContentPartImageUrl url={contentPart.url} />
-          ) : contentPart.type === 'document_url' ? (
-            <ContentPartDocumentUrl url={contentPart.url} />
-          ) : (
-            <div>Unknown content part</div>
-          )}
+          {renderContentPart(contentPart)}
         </div>
       ))}
     </div>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -28,6 +28,14 @@ export type ChatMessageDocumentUrl = {
   url: string;
 };
 
+export type OpenAIImageUrl = {
+  type: 'image_url';
+  image_url: {
+    url: string;
+    detail: string | null;
+  };
+};
+
 export type ChatMessageContentPart =
   | ChatMessageText
   | ChatMessageImageUrl


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds handling for OpenAI image URLs in chat messages by introducing `OpenAIImageUrl` type and refactoring rendering logic.
> 
>   - **Behavior**:
>     - Adds handling for `OpenAIImageUrl` in `ContentParts` component in `chat-message-list-tab.tsx`.
>     - Renders OpenAI image URLs directly if `contentPart.url` is not available.
>   - **Types**:
>     - Adds `OpenAIImageUrl` type to `types.ts` for handling OpenAI image URLs.
>   - **Refactoring**:
>     - Refactors `ContentParts` component to use `renderContentPart` function for rendering logic in `chat-message-list-tab.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d340e51ef88097e4a2b2a76077f37fa9458a513c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->