### PR TITLE
handle span path more gracefully if it is absent or is string

### DIFF
--- a/frontend/components/traces/span-view-span.tsx
+++ b/frontend/components/traces/span-view-span.tsx
@@ -36,8 +36,8 @@ export function SpanViewSpan({ span }: SpanViewSpanProps) {
     });
   }
 
-  const pathKeyVal = span.attributes?.["lmnr.span.path"] ?? [span.name];
-  const pathKey = typeof pathKeyVal === "string" ? pathKeyVal.split(".") : pathKeyVal;
+  const spanPath = span.attributes?.["lmnr.span.path"] ?? [span.name];
+  const spanPathArray = typeof spanPath === "string" ? spanPath.split(".") : spanPath;
 
   return (
     <ScrollArea className="h-full mt-0">
@@ -56,14 +56,14 @@ export function SpanViewSpan({ span }: SpanViewSpanProps) {
               <ChatMessageListTab
                 reversed={reversed}
                 messages={spanInput}
-                presetKey={`input-${pathKey.join(".")}`}
+                presetKey={`input-${spanPathArray.join(".")}`}
               />
             ) : (
               <Formatter
                 className="max-h-[400px]"
                 collapsible
                 value={typeof spanInput === "string" ? spanInput : JSON.stringify(spanInput)}
-                presetKey={`input-${pathKey.join(".")}`}
+                presetKey={`input-${spanPathArray.join(".")}`}
               />
             )}
           </div>
@@ -72,7 +72,7 @@ export function SpanViewSpan({ span }: SpanViewSpanProps) {
             <Formatter
               className="max-h-[400px]"
               value={typeof spanOutput === "string" ? spanOutput : JSON.stringify(spanOutput)}
-              presetKey={`output-${pathKey.join(".")}`}
+              presetKey={`output-${spanPathArray.join(".")}`}
               collapsible
             />
           </div>

--- a/frontend/components/traces/span-view-span.tsx
+++ b/frontend/components/traces/span-view-span.tsx
@@ -36,6 +36,9 @@ export function SpanViewSpan({ span }: SpanViewSpanProps) {
     });
   }
 
+  const pathKeyVal = span.attributes?.["lmnr.span.path"] ?? [span.name];
+  const pathKey = typeof pathKeyVal === "string" ? pathKeyVal.split(".") : pathKeyVal;
+
   return (
     <ScrollArea className="h-full mt-0">
       <div className="max-h-0">
@@ -53,14 +56,14 @@ export function SpanViewSpan({ span }: SpanViewSpanProps) {
               <ChatMessageListTab
                 reversed={reversed}
                 messages={spanInput}
-                presetKey={`input-${span.attributes["lmnr.span.path"].join(".")}`}
+                presetKey={`input-${pathKey.join(".")}`}
               />
             ) : (
               <Formatter
                 className="max-h-[400px]"
                 collapsible
                 value={typeof spanInput === "string" ? spanInput : JSON.stringify(spanInput)}
-                presetKey={`input-${span.attributes["lmnr.span.path"].join(".")}`}
+                presetKey={`input-${pathKey.join(".")}`}
               />
             )}
           </div>
@@ -69,7 +72,7 @@ export function SpanViewSpan({ span }: SpanViewSpanProps) {
             <Formatter
               className="max-h-[400px]"
               value={typeof spanOutput === "string" ? spanOutput : JSON.stringify(spanOutput)}
-              presetKey={`output-${span.attributes["lmnr.span.path"].join(".")}`}
+              presetKey={`output-${pathKey.join(".")}`}
               collapsible
             />
           </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve `spanPath` handling in `SpanViewSpan` to support absent or string values, updating `presetKey` usage accordingly.
> 
>   - **Behavior**:
>     - In `SpanViewSpan`, handle `spanPath` as an array or string, defaulting to `[span.name]` if absent.
>     - Update `presetKey` construction in `ChatMessageListTab` and `Formatter` to use `spanPathArray`.
>   - **Misc**:
>     - Improve robustness of `spanPath` handling to prevent errors when `spanPath` is absent or a string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for be44ae300e1ec68773c26b66cc46d6d4e94e1605. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->