### PR TITLE
fix: undo double text

### DIFF
--- a/frontend/components/chat/side-bar.tsx
+++ b/frontend/components/chat/side-bar.tsx
@@ -193,7 +193,7 @@ const PureChatItem = ({ chat, isActive }: { chat: AgentSession; isActive: boolea
           </div>
         ) : (
           <Link className="overflow-hidden" href={`/chat/${chat.sessionId}`} key={chat.sessionId} passHref>
-            <AnimatedText animate={Boolean(chat?.isNew)} text={`${chat.chatName} ${chat.chatName}`} />
+            <AnimatedText animate={Boolean(chat?.isNew)} text={chat.chatName} />
           </Link>
         )}
       </SidebarMenuButton>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes duplicate chat name rendering in `PureChatItem` in `side-bar.tsx`.
> 
>   - Fixes duplicate chat name rendering in `PureChatItem` in `side-bar.tsx`.
>     - `AnimatedText` now receives `chat.chatName` instead of `${chat.chatName} ${chat.chatName}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7bcceb2078c91d0c5fe85009dc0ce1054bc1cb0e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->