### PR TITLE
revert browser events query to the previous state

### DIFF
--- a/app-server/src/browser_events/mod.rs
+++ b/app-server/src/browser_events/mod.rs
@@ -1,4 +1,4 @@
-use std::{env, sync::Arc};
+use std::sync::Arc;
 
 use backoff::ExponentialBackoffBuilder;
 use serde::{Deserialize, Serialize};
@@ -60,105 +60,82 @@ async fn inner_process_browser_events(clickhouse: clickhouse::Client, queue: Arc
             continue;
         }
 
-        let max_batch_size = env::var("BROWSER_EVENTS_MAX_BATCH_SIZE")
-            .unwrap_or(String::from("64"))
-            .parse()
-            .unwrap_or(64);
+        // We could further tune async_insert by setting
+        // - `async_insert_max_data_size` (bytes)
+        // - `async_insert_busy_timeout_ms`
+        // These are defaulted globally to 10MiB and 1000ms respectively.
+        // More: https://clickhouse.com/docs/en/optimize/asynchronous-inserts
+        let mut query = String::from(
+            "
+        INSERT INTO browser_session_events (
+            event_id, session_id, trace_id, timestamp,
+            event_type, data, project_id
+        )
+        SETTINGS async_insert = 1,
+            wait_for_async_insert = 1
+        VALUES ",
+        );
 
-        // Split large batches into smaller chunks
-        for chunk in batch.events.chunks(max_batch_size) {
-            let chunk_batch = EventBatch {
-                events: chunk.to_vec(),
-                session_id: batch.session_id,
-                trace_id: batch.trace_id,
-            };
-
-            // We could further tune async_insert by setting
-            // - `async_insert_max_data_size` (bytes)
-            // - `async_insert_busy_timeout_ms`
-            // These are defaulted globally to 10MiB and 1000ms respectively.
-            // More: https://clickhouse.com/docs/en/optimize/asynchronous-inserts
-            let query = "
-                INSERT INTO browser_session_events (
-                    event_id, session_id, trace_id, timestamp,
-                    event_type, data, project_id
-                )
-                SELECT
-                    event_id,
-                    session_id,
-                    trace_id,
-                    timestamp,
-                    event_type,
-                    data,
-                    project_id
-                FROM (
-                    SELECT
-                        generateUUIDv4() as event_id,
-                        ? as session_id,
-                        ? as trace_id,
-                        arr.1 as timestamp,
-                        arr.2 as event_type,
-                        arr.3 as data,
-                        ? as project_id
-                    FROM (
-                        SELECT arrayJoin(arrayZip(?, ?, ?)) as arr
-                    )
-                )
-                SETTINGS async_insert = 1,
-                    wait_for_async_insert = 1";
-
-            // Prepare arrays for batch insert
-            let timestamps: Vec<String> = chunk_batch
-                .events
-                .iter()
-                .map(|e| e.timestamp.to_string())
-                .collect();
-            let event_types: Vec<String> = chunk_batch
-                .events
-                .iter()
-                .map(|e| e.event_type.to_string())
-                .collect();
-            let event_data: Vec<&str> = chunk_batch.events.iter().map(|e| e.data.get()).collect();
-
-            let final_query = clickhouse
-                .query(query)
-                .bind(chunk_batch.session_id.to_string())
-                .bind(chunk_batch.trace_id.to_string())
-                .bind(project_id.to_string())
-                .bind(timestamps)
-                .bind(event_types)
-                .bind(event_data);
-
-            let insert_browser_events = || async {
-                final_query.clone().execute().await
-                    .map_err(|e| {
-                        log::error!(
-                            "Failed attempt to insert chunk of browser events. Will retry according to backoff policy. Error: {:?}",
-                            e
-                        );
-                        backoff::Error::Transient {
-                            err: e,
-                            retry_after: None,
-                        }
-                    })
-            };
-            // Starting with 0.5 second delay, delay multiplies by random factor between 1 and 2
-            // up to 1 minute and until the total elapsed time is 60 seconds
-            // https://docs.rs/backoff/latest/backoff/default/index.html
-            let exponential_backoff = ExponentialBackoffBuilder::new()
-                .with_initial_interval(std::time::Duration::from_millis(500))
-                .with_multiplier(1.5)
-                .with_randomization_factor(0.5)
-                .with_max_interval(std::time::Duration::from_secs(60))
-                .with_max_elapsed_time(Some(std::time::Duration::from_secs(60)))
-                .build();
-
-            let _ = backoff::future::retry(exponential_backoff, insert_browser_events)
-                .await
-                .map_err(|e| {
-                    log::error!("Failed to insert chunk of browser events: {:?}", e);
-                });
+        for i in 0..batch.events.len() {
+            if i > 0 {
+                query.push_str(", ");
+            }
+            query.push_str("(generateUUIDv4(), ?, ?, ?, ?, ?, ?)");
         }
+
+        let values = batch
+            .events
+            .into_iter()
+            .flat_map(|event| {
+                vec![
+                    batch.session_id.to_string(),
+                    batch.trace_id.to_string(),
+                    event.timestamp.to_string(),
+                    event.event_type.to_string(),
+                    // TODO: see if we can get away with not cloning the data
+                    // for now it is causing issues with temporary lifetimes.
+                    event.data.get().to_string(),
+                    project_id.to_string(),
+                ]
+            })
+            .collect::<Vec<_>>();
+
+        // Execute batch insert with individual bindings
+        let mut query_with_bindings = clickhouse.query(&query);
+        for value in values {
+            query_with_bindings = query_with_bindings.bind(value);
+        }
+        let final_query = query_with_bindings;
+        let insert_browser_events = || async {
+            final_query.clone().execute().await
+                .map_err(|e| {
+                    log::error!(
+                        "Failed attempt to insert browser events. Will retry according to backoff policy. Error: {:?}",
+                        e
+                    );
+                    backoff::Error::Transient {
+                        err: e,
+                        retry_after: None,
+                    }
+                })
+        };
+
+        // Starting with 1 second delay, delay multiplies by random factor between 1 and 2
+        // up to 1 minute and until the total elapsed time is 60 seconds
+        // https://docs.rs/backoff/latest/backoff/default/index.html
+        let exponential_backoff = ExponentialBackoffBuilder::new()
+            .with_initial_interval(std::time::Duration::from_millis(1000))
+            .with_multiplier(1.5)
+            .with_randomization_factor(0.5)
+            .with_max_interval(std::time::Duration::from_secs(60))
+            .with_max_elapsed_time(Some(std::time::Duration::from_secs(60)))
+            .build();
+
+        let _ = backoff::future::retry(exponential_backoff, insert_browser_events)
+            .await
+            .map_err(|e| {
+                log::error!("Failed to insert chunk of browser events: {:?}", e);
+            });
 
         // Only ack the message after all chunks have been processed
         if let Err(e) = acker.ack().await {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reverts browser events query logic to previous state, removing chunking and adjusting backoff strategy in `mod.rs`.
> 
>   - **Behavior**:
>     - Reverts browser events query logic in `inner_process_browser_events` to previous state, removing event chunking.
>     - Changes backoff strategy: initial delay from 0.5s to 1s, with retries up to 60s.
>   - **Code Changes**:
>     - Removes `max_batch_size` and chunking logic for event batches.
>     - Simplifies query construction by directly appending values for each event.
>     - Adjusts error handling to log and retry on insertion failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for eecbe323a3264dfccaf328cb9420f955ae893686. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->