### PR TITLE
separate env vars that control number of workers

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -417,18 +417,18 @@ fn main() -> anyhow::Result<()> {
                     let shared_secret_auth =
                         HttpAuthentication::bearer(auth::shared_secret_validator);
 
-                    let num_trace_workers_per_thread = env::var("NUM_WORKERS_PER_THREAD")
-                        .unwrap_or(String::from("2"))
+                    let num_spans_workers_per_thread = env::var("NUM_SPANS_WORKERS_PER_THREAD")
+                        .unwrap_or(String::from("4"))
                         .parse::<u8>()
-                        .unwrap_or(2);
+                        .unwrap_or(4);
 
                     let num_browser_events_workers_per_thread =
                         env::var("NUM_BROWSER_EVENTS_WORKERS_PER_THREAD")
-                            .unwrap_or(String::from("2"))
+                            .unwrap_or(String::from("4"))
                             .parse::<u8>()
-                            .unwrap_or(2);
+                            .unwrap_or(4);
 
-                    for _ in 0..num_trace_workers_per_thread {
+                    for _ in 0..num_spans_workers_per_thread {
                         tokio::spawn(process_queue_spans(
                             pipeline_runner.clone(),
                             db_for_http.clone(),

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -417,12 +417,18 @@ fn main() -> anyhow::Result<()> {
                     let shared_secret_auth =
                         HttpAuthentication::bearer(auth::shared_secret_validator);
 
-                    let num_workers_per_thread = env::var("NUM_WORKERS_PER_THREAD")
-                        .unwrap_or(String::from("8"))
+                    let num_trace_workers_per_thread = env::var("NUM_WORKERS_PER_THREAD")
+                        .unwrap_or(String::from("2"))
                         .parse::<u8>()
-                        .unwrap_or(8);
+                        .unwrap_or(2);
 
-                    for _ in 0..num_workers_per_thread {
+                    let num_browser_events_workers_per_thread =
+                        env::var("NUM_BROWSER_EVENTS_WORKERS_PER_THREAD")
+                            .unwrap_or(String::from("2"))
+                            .parse::<u8>()
+                            .unwrap_or(2);
+
+                    for _ in 0..num_trace_workers_per_thread {
                         tokio::spawn(process_queue_spans(
                             pipeline_runner.clone(),
                             db_for_http.clone(),
@@ -431,7 +437,9 @@ fn main() -> anyhow::Result<()> {
                             clickhouse.clone(),
                             storage.clone(),
                         ));
+                    }
 
+                    for _ in 0..num_browser_events_workers_per_thread {
                         tokio::spawn(process_browser_events(
                             clickhouse.clone(),
                             browser_events_message_queue.clone(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Separate environment variables for controlling the number of workers for spans and browser events in `main.rs`.
> 
>   - **Environment Variables**:
>     - Introduced `NUM_SPANS_WORKERS_PER_THREAD` and `NUM_BROWSER_EVENTS_WORKERS_PER_THREAD` in `main.rs` to separately control the number of workers for spans and browser events.
>     - Default values set to 4 for both if environment variables are not provided.
>   - **Worker Spawning**:
>     - `process_queue_spans` now uses `NUM_SPANS_WORKERS_PER_THREAD`.
>     - `process_browser_events` now uses `NUM_BROWSER_EVENTS_WORKERS_PER_THREAD`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 15e544894b0e9e89686a700ebbdf9b39e419d2b1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->