### PR TITLE
fix manual span images

### DIFF
--- a/app-server/src/language_model/chat_message.rs
+++ b/app-server/src/language_model/chat_message.rs
@@ -269,8 +269,8 @@ impl ChatMessageContentPart {
                 // https://python.langchain.com/docs/how_to/multimodal_inputs/
                 // Discussion we've opened with OpenLLMetry:
                 // https://github.com/traceloop/openllmetry/issues/2516
-                let pattern = Regex::new(r"^data:image/[a-zA-z]+;base64,.*$").unwrap();
-                if pattern.is_match(&image_url.url) {
+                let pattern = Regex::new(r"^data:image\/[a-zA-z]+;base64,.*$").unwrap();
+                if pattern.is_match(&image_url.url.chars().take(50).collect::<String>()) {
                     let base64_data = image_url.url.split(',').last().unwrap();
                     let data = crate::storage::base64_to_bytes(base64_data)?;
                     let key = crate::storage::create_key(project_id, &None);

--- a/app-server/src/language_model/chat_message.rs
+++ b/app-server/src/language_model/chat_message.rs
@@ -263,13 +263,14 @@ impl ChatMessageContentPart {
                 ))
             }
             ChatMessageContentPart::ImageUrl(image_url) => {
-                // LangChain allows `image_url` to be a base64 encoded image
+                // OpenAI and LangChain allow `image_url` to be a base64 encoded image
                 // This somewhat hacky solution is to check if the url is a base64 encoded image
                 // and if so, store the image and return the new url
                 // https://python.langchain.com/docs/how_to/multimodal_inputs/
+                // https://platform.openai.com/docs/guides/vision#uploading-base64-encoded-images
                 // Discussion we've opened with OpenLLMetry:
                 // https://github.com/traceloop/openllmetry/issues/2516
-                let pattern = Regex::new(r"^data:image\/[a-zA-z]+;base64,.*$").unwrap();
+                let pattern = Regex::new(r"^data:image/[a-zA-Z]+;base64,.*$").unwrap();
                 if pattern.is_match(&image_url.url.chars().take(50).collect::<String>()) {
                     let base64_data = image_url.url.split(',').last().unwrap();
                     let data = crate::storage::base64_to_bytes(base64_data)?;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes manual span image handling by updating regex and input/output attribute processing for LLM spans.
> 
>   - **Behavior**:
>     - Fixes regex pattern in `chat_message.rs` to correctly identify base64 encoded images by limiting the check to the first 50 characters.
>     - Updates handling of `lmnr.span.input` and `lmnr.span.output` attributes in `spans.rs` to prefer these over other attributes for manually sent LLM spans.
>   - **Functions**:
>     - Adds `input_chat_messages_from_json()` in `spans.rs` to parse chat messages from JSON input.
>   - **Misc**:
>     - Corrects typo in regex pattern in `chat_message.rs` from `[a-zA-z]` to `[a-zA-Z]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 97f576ec058b90d00dee24e0c8d0023ddd7c8ac3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->