### PR TITLE
quick hack to wait more than time sleep on agent-manager health

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -98,7 +98,7 @@ services:
     healthcheck:
       test: ["CMD", "sleep", "5"]
       interval: 10s
-      timeout: 5s
+      timeout: 6s
       retries: 1
 
   app-server:

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -95,7 +95,7 @@ services:
     healthcheck:
       test: ["CMD", "sleep", "5"]
       interval: 10s
-      timeout: 5s
+      timeout: 6s
       retries: 1
 
   app-server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       # naive sleep to ensure agent-manager is ready
       test: ["CMD", "sleep", "3"]
       interval: 3s
-      timeout: 5s
+      timeout: 6s
       retries: 1
 
   app-server:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase healthcheck timeout for `agent-manager` service from `5s` to `6s` in three Docker Compose files.
> 
>   - **Healthcheck Timeout**:
>     - Increase `timeout` from `5s` to `6s` for `agent-manager` service in `docker-compose-full.yml`, `docker-compose-local-build.yml`, and `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for dec667ecd9ad1d790bbed31db40a5aa04eab2eb9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->