### PR TITLE
Fix/events

### DIFF
--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -69,15 +69,17 @@ impl CHSpan {
     pub fn from_db_span(span: &Span, usage: SpanUsage, project_id: Uuid) -> Self {
         let span_attributes = span.get_attributes();
 
-        // let span_input = span
-        //     .input
-        //     .clone()
-        //     .unwrap_or(Value::String(String::from("")));
+        let span_input_string = span
+            .input
+            .clone()
+            .unwrap_or(Value::String(String::from("")))
+            .to_string();
 
-        // let span_output = span
-        //     .output
-        //     .clone()
-        //     .unwrap_or(Value::String(String::from("")));
+        let span_output_string = span
+            .output
+            .clone()
+            .unwrap_or(Value::String(String::from("")))
+            .to_string();
 
         CHSpan {
             span_id: span.span_id,
@@ -105,11 +107,8 @@ impl CHSpan {
             path: span_attributes
                 .flat_path()
                 .unwrap_or(String::from("<null>")),
-            input: String::from("<null>"),
-            output: String::from("<null>"),
-            // TODO: actually write input and output if CPU usage is ok
-            // input: json_value_to_string(span_input),
-            // output: json_value_to_string(span_output),
+            input: span_input_string,
+            output: span_output_string,
         }
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves error handling for invalid `trace_id` in `browser_sessions.rs` and updates `CHSpan` in `spans.rs` to include input and output strings.
> 
>   - **Error Handling**:
>     - In `browser_sessions.rs`, `create_session_event()` now returns a 400 Bad Request if `trace_id` is `Uuid::nil()`.
>   - **Data Processing**:
>     - In `spans.rs`, `CHSpan::from_db_span()` now converts `span.input` and `span.output` to strings, storing them in `input` and `output` fields of `CHSpan`.
>     - Removed commented-out code related to `span_input` and `span_output` in `spans.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 65349d7da9be173da33b907000c532c343af9d41. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->