### PR TITLE
fix: pick only necessary fields

### DIFF
--- a/frontend/app/api/projects/[projectId]/playgrounds/route.ts
+++ b/frontend/app/api/projects/[projectId]/playgrounds/route.ts
@@ -11,6 +11,11 @@ export async function GET(req: Request, props: { params: Promise<{ projectId: st
   const result = await db.query.playgrounds.findMany({
     where: eq(playgrounds.projectId, projectId),
     orderBy: [desc(playgrounds.createdAt)],
+    columns: {
+      id: true,
+      name: true,
+      createdAt: true,
+    },
   });
 
   return new Response(JSON.stringify(result));

--- a/frontend/components/playgrounds/playgrounds.tsx
+++ b/frontend/components/playgrounds/playgrounds.tsx
@@ -1,33 +1,40 @@
-'use client';
+"use client";
 
-import { ColumnDef } from '@tanstack/react-table';
-import { Loader2, Trash2 } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import useSWR from 'swr';
+import { ColumnDef } from "@tanstack/react-table";
+import { Loader2, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import useSWR from "swr";
 
-import { Button } from '@/components/ui/button';
-import { useProjectContext } from '@/contexts/project-context';
-import { useToast } from '@/lib/hooks/use-toast';
-import { Playground } from '@/lib/playground/types';
-import { swrFetcher } from '@/lib/utils';
+import { Button } from "@/components/ui/button";
+import { useProjectContext } from "@/contexts/project-context";
+import { useToast } from "@/lib/hooks/use-toast";
+import { Playground } from "@/lib/playground/types";
+import { swrFetcher } from "@/lib/utils";
 
-import ClientTimestampFormatter from '../client-timestamp-formatter';
-import { DataTable } from '../ui/datatable';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '../ui/dialog';
-import Header from '../ui/header';
-import Mono from '../ui/mono';
-import { TableCell, TableRow } from '../ui/table';
-import CreatePlaygroundDialog from './create-playground-dialog';
+import ClientTimestampFormatter from "../client-timestamp-formatter";
+import { DataTable } from "../ui/datatable";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
+import Header from "../ui/header";
+import Mono from "../ui/mono";
+import { TableCell, TableRow } from "../ui/table";
+import CreatePlaygroundDialog from "./create-playground-dialog";
+
+type SearchPlayground = Pick<Playground, "id" | "name" | "createdAt">;
 
 export default function Playgrounds() {
   const { projectId } = useProjectContext();
 
   const router = useRouter();
-  const { data, mutate } = useSWR<Playground[]>(
-    `/api/projects/${projectId}/playgrounds`,
-    swrFetcher
-  );
+  const { data, mutate } = useSWR<SearchPlayground[]>(`/api/projects/${projectId}/playgrounds`, swrFetcher);
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -36,50 +43,45 @@ export default function Playgrounds() {
   const handleDeletePlaygrounds = async (playgroundIds: string[]) => {
     setIsDeleting(true);
     try {
-      const res = await fetch(
-        `/api/projects/${projectId}/playgrounds?playgroundIds=${playgroundIds.join(',')}`,
-        {
-          method: 'DELETE',
-        }
-      );
+      const res = await fetch(`/api/projects/${projectId}/playgrounds?playgroundIds=${playgroundIds.join(",")}`, {
+        method: "DELETE",
+      });
 
       if (res.ok) {
         mutate();
         toast({
-          title: 'Playgrounds deleted',
+          title: "Playgrounds deleted",
           description: `Successfully deleted ${playgroundIds.length} playground(s).`,
         });
       } else {
-        throw new Error('Failed to delete playgrounds');
+        throw new Error("Failed to delete playgrounds");
       }
     } catch (error) {
       toast({
-        title: 'Error',
-        description: 'Failed to delete playgrounds. Please try again.',
-        variant: 'destructive',
+        title: "Error",
+        description: "Failed to delete playgrounds. Please try again.",
+        variant: "destructive",
       });
     }
     setIsDeleting(false);
     setIsDeleteDialogOpen(false);
   };
 
-  const columns: ColumnDef<Playground>[] = [
+  const columns: ColumnDef<SearchPlayground>[] = [
     {
       cell: ({ row }) => <Mono>{row.original.id}</Mono>,
       size: 300,
-      header: 'ID'
+      header: "ID",
     },
     {
-      accessorKey: 'name',
-      header: 'name',
-      size: 300
+      accessorKey: "name",
+      header: "name",
+      size: 300,
     },
     {
-      header: 'Created at',
-      accessorKey: 'createdAt',
-      cell: (row) => (
-        <ClientTimestampFormatter timestamp={String(row.getValue())} />
-      )
+      header: "Created at",
+      accessorKey: "createdAt",
+      cell: (row) => <ClientTimestampFormatter timestamp={String(row.getValue())} />,
     },
   ];
 
@@ -87,9 +89,7 @@ export default function Playgrounds() {
     <div className="h-full flex flex-col">
       <Header path="playgrounds" />
       <div className="flex justify-between items-center p-4 flex-none">
-        <h1 className="scroll-m-20 text-2xl font-medium">
-          Playgrounds
-        </h1>
+        <h1 className="scroll-m-20 text-2xl font-medium">Playgrounds</h1>
         <CreatePlaygroundDialog />
       </div>
       <div className="flex-grow">
@@ -98,7 +98,7 @@ export default function Playgrounds() {
           onRowClick={(row) => {
             router.push(`/project/${projectId}/playgrounds/${row.original.id}`);
           }}
-          getRowId={(row: Playground) => row.id}
+          getRowId={(row) => row.id}
           columns={columns}
           data={data}
           selectionPanel={(selectedRowIds) => (
@@ -113,8 +113,8 @@ export default function Playgrounds() {
                   <DialogHeader>
                     <DialogTitle>Delete Playgrounds</DialogTitle>
                     <DialogDescription>
-                      Are you sure you want to delete {selectedRowIds.length} playground(s)?
-                      This action cannot be undone.
+                      Are you sure you want to delete {selectedRowIds.length} playground(s)? This action cannot be
+                      undone.
                     </DialogDescription>
                   </DialogHeader>
                   <DialogFooter>

--- a/frontend/components/playgrounds/playgrounds.tsx
+++ b/frontend/components/playgrounds/playgrounds.tsx
@@ -9,7 +9,7 @@ import useSWR from "swr";
 import { Button } from "@/components/ui/button";
 import { useProjectContext } from "@/contexts/project-context";
 import { useToast } from "@/lib/hooks/use-toast";
-import { Playground } from "@/lib/playground/types";
+import { PlaygroundInfo } from "@/lib/playground/types";
 import { swrFetcher } from "@/lib/utils";
 
 import ClientTimestampFormatter from "../client-timestamp-formatter";
@@ -28,13 +28,11 @@ import Mono from "../ui/mono";
 import { TableCell, TableRow } from "../ui/table";
 import CreatePlaygroundDialog from "./create-playground-dialog";
 
-type SearchPlayground = Pick<Playground, "id" | "name" | "createdAt">;
-
 export default function Playgrounds() {
   const { projectId } = useProjectContext();
 
   const router = useRouter();
-  const { data, mutate } = useSWR<SearchPlayground[]>(`/api/projects/${projectId}/playgrounds`, swrFetcher);
+  const { data, mutate } = useSWR<PlaygroundInfo[]>(`/api/projects/${projectId}/playgrounds`, swrFetcher);
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -67,7 +65,7 @@ export default function Playgrounds() {
     setIsDeleteDialogOpen(false);
   };
 
-  const columns: ColumnDef<SearchPlayground>[] = [
+  const columns: ColumnDef<PlaygroundInfo>[] = [
     {
       cell: ({ row }) => <Mono>{row.original.id}</Mono>,
       size: 300,

--- a/frontend/lib/playground/types.ts
+++ b/frontend/lib/playground/types.ts
@@ -9,6 +9,8 @@ export type Playground = typeof playgrounds.$inferSelect & {
   promptMessages: ChatMessage[];
 };
 
+export type PlaygroundInfo = Pick<Playground, "id" | "name" | "createdAt">;
+
 export interface ImagePart {
   type: "image";
   image: DataContent | URL;


### PR DESCRIPTION
- return only necessary fields for playgrounds
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize playground data retrieval by selecting only necessary fields in API and frontend.
> 
>   - **API Changes**:
>     - In `route.ts`, modify `GET` function to return only `id`, `name`, and `createdAt` fields for playgrounds.
>   - **Frontend Changes**:
>     - In `playgrounds.tsx`, define `SearchPlayground` type to include only `id`, `name`, and `createdAt`.
>     - Update `useSWR` hook to use `SearchPlayground` type.
>     - Adjust `columns` definition to use `SearchPlayground` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d919a4d0b6b9854b30fc25cf4d2f4908acf174f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->