### PR TITLE
re-enable transient error on failed to insert

### DIFF
--- a/app-server/src/browser_events/mod.rs
+++ b/app-server/src/browser_events/mod.rs
@@ -98,7 +98,10 @@ async fn inner_process_browser_events(
                         "Failed attempt to insert browser events. Will retry according to backoff policy. Error: {:?}",
                         e
                     );
-                    backoff::Error::Permanent(e)
+                    backoff::Error::Transient {
+                        err: e,
+                        retry_after: None,
+                    }
                 })
         };
         // Starting with 0.5 second delay, delay multiplies by random factor between 1 and 2

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -151,7 +151,10 @@ pub async fn record_span_to_db(
                     span.span_id,
                     e
                 );
-                backoff::Error::Permanent(e)
+                backoff::Error::Transient {
+                    err: e,
+                    retry_after: None,
+                }
             })
     };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change error handling from permanent to transient for database insertions in `mod.rs` and `utils.rs` to enable retries.
> 
>   - **Error Handling**:
>     - Change error handling from `Permanent` to `Transient` in `inner_process_browser_events()` in `mod.rs` and `record_span_to_db()` in `utils.rs`.
>     - Allows retries for failed database insertions with `backoff::Error::Transient`.
>   - **Files Affected**:
>     - `mod.rs`: Handles browser event insertions.
>     - `utils.rs`: Handles span recording to the database.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 618abe5de3a0d2c0d2cc2e989a8e52322e4e3525. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->