### PR TITLE
anthropic cache

### DIFF
--- a/app-server/src/language_model/costs/mod.rs
+++ b/app-server/src/language_model/costs/mod.rs
@@ -8,13 +8,10 @@ use crate::{
         prices::{get_price, DBPriceEntry},
         DB,
     },
+    traces::spans::InputTokens,
 };
 
 use super::providers::utils::calculate_cost;
-pub enum TokensKind {
-    Input,
-    Output,
-}
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct LLMPriceEntry {
@@ -22,17 +19,8 @@ pub struct LLMPriceEntry {
     _model: String,
     input_price_per_million: f64,
     output_price_per_million: f64,
-    _input_cached_price_per_million: Option<f64>,
-    _additional_prices: HashMap<String, f64>,
-}
-
-impl LLMPriceEntry {
-    pub fn get_price(&self, kind: TokensKind) -> Option<f64> {
-        match kind {
-            TokensKind::Input => Some(self.input_price_per_million),
-            TokensKind::Output => Some(self.output_price_per_million),
-        }
-    }
+    input_cached_price_per_million: Option<f64>,
+    additional_prices: HashMap<String, f64>,
 }
 
 impl From<DBPriceEntry> for LLMPriceEntry {
@@ -42,22 +30,22 @@ impl From<DBPriceEntry> for LLMPriceEntry {
             _model: value.model,
             input_price_per_million: value.input_price_per_million,
             output_price_per_million: value.output_price_per_million,
-            _input_cached_price_per_million: value.input_cached_price_per_million,
-            _additional_prices: serde_json::from_value(value.additional_prices).unwrap(),
+            input_cached_price_per_million: value.input_cached_price_per_million,
+            additional_prices: serde_json::from_value(value.additional_prices).unwrap(),
         }
     }
 }
 
