### PR TITLE
add anthropic thinking outputs, remove legacy litellm support

### DIFF
--- a/frontend/components/traces/span-view-span.tsx
+++ b/frontend/components/traces/span-view-span.tsx
@@ -69,12 +69,20 @@ export function SpanViewSpan({ span }: SpanViewSpanProps) {
           </div>
           <div className="">
             <div className="pb-2 font-medium text-lg">Output</div>
-            <Formatter
-              className="max-h-[400px]"
-              value={typeof spanOutput === "string" ? spanOutput : JSON.stringify(spanOutput)}
-              presetKey={`output-${spanPathArray.join(".")}`}
-              collapsible
-            />
+            {isChatMessageList(spanOutput) ? (
+              <ChatMessageListTab
+                reversed={reversed}
+                messages={spanOutput}
+                presetKey={`output-${spanPathArray.join(".")}`}
+              />
+            ) : (
+              <Formatter
+                className="max-h-[400px]"
+                collapsible
+                value={typeof spanOutput === "string" ? spanOutput : JSON.stringify(spanOutput)}
+                presetKey={`output-${spanPathArray.join(".")}`}
+              />
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove legacy LiteLLM support and add Anthropic thinking outputs handling in LLM spans, updating both backend and frontend components.
> 
>   - **Behavior**:
>     - Remove legacy LiteLLM support in `spans.rs` by deleting handling for `SpanAttributes.LLM_PROMPTS` and `SpanAttributes.LLM_COMPLETIONS`.
>     - Add support for Anthropic thinking outputs in `spans.rs` by updating `input_tokens()` to handle `anthropic` provider.
>   - **Functions**:
>     - Simplify `output_from_completion_content()` in `spans.rs` by removing `tool_call_attribute()` and refactoring logic.
>     - Update `output_message_from_completion_content()` in `spans.rs` to handle message content and role.
>   - **Frontend**:
>     - Update `SpanViewSpan` in `span-view-span.tsx` to use `ChatMessageListTab` for chat message lists in both input and output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 1930ab89dd71717d19f59a69423e5cf0f877b194. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->