### PR TITLE
fix: json string on manual spans

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -875,7 +875,7 @@ fn input_chat_messages_from_json(input: &serde_json::Value) -> Result<Vec<ChatMe
                         }
                         ChatMessageContent::ContentPartList(parts)
                     }
-                    Err(_) => ChatMessageContent::Text(otel_content.to_string()),
+                    Err(_) => ChatMessageContent::Text(json_value_to_string(otel_content)),
                 };
                 Ok(ChatMessage {
                     role: role.to_string(),


### PR DESCRIPTION
Manual spans send a double stringified json in the input, so fix this on inputs that match chat messages
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes double stringification of JSON in `input_chat_messages_from_json()` in `spans.rs` by using `json_value_to_string`.
> 
>   - **Behavior**:
>     - Fixes double stringification of JSON in `input_chat_messages_from_json()` in `spans.rs`.
>     - Uses `json_value_to_string` to convert JSON values to strings for `ChatMessageContent::Text`.
>   - **Functions**:
>     - Updates `input_chat_messages_from_json()` to handle JSON input correctly for manual spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for f997bd80b9b157eab20f2e51ad4eecf1225fa9e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->