-pub async fn estimate_cost(
+pub async fn estimate_output_cost(
     db: Arc<DB>,
     cache: Arc<Cache>,
     provider: &str,
     model: &str,
-    num_tokens: u32,
-    tokens_kind: TokensKind,
+    num_tokens: i64,
 ) -> Option<f64> {
     let cache_key = format!("{LLM_PRICES_CACHE_KEY}:{provider}:{model}");
     let cache_res = cache.get::<LLMPriceEntry>(&cache_key).await.ok()?;
+
     let price_per_million_tokens = match cache_res {
         Some(price) => price.input_price_per_million,
         None => {
@@ -66,10 +54,54 @@ pub async fn estimate_cost(
             let _ = cache
                 .insert::<LLMPriceEntry>(&cache_key, price.clone())
                 .await;
-            price.get_price(tokens_kind)?
+            price.output_price_per_million
         }
     };
     Some(calculate_cost(num_tokens, price_per_million_tokens))
+}
+
+pub async fn estimate_input_cost(
+    db: Arc<DB>,
+    cache: Arc<Cache>,
+    provider: &str,
+    model: &str,
+    input_tokens: InputTokens,
+) -> Option<f64> {
+    let cache_key = format!("{LLM_PRICES_CACHE_KEY}:{provider}:{model}");
+    // let cache_res = cache.get::<LLMPriceEntry>(&cache_key).await.ok()?;
+    let cache_res = None;
+
+    let price = match cache_res {
+        Some(price) => price,
+        None => {
+            let price = get_price(&db.pool, provider, model).await.ok()?;
+            let price = LLMPriceEntry::from(price);
+            let _ = cache
+                .insert::<LLMPriceEntry>(&cache_key, price.clone())
+                .await;
+            price
+        }
+    };
+
+    let regular_input_tokens = input_tokens.regular_input_tokens;
+    let cache_write_tokens = input_tokens.cache_write_tokens;
+    let cache_read_tokens = input_tokens.cache_read_tokens;
+
+    let regular_input_cost = calculate_cost(regular_input_tokens, price.input_price_per_million);
+    let cache_read_cost = calculate_cost(
+        cache_read_tokens,
+        price.input_cached_price_per_million.unwrap_or(0.0),
+    );
+    let cache_write_cost = if let Some(cache_write_cost) = price
+        .additional_prices
+        .get("input_cache_write_price_per_million")
+    {
+        calculate_cost(cache_write_tokens, *cache_write_cost)
+    } else {
+        0.0
+    };
+
+    Some(regular_input_cost + cache_write_cost + cache_read_cost)
 }
 
 pub struct CostEntry {
@@ -86,16 +118,15 @@ pub async fn estimate_cost_by_provider_name(
     cache: Arc<Cache>,
     provider_name: &str,
     model: &str,
-    input_tokens: u32,
-    output_tokens: u32,
+    input_tokens: InputTokens,
+    output_tokens: i64,
 ) -> Option<CostEntry> {
-    let input_cost = estimate_cost(
+    let input_cost = estimate_input_cost(
         db.clone(),
         cache.clone(),
         provider_name,
         model,
         input_tokens,
-        TokensKind::Input,
     )
     .await
     .or_else(|| {
@@ -106,13 +137,12 @@ pub async fn estimate_cost_by_provider_name(
         );
         None
     })?;
-    let output_cost = estimate_cost(
+    let output_cost = estimate_output_cost(
         db.clone(),
         cache.clone(),
         provider_name,
         model,
         output_tokens,
-        TokensKind::Output,
     )
     .await?;
 

--- a/app-server/src/language_model/providers/utils.rs
+++ b/app-server/src/language_model/providers/utils.rs
@@ -19,6 +19,6 @@ pub fn get_required_env_vars_for_model(model: &str) -> HashSet<String> {
     }
 }
 
-pub fn calculate_cost(tokens: u32, price_per_million_tokens: f64) -> f64 {
+pub fn calculate_cost(tokens: i64, price_per_million_tokens: f64) -> f64 {
     tokens as f64 * price_per_million_tokens / 1_000_000.0
 }

--- a/app-server/src/traces/span_attributes.rs
+++ b/app-server/src/traces/span_attributes.rs
@@ -30,3 +30,7 @@ pub const SPAN_TYPE: &str = "lmnr.span.type";
 pub const SPAN_PATH: &str = "lmnr.span.path";
 pub const SPAN_IDS_PATH: &str = "lmnr.span.ids_path";
 pub const LLM_NODE_RENDERED_PROMPT: &str = "lmnr.span.prompt";
+
+pub const GEN_AI_ANTHROPIC_CACHE_WRITE_INPUT_TOKENS: &str =
+    "gen_ai.usage.cache_creation_input_tokens";
+pub const GEN_AI_ANTHROPIC_CACHE_READ_INPUT_TOKENS: &str = "gen_ai.usage.cache_read_input_tokens";

--- a/app-server/src/traces/span_attributes.rs
+++ b/app-server/src/traces/span_attributes.rs
@@ -31,6 +31,5 @@ pub const SPAN_PATH: &str = "lmnr.span.path";
 pub const SPAN_IDS_PATH: &str = "lmnr.span.ids_path";
 pub const LLM_NODE_RENDERED_PROMPT: &str = "lmnr.span.prompt";
 
-pub const GEN_AI_ANTHROPIC_CACHE_WRITE_INPUT_TOKENS: &str =
-    "gen_ai.usage.cache_creation_input_tokens";
-pub const GEN_AI_ANTHROPIC_CACHE_READ_INPUT_TOKENS: &str = "gen_ai.usage.cache_read_input_tokens";
+pub const GEN_AI_CACHE_WRITE_INPUT_TOKENS: &str = "gen_ai.usage.cache_creation_input_tokens";
+pub const GEN_AI_CACHE_READ_INPUT_TOKENS: &str = "gen_ai.usage.cache_read_input_tokens";

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -105,7 +105,7 @@ impl SpanAttributes {
     }
 
     pub fn input_tokens(&mut self) -> InputTokens {
-        let regular_input_tokens =
+        let total_input_tokens =
             if let Some(Value::Number(n)) = self.attributes.get(GEN_AI_INPUT_TOKENS) {
                 n.as_i64().unwrap_or(0)
             } else if let Some(Value::Number(n)) = self.attributes.get(GEN_AI_PROMPT_TOKENS) {
@@ -131,7 +131,7 @@ impl SpanAttributes {
                 .unwrap_or(0);
 
             let regular_input_tokens =
-                regular_input_tokens - (cache_write_tokens + cache_read_tokens);
+                total_input_tokens - (cache_write_tokens + cache_read_tokens);
             let cache_write_tokens = cache_write_tokens;
             let cache_read_tokens = cache_read_tokens;
 
@@ -142,7 +142,7 @@ impl SpanAttributes {
             }
         } else {
             InputTokens {
-                regular_input_tokens,
+                regular_input_tokens: total_input_tokens,
                 cache_write_tokens: 0,
                 cache_read_tokens: 0,
             }

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -42,7 +42,7 @@ pub async fn get_llm_usage_for_span(
 ) -> SpanUsage {
     let input_tokens = attributes.input_tokens();
     let output_tokens = attributes.completion_tokens();
-    let total_tokens = input_tokens + output_tokens;
+    let total_tokens = input_tokens.total() + output_tokens;
 
     let mut input_cost: f64 = 0.0;
     let mut output_cost: f64 = 0.0;
@@ -50,9 +50,7 @@ pub async fn get_llm_usage_for_span(
 
     let response_model = attributes.response_model();
     let model_name = response_model.or(attributes.request_model());
-    let provider_name = attributes
-        .provider_name()
-        .map(|name| name.to_lowercase().trim().to_string());
+    let provider_name = attributes.provider_name();
 
     if let Some(model) = model_name.as_deref() {
         if let Some(provider) = &provider_name {
@@ -61,8 +59,8 @@ pub async fn get_llm_usage_for_span(
                 cache.clone(),
                 provider,
                 model,
-                input_tokens as u32,
-                output_tokens as u32,
+                input_tokens,
+                output_tokens,
             )
             .await;
             if let Some(cost_entry) = cost_entry {
@@ -74,7 +72,7 @@ pub async fn get_llm_usage_for_span(
     }
 
     SpanUsage {
-        input_tokens,
+        input_tokens: input_tokens.total(),
         output_tokens,
         total_tokens,
         input_cost,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces caching for input tokens in Anthropic provider, updating cost estimation and token handling logic.
> 
>   - **Behavior**:
>     - Introduces `estimate_input_cost` and `estimate_output_cost` functions in `costs/mod.rs` to handle input and output token cost estimation separately.
>     - Adds caching logic for input tokens in `estimate_input_cost`, considering `regular_input_tokens`, `cache_write_tokens`, and `cache_read_tokens`.
>     - Updates `get_llm_usage_for_span` in `utils.rs` to use the new input token structure.
>   - **Data Structures**:
>     - Modifies `InputTokens` struct in `spans.rs` to include `regular_input_tokens`, `cache_write_tokens`, and `cache_read_tokens`.
>     - Updates `SpanAttributes::input_tokens()` to return `InputTokens` with cache-related fields.
>   - **Misc**:
>     - Removes `TokensKind` enum from `costs/mod.rs`.
>     - Changes token type from `u32` to `i64` in `calculate_cost` in `providers/utils.rs` and related functions.
>     - Adds constants `GEN_AI_CACHE_WRITE_INPUT_TOKENS` and `GEN_AI_CACHE_READ_INPUT_TOKENS` in `span_attributes.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d8bfd7eabdbd21c89bc3f282a853681e118946a4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->