### PR TITLE
use drizzle's join instead of explicit (uses efficient lateral under the hood)

### DIFF
--- a/frontend/app/api/projects/[projectId]/traces/[traceId]/spans/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/[traceId]/spans/route.ts
@@ -1,10 +1,10 @@
-import { and, asc, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { searchSpans } from '@/lib/clickhouse/spans';
 import { TimeRange } from '@/lib/clickhouse/utils';
 import { db } from '@/lib/db/drizzle';
-import { events, spans } from '@/lib/db/migrations/schema';
+import { spans } from '@/lib/db/migrations/schema';
 
 export async function GET(
   req: NextRequest,
@@ -22,50 +22,30 @@ export async function GET(
     searchSpanIds = Array.from(searchResult.spanIds);
   }
 
-  const spanEventsQuery = db.$with('span_events').as(
-    db.select({
-      spanId: events.spanId,
-      projectId: events.projectId,
-      events: sql`jsonb_agg(jsonb_build_object(
-        'id', events.id,
-        'spanId', events.span_id,
-        'timestamp', events.timestamp,
-        'name', events.name,
-        'attributes', events.attributes
-      ))`.as('events')
-    })
-      .from(events)
-      .groupBy(events.spanId, events.projectId)
-  );
-
-  const spanItems = await db.with(spanEventsQuery).select({
-    // inputs and outputs are ignored on purpose
-    spanId: spans.spanId,
-    startTime: spans.startTime,
-    endTime: spans.endTime,
-    traceId: spans.traceId,
-    parentSpanId: spans.parentSpanId,
-    name: spans.name,
-    attributes: spans.attributes,
-    spanType: spans.spanType,
-    events: sql`COALESCE(${spanEventsQuery.events}, '[]'::jsonb)`.as('events'),
-  })
-    .from(spans)
-    .leftJoin(spanEventsQuery,
-      and(
-        eq(spans.spanId, spanEventsQuery.spanId),
-        eq(spans.projectId, spanEventsQuery.projectId)
-      )
-    )
-    .where(
-      and(
-        eq(spans.traceId, traceId),
-        eq(spans.projectId, projectId),
-        ...(searchSpanIds ? [inArray(spans.spanId, searchSpanIds)] : [])
-      )
-    )
-    .orderBy(asc(spans.startTime));
-
+  const spanItems = await db.query.spans.findMany({
+    where: and(
+      eq(spans.traceId, traceId),
+      eq(spans.projectId, projectId),
+      ...(searchSpanIds ? [inArray(spans.spanId, searchSpanIds)] : [])
+    ),
+    columns: {
+      spanId: true,
+      startTime: true,
+      endTime: true,
+      traceId: true,
+      parentSpanId: true,
+      name: true,
+      attributes: true,
+      spanType: true,
+      // inputs and outputs are intentionally ignored and marked so explicitly
+      input: false,
+      output: false,
+    },
+    orderBy: asc(spans.startTime),
+    with: {
+      events: true,
+    },
+  });
 
   return NextResponse.json(spanItems);
 }

--- a/frontend/lib/clickhouse/spans.ts
+++ b/frontend/lib/clickhouse/spans.ts
@@ -179,7 +179,8 @@ const DEFAULT_LIMIT: number = 200;
 export const searchSpans = async (
   projectId: string,
   searchQuery: string,
-  timeRange: TimeRange
+  timeRange: TimeRange,
+  traceId?: string
 ): Promise<{
   spanIds: Set<string>;
   traceIds: Set<string>;
@@ -192,6 +193,7 @@ export const searchSpans = async (
         input_lower LIKE {query: String} 
         OR
         output_lower LIKE {query: String}
+        ${traceId ? `OR trace_id = {traceId: String}` : ""}
       )`;
 
   const query = addTimeRangeToQuery(baseQuery, timeRange, "start_time");
@@ -202,6 +204,7 @@ export const searchSpans = async (
     query_params: {
       projectId,
       query: `%${searchQuery.toLowerCase()}%`,
+      traceId,
     },
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor to use Drizzle's join in `route.ts` and add `traceId` filtering to `searchSpans` in `spans.ts`.
> 
>   - **Refactor**:
>     - Replace explicit join with Drizzle's `findMany` in `route.ts` for efficient lateral join.
>     - Remove `events` import from `route.ts`.
>   - **Functionality**:
>     - Add `traceId` parameter to `searchSpans` in `spans.ts` to filter by trace ID.
>     - Update query in `searchSpans` to include `traceId` conditionally.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 91377ae0061c15364c96cf35196a2e0d7a3431fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->