### PR TITLE
rabbit pooler

### DIFF
--- a/app-server/Cargo.lock
+++ b/app-server/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "clickhouse",
  "csv",
  "dashmap",
+ "deadpool",
  "dotenv",
  "enum_dispatch",
  "env_logger 0.10.2",
@@ -1920,6 +1921,23 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "deadpool"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"

--- a/app-server/Cargo.toml
+++ b/app-server/Cargo.toml
@@ -69,6 +69,7 @@ tokio-stream = {version = "0.1", features = ["net"]}
 tokio-tungstenite = "0.24"
 url = "2.5.0"
 uuid = {version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics", "serde"]}
+deadpool = "0.12.2"
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -192,7 +192,13 @@ fn main() -> anyhow::Result<()> {
                 .await
                 .unwrap();
 
-            Arc::new(mq::rabbit::RabbitMQ::new(connection.clone()).into())
+            let max_channel_pool_size = env::var("RABBITMQ_MAX_CHANNEL_POOL_SIZE")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(64);
+
+            let rabbit_mq = mq::rabbit::RabbitMQ::new(connection.clone(), max_channel_pool_size);
+            Arc::new(rabbit_mq.into())
         })
     } else {
         Arc::new(mq::tokio_mpsc::TokioMpscQueue::new().into())
@@ -222,7 +228,13 @@ fn main() -> anyhow::Result<()> {
                 .await
                 .unwrap();
 
-            Arc::new(mq::rabbit::RabbitMQ::new(connection).into())
+            let max_channels = env::var("RABBITMQ_MAX_CHANNEL_POOL_SIZE")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(64);
+
+            let rabbit_mq = mq::rabbit::RabbitMQ::new(connection, max_channels);
+            Arc::new(rabbit_mq.into())
         })
     } else {
         Arc::new(mq::tokio_mpsc::TokioMpscQueue::new().into())

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -228,12 +228,12 @@ fn main() -> anyhow::Result<()> {
                 .await
                 .unwrap();
 
-            let max_channels = env::var("RABBITMQ_MAX_CHANNEL_POOL_SIZE")
+            let max_channel_pool_size = env::var("RABBITMQ_MAX_CHANNEL_POOL_SIZE")
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(64);
 
-            let rabbit_mq = mq::rabbit::RabbitMQ::new(connection, max_channels);
+            let rabbit_mq = mq::rabbit::RabbitMQ::new(connection, max_channel_pool_size);
             Arc::new(rabbit_mq.into())
         })
     } else {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces RabbitMQ channel pooling using `deadpool` to optimize channel management in `rabbit.rs` and updates `main.rs` accordingly.
> 
>   - **Behavior**:
>     - Introduces channel pooling for RabbitMQ using `deadpool` in `rabbit.rs`.
>     - Configurable pool size via `RABBITMQ_MAX_CHANNEL_POOL_SIZE` environment variable, defaulting to 64.
>     - Updates `main.rs` to use the new `RabbitMQ` constructor with channel pooling.
>   - **Dependencies**:
>     - Adds `deadpool` version `0.12.2` to `Cargo.toml` and `Cargo.lock`.
>   - **Functions**:
>     - `RabbitMQ::new()` in `rabbit.rs` now accepts `max_channel_pool_size`.
>     - `RabbitMQ::publish()` uses a pooled channel for message publishing.
>     - `RabbitMQ::get_receiver()` remains unchanged, still creates a new channel per call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for ef24121074f2f63cf461d3cc6e74db9f11316579. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->