### PR TITLE
add backoff on insert span to DB and browser events to CH

### DIFF
--- a/app-server/Cargo.lock
+++ b/app-server/Cargo.lock
@@ -457,6 +457,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-bedrockruntime",
  "aws-sdk-s3",
+ "backoff",
  "base64 0.22.1",
  "bimap",
  "bytes",
@@ -1210,6 +1211,20 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/app-server/Cargo.toml
+++ b/app-server/Cargo.toml
@@ -68,6 +68,7 @@ tokio-tungstenite = "0.24"
 url = "2.5.0"
 uuid = {version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics", "serde"]}
 zstd = "0.13.2"
+backoff = { version = "0.4.0", features = ["tokio"] }
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/app-server/src/browser_events/mod.rs
+++ b/app-server/src/browser_events/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use backoff::ExponentialBackoff;
+use backoff::ExponentialBackoffBuilder;
 use uuid::Uuid;
 
 use crate::{
@@ -107,7 +107,13 @@ async fn inner_process_browser_events(
         // Starting with 0.5 second delay, delay multiplies by random factor between 1 and 2
         // up to 1 minute and until the total elapsed time is 15 minutes
         // https://docs.rs/backoff/latest/backoff/default/index.html
-        let exponential_backoff = ExponentialBackoff::default();
+        let exponential_backoff = ExponentialBackoffBuilder::new()
+            .with_initial_interval(std::time::Duration::from_millis(500))
+            .with_multiplier(1.5)
+            .with_randomization_factor(0.5)
+            .with_max_interval(std::time::Duration::from_secs(1 * 60))
+            .with_max_elapsed_time(Some(std::time::Duration::from_secs(15 * 60)))
+            .build();
         match backoff::future::retry(exponential_backoff, insert_browser_events).await {
             Ok(_) => {
                 if let Err(e) = delivery.ack().await {

--- a/app-server/src/browser_events/mod.rs
+++ b/app-server/src/browser_events/mod.rs
@@ -105,14 +105,14 @@ async fn inner_process_browser_events(
                 })
         };
         // Starting with 0.5 second delay, delay multiplies by random factor between 1 and 2
-        // up to 1 minute and until the total elapsed time is 15 minutes
+        // up to 1 minute and until the total elapsed time is 5 minutes (default is 15 minutes)
         // https://docs.rs/backoff/latest/backoff/default/index.html
         let exponential_backoff = ExponentialBackoffBuilder::new()
             .with_initial_interval(std::time::Duration::from_millis(500))
             .with_multiplier(1.5)
             .with_randomization_factor(0.5)
             .with_max_interval(std::time::Duration::from_secs(1 * 60))
-            .with_max_elapsed_time(Some(std::time::Duration::from_secs(15 * 60)))
+            .with_max_elapsed_time(Some(std::time::Duration::from_secs(5 * 60)))
             .build();
         match backoff::future::retry(exponential_backoff, insert_browser_events).await {
             Ok(_) => {

--- a/app-server/src/mq/mod.rs
+++ b/app-server/src/mq/mod.rs
@@ -14,6 +14,8 @@ pub trait MessageQueueReceiver<T>: Send + Sync {
 #[async_trait]
 pub trait MessageQueueDelivery<T>: Send + Sync {
     async fn ack(&self) -> anyhow::Result<()>;
+    async fn nack(&self, requeue: bool) -> anyhow::Result<()>;
+    async fn reject(&self, requeue: bool) -> anyhow::Result<()>;
     fn data(&self) -> T
     where
         T: for<'de> Deserialize<'de> + Clone;

--- a/app-server/src/mq/rabbit.rs
+++ b/app-server/src/mq/rabbit.rs
@@ -2,7 +2,10 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use lapin::{
     message::Delivery,
-    options::{BasicAckOptions, BasicConsumeOptions, BasicPublishOptions, QueueBindOptions},
+    options::{
+        BasicAckOptions, BasicConsumeOptions, BasicNackOptions, BasicPublishOptions,
+        BasicRejectOptions, QueueBindOptions,
+    },
     types::FieldTable,
     BasicProperties, Connection, Consumer,
 };
@@ -31,6 +34,21 @@ where
 {
     async fn ack(&self) -> anyhow::Result<()> {
         self.delivery.ack(BasicAckOptions::default()).await?;
+        Ok(())
+    }
+
+    async fn nack(&self, requeue: bool) -> anyhow::Result<()> {
+        self.delivery
+            .nack(BasicNackOptions {
+                multiple: false,
+                requeue,
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn reject(&self, requeue: bool) -> anyhow::Result<()> {
+        self.delivery.reject(BasicRejectOptions { requeue }).await?;
         Ok(())
     }
 

--- a/app-server/src/mq/tokio_mpsc.rs
+++ b/app-server/src/mq/tokio_mpsc.rs
@@ -31,6 +31,26 @@ where
         Ok(())
     }
 
+    async fn nack(&self, requeue: bool) -> anyhow::Result<()> {
+        if requeue {
+            Err(anyhow::anyhow!(
+                "Nack with requeue is not supported for TokioMpsc queue"
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn reject(&self, requeue: bool) -> anyhow::Result<()> {
+        if requeue {
+            Err(anyhow::anyhow!(
+                "Reject with requeue is not supported for TokioMpsc queue"
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     fn data(&self) -> T
     where
         T: for<'de> Deserialize<'de> + Clone,

--- a/app-server/src/traces/mod.rs
+++ b/app-server/src/traces/mod.rs
@@ -49,7 +49,7 @@ pub async fn process_spans_and_events<T>(
     match record_span_to_db(db.clone(), &span_usage, &project_id, span).await {
         Ok(_) => {
             let _ = delivery.ack().await.map_err(|e| {
-                log::error!("Failed to ack MQ delivery: {:?}", e);
+                log::error!("Failed to ack MQ delivery (span): {:?}", e);
             });
         }
         Err(e) => {
@@ -59,6 +59,10 @@ pub async fn process_spans_and_events<T>(
                 project_id,
                 e
             );
+            // TODO: Implement proper nacks and DLX
+            let _ = delivery.reject(false).await.map_err(|e| {
+                log::error!("Failed to reject MQ delivery (span): {:?}", e);
+            });
         }
     }
 

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use backoff::{Error, ExponentialBackoff};
+use backoff::ExponentialBackoff;
 use regex::Regex;
 use serde_json::Value;
 use uuid::Uuid;
@@ -151,7 +151,7 @@ pub async fn record_span_to_db(
                     span.span_id,
                     e
                 );
-                Error::Transient {
+                backoff::Error::Transient {
                     err: e,
                     retry_after: None,
                 }
@@ -162,13 +162,16 @@ pub async fn record_span_to_db(
     // up to 1 minute and until the total elapsed time is 15 minutes
     // https://docs.rs/backoff/latest/backoff/default/index.html
     let exponential_backoff = ExponentialBackoff::default();
-    if let Err(e) = backoff::future::retry(exponential_backoff, insert_span).await {
-        log::error!(
-            "Exhausted backoff retries for span [{}]: {:?}",
-            span.span_id,
+    backoff::future::retry(exponential_backoff, insert_span)
+        .await
+        .map_err(|e| {
+            log::error!(
+                "Exhausted backoff retries for span [{}]: {:?}",
+                span.span_id,
+                e
+            );
             e
-        );
-    }
+        })?;
 
     Ok(())
 }

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -159,14 +159,14 @@ pub async fn record_span_to_db(
     };
 
     // Starting with 0.5 second delay, delay multiplies by random factor between 1 and 2
-    // up to 1 minute and until the total elapsed time is 15 minutes
+    // up to 1 minute and until the total elapsed time is 5 minutes (default is 15 minutes)
     // https://docs.rs/backoff/latest/backoff/default/index.html
     let exponential_backoff = ExponentialBackoffBuilder::new()
         .with_initial_interval(std::time::Duration::from_millis(500))
         .with_multiplier(1.5)
         .with_randomization_factor(0.5)
         .with_max_interval(std::time::Duration::from_secs(1 * 60))
-        .with_max_elapsed_time(Some(std::time::Duration::from_secs(15 * 60)))
+        .with_max_elapsed_time(Some(std::time::Duration::from_secs(5 * 60)))
         .build();
     backoff::future::retry(exponential_backoff, insert_span)
         .await


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add exponential backoff for retrying database and message queue operations in `browser_events` and `traces`, with support for message rejection.
> 
>   - **Behavior**:
>     - Add exponential backoff for retrying `insert_browser_events` in `browser_events/mod.rs` and `record_span_to_db` in `traces/utils.rs`.
>     - Retry logic uses `backoff` crate with initial delay of 0.5s, multiplier of 1.5, and max delay of 1 minute, up to 5 minutes total.
>     - On failure after retries, logs error and rejects message delivery.
>   - **Message Queue**:
>     - Add `nack()` and `reject()` methods to `MessageQueueDelivery` trait in `mq/mod.rs`.
>     - Implement `nack()` and `reject()` in `rabbit.rs` and `tokio_mpsc.rs`.
>   - **Dependencies**:
>     - Add `backoff` crate to `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 129c4ccc03d35373b8fb5b9b1e7c2758725acabd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->