### PR TITLE
fix: memo chat message list

### DIFF
--- a/frontend/components/traces/chat-message-list-tab.tsx
+++ b/frontend/components/traces/chat-message-list-tab.tsx
@@ -1,5 +1,5 @@
 import { uniqueId } from "lodash";
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 
 import ImageWithPreview from "@/components/playground/image-with-preview";
 import { ChatMessage, ChatMessageContentPart, OpenAIImageUrl } from "@/lib/types";
@@ -92,12 +92,12 @@ interface ChatMessageListTabProps {
   reversed: boolean;
 }
 
-export default function ChatMessageListTab({ messages, presetKey, reversed }: ChatMessageListTabProps) {
+function PureChatMessageListTab({ messages, presetKey, reversed }: ChatMessageListTabProps) {
   // Memoize messages to prevent unnecessary re-renders
   const memoizedMessages = useMemo(() => (reversed ? [...messages].reverse() : messages), [messages, reversed]);
 
   return (
-    <div className="w-full flex flex-col space-y-4">
+    <div className="w-full flex flex-col space-y-4 flex-wrap">
       {memoizedMessages.map((message, index) => (
         <div key={uniqueId()} className="flex flex-col border rounded" style={{ contain: "content" }}>
           <div className="font-medium text-sm text-secondary-foreground border-b p-2">{message.role.toUpperCase()}</div>
@@ -111,3 +111,7 @@ export default function ChatMessageListTab({ messages, presetKey, reversed }: Ch
     </div>
   );
 }
+
+const ChatMessageListTab = memo(PureChatMessageListTab);
+
+export default ChatMessageListTab;

--- a/frontend/components/traces/span-view.tsx
+++ b/frontend/components/traces/span-view.tsx
@@ -70,7 +70,7 @@ export function SpanView({ spanId }: SpanViewProps) {
               <AddToLabelingQueuePopover span={span} />
               <ExportSpansDialog span={span} />
             </div>
-            <div className="flex py-1 gap-2">
+            <div className="flex flex-wrap py-1 gap-2">
               <StatsShields
                 startTime={span.startTime}
                 endTime={span.endTime}


### PR DESCRIPTION
- added memoization to prevent rerendering on resize
- added wrapping to prevent overflow
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added memoization and `flex-wrap` to optimize rendering and layout in `chat-message-list-tab.tsx` and `span-view.tsx`.
> 
>   - **Memoization**:
>     - Added `memo` to `PureChatMessageListTab` in `chat-message-list-tab.tsx` to prevent unnecessary re-renders on resize.
>     - Utilized `useMemo` for `memoizedMessages` to optimize message rendering.
>   - **Layout**:
>     - Added `flex-wrap` to the container `div` in `chat-message-list-tab.tsx` to prevent overflow.
>     - Added `flex-wrap` to the `div` in `span-view.tsx` to handle layout more flexibly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 353438be1724de45703a420795364ffe0559bb60. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->