### PR TITLE
health probes

### DIFF
--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -69,17 +69,17 @@ impl CHSpan {
     pub fn from_db_span(span: &Span, usage: SpanUsage, project_id: Uuid) -> Self {
         let span_attributes = span.get_attributes();
 
-        let span_input_string = span
-            .input
-            .clone()
-            .unwrap_or(Value::String(String::from("")))
-            .to_string();
+        let span_input_string = json_value_to_string(
+            span.input
+                .clone()
+                .unwrap_or(Value::String(String::from(""))),
+        );
 
-        let span_output_string = span
-            .output
-            .clone()
-            .unwrap_or(Value::String(String::from("")))
-            .to_string();
+        let span_output_string = json_value_to_string(
+            span.output
+                .clone()
+                .unwrap_or(Value::String(String::from(""))),
+        );
 
         CHSpan {
             span_id: span.span_id,

--- a/app-server/src/routes/mod.rs
+++ b/app-server/src/routes/mod.rs
@@ -6,13 +6,13 @@ pub mod evaluations;
 pub mod labels;
 pub mod limits;
 pub mod pipelines;
+pub mod probes;
 pub mod projects;
 pub mod provider_api_keys;
 pub mod subscriptions;
 pub mod traces;
 pub mod types;
 pub mod workspace;
-
 use serde::{Deserialize, Serialize};
 use types::*;
 

--- a/app-server/src/routes/probes.rs
+++ b/app-server/src/routes/probes.rs
@@ -1,0 +1,36 @@
+use actix_web::web::Data;
+use actix_web::{get, HttpResponse, Responder};
+use lapin::Connection;
+use std::sync::Arc;
+
+#[get("/health")]
+pub async fn check_health(connection: Data<Option<Arc<Connection>>>) -> impl Responder {
+    let rabbitmq_status = if let Some(conn) = connection.as_ref() {
+        conn.status().connected()
+    } else {
+        // If connection is None, we're in mock mode so return true
+        true
+    };
+
+    if !rabbitmq_status {
+        return HttpResponse::InternalServerError().body("RabbitMQ connection failed");
+    }
+
+    HttpResponse::Ok().body("OK")
+}
+
+#[get("/ready")]
+pub async fn check_ready(connection: Data<Option<Arc<Connection>>>) -> impl Responder {
+    let rabbitmq_status = if let Some(conn) = connection.as_ref() {
+        conn.status().connected()
+    } else {
+        // If connection is None, we're in mock mode so return true
+        true
+    };
+
+    if !rabbitmq_status {
+        return HttpResponse::InternalServerError().body("RabbitMQ connection failed");
+    }
+
+    HttpResponse::Ok().body("OK")
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add health and readiness probes to check RabbitMQ connection status and refactor JSON value conversion in `spans.rs`.
> 
>   - **Health and Readiness Probes**:
>     - Adds `check_health` and `check_ready` endpoints in `probes.rs` to verify RabbitMQ connection status.
>     - Integrates these endpoints into the HTTP server in `main.rs`.
>   - **Code Refactoring**:
>     - Refactors `from_db_span` in `spans.rs` to use `json_value_to_string` for converting JSON values to strings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for fe3cde3124af8f3b71b971898a574d63dfc214e6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->