### PR TITLE
set clickhouse url and in compose

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -1,5 +1,5 @@
 # This compose definition pulls the latest images from the GitHub Container Registry.
-# This is the best and fastest for self hosting, as the images are already built and ready to go.
+# This is the best and fastest for self-hosting, as the images are already built and ready to go.
 # If you want to build images locally, you can use the docker-compose-local-build.yml file instead.
 
 name: lmnr

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -26,8 +26,6 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:latest
     container_name: clickhouse
-    ports:
-      - "8123:8123"
     volumes:
       - type: volume
         source: clickhouse-data
@@ -51,17 +49,16 @@ services:
       nofile:
         soft: 262144
         hard: 262144
-    
 
   semantic-search-service:
     image: ghcr.io/lmnr-ai/semantic-search-service
     depends_on:
       - qdrant
     environment:
-      - PORT=8080
-      - QDRANT_URL=http://qdrant:6334
-      - COHERE_ENDPOINT=https://api.cohere.ai/v1/embed
-      - COHERE_API_KEY=${COHERE_API_KEY}
+      PORT: 8080
+      QDRANT_URL: http://qdrant:6334
+      COHERE_ENDPOINT: https://api.cohere.ai/v1/embed
+      COHERE_API_KEY: ${COHERE_API_KEY}
     pull_policy: always
 
   python-executor:
@@ -98,17 +95,18 @@ services:
         condition: service_started
     pull_policy: always
     environment:
-      - PORT=8000
-      - GRPC_PORT=8001
-      - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-      - SEMANTIC_SEARCH_URL=http://semantic-search-service:8080
-      - RABBITMQ_URL=amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@rabbitmq:5672/%2f
-      - CLICKHOUSE_URL=http://clickhouse:8123
-      - CLICKHOUSE_USER=${CLICKHOUSE_USER}
-      - CODE_EXECUTOR_URL=http://python-executor:8811
-      - SHARED_SECRET_TOKEN=${SHARED_SECRET_TOKEN}
-      - ENVIRONMENT=FULL
-      - AEAD_SECRET_KEY=${AEAD_SECRET_KEY}
+      PORT: 8000
+      GRPC_PORT: 8001
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      SEMANTIC_SEARCH_URL: http://semantic-search-service:8080
+      RABBITMQ_URL: amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@rabbitmq:5672/%2f
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
+      CODE_EXECUTOR_URL: http://python-executor:8811
+      SHARED_SECRET_TOKEN: ${SHARED_SECRET_TOKEN}
+      ENVIRONMENT: FULL
+      AEAD_SECRET_KEY: ${AEAD_SECRET_KEY}
+
   frontend:
     image: ghcr.io/lmnr-ai/frontend
     ports:
@@ -120,16 +118,16 @@ services:
       clickhouse:
         condition: service_started
     environment:
-      - PORT=5667
-      - BACKEND_URL=http://app-server:8000
-      - SHARED_SECRET_TOKEN=${SHARED_SECRET_TOKEN}
-      - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-      - NEXTAUTH_URL=http://localhost:5667
-      - NEXTAUTH_SECRET=some_secret
-      - NEXT_PUBLIC_URL=http://localhost:5667
-      - ENVIRONMENT=FULL
-      - CLICKHOUSE_URL=http://clickhouse:8123
-      - CLICKHOUSE_USER=${CLICKHOUSE_USER}
+      PORT: 5667
+      BACKEND_URL: http://app-server:8000
+      SHARED_SECRET_TOKEN: ${SHARED_SECRET_TOKEN}
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      NEXTAUTH_URL: http://localhost:5667
+      NEXTAUTH_SECRET: some_secret
+      NEXT_PUBLIC_URL: http://localhost:5667
+      ENVIRONMENT: FULL
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
 
 volumes:
   qdrant-data:

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -119,13 +119,13 @@ services:
       clickhouse:
         condition: service_started
     environment:
-      - PORT=3000
-      - BACKEND_URL=http://app-server:8000
-      - SHARED_SECRET_TOKEN=${SHARED_SECRET_TOKEN}
-      - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-      - ENVIRONMENT=FULL
-      - CLICKHOUSE_URL=http://clickhouse:8123
-      - CLICKHOUSE_USER=${CLICKHOUSE_USER}
+      PORT: 3000
+      BACKEND_URL: http://app-server:8000
+      SHARED_SECRET_TOKEN: ${SHARED_SECRET_TOKEN}
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      ENVIRONMENT: FULL
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
 
 volumes:
   qdrant-data:

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -24,8 +24,6 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:latest
     container_name: clickhouse
-    ports:
-      - "8123:8123"
     volumes:
       - type: volume
         source: clickhouse-data
@@ -53,10 +51,10 @@ services:
     depends_on:
       - qdrant
     environment:
-      - PORT=8080
-      - QDRANT_URL=http://qdrant:6334
-      - COHERE_ENDPOINT=https://api.cohere.ai/v1/embed
-      - COHERE_API_KEY=${COHERE_API_KEY}
+      PORT: 8080
+      QDRANT_URL: http://qdrant:6334
+      COHERE_ENDPOINT: https://api.cohere.ai/v1/embed
+      COHERE_API_KEY: ${COHERE_API_KEY}
 
   postgres:
     image: postgres:16
@@ -98,16 +96,16 @@ services:
       python-executor:
         condition: service_started
     environment:
-      - PORT=8000
-      - GRPC_PORT=8001
-      - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-      - SEMANTIC_SEARCH_URL=http://semantic-search-service:8080
-      - RABBITMQ_URL=amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@rabbitmq:5672/%2f
-      - SHARED_SECRET_TOKEN=${SHARED_SECRET_TOKEN}
-      - CLICKHOUSE_URL=http://clickhouse:8123
-      - CLICKHOUSE_USER=${CLICKHOUSE_USER}
-      - CODE_EXECUTOR_URL=http://python-executor:8811
-      - ENVIRONMENT=FULL
+      PORT: 8000
+      GRPC_PORT: 8001
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      SEMANTIC_SEARCH_URL: http://semantic-search-service:8080
+      RABBITMQ_URL: amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@rabbitmq:5672/%2f
+      SHARED_SECRET_TOKEN: ${SHARED_SECRET_TOKEN}
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
+      CODE_EXECUTOR_URL: http://python-executor:8811
+      ENVIRONMENT: FULL
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:latest
     container_name: clickhouse
-    ports:
-      - "8123:8123"
     volumes:
       - type: volume
         source: clickhouse-data
@@ -62,7 +60,9 @@ services:
       NEXTAUTH_URL: http://localhost:5667
       NEXTAUTH_SECRET: some_secret
       NEXT_PUBLIC_URL: http://localhost:5667
-      ENVIRONMENT: LITE # this disables runtime dependency on clickhouse
+      ENVIRONMENT: LITE # this disables some runtime dependencies
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
 
   app-server:
     image: ghcr.io/lmnr-ai/app-server


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set `CLICKHOUSE_URL` and `CLICKHOUSE_USER` in all compose files and removed `clickhouse` port mapping.
> 
>   - **Environment Variables**:
>     - Set `CLICKHOUSE_URL` and `CLICKHOUSE_USER` in `docker-compose-full.yml`, `docker-compose-local-build.yml`, and `docker-compose.yml`.
>     - Changed environment variable format from `- key=value` to `key: value` in `docker-compose-full.yml` and `docker-compose-local-build.yml`.
>   - **Ports**:
>     - Removed `8123:8123` port mapping for `clickhouse` service in `docker-compose-full.yml`, `docker-compose-local-build.yml`, and `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3755eaad00b7115f0ee72e20184f237d11458496. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->