### PR TITLE
Code executor enum

### DIFF
--- a/app-server/src/api/v1/semantic_search.rs
+++ b/app-server/src/api/v1/semantic_search.rs
@@ -11,7 +11,7 @@ use crate::db::project_api_keys::ProjectApiKey;
 use crate::db::{self, DB};
 use crate::features::{is_feature_enabled, Feature};
 use crate::routes::types::ResponseResult;
-use crate::semantic_search::SemanticSearch;
+use crate::semantic_search::{SemanticSearch, SemanticSearchTrait};
 use crate::traces::utils::json_value_to_string;
 
 const DEFAULT_LIMIT: u32 = 10;
@@ -55,7 +55,7 @@ pub async fn semantic_search(
     params: web::Json<SemanticSearchRequest>,
     db: web::Data<DB>,
     project_api_key: ProjectApiKey,
-    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+    semantic_search: web::Data<Arc<SemanticSearch>>,
 ) -> ResponseResult {
     if !is_feature_enabled(Feature::FullBuild) {
         let error = "Semantic search is not enabled. Please enable full build";

--- a/app-server/src/cache/mod.rs
+++ b/app-server/src/cache/mod.rs
@@ -2,12 +2,12 @@ use async_trait::async_trait;
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 
+use in_memory::InMemoryCache;
+use redis::RedisCache;
+
 pub mod in_memory;
 pub mod keys;
 pub mod redis;
-
-pub use in_memory::InMemoryCache;
-pub use redis::RedisCache;
 
 #[derive(thiserror::Error, Debug)]
 pub enum CacheError {

--- a/app-server/src/code_executor/code_executor_impl.rs
+++ b/app-server/src/code_executor/code_executor_impl.rs
@@ -9,7 +9,7 @@ use crate::pipeline::nodes::{HandleType, NodeInput};
 use super::code_executor_grpc::{
     code_executor_client::CodeExecutorClient, ExecuteCodeRequest, HandleType as GrpcHandleType,
 };
-use super::CodeExecutor;
+use super::CodeExecutorTrait;
 
 pub struct CodeExecutorImpl {
     client: Arc<CodeExecutorClient<Channel>>,
@@ -22,7 +22,7 @@ impl CodeExecutorImpl {
 }
 
 #[async_trait]
-impl CodeExecutor for CodeExecutorImpl {
+impl CodeExecutorTrait for CodeExecutorImpl {
     async fn execute(
         &self,
         code: &String,

--- a/app-server/src/code_executor/mock.rs
+++ b/app-server/src/code_executor/mock.rs
@@ -3,13 +3,13 @@ use std::collections::HashMap;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::code_executor::CodeExecutor;
+use crate::code_executor::CodeExecutorTrait;
 use crate::pipeline::nodes::{HandleType, NodeInput};
 
 pub struct MockCodeExecutor {}
 
 #[async_trait]
-impl CodeExecutor for MockCodeExecutor {
+impl CodeExecutorTrait for MockCodeExecutor {
     async fn execute(
         &self,
         _code: &String,

--- a/app-server/src/code_executor/mod.rs
+++ b/app-server/src/code_executor/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use code_executor_grpc::{chat_message_content, chat_message_content_part, StringList};
+use enum_dispatch::enum_dispatch;
 
 use crate::{
     language_model::{
@@ -12,21 +12,31 @@ use crate::{
     pipeline::nodes::{HandleType, NodeInput},
 };
 
-use self::code_executor_grpc::{
-    arg, chat_message_list, execute_code_response, Arg,
-    ChatMessageContent as ArgChatMessageContent,
+use code_executor_grpc::{
+    arg, chat_message_content, chat_message_content_part, chat_message_list, execute_code_response,
+    Arg, ChatMessageContent as ArgChatMessageContent,
     ChatMessageContentPart as ArgChatMessageContentPart, ChatMessageImage as ArgChatMessageImage,
     ChatMessageImageUrl as ArgChatMessageImageUrl, ChatMessageList,
     ChatMessageText as ArgChatMessageText, ContentPartList as ArgContentPartList,
-    ExecuteCodeResponse,
+    ExecuteCodeResponse, StringList,
 };
+
+use code_executor_impl::CodeExecutorImpl;
+use mock::MockCodeExecutor;
 
 pub mod code_executor_grpc;
 pub mod code_executor_impl;
 pub mod mock;
 
+#[enum_dispatch]
+pub enum CodeExecutor {
+    Grpc(CodeExecutorImpl),
+    Mock(MockCodeExecutor),
+}
+
 #[async_trait]
-pub trait CodeExecutor: Sync + Send {
+#[enum_dispatch(CodeExecutor)]
+pub trait CodeExecutorTrait: Sync + Send {
     async fn execute(
         &self,
         code: &String,

--- a/app-server/src/datasets/utils.rs
+++ b/app-server/src/datasets/utils.rs
@@ -1,6 +1,10 @@
 use std::{collections::HashMap, result::Result, sync::Arc};
 
-use crate::{pipeline::nodes::NodeInput, routes::error::Error, semantic_search::SemanticSearch};
+use crate::{
+    pipeline::nodes::NodeInput,
+    routes::error::Error,
+    semantic_search::{SemanticSearch, SemanticSearchTrait},
+};
 use actix_multipart::Multipart;
 use anyhow::Context;
 use futures_util::StreamExt;
@@ -40,7 +44,7 @@ pub async fn read_multipart_file(mut payload: Multipart) -> Result<ParsedFile, E
 
 pub async fn index_new_points(
     datapoints: Vec<Datapoint>,
-    semantic_search: Arc<dyn SemanticSearch>,
+    semantic_search: Arc<SemanticSearch>,
     collection_name: String,
     new_index_column: Option<String>,
 ) -> anyhow::Result<()> {

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -331,20 +331,18 @@ fn main() -> anyhow::Result<()> {
                             .await
                             .unwrap(),
                     );
-                    Arc::new(semantic_search::SemanticSearch::Grpc(
+                    Arc::new(
                         semantic_search::semantic_search_impl::SemanticSearchImpl::new(
                             semantic_search_client,
-                        ),
-                    ))
+                        )
+                        .into(),
+                    )
                 } else {
-                    Arc::new(semantic_search::SemanticSearch::Mock(
-                        semantic_search::mock::MockSemanticSearch {},
-                    ))
+                    Arc::new(semantic_search::mock::MockSemanticSearch {}.into())
                 };
 
                 // == Python executor ==
-                let code_executor: Arc<dyn CodeExecutor> = if is_feature_enabled(Feature::FullBuild)
-                {
+                let code_executor: Arc<CodeExecutor> = if is_feature_enabled(Feature::FullBuild) {
                     let code_executor_url =
                         env::var("CODE_EXECUTOR_URL").expect("CODE_EXECUTOR_URL must be set");
                     let code_executor_client = Arc::new(
@@ -352,11 +350,14 @@ fn main() -> anyhow::Result<()> {
                             .await
                             .unwrap(),
                     );
-                    Arc::new(code_executor::code_executor_impl::CodeExecutorImpl::new(
-                        code_executor_client,
-                    ))
+                    Arc::new(
+                        code_executor::code_executor_impl::CodeExecutorImpl::new(
+                            code_executor_client,
+                        )
+                        .into(),
+                    )
                 } else {
-                    Arc::new(code_executor::mock::MockCodeExecutor {})
+                    Arc::new(code_executor::mock::MockCodeExecutor {}.into())
                 };
 
                 // == Language models ==

--- a/app-server/src/pipeline/context.rs
+++ b/app-server/src/pipeline/context.rs
@@ -13,7 +13,7 @@ use super::{nodes::StreamChunk, runner::PipelineRunner, RunType};
 
 pub struct Context {
     pub language_model: Arc<LanguageModelRunner>,
-    pub semantic_search: Arc<dyn SemanticSearch>,
+    pub semantic_search: Arc<SemanticSearch>,
     pub env: HashMap<String, String>,
     pub tx: Option<Sender<StreamChunk>>,
     pub metadata: HashMap<String, String>,

--- a/app-server/src/pipeline/context.rs
+++ b/app-server/src/pipeline/context.rs
@@ -23,7 +23,7 @@ pub struct Context {
     /// This is stored in the context before runtime
     /// to avoid the schema being validated on every LLM node run.
     pub baml_schemas: HashMap<Uuid, BamlContext>,
-    pub code_executor: Arc<dyn CodeExecutor>,
+    pub code_executor: Arc<CodeExecutor>,
     pub db: Arc<DB>,
     pub cache: Arc<Cache>,
 }

--- a/app-server/src/pipeline/nodes/code.rs
+++ b/app-server/src/pipeline/nodes/code.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
+use crate::code_executor::CodeExecutorTrait;
 use crate::engine::{RunOutput, RunnableNode};
 use crate::pipeline::context::Context;
 use anyhow::Result;

--- a/app-server/src/pipeline/nodes/semantic_search_utils.rs
+++ b/app-server/src/pipeline/nodes/semantic_search_utils.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::db::datapoints::DBDatapoint;
-use crate::semantic_search::SemanticSearch;
+use crate::semantic_search::{SemanticSearch, SemanticSearchTrait};
 use crate::{datasets::Dataset, db::DB, pipeline::nodes::utils::render_template};
 
 use super::NodeInput;
@@ -21,7 +21,7 @@ pub struct SemanticSearchPoint {
 
 pub(super) async fn query_datasources(
     datasets: &Vec<Dataset>,
-    semantic_search: Arc<dyn SemanticSearch>,
+    semantic_search: Arc<SemanticSearch>,
     db: Arc<DB>,
     query: String,
     collection_name: String,

--- a/app-server/src/pipeline/nodes/semantic_similarity.rs
+++ b/app-server/src/pipeline/nodes/semantic_similarity.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use crate::{
     engine::{RunOutput, RunnableNode},
     pipeline::context::Context,
+    semantic_search::SemanticSearchTrait,
 };
 
 use super::{utils::map_handles, Handle, NodeInput};

--- a/app-server/src/pipeline/runner.rs
+++ b/app-server/src/pipeline/runner.rs
@@ -94,7 +94,7 @@ impl Serialize for PipelineRunnerError {
 #[derive(Clone)]
 pub struct PipelineRunner {
     language_model: Arc<LanguageModelRunner>,
-    semantic_search: Arc<dyn SemanticSearch>,
+    semantic_search: Arc<SemanticSearch>,
     queue: Arc<dyn MessageQueue<RabbitMqSpanMessage>>,
     code_executor: Arc<dyn CodeExecutor>,
     db: Arc<DB>,
@@ -104,7 +104,7 @@ pub struct PipelineRunner {
 impl PipelineRunner {
     pub fn new(
         language_model: Arc<LanguageModelRunner>,
-        semantic_search: Arc<dyn SemanticSearch>,
+        semantic_search: Arc<SemanticSearch>,
         queue: Arc<dyn MessageQueue<RabbitMqSpanMessage>>,
         code_executor: Arc<dyn CodeExecutor>,
         db: Arc<DB>,

--- a/app-server/src/pipeline/runner.rs
+++ b/app-server/src/pipeline/runner.rs
@@ -96,7 +96,7 @@ pub struct PipelineRunner {
     language_model: Arc<LanguageModelRunner>,
     semantic_search: Arc<SemanticSearch>,
     queue: Arc<dyn MessageQueue<RabbitMqSpanMessage>>,
-    code_executor: Arc<dyn CodeExecutor>,
+    code_executor: Arc<CodeExecutor>,
     db: Arc<DB>,
     cache: Arc<Cache>,
 }
@@ -106,7 +106,7 @@ impl PipelineRunner {
         language_model: Arc<LanguageModelRunner>,
         semantic_search: Arc<SemanticSearch>,
         queue: Arc<dyn MessageQueue<RabbitMqSpanMessage>>,
-        code_executor: Arc<dyn CodeExecutor>,
+        code_executor: Arc<CodeExecutor>,
         db: Arc<DB>,
         cache: Arc<Cache>,
     ) -> Self {

--- a/app-server/src/routes/datasets.rs
+++ b/app-server/src/routes/datasets.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     db::{self, datasets, DB},
     routes::ResponseResult,
-    semantic_search::SemanticSearch,
+    semantic_search::{SemanticSearch, SemanticSearchTrait},
 };
 
 const BATCH_SIZE: usize = 50;
@@ -22,7 +22,7 @@ const BATCH_SIZE: usize = 50;
 async fn delete_dataset(
     db: web::Data<DB>,
     path: web::Path<(Uuid, Uuid)>,
-    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+    semantic_search: web::Data<Arc<SemanticSearch>>,
 ) -> ResponseResult {
     let (project_id, dataset_id) = path.into_inner();
 
@@ -49,7 +49,7 @@ async fn upload_datapoint_file(
     payload: Multipart,
     path: web::Path<(Uuid, Uuid)>,
     db: web::Data<DB>,
-    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+    semantic_search: web::Data<Arc<SemanticSearch>>,
 ) -> ResponseResult {
     let (project_id, dataset_id) = path.into_inner();
     let db = db.into_inner();
@@ -89,7 +89,7 @@ struct CreateDatapointsRequest {
 async fn create_datapoint_embeddings(
     path: web::Path<(Uuid, Uuid)>,
     req: web::Json<CreateDatapointsRequest>,
-    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+    semantic_search: web::Data<Arc<SemanticSearch>>,
 ) -> ResponseResult {
     let (project_id, dataset_id) = path.into_inner();
     let req = req.into_inner();
@@ -130,7 +130,7 @@ struct UpdateDatapointRequest {
 async fn update_datapoint_embeddings(
     path: web::Path<(Uuid, Uuid, Uuid)>,
     req: web::Json<UpdateDatapointRequest>,
-    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+    semantic_search: web::Data<Arc<SemanticSearch>>,
 ) -> ResponseResult {
     let (project_id, dataset_id, datapoint_id) = path.into_inner();
     let req = req.into_inner();
@@ -173,7 +173,7 @@ pub struct DeleteDatapointRequest {
 async fn delete_datapoint_embeddings(
     path: web::Path<(Uuid, Uuid)>,
     req: web::Json<DeleteDatapointRequest>,
-    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+    semantic_search: web::Data<Arc<SemanticSearch>>,
 ) -> ResponseResult {
     let (project_id, dataset_id) = path.into_inner();
     let datapoint_ids = req.into_inner().ids;
@@ -200,7 +200,7 @@ async fn delete_datapoint_embeddings(
 async fn delete_all_datapoints(
     path: web::Path<(Uuid, Uuid)>,
     db: web::Data<DB>,
-    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+    semantic_search: web::Data<Arc<SemanticSearch>>,
 ) -> ResponseResult {
     let (project_id, dataset_id) = path.into_inner();
 
@@ -230,7 +230,7 @@ async fn index_dataset(
     db: web::Data<DB>,
     path: web::Path<(Uuid, Uuid)>,
     request: web::Json<IndexDatasetRequest>,
-    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+    semantic_search: web::Data<Arc<SemanticSearch>>,
 ) -> ResponseResult {
     let (project_id, dataset_id) = path.into_inner();
     let index_column = &request.index_column;

--- a/app-server/src/routes/projects.rs
+++ b/app-server/src/routes/projects.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::{
     db::{self, DB},
     routes::ResponseResult,
-    semantic_search::SemanticSearch,
+    semantic_search::{SemanticSearch, SemanticSearchTrait},
 };
 
 #[derive(Serialize)]
@@ -45,7 +45,7 @@ async fn get_project(project_id: web::Path<Uuid>, db: web::Data<DB>) -> Response
 async fn delete_project(
     project_id: web::Path<Uuid>,
     db: web::Data<DB>,
-    semantic_search: web::Data<Arc<dyn SemanticSearch>>,
+    semantic_search: web::Data<Arc<SemanticSearch>>,
 ) -> ResponseResult {
     let project_id = project_id.into_inner();
 

--- a/app-server/src/semantic_search/mock.rs
+++ b/app-server/src/semantic_search/mock.rs
@@ -8,13 +8,13 @@ use super::semantic_search_grpc::{
     DeleteCollectionsResponse, DeleteEmbeddingsResponse, IndexResponse, QueryResponse,
 };
 
-use super::SemanticSearch;
+use super::SemanticSearchTrait;
 
 #[derive(Clone)]
 pub struct MockSemanticSearch {}
 
 #[async_trait]
-impl SemanticSearch for MockSemanticSearch {
+impl SemanticSearchTrait for MockSemanticSearch {
     async fn query(
         &self,
         _: &str,

--- a/app-server/src/semantic_search/mod.rs
+++ b/app-server/src/semantic_search/mod.rs
@@ -2,19 +2,30 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use enum_dispatch::enum_dispatch;
 
 use self::semantic_search_grpc::{
     index_request::Datapoint, CalculateSimilarityScoresResponse, CreateCollectionResponse,
     DeleteCollectionsResponse, DeleteEmbeddingsResponse, IndexResponse, QueryResponse,
 };
 
+use mock::MockSemanticSearch;
+use semantic_search_impl::SemanticSearchImpl;
+
 pub mod mock;
 pub mod semantic_search_grpc;
 pub mod semantic_search_impl;
 pub mod utils;
 
+#[enum_dispatch]
+pub enum SemanticSearch {
+    Grpc(SemanticSearchImpl),
+    Mock(MockSemanticSearch),
+}
+
 #[async_trait]
-pub trait SemanticSearch: Sync + Send {
+#[enum_dispatch(SemanticSearch)]
+pub trait SemanticSearchTrait: Sync + Send {
     async fn query(
         &self,
         collection_name: &str,

--- a/app-server/src/semantic_search/semantic_search_impl.rs
+++ b/app-server/src/semantic_search/semantic_search_impl.rs
@@ -13,7 +13,7 @@ use super::semantic_search_grpc::{
     RequestPayload,
 };
 
-use crate::semantic_search::SemanticSearch;
+use crate::semantic_search::SemanticSearchTrait;
 
 #[derive(Clone, Debug)]
 pub struct SemanticSearchImpl {
@@ -27,7 +27,7 @@ impl SemanticSearchImpl {
 }
 
 #[async_trait]
-impl SemanticSearch for SemanticSearchImpl {
+impl SemanticSearchTrait for SemanticSearchImpl {
     async fn query(
         &self,
         collection_name: &str,


### PR DESCRIPTION
To be reviewed after/on top of #402 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor code execution and semantic search functionalities using `enum_dispatch` for cleaner implementation management.
> 
>   - **Behavior**:
>     - Replace `dyn` trait objects with `enum_dispatch` for `SemanticSearch` and `CodeExecutor` in `main.rs`, `context.rs`, and `runner.rs`.
>     - Use `SemanticSearch` enum in `semantic_search.rs`, `datasets.rs`, and `projects.rs` for gRPC and mock implementations.
>     - Use `CodeExecutor` enum in `code_executor.rs` and `nodes/code.rs` for gRPC and mock implementations.
>   - **Traits and Enums**:
>     - Introduce `SemanticSearch` enum with `Grpc` and `Mock` variants in `semantic_search/mod.rs`.
>     - Introduce `CodeExecutor` enum with `Grpc` and `Mock` variants in `code_executor/mod.rs`.
>     - Define `SemanticSearchTrait` and `CodeExecutorTrait` for respective functionalities.
>   - **Refactoring**:
>     - Update function signatures to use `Arc<SemanticSearch>` and `Arc<CodeExecutor>` instead of `Arc<dyn Trait>` in multiple files.
>     - Adjust imports and usage of `SemanticSearchTrait` and `CodeExecutorTrait` in `semantic_search_impl.rs`, `mock.rs`, and `code_executor_impl.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for b31fae8b7f2da7cd7e7359c5f150f1a6329eecfa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->