### PR TITLE
tmp: disable writes of span inputs and outputs and browser events to clickhouse

### DIFF
--- a/app-server/src/browser_events/mod.rs
+++ b/app-server/src/browser_events/mod.rs
@@ -85,13 +85,13 @@ async fn inner_process_browser_events(
         }
 
         // Execute batch insert with individual bindings
-        let mut query_with_bindings = clickhouse.query(&query);
-        for value in values {
-            query_with_bindings = query_with_bindings.bind(value);
-        }
-        if let Err(e) = query_with_bindings.execute().await {
-            log::error!("Failed to insert browser events: {:?}", e);
-        }
+        // let mut query_with_bindings = clickhouse.query(&query);
+        // for value in values {
+        //     query_with_bindings = query_with_bindings.bind(value);
+        // }
+        // if let Err(e) = query_with_bindings.execute().await {
+        //     log::error!("Failed to insert browser events: {:?}", e);
+        // }
 
         if let Err(e) = delivery.ack().await {
             log::error!("Failed to ack message: {:?}", e);

--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -69,15 +69,15 @@ impl CHSpan {
     pub fn from_db_span(span: &Span, usage: SpanUsage, project_id: Uuid) -> Self {
         let span_attributes = span.get_attributes();
 
-        let span_input = span
-            .input
-            .clone()
-            .unwrap_or(Value::String(String::from("")));
+        // let span_input = span
+        //     .input
+        //     .clone()
+        //     .unwrap_or(Value::String(String::from("")));
 
-        let span_output = span
-            .output
-            .clone()
-            .unwrap_or(Value::String(String::from("")));
+        // let span_output = span
+        //     .output
+        //     .clone()
+        //     .unwrap_or(Value::String(String::from("")));
 
         CHSpan {
             span_id: span.span_id,
@@ -105,8 +105,10 @@ impl CHSpan {
             path: span_attributes
                 .flat_path()
                 .unwrap_or(String::from("<null>")),
-            input: json_value_to_string(span_input),
-            output: json_value_to_string(span_output),
+            input: String::from("<null>"),
+            output: String::from("<null>"),
+            // input: json_value_to_string(span_input),
+            // output: json_value_to_string(span_output),
         }
     }
 }


### PR DESCRIPTION
disable writing browser events temporarily to check if this reduces load