### PR TITLE
feat: configurable host port mapping

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ SCRAPYBARA_API_KEY=scrapy-01234567-89ab-cdef-0123-456789abcdef
 # Uncomment and set these to override the default exposed ports.
 # APP_SERVER_HOST_PORT=8080
 # APP_SERVER_GRPC_HOST_PORT=8081
-# FRONTEND_HOST_PORT=6667
+# FRONTEND_HOST_PORT=5667
 # AGENT_MANAGER_HOST_PORT=8901
 
 # Uncomment and set this to enable OpenAI support. Currently used in Next.js

--- a/.env
+++ b/.env
@@ -15,6 +15,12 @@ AEAD_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ANTHROPIC_API_KEY=sk-ant-api03-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 SCRAPYBARA_API_KEY=scrapy-01234567-89ab-cdef-0123-456789abcdef
 
+# Uncomment and set these to override the default exposed ports.
+# APP_SERVER_HOST_PORT=8080
+# APP_SERVER_GRPC_HOST_PORT=8081
+# FRONTEND_HOST_PORT=6667
+# AGENT_MANAGER_HOST_PORT=8901
+
 # Uncomment and set this to enable OpenAI support. Currently used in Next.js
 # to generate chat names.
 # OPENAI_API_KEY

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -74,7 +74,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
+      test:
+        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -83,7 +84,7 @@ services:
     image: ghcr.io/lmnr-ai/agent-manager
     pull_policy: always
     ports:
-      - "8901:8901"
+      - "${AGENT_MANAGER_HOST_PORT:-8901}:8901"
     depends_on:
       postgres:
         condition: service_healthy
@@ -105,8 +106,8 @@ services:
     image: ghcr.io/lmnr-ai/app-server
     pull_policy: always
     ports:
-      - "8000:8000"
-      - "8001:8001"
+      - "${APP_SERVER_HOST_PORT:-8000}:8000"
+      - "${APP_SERVER_GRPC_HOST_PORT:-8001}:8001"
     depends_on:
       semantic-search-service:
         condition: service_started
@@ -135,7 +136,7 @@ services:
   frontend:
     image: ghcr.io/lmnr-ai/frontend
     ports:
-      - "5667:5667"
+      - "${FRONTEND_HOST_PORT:-5667}:5667"
     pull_policy: always
     depends_on:
       postgres:

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -9,7 +9,7 @@ services:
       - type: volume
         source: qdrant-data
         target: /data
-    
+
   rabbitmq:
     image: rabbitmq
     environment:
@@ -65,7 +65,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
+      test:
+        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -83,7 +84,7 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "8901:8901"
+      - "${AGENT_MANAGER_HOST_PORT:-8901}:8901"
     environment:
       PORT: 8901
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
@@ -100,8 +101,8 @@ services:
 
   app-server:
     ports:
-      - "8000:8000"
-      - "8001:8001"
+      - "${APP_SERVER_HOST_PORT:-8000}:8000"
+      - "${APP_SERVER_GRPC_HOST_PORT:-8001}:8001"
     build:
       context: ./app-server
       args:
@@ -137,7 +138,7 @@ services:
       context: ./frontend
     container_name: frontend
     ports:
-      - "3000:3000"
+      - "${FRONTEND_HOST_PORT:-3000}:3000"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -19,7 +19,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
+      test:
+        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -57,8 +58,8 @@ services:
     image: ghcr.io/lmnr-ai/app-server
     pull_policy: always
     ports:
-      - "8000:8000"
-      - "8001:8001"
+      - "${APP_SERVER_HOST_PORT:-8000}:8000"
+      - "${APP_SERVER_GRPC_HOST_PORT:-8001}:8001"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
+      test:
+        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -47,7 +48,7 @@ services:
     image: ghcr.io/lmnr-ai/frontend
     pull_policy: always
     ports:
-      - "5667:5667"
+      - "${FRONTEND_HOST_PORT:-5667}:5667"
     depends_on:
       postgres:
         condition: service_healthy
@@ -68,7 +69,7 @@ services:
     image: ghcr.io/lmnr-ai/agent-manager
     pull_policy: always
     ports:
-      - "8901:8901"
+      - "${AGENT_MANAGER_HOST_PORT:-8901}:8901"
     depends_on:
       postgres:
         condition: service_healthy
@@ -91,8 +92,8 @@ services:
     image: ghcr.io/lmnr-ai/app-server
     pull_policy: always
     ports:
-      - "8000:8000"
-      - "8001:8001"
+      - "${APP_SERVER_HOST_PORT:-8000}:8000"
+      - "${APP_SERVER_GRPC_HOST_PORT:-8001}:8001"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
# Configurable Port Mapping for Docker Compose Services

This PR adds the ability to customize host port mappings for all services through environment variables, making it easier to run multiple instances or avoid port conflicts without modifying the docker-compose files.

## Changes:
- Added configurable port mapping for app-server (HTTP and gRPC), frontend, and agent-manager services
- Updated docker-compose files to use environment variables with sensible defaults
- Added commented examples in the .env file to show how to override the default ports

## Usage:
Users can now set the following environment variables to customize port mappings:
- `APP_SERVER_HOST_PORT` (defaults to 8000)
- `APP_SERVER_GRPC_HOST_PORT` (defaults to 8001)
- `FRONTEND_HOST_PORT` (defaults to 5667)
- `AGENT_MANAGER_HOST_PORT` (defaults to 8901)

This makes it easier to run the application in environments where the default ports might be in use or when running multiple instances side by side.

Issue: [#490](https://github.com/lmnr-ai/lmnr/issues/490)

<img width="1260" alt="Screenshot 2025-04-15 at 09 21 08" src="https://github.com/user-attachments/assets/fcaf3ec1-a29a-4288-9d12-f954b175eb47" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds environment variable-based port configuration for Docker Compose services to allow customizable host port mappings.
> 
>   - **Behavior**:
>     - Adds environment variable-based port configuration for `app-server`, `frontend`, and `agent-manager` services in `docker-compose.yml`.
>     - Default ports are set to 8000, 8001, 5667, and 8901, respectively, with the ability to override via `.env` file.
>   - **Configuration**:
>     - Updates `docker-compose files` to use `${APP_SERVER_HOST_PORT:-8000}`, `${APP_SERVER_GRPC_HOST_PORT:-8001}`, `${FRONTEND_HOST_PORT:-5667}`, and `${AGENT_MANAGER_HOST_PORT:-8901}` for port mappings.
>     - Adds commented examples in `.env` for overriding default ports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for abdc11faa4b6eacf651bf07efd67b28181f5fef1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->