### PR TITLE
hotfix migrations so enum doesn't fail

### DIFF
--- a/frontend/lib/db/migrations/0025_amazing_drax.sql
+++ b/frontend/lib/db/migrations/0025_amazing_drax.sql
@@ -3,7 +3,7 @@ CREATE TABLE "agent_messages" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"chat_id" uuid NOT NULL,
 	"user_id" uuid NOT NULL,
-	"message_type" text DEFAULT '' NOT NULL,
+	"message_type" text DEFAULT 'assistant' NOT NULL,
 	"content" jsonb DEFAULT '{}'::jsonb
 );
 --> statement-breakpoint

--- a/frontend/lib/db/migrations/0026_lively_leper_queen.sql
+++ b/frontend/lib/db/migrations/0026_lively_leper_queen.sql
@@ -30,12 +30,17 @@ DROP INDEX "spans_project_id_trace_id_start_time_idx";--> statement-breakpoint
 DROP INDEX "spans_root_project_id_start_time_end_time_trace_id_idx";--> statement-breakpoint
 DROP INDEX "traces_id_project_id_start_time_times_not_null_idx";--> statement-breakpoint
 DROP INDEX "traces_project_id_trace_type_start_time_end_time_idx";--> statement-breakpoint
-ALTER TABLE "agent_messages" ALTER COLUMN "message_type" SET DATA TYPE agent_message_type;--> statement-breakpoint
+
+-- manual changes so migration doesn't fail
+UPDATE "agent_messages" SET "message_type" = 'assistant' WHERE "message_type" NOT IN ('user', 'assistant', 'step'); --> statement-breakpoint
+ALTER TABLE "agent_messages" ALTER COLUMN "message_type" DROP DEFAULT; --> statement-breakpoint
+ALTER TABLE "agent_messages" ALTER COLUMN "message_type" SET DATA TYPE agent_message_type USING "message_type"::agent_message_type;--> statement-breakpoint
+-- end of manual changes
+
 ALTER TABLE "agent_messages" ALTER COLUMN "message_type" DROP DEFAULT;--> statement-breakpoint
 ALTER TABLE "agent_sessions" ALTER COLUMN "cdp_url" DROP NOT NULL;--> statement-breakpoint
 ALTER TABLE "agent_sessions" ALTER COLUMN "vnc_url" DROP NOT NULL;--> statement-breakpoint
 ALTER TABLE "agent_sessions" ALTER COLUMN "state" SET DATA TYPE text;--> statement-breakpoint
-ALTER TABLE "subscription_tiers" ALTER COLUMN "id" SET MAXVALUE 9223372036854775000;--> statement-breakpoint
 ALTER TABLE "agent_messages" ADD COLUMN "trace_id" uuid;--> statement-breakpoint
 ALTER TABLE "agent_sessions" ADD COLUMN "updated_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
 ALTER TABLE "agent_sessions" ADD COLUMN "agent_status" text DEFAULT 'idle' NOT NULL;--> statement-breakpoint

--- a/frontend/lib/db/migrations/0026_lively_leper_queen.sql
+++ b/frontend/lib/db/migrations/0026_lively_leper_queen.sql
@@ -37,7 +37,6 @@ ALTER TABLE "agent_messages" ALTER COLUMN "message_type" DROP DEFAULT; --> state
 ALTER TABLE "agent_messages" ALTER COLUMN "message_type" SET DATA TYPE agent_message_type USING "message_type"::agent_message_type;--> statement-breakpoint
 -- end of manual changes
 
-ALTER TABLE "agent_messages" ALTER COLUMN "message_type" DROP DEFAULT;--> statement-breakpoint
 ALTER TABLE "agent_sessions" ALTER COLUMN "cdp_url" DROP NOT NULL;--> statement-breakpoint
 ALTER TABLE "agent_sessions" ALTER COLUMN "vnc_url" DROP NOT NULL;--> statement-breakpoint
 ALTER TABLE "agent_sessions" ALTER COLUMN "state" SET DATA TYPE text;--> statement-breakpoint

--- a/frontend/lib/db/migrations/meta/0025_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0025_snapshot.json
@@ -39,7 +39,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "''"
+          "default": "'assistant'"
         },
         "content": {
           "name": "content",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix migration failure by updating `agent_messages.message_type` to use `agent_message_type` enum with default adjustments.
> 
>   - **Migrations**:
>     - In `0025_amazing_drax.sql`, change `message_type` default to `'assistant'`.
>     - In `0026_lively_leper_queen.sql`, update `agent_messages` to set `message_type` to `'assistant'` where it is not in the enum values ('user', 'assistant', 'step').
>     - Change `message_type` column to use `agent_message_type` enum, dropping default value after update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3d4350031998bb0000716a7a31c5bae3822c95c6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->