### PR TITLE
feat: add real time update on sessions LAM-532

### DIFF
--- a/app-server/src/agent_manager/worker.rs
+++ b/app-server/src/agent_manager/worker.rs
@@ -57,7 +57,7 @@ pub async fn run_agent_worker(
         )
         .await;
 
-    if let Err(e) = db::agent_chats::update_agent_chat(&db.pool, "working", Utc::now(), &session_id).await {
+    if let Err(e) = db::agent_chats::update_agent_chat_status(&db.pool, "working", Utc::now(), &session_id).await {
         log::error!("Error updating agent chat: {}", e);
     }
 
@@ -137,7 +137,7 @@ pub async fn run_agent_worker(
         }
     }
 
-    if let Err(e) = db::agent_chats::update_agent_chat(&db.pool, "idle", Utc::now(), &session_id).await {
+    if let Err(e) = db::agent_chats::update_agent_chat_status(&db.pool, "idle", Utc::now(), &session_id).await {
         log::error!("Error updating agent chat: {}", e);
     }
 }

--- a/app-server/src/agent_manager/worker.rs
+++ b/app-server/src/agent_manager/worker.rs
@@ -4,7 +4,7 @@ use futures::StreamExt;
 use uuid::Uuid;
 
 use crate::db::{self, agent_messages::MessageType, DB};
-
+use chrono::Utc;
 use super::{
     channel::AgentManagerWorkers,
     cookies,
@@ -56,6 +56,10 @@ pub async fn run_agent_worker(
             options.return_screenshots,
         )
         .await;
+
+    if let Err(e) = db::agent_chats::update_agent_chat(&db.pool, "working", Utc::now(), &session_id).await {
+        log::error!("Error updating agent chat: {}", e);
+    }
 
     while let Some(chunk) = stream.next().await {
         if worker_channel.is_stopped(session_id) {
@@ -131,5 +135,9 @@ pub async fn run_agent_worker(
                 worker_channel.end_session(session_id);
             }
         }
+    }
+
+    if let Err(e) = db::agent_chats::update_agent_chat(&db.pool, "idle", Utc::now(), &session_id).await {
+        log::error!("Error updating agent chat: {}", e);
     }
 }

--- a/app-server/src/db/agent_chats.rs
+++ b/app-server/src/db/agent_chats.rs
@@ -1,7 +1,7 @@
 use sqlx::PgPool;
 use uuid::Uuid;
 
-pub async fn update_agent_chat(
+pub async fn update_agent_chat_status(
     pool: &PgPool,
     agent_status: &str,
     updated_at: chrono::DateTime<chrono::Utc>,

--- a/app-server/src/db/agent_chats.rs
+++ b/app-server/src/db/agent_chats.rs
@@ -1,0 +1,22 @@
+use sqlx::PgPool;
+use uuid::Uuid;
+
+pub async fn update_agent_chat(
+    pool: &PgPool,
+    agent_status: &str,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    session_id: &Uuid,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "UPDATE agent_chats
+        SET agent_status = $1, updated_at = $2
+        WHERE session_id = $3",
+    )
+    .bind(agent_status)
+    .bind(updated_at)
+    .bind(session_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}

--- a/app-server/src/db/mod.rs
+++ b/app-server/src/db/mod.rs
@@ -1,5 +1,6 @@
 use sqlx::PgPool;
 
+pub mod agent_chats;
 pub mod agent_messages;
 pub mod datapoints;
 pub mod datasets;

--- a/frontend/app/api/agent-sessions/route.ts
+++ b/frontend/app/api/agent-sessions/route.ts
@@ -40,15 +40,16 @@ export async function GET(_req: NextRequest): Promise<Response> {
   });
 
   // Flatten the data to the AgentSession type
-  const flattenedData = data.flatMap((session) => (
+  const flattenedData = data.flatMap((session) =>
     session.agentChats.map((chat) => ({
       sessionId: session.sessionId,
       updatedAt: session.updatedAt,
       chatName: chat.chatName,
       machineStatus: chat.machineStatus,
       userId: chat.userId,
+      agentStatus: chat.agentStatus,
     }))
-  ));
+  );
 
   return new Response(JSON.stringify(flattenedData));
 }

--- a/frontend/app/chat/layout.tsx
+++ b/frontend/app/chat/layout.tsx
@@ -34,16 +34,18 @@ export default async function Layout({ children }: PropsWithChildren) {
   }
 
   const chatUser: ChatUser = {
+    id: user.id,
     email: user.email,
     name: user.name,
     image: session.user.image || "",
     userSubscriptionTier: user.userSubscriptionTier.name,
+    supabaseAccessToken: session.supabaseAccessToken,
   };
 
   return (
     <SidebarProvider style={sidebarRef}>
       <PricingProvider user={chatUser}>
-        <AgentSidebar user={chatUser} />
+        <AgentSidebar />
         <SidebarInset>{children}</SidebarInset>
       </PricingProvider>
     </SidebarProvider>

--- a/frontend/components/chat/browser-window.tsx
+++ b/frontend/components/chat/browser-window.tsx
@@ -34,7 +34,7 @@ const BrowserWindow = ({ onControl, isControlled }: BrowserWindowProps) => {
         className={cn(
           "z-50 bg-background rounded-lg w-full flex flex-col transition-all duration-300 aspect-[4/3]",
           isBrowserActive
-            ? "max-w-md sm:max-w-sm md:max-w-md xl:max-w-4xl 2xl:max-w-[60%] sm:px-4 md:px-8 lg:px-12"
+            ? "max-w-md sm:max-w-sm md:max-w-md xl:max-w-3xl 2xl:max-w-[60%] sm:px-4 md:px-8 lg:px-12"
             : "max-w-0",
           {
             "!max-w-full left-0 right-0 top-0 bottom-0 p-4": isControlled,

--- a/frontend/components/chat/index.tsx
+++ b/frontend/components/chat/index.tsx
@@ -12,7 +12,6 @@ import Placeholder from "@/components/chat/placeholder";
 import Suggestions from "@/components/chat/suggestions";
 import { AgentSession, ChatMessage } from "@/components/chat/types";
 import { useAgentChat } from "@/components/chat/use-agent-chat";
-import { useSidebar } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 
 interface ChatProps {
@@ -28,7 +27,6 @@ const Chat = ({ sessionId, agentStatus, user, initialMessages }: ChatProps) => {
     enableThinking: true,
   });
 
-  const { setOpen } = useSidebar();
   const { messages, handleSubmit, stop, isLoading, input, setInput, isControlled, setIsControlled } = useAgentChat({
     id: sessionId,
     initialMessages,
@@ -49,7 +47,7 @@ const Chat = ({ sessionId, agentStatus, user, initialMessages }: ChatProps) => {
     if (e) {
       e.preventDefault();
     }
-    handleSubmit(e, modelState).then(() => setOpen(false));
+    handleSubmit(e, modelState);
   };
 
   const handleSubmitWithInput = (input: string) => {

--- a/frontend/components/chat/multimodal-input.tsx
+++ b/frontend/components/chat/multimodal-input.tsx
@@ -74,7 +74,9 @@ const MultimodalInput = ({
     <div className="relative w-full gap-4">
       <div className={cn("peer relative rounded-t-xl bg-zinc-700", { hidden: isHidden || isPro })}>
         <div className="banner flex items-center justify-between pl-3 pr-2 text-sm">
-          <span className="text-secondary-foreground">Get unlimited messages with Pro.</span>
+          <span title="Get unlimited messages with Pro." className="text-secondary-foreground truncate">
+            Get unlimited messages with Pro.
+          </span>
           <div className="flex items-center gap-1">
             <Button
               onClick={(e) => {
@@ -98,6 +100,7 @@ const MultimodalInput = ({
         })}
       >
         <Textarea
+          autoFocus
           ref={textareaRef}
           placeholder="Send a message..."
           value={value}

--- a/frontend/components/chat/pricing-context.tsx
+++ b/frontend/components/chat/pricing-context.tsx
@@ -1,21 +1,25 @@
 "use client";
 
+import { SupabaseClient } from "@supabase/supabase-js";
 import { createContext, PropsWithChildren, useContext, useMemo, useState } from "react";
 
 import ChatPricing from "@/components/chat/chat-pricing";
 import { ChatUser } from "@/components/chat/types";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { createSupabaseClient } from "@/lib/supabase";
 
 type PricingContextType = {
   open: boolean;
   handleOpen: (open: boolean) => void;
   user?: ChatUser;
+  supabaseClient?: SupabaseClient;
 };
 
 const PricingContext = createContext<PricingContextType>({
   open: false,
   handleOpen: () => {},
   user: undefined,
+  supabaseClient: undefined,
 });
 
 export const usePricingContext = () => useContext(PricingContext);
@@ -23,13 +27,16 @@ export const usePricingContext = () => useContext(PricingContext);
 const PricingProvider = ({ children, user }: PropsWithChildren<{ user: ChatUser }>) => {
   const [open, setOpen] = useState(false);
 
+  const client = createSupabaseClient(user.supabaseAccessToken);
+
   const value = useMemo<PricingContextType>(
     () => ({
       open,
       handleOpen: setOpen,
       user,
+      supabaseClient: client,
     }),
-    [open, user]
+    [client, open, user]
   );
 
   return (

--- a/frontend/components/chat/sidebar-footer.tsx
+++ b/frontend/components/chat/sidebar-footer.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 
 import { ChatUser } from "./types";
 
-const AgentSidebarFooter = ({ user }: { user: ChatUser }) => {
+const AgentSidebarFooter = ({ user }: { user?: ChatUser }) => {
   const { state } = useSidebar();
 
   const { handleOpen } = usePricingContext();
@@ -27,7 +27,7 @@ const AgentSidebarFooter = ({ user }: { user: ChatUser }) => {
           className={cn(
             "bg-primary/90 primary text-primary-foreground/90 hover:bg-primary border-white/20 border hover:border-white/50 active:bg-primary",
             {
-              hidden: state === "collapsed" || user.userSubscriptionTier.trim().toLowerCase() !== "free",
+              hidden: state === "collapsed" || user?.userSubscriptionTier.trim().toLowerCase() !== "free",
             }
           )}
           onClick={() => handleOpen(true)}
@@ -45,25 +45,25 @@ const AgentSidebarFooter = ({ user }: { user: ChatUser }) => {
                 )}
               >
                 <Avatar className="h-8 w-8 rounded-lg">
-                  <AvatarImage src={user.image} alt="user-image" />
-                  <AvatarFallback className="rounded-lg">{user.name?.[0] ?? "L"}</AvatarFallback>
+                  <AvatarImage src={user?.image} alt="user-image" />
+                  <AvatarFallback className="rounded-lg">{user?.name?.[0] ?? "L"}</AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span
                     className={cn(
                       "text-xs truncate text-muted-foreground",
-                      user.userSubscriptionTier === "free" ? "text-muted-foreground" : "text-primary"
+                      user?.userSubscriptionTier === "free" ? "text-muted-foreground" : "text-primary"
                     )}
                   >
-                    {user.userSubscriptionTier === "free" ? "Free" : "Pro"}
+                    {user?.userSubscriptionTier === "free" ? "Free" : "Pro"}
                   </span>
-                  <span className="truncate">{user.email}</span>
+                  <span className="truncate">{user?.email}</span>
                 </div>
                 <ChevronsUpDown className="ml-auto size-4" />
               </SidebarMenuButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent side="top" className="w-[--radix-popper-anchor-width]">
-              {user.userSubscriptionTier.trim().toLowerCase() !== "free" && (
+              {user?.userSubscriptionTier.trim().toLowerCase() !== "free" && (
                 <DropdownMenuItem>
                   <Link href="/checkout/portal" className="w-full cursor-pointer">
                     Manage billing

--- a/frontend/components/chat/types.ts
+++ b/frontend/components/chat/types.ts
@@ -1,4 +1,3 @@
-
 export interface LaminarSpanContext {
   traceId: string;
   spanId: string;
@@ -126,8 +125,10 @@ export interface AgentSession {
 }
 
 export interface ChatUser {
+  id: string;
   email: string;
   name: string;
   image: string;
   userSubscriptionTier: string;
+  supabaseAccessToken: string;
 }

--- a/frontend/components/chat/utils.ts
+++ b/frontend/components/chat/utils.ts
@@ -165,7 +165,7 @@ export const initiateChat = async (
       userId,
       sessionId: sessionId,
       isNew: true,
-      agentStatus: "working",
+      agentStatus: "idle",
     };
     await appendChat(optimisticChat);
   }

--- a/frontend/lib/db/migrations/0028_futuristic_blonde_phantom.sql
+++ b/frontend/lib/db/migrations/0028_futuristic_blonde_phantom.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent_chats" ADD COLUMN "agent_status" text DEFAULT 'idle' NOT NULL;--> statement-breakpoint

--- a/frontend/lib/db/migrations/meta/0028_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0028_snapshot.json
@@ -1,0 +1,3538 @@
+{
+  "id": "fd487639-fccb-4671-8761-2ec2d4915b71",
+  "prevId": "539f53a0-582a-4e9f-baf8-5d8adc5b7405",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_chats": {
+      "name": "agent_chats",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_name": {
+          "name": "chat_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_status": {
+          "name": "machine_status",
+          "type": "agent_machine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agent_status": {
+          "name": "agent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        }
+      },
+      "indexes": {
+        "agent_chats_created_at_idx": {
+          "name": "agent_chats_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_updated_at_idx": {
+          "name": "agent_chats_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_user_id_idx": {
+          "name": "agent_chats_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chats_user_id_fkey": {
+          "name": "agent_chats_user_id_fkey",
+          "tableFrom": "agent_chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_chats_session_id_fkey": {
+          "name": "agent_chats_session_id_fkey",
+          "tableFrom": "agent_chats",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_messages": {
+      "name": "agent_messages",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "agent_message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_messages_session_id_created_at_idx": {
+          "name": "agent_messages_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_messages_session_id_fkey": {
+          "name": "agent_messages_session_id_fkey",
+          "tableFrom": "agent_messages",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cdp_url": {
+          "name": "cdp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vnc_url": {
+          "name": "vnc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agent_status": {
+          "name": "agent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        }
+      },
+      "indexes": {
+        "agent_sessions_created_at_idx": {
+          "name": "agent_sessions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_updated_at_idx": {
+          "name": "agent_sessions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datapoint_to_span": {
+      "name": "datapoint_to_span",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "datapoint_id": {
+          "name": "datapoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datapoint_to_span_datapoint_id_fkey": {
+          "name": "datapoint_to_span_datapoint_id_fkey",
+          "tableFrom": "datapoint_to_span",
+          "tableTo": "dataset_datapoints",
+          "columnsFrom": [
+            "datapoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "datapoint_to_span_span_id_project_id_fkey": {
+          "name": "datapoint_to_span_span_id_project_id_fkey",
+          "tableFrom": "datapoint_to_span",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "span_id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "datapoint_to_span_pkey": {
+          "name": "datapoint_to_span_pkey",
+          "columns": [
+            "datapoint_id",
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_datapoints": {
+      "name": "dataset_datapoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_on": {
+          "name": "indexed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "index_in_batch": {
+          "name": "index_in_batch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dataset_datapoints_dataset_id_fkey": {
+          "name": "dataset_datapoints_dataset_id_fkey",
+          "tableFrom": "dataset_datapoints",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "indexed_on": {
+          "name": "indexed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "datasets_project_id_hash_idx": {
+          "name": "datasets_project_id_hash_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_datasets_project_id_fkey": {
+          "name": "public_datasets_project_id_fkey",
+          "tableFrom": "datasets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "executor_output": {
+          "name": "executor_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_in_batch": {
+          "name": "index_in_batch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "evaluation_results_evaluation_id_idx": {
+          "name": "evaluation_results_evaluation_id_idx",
+          "columns": [
+            {
+              "expression": "evaluation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_evaluation_id_fkey1": {
+          "name": "evaluation_results_evaluation_id_fkey1",
+          "tableFrom": "evaluation_results",
+          "tableTo": "evaluations",
+          "columnsFrom": [
+            "evaluation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_scores": {
+      "name": "evaluation_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "evaluation_scores_result_id_idx": {
+          "name": "evaluation_scores_result_id_idx",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_scores_result_id_fkey": {
+          "name": "evaluation_scores_result_id_fkey",
+          "tableFrom": "evaluation_scores",
+          "tableTo": "evaluation_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evaluation_results_names_unique": {
+          "name": "evaluation_results_names_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "result_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluations": {
+      "name": "evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {
+        "evaluations_project_id_hash_idx": {
+          "name": "evaluations_project_id_hash_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluations_project_id_fkey1": {
+          "name": "evaluations_project_id_fkey1",
+          "tableFrom": "evaluations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "events_span_id_project_id_idx": {
+          "name": "events_span_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "span_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_span_id_project_id_fkey": {
+          "name": "events_span_id_project_id_fkey",
+          "tableFrom": "events",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "span_id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_classes": {
+      "name": "label_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluator_runnable_graph": {
+          "name": "evaluator_runnable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_version_id": {
+          "name": "pipeline_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rgb(190, 194, 200)'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_classes_project_id_fkey": {
+          "name": "label_classes_project_id_fkey",
+          "tableFrom": "label_classes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_classes_project_id_id_key": {
+          "name": "label_classes_project_id_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "label_classes_name_project_id_unique": {
+          "name": "label_classes_name_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_classes_for_path": {
+      "name": "label_classes_for_path",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_class_id": {
+          "name": "label_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "autoeval_labels_project_id_fkey": {
+          "name": "autoeval_labels_project_id_fkey",
+          "tableFrom": "label_classes_for_path",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_project_id_path_label_class": {
+          "name": "unique_project_id_path_label_class",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "path",
+            "label_class_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeling_queue_items": {
+      "name": "labeling_queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labelling_queue_items_queue_id_fkey": {
+          "name": "labelling_queue_items_queue_id_fkey",
+          "tableFrom": "labeling_queue_items",
+          "tableTo": "labeling_queues",
+          "columnsFrom": [
+            "queue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeling_queues": {
+      "name": "labeling_queues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labeling_queues_project_id_fkey": {
+          "name": "labeling_queues_project_id_fkey",
+          "tableFrom": "labeling_queues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "label_source": {
+          "name": "label_source",
+          "type": "label_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labels_class_id_project_id_fkey": {
+          "name": "labels_class_id_project_id_fkey",
+          "tableFrom": "labels",
+          "tableTo": "label_classes",
+          "columnsFrom": [
+            "class_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_span_id_class_id_key": {
+          "name": "labels_span_id_class_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "class_id",
+            "span_id"
+          ]
+        },
+        "labels_span_id_class_id_user_id_key": {
+          "name": "labels_span_id_class_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "class_id",
+            "span_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_prices": {
+      "name": "llm_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_price_per_million": {
+          "name": "input_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_price_per_million": {
+          "name": "output_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_cached_price_per_million": {
+          "name": "input_cached_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_prices": {
+          "name": "additional_prices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "machines_project_id_fkey": {
+          "name": "machines_project_id_fkey",
+          "tableFrom": "machines",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "machines_pkey": {
+          "name": "machines_pkey",
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members_of_workspaces": {
+      "name": "members_of_workspaces",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_role": {
+          "name": "member_role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        }
+      },
+      "indexes": {
+        "members_of_workspaces_user_id_idx": {
+          "name": "members_of_workspaces_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_of_workspaces_user_id_fkey": {
+          "name": "members_of_workspaces_user_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "public_members_of_workspaces_workspace_id_fkey": {
+          "name": "public_members_of_workspaces_workspace_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_of_workspaces_user_workspace_unique": {
+          "name": "members_of_workspaces_user_workspace_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_templates": {
+      "name": "pipeline_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "runnable_graph": {
+          "name": "runnable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "displayable_graph": {
+          "name": "displayable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "number_of_nodes": {
+          "name": "number_of_nodes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "display_group": {
+          "name": "display_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'build'"
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_versions": {
+      "name": "pipeline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayable_graph": {
+          "name": "displayable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runnable_graph": {
+          "name": "runnable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline_type": {
+          "name": "pipeline_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipelines": {
+      "name": "pipelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "python_requirements": {
+          "name": "python_requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "pipelines_name_project_id_idx": {
+          "name": "pipelines_name_project_id_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipelines_project_id_idx": {
+          "name": "pipelines_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipelines_project_id_fkey": {
+          "name": "pipelines_project_id_fkey",
+          "tableFrom": "pipelines",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_project_id_pipeline_name": {
+          "name": "unique_project_id_pipeline_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playgrounds": {
+      "name": "playgrounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_messages": {
+          "name": "prompt_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[{\"role\":\"user\",\"content\":\"\"}]'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playgrounds_project_id_fkey": {
+          "name": "playgrounds_project_id_fkey",
+          "tableFrom": "playgrounds",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_api_keys": {
+      "name": "project_api_keys",
+      "schema": "",
+      "columns": {
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shorthand": {
+          "name": "shorthand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {
+        "project_api_keys_hash_idx": {
+          "name": "project_api_keys_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_project_api_keys_project_id_fkey": {
+          "name": "public_project_api_keys_project_id_fkey",
+          "tableFrom": "project_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_workspace_id_idx": {
+          "name": "projects_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_fkey": {
+          "name": "projects_workspace_id_fkey",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_api_keys": {
+      "name": "provider_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hex": {
+          "name": "nonce_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_api_keys_project_id_fkey": {
+          "name": "provider_api_keys_project_id_fkey",
+          "tableFrom": "provider_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_templates": {
+      "name": "render_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "render_templates_project_id_fkey": {
+          "name": "render_templates_project_id_fkey",
+          "tableFrom": "render_templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spans": {
+      "name": "spans",
+      "schema": "",
+      "columns": {
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parent_span_id": {
+          "name": "parent_span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "span_type": {
+          "name": "span_type",
+          "type": "span_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_preview": {
+          "name": "input_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_preview": {
+          "name": "output_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_url": {
+          "name": "input_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_url": {
+          "name": "output_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "span_path_idx": {
+          "name": "span_path_idx",
+          "columns": [
+            {
+              "expression": "(attributes -> 'lmnr.span.path'::text)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_project_id_idx": {
+          "name": "spans_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "spans_project_id_trace_id_start_time_idx": {
+          "name": "spans_project_id_trace_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_root_project_id_start_time_end_time_trace_id_idx": {
+          "name": "spans_root_project_id_start_time_end_time_trace_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(parent_span_id IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_start_time_end_time_idx": {
+          "name": "spans_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_trace_id_idx": {
+          "name": "spans_trace_id_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_trace_id_start_time_idx": {
+          "name": "spans_trace_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spans_project_id_fkey": {
+          "name": "spans_project_id_fkey",
+          "tableFrom": "spans",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "spans_pkey": {
+          "name": "spans_pkey",
+          "columns": [
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_span_id_project_id": {
+          "name": "unique_span_id_project_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "subscription_tiers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_mib": {
+          "name": "storage_mib",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_retention_days": {
+          "name": "log_retention_days",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "members_per_workspace": {
+          "name": "members_per_workspace",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "steps": {
+          "name": "steps",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "spans": {
+          "name": "spans",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_span_price": {
+          "name": "extra_span_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_step_price": {
+          "name": "extra_step_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.target_pipeline_versions": {
+      "name": "target_pipeline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline_version_id": {
+          "name": "pipeline_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "target_pipeline_versions_pipeline_id_fkey": {
+          "name": "target_pipeline_versions_pipeline_id_fkey",
+          "tableFrom": "target_pipeline_versions",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "target_pipeline_versions_pipeline_version_id_fkey": {
+          "name": "target_pipeline_versions_pipeline_version_id_fkey",
+          "tableFrom": "target_pipeline_versions",
+          "tableTo": "pipeline_versions",
+          "columnsFrom": [
+            "pipeline_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pipeline_id": {
+          "name": "unique_pipeline_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pipeline_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traces": {
+      "name": "traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_token_count": {
+          "name": "total_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trace_type": {
+          "name": "trace_type",
+          "type": "trace_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DEFAULT'"
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "input_cost": {
+          "name": "input_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_cost": {
+          "name": "output_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "has_browser_session": {
+          "name": "has_browser_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_span_id": {
+          "name": "top_span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trace_metadata_gin_idx": {
+          "name": "trace_metadata_gin_idx",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "traces_id_project_id_start_time_times_not_null_idx": {
+          "name": "traces_id_project_id_start_time_times_not_null_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "((start_time IS NOT NULL) AND (end_time IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_project_id_idx": {
+          "name": "traces_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_project_id_trace_type_start_time_end_time_idx": {
+          "name": "traces_project_id_trace_type_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "((trace_type = 'DEFAULT'::trace_type) AND (start_time IS NOT NULL) AND (end_time IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_session_id_idx": {
+          "name": "traces_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_start_time_end_time_idx": {
+          "name": "traces_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_traces_project_id_fkey": {
+          "name": "new_traces_project_id_fkey",
+          "tableFrom": "traces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cookies": {
+      "name": "user_cookies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cookies": {
+          "name": "cookies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_cookies_user_id_fkey": {
+          "name": "user_cookies_user_id_fkey",
+          "tableFrom": "user_cookies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscription_info": {
+      "name": "user_subscription_info",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_subscription_info_stripe_customer_id_idx": {
+          "name": "user_subscription_info_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscription_info_fkey": {
+          "name": "user_subscription_info_fkey",
+          "tableFrom": "user_subscription_info",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscription_tiers": {
+      "name": "user_subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "user_subscription_tiers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "index_chat_messages": {
+          "name": "index_chat_messages",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_usage": {
+      "name": "user_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "index_chat_message_count": {
+          "name": "index_chat_message_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "index_chat_message_count_since_reset": {
+          "name": "index_chat_message_count_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "prev_index_chat_message_count": {
+          "name": "prev_index_chat_message_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "reset_time": {
+          "name": "reset_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reset_reason": {
+          "name": "reset_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signup'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_usage_user_id_fkey": {
+          "name": "user_usage_user_id_fkey",
+          "tableFrom": "user_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_tier_id_fkey": {
+          "name": "users_tier_id_fkey",
+          "tableFrom": "users",
+          "tableTo": "user_subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_usage": {
+      "name": "workspace_usage",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "span_count": {
+          "name": "span_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "span_count_since_reset": {
+          "name": "span_count_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "prev_span_count": {
+          "name": "prev_span_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "step_count": {
+          "name": "step_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "step_count_since_reset": {
+          "name": "step_count_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "prev_step_count": {
+          "name": "prev_step_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "reset_time": {
+          "name": "reset_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reset_reason": {
+          "name": "reset_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signup'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_usage_workspace_id_fkey": {
+          "name": "user_usage_workspace_id_fkey",
+          "tableFrom": "workspace_usage",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_usage_workspace_id_key": {
+          "name": "user_usage_workspace_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_seats": {
+          "name": "additional_seats",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_tier_id_fkey": {
+          "name": "workspaces_tier_id_fkey",
+          "tableFrom": "workspaces",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_machine_status": {
+      "name": "agent_machine_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "running",
+        "paused",
+        "stopped"
+      ]
+    },
+    "public.agent_message_type": {
+      "name": "agent_message_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "step"
+      ]
+    },
+    "public.label_source": {
+      "name": "label_source",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO",
+        "CODE"
+      ]
+    },
+    "public.span_type": {
+      "name": "span_type",
+      "schema": "public",
+      "values": [
+        "DEFAULT",
+        "LLM",
+        "PIPELINE",
+        "EXECUTOR",
+        "EVALUATOR",
+        "EVALUATION",
+        "TOOL"
+      ]
+    },
+    "public.trace_type": {
+      "name": "trace_type",
+      "schema": "public",
+      "values": [
+        "DEFAULT",
+        "EVENT",
+        "EVALUATION"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1743853103073,
       "tag": "0027_massive_hawkeye",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1744730518944,
+      "tag": "0028_futuristic_blonde_phantom",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/db/migrations/relations.ts
+++ b/frontend/lib/db/migrations/relations.ts
@@ -69,13 +69,13 @@ export const membersOfWorkspacesRelations = relations(membersOfWorkspaces, ({one
 export const usersRelations = relations(users, ({one, many}) => ({
   membersOfWorkspaces: many(membersOfWorkspaces),
   userSubscriptionInfos: many(userSubscriptionInfo),
+  apiKeys: many(apiKeys),
+  agentChats: many(agentChats),
+  userCookies: many(userCookies),
   userSubscriptionTier: one(userSubscriptionTiers, {
     fields: [users.tierId],
     references: [userSubscriptionTiers.id]
   }),
-  apiKeys: many(apiKeys),
-  userCookies: many(userCookies),
-  agentChats: many(agentChats),
   userUsages: many(userUsage),
 }));
 
@@ -147,10 +147,6 @@ export const labelingQueueItemsRelations = relations(labelingQueueItems, ({one})
     fields: [labelingQueueItems.queueId],
     references: [labelingQueues.id]
   }),
-}));
-
-export const userSubscriptionTiersRelations = relations(userSubscriptionTiers, ({many}) => ({
-  users: many(users),
 }));
 
 export const apiKeysRelations = relations(apiKeys, ({one}) => ({
@@ -228,10 +224,26 @@ export const labelsRelations = relations(labels, ({one}) => ({
   }),
 }));
 
-export const userCookiesRelations = relations(userCookies, ({one}) => ({
+export const agentChatsRelations = relations(agentChats, ({one}) => ({
   user: one(users, {
-    fields: [userCookies.userId],
+    fields: [agentChats.userId],
     references: [users.id]
+  }),
+  agentSession: one(agentSessions, {
+    fields: [agentChats.sessionId],
+    references: [agentSessions.sessionId]
+  }),
+}));
+
+export const agentSessionsRelations = relations(agentSessions, ({many}) => ({
+  agentChats: many(agentChats),
+  agentMessages: many(agentMessages),
+}));
+
+export const agentMessagesRelations = relations(agentMessages, ({one}) => ({
+  agentSession: one(agentSessions, {
+    fields: [agentMessages.sessionId],
+    references: [agentSessions.sessionId]
   }),
 }));
 
@@ -242,27 +254,15 @@ export const tracesRelations = relations(traces, ({one}) => ({
   }),
 }));
 
-export const agentMessagesRelations = relations(agentMessages, ({one}) => ({
-  agentSession: one(agentSessions, {
-    fields: [agentMessages.sessionId],
-    references: [agentSessions.sessionId]
-  }),
-}));
-
-export const agentSessionsRelations = relations(agentSessions, ({many}) => ({
-  agentMessages: many(agentMessages),
-  agentChats: many(agentChats),
-}));
-
-export const agentChatsRelations = relations(agentChats, ({one}) => ({
+export const userCookiesRelations = relations(userCookies, ({one}) => ({
   user: one(users, {
-    fields: [agentChats.userId],
+    fields: [userCookies.userId],
     references: [users.id]
   }),
-  agentSession: one(agentSessions, {
-    fields: [agentChats.sessionId],
-    references: [agentSessions.sessionId]
-  }),
+}));
+
+export const userSubscriptionTiersRelations = relations(userSubscriptionTiers, ({many}) => ({
+  users: many(users),
 }));
 
 export const userUsageRelations = relations(userUsage, ({one}) => ({

--- a/frontend/lib/db/migrations/schema.ts
+++ b/frontend/lib/db/migrations/schema.ts
@@ -1,18 +1,40 @@
 import { sql } from "drizzle-orm";
-import { bigint, boolean, doublePrecision, foreignKey, index, integer, jsonb, pgEnum,pgTable, primaryKey, text, timestamp, unique, uuid } from "drizzle-orm/pg-core";
+import {
+  bigint,
+  boolean,
+  doublePrecision,
+  foreignKey,
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from "drizzle-orm/pg-core";
 
-export const agentMachineStatus = pgEnum("agent_machine_status", ['not_started', 'running', 'paused', 'stopped']);
-export const agentMessageType = pgEnum("agent_message_type", ['user', 'assistant', 'step']);
-export const labelSource = pgEnum("label_source", ['MANUAL', 'AUTO', 'CODE']);
-export const spanType = pgEnum("span_type", ['DEFAULT', 'LLM', 'PIPELINE', 'EXECUTOR', 'EVALUATOR', 'EVALUATION', 'TOOL']);
-export const traceType = pgEnum("trace_type", ['DEFAULT', 'EVENT', 'EVALUATION']);
-export const workspaceRole = pgEnum("workspace_role", ['member', 'owner']);
-
+export const agentMachineStatus = pgEnum("agent_machine_status", ["not_started", "running", "paused", "stopped"]);
+export const agentMessageType = pgEnum("agent_message_type", ["user", "assistant", "step"]);
+export const labelSource = pgEnum("label_source", ["MANUAL", "AUTO", "CODE"]);
+export const spanType = pgEnum("span_type", [
+  "DEFAULT",
+  "LLM",
+  "PIPELINE",
+  "EXECUTOR",
+  "EVALUATOR",
+  "EVALUATION",
+  "TOOL",
+]);
+export const traceType = pgEnum("trace_type", ["DEFAULT", "EVENT", "EVALUATION"]);
+export const workspaceRole = pgEnum("workspace_role", ["member", "owner"]);
 
 export const llmPrices = pgTable("llm_prices", {
   id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   provider: text().notNull(),
   model: text().notNull(),
   inputPricePerMillion: doublePrecision("input_price_per_million").notNull(),
@@ -23,321 +45,442 @@ export const llmPrices = pgTable("llm_prices", {
 
 export const pipelineTemplates = pgTable("pipeline_templates", {
   id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   runnableGraph: jsonb("runnable_graph").default({}).notNull(),
   displayableGraph: jsonb("displayable_graph").default({}).notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
   numberOfNodes: bigint("number_of_nodes", { mode: "number" }).notNull(),
-  name: text().default('').notNull(),
-  description: text().default('').notNull(),
-  displayGroup: text("display_group").default('build').notNull(),
+  name: text().default("").notNull(),
+  description: text().default("").notNull(),
+  displayGroup: text("display_group").default("build").notNull(),
   ordinal: integer().default(500).notNull(),
 });
 
-export const datasets = pgTable("datasets", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  projectId: uuid("project_id").defaultRandom().notNull(),
-  indexedOn: text("indexed_on"),
-}, (table) => [
-  index("datasets_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "public_datasets_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const datasets = pgTable(
+  "datasets",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    indexedOn: text("indexed_on"),
+  },
+  (table) => [
+    index("datasets_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "public_datasets_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const datasetDatapoints = pgTable("dataset_datapoints", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  datasetId: uuid("dataset_id").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  data: jsonb().notNull(),
-  indexedOn: text("indexed_on"),
-  target: jsonb().default({}),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexInBatch: bigint("index_in_batch", { mode: "number" }),
-  metadata: jsonb().default({}),
-}, (table) => [
-  foreignKey({
-    columns: [table.datasetId],
-    foreignColumns: [datasets.id],
-    name: "dataset_datapoints_dataset_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const datasetDatapoints = pgTable(
+  "dataset_datapoints",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    datasetId: uuid("dataset_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    data: jsonb().notNull(),
+    indexedOn: text("indexed_on"),
+    target: jsonb().default({}),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    indexInBatch: bigint("index_in_batch", { mode: "number" }),
+    metadata: jsonb().default({}),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.datasetId],
+      foreignColumns: [datasets.id],
+      name: "dataset_datapoints_dataset_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const projects = pgTable("projects", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  workspaceId: uuid("workspace_id").notNull(),
-}, (table) => [
-  index("projects_workspace_id_idx").using("btree", table.workspaceId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.workspaceId],
-    foreignColumns: [workspaces.id],
-    name: "projects_workspace_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const projects = pgTable(
+  "projects",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+  },
+  (table) => [
+    index("projects_workspace_id_idx").using("btree", table.workspaceId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "projects_workspace_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const labelClassesForPath = pgTable("label_classes_for_path", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  projectId: uuid("project_id").defaultRandom().notNull(),
-  path: text().notNull(),
-  labelClassId: uuid("label_class_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "autoeval_labels_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("unique_project_id_path_label_class").on(table.projectId, table.path, table.labelClassId),
-]);
+export const labelClassesForPath = pgTable(
+  "label_classes_for_path",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    path: text().notNull(),
+    labelClassId: uuid("label_class_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "autoeval_labels_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("unique_project_id_path_label_class").on(table.projectId, table.path, table.labelClassId),
+  ]
+);
 
-export const membersOfWorkspaces = pgTable("members_of_workspaces", {
-  workspaceId: uuid("workspace_id").notNull(),
-  userId: uuid("user_id").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  memberRole: workspaceRole("member_role").default('owner').notNull(),
-}, (table) => [
-  index("members_of_workspaces_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "members_of_workspaces_user_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  foreignKey({
-    columns: [table.workspaceId],
-    foreignColumns: [workspaces.id],
-    name: "public_members_of_workspaces_workspace_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("members_of_workspaces_user_workspace_unique").on(table.workspaceId, table.userId),
-]);
+export const membersOfWorkspaces = pgTable(
+  "members_of_workspaces",
+  {
+    workspaceId: uuid("workspace_id").notNull(),
+    userId: uuid("user_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    memberRole: workspaceRole("member_role").default("owner").notNull(),
+  },
+  (table) => [
+    index("members_of_workspaces_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "members_of_workspaces_user_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "public_members_of_workspaces_workspace_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("members_of_workspaces_user_workspace_unique").on(table.workspaceId, table.userId),
+  ]
+);
 
-export const workspaces = pgTable("workspaces", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  tierId: bigint("tier_id", { mode: "number" }).default(sql`'1'`).notNull(),
-  subscriptionId: text("subscription_id"),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  additionalSeats: bigint("additional_seats", { mode: "number" }).default(sql`'0'`).notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.tierId],
-    foreignColumns: [subscriptionTiers.id],
-    name: "workspaces_tier_id_fkey"
-  }).onUpdate("cascade"),
-]);
+export const workspaces = pgTable(
+  "workspaces",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    tierId: bigint("tier_id", { mode: "number" })
+      .default(sql`'1'`)
+      .notNull(),
+    subscriptionId: text("subscription_id"),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    additionalSeats: bigint("additional_seats", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.tierId],
+      foreignColumns: [subscriptionTiers.id],
+      name: "workspaces_tier_id_fkey",
+    }).onUpdate("cascade"),
+  ]
+);
 
-export const pipelines = pgTable("pipelines", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  projectId: uuid("project_id").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  visibility: text().default('PRIVATE').notNull(),
-  pythonRequirements: text("python_requirements").default('').notNull(),
-}, (table) => [
-  index("pipelines_name_project_id_idx").using("btree", table.name.asc().nullsLast().op("text_ops"), table.projectId.asc().nullsLast().op("uuid_ops")),
-  index("pipelines_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "pipelines_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("unique_project_id_pipeline_name").on(table.projectId, table.name),
-]);
+export const pipelines = pgTable(
+  "pipelines",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    projectId: uuid("project_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    visibility: text().default("PRIVATE").notNull(),
+    pythonRequirements: text("python_requirements").default("").notNull(),
+  },
+  (table) => [
+    index("pipelines_name_project_id_idx").using(
+      "btree",
+      table.name.asc().nullsLast().op("text_ops"),
+      table.projectId.asc().nullsLast().op("uuid_ops")
+    ),
+    index("pipelines_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "pipelines_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("unique_project_id_pipeline_name").on(table.projectId, table.name),
+  ]
+);
 
-export const projectApiKeys = pgTable("project_api_keys", {
-  value: text().default('').notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text(),
-  projectId: uuid("project_id").notNull(),
-  shorthand: text().default('').notNull(),
-  hash: text().default('').notNull(),
-  id: uuid().defaultRandom().primaryKey().notNull(),
-}, (table) => [
-  index("project_api_keys_hash_idx").using("hash", table.hash.asc().nullsLast().op("text_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "public_project_api_keys_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const projectApiKeys = pgTable(
+  "project_api_keys",
+  {
+    value: text().default("").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text(),
+    projectId: uuid("project_id").notNull(),
+    shorthand: text().default("").notNull(),
+    hash: text().default("").notNull(),
+    id: uuid().defaultRandom().primaryKey().notNull(),
+  },
+  (table) => [
+    index("project_api_keys_hash_idx").using("hash", table.hash.asc().nullsLast().op("text_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "public_project_api_keys_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const providerApiKeys = pgTable("provider_api_keys", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  projectId: uuid("project_id").defaultRandom().notNull(),
-  nonceHex: text("nonce_hex").notNull(),
-  value: text().notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "provider_api_keys_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const providerApiKeys = pgTable(
+  "provider_api_keys",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    nonceHex: text("nonce_hex").notNull(),
+    value: text().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "provider_api_keys_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const targetPipelineVersions = pgTable("target_pipeline_versions", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  pipelineId: uuid("pipeline_id").notNull(),
-  pipelineVersionId: uuid("pipeline_version_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.pipelineId],
-    foreignColumns: [pipelines.id],
-    name: "target_pipeline_versions_pipeline_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  foreignKey({
-    columns: [table.pipelineVersionId],
-    foreignColumns: [pipelineVersions.id],
-    name: "target_pipeline_versions_pipeline_version_id_fkey"
-  }),
-  unique("unique_pipeline_id").on(table.pipelineId),
-]);
+export const targetPipelineVersions = pgTable(
+  "target_pipeline_versions",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    pipelineId: uuid("pipeline_id").notNull(),
+    pipelineVersionId: uuid("pipeline_version_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.pipelineId],
+      foreignColumns: [pipelines.id],
+      name: "target_pipeline_versions_pipeline_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    foreignKey({
+      columns: [table.pipelineVersionId],
+      foreignColumns: [pipelineVersions.id],
+      name: "target_pipeline_versions_pipeline_version_id_fkey",
+    }),
+    unique("unique_pipeline_id").on(table.pipelineId),
+  ]
+);
 
-export const userSubscriptionInfo = pgTable("user_subscription_info", {
-  userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  stripeCustomerId: text("stripe_customer_id").notNull(),
-  activated: boolean().default(false).notNull(),
-}, (table) => [
-  index("user_subscription_info_stripe_customer_id_idx").using("btree", table.stripeCustomerId.asc().nullsLast().op("text_ops")),
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "user_subscription_info_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const userSubscriptionInfo = pgTable(
+  "user_subscription_info",
+  {
+    userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    stripeCustomerId: text("stripe_customer_id").notNull(),
+    activated: boolean().default(false).notNull(),
+  },
+  (table) => [
+    index("user_subscription_info_stripe_customer_id_idx").using(
+      "btree",
+      table.stripeCustomerId.asc().nullsLast().op("text_ops")
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "user_subscription_info_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const workspaceUsage = pgTable("workspace_usage", {
-  workspaceId: uuid("workspace_id").defaultRandom().primaryKey().notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  spanCount: bigint("span_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  spanCountSinceReset: bigint("span_count_since_reset", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  prevSpanCount: bigint("prev_span_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  stepCount: bigint("step_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  stepCountSinceReset: bigint("step_count_since_reset", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  prevStepCount: bigint("prev_step_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  resetTime: timestamp("reset_time", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  resetReason: text("reset_reason").default('signup').notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.workspaceId],
-    foreignColumns: [workspaces.id],
-    name: "user_usage_workspace_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("user_usage_workspace_id_key").on(table.workspaceId),
-]);
+export const workspaceUsage = pgTable(
+  "workspace_usage",
+  {
+    workspaceId: uuid("workspace_id").defaultRandom().primaryKey().notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    spanCount: bigint("span_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    spanCountSinceReset: bigint("span_count_since_reset", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    prevSpanCount: bigint("prev_span_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    stepCount: bigint("step_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    stepCountSinceReset: bigint("step_count_since_reset", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    prevStepCount: bigint("prev_step_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    resetTime: timestamp("reset_time", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    resetReason: text("reset_reason").default("signup").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "user_usage_workspace_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("user_usage_workspace_id_key").on(table.workspaceId),
+  ]
+);
 
 export const subscriptionTiers = pgTable("subscription_tiers", {
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  id: bigint({ mode: "number" }).primaryKey().generatedByDefaultAsIdentity({ name: "subscription_tiers_id_seq", startWith: 1, increment: 1, minValue: 1, maxValue: 9223372036854775000, cache: 1 }),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  id: bigint({ mode: "number" })
+    .primaryKey()
+    .generatedByDefaultAsIdentity({
+      name: "subscription_tiers_id_seq",
+      startWith: 1,
+      increment: 1,
+      minValue: 1,
+      maxValue: 9223372036854775807,
+      cache: 1,
+    }),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   name: text().notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
   storageMib: bigint("storage_mib", { mode: "number" }).notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
   logRetentionDays: bigint("log_retention_days", { mode: "number" }).notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  membersPerWorkspace: bigint("members_per_workspace", { mode: "number" }).default(sql`'-1'`).notNull(),
-  stripeProductId: text("stripe_product_id").default('').notNull(),
+  membersPerWorkspace: bigint("members_per_workspace", { mode: "number" })
+    .default(sql`'-1'`)
+    .notNull(),
+  stripeProductId: text("stripe_product_id").default("").notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  steps: bigint({ mode: "number" }).default(sql`'0'`).notNull(),
+  steps: bigint({ mode: "number" })
+    .default(sql`'0'`)
+    .notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  spans: bigint({ mode: "number" }).default(sql`'0'`).notNull(),
-  extraSpanPrice: doublePrecision("extra_span_price").default(sql`'0'`).notNull(),
-  extraStepPrice: doublePrecision("extra_step_price").default(sql`'0'`).notNull(),
+  spans: bigint({ mode: "number" })
+    .default(sql`'0'`)
+    .notNull(),
+  extraSpanPrice: doublePrecision("extra_span_price")
+    .default(sql`'0'`)
+    .notNull(),
+  extraStepPrice: doublePrecision("extra_step_price")
+    .default(sql`'0'`)
+    .notNull(),
 });
 
-export const labelingQueues = pgTable("labeling_queues", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "labeling_queues_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const labelingQueues = pgTable(
+  "labeling_queues",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "labeling_queues_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const labelingQueueItems = pgTable("labeling_queue_items", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  queueId: uuid("queue_id").defaultRandom().notNull(),
-  action: jsonb().notNull(),
-  spanId: uuid("span_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.queueId],
-    foreignColumns: [labelingQueues.id],
-    name: "labelling_queue_items_queue_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const labelingQueueItems = pgTable(
+  "labeling_queue_items",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    queueId: uuid("queue_id").defaultRandom().notNull(),
+    action: jsonb().notNull(),
+    spanId: uuid("span_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.queueId],
+      foreignColumns: [labelingQueues.id],
+      name: "labelling_queue_items_queue_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const users = pgTable("users", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  email: text().notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  tierId: bigint("tier_id", { mode: "number" }).default(sql`'1'`).notNull(),
-  subscriptionId: text("subscription_id"),
-}, (table) => [
-  foreignKey({
-    columns: [table.tierId],
-    foreignColumns: [userSubscriptionTiers.id],
-    name: "users_tier_id_fkey"
-  }),
-  unique("users_email_key").on(table.email),
-]);
+export const apiKeys = pgTable(
+  "api_keys",
+  {
+    apiKey: text("api_key").primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    userId: uuid("user_id").notNull(),
+    name: text().default("default").notNull(),
+  },
+  (table) => [
+    index("api_keys_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "api_keys_user_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const apiKeys = pgTable("api_keys", {
-  apiKey: text("api_key").primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  userId: uuid("user_id").notNull(),
-  name: text().default('default').notNull(),
-}, (table) => [
-  index("api_keys_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "api_keys_user_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
-
-export const evaluations = pgTable("evaluations", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  projectId: uuid("project_id").notNull(),
-  name: text().notNull(),
-  groupId: text("group_id").default('default').notNull(),
-}, (table) => [
-  index("evaluations_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "evaluations_project_id_fkey1"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const evaluations = pgTable(
+  "evaluations",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").notNull(),
+    name: text().notNull(),
+    groupId: text("group_id").default("default").notNull(),
+  },
+  (table) => [
+    index("evaluations_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "evaluations_project_id_fkey1",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
 export const pipelineVersions = pgTable("pipeline_versions", {
   id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   pipelineId: uuid("pipeline_id").notNull(),
   displayableGraph: jsonb("displayable_graph").notNull(),
   runnableGraph: jsonb("runnable_graph").notNull(),
@@ -345,321 +488,515 @@ export const pipelineVersions = pgTable("pipeline_versions", {
   name: text().notNull(),
 });
 
-export const playgrounds = pgTable("playgrounds", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  projectId: uuid("project_id").notNull(),
-  promptMessages: jsonb("prompt_messages").default([{ "role": "user", "content": "" }]).notNull(),
-  modelId: text("model_id").default('').notNull(),
-  outputSchema: text("output_schema"),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "playgrounds_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const playgrounds = pgTable(
+  "playgrounds",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").notNull(),
+    promptMessages: jsonb("prompt_messages")
+      .default([{ role: "user", content: "" }])
+      .notNull(),
+    modelId: text("model_id").default("").notNull(),
+    outputSchema: text("output_schema"),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "playgrounds_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const evaluationScores = pgTable("evaluation_scores", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  resultId: uuid("result_id").defaultRandom().notNull(),
-  name: text().default('').notNull(),
-  score: doublePrecision().notNull(),
-  labelId: uuid("label_id"),
-}, (table) => [
-  index("evaluation_scores_result_id_idx").using("hash", table.resultId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.resultId],
-    foreignColumns: [evaluationResults.id],
-    name: "evaluation_scores_result_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("evaluation_results_names_unique").on(table.resultId, table.name),
-]);
+export const evaluationScores = pgTable(
+  "evaluation_scores",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    resultId: uuid("result_id").defaultRandom().notNull(),
+    name: text().default("").notNull(),
+    score: doublePrecision().notNull(),
+    labelId: uuid("label_id"),
+  },
+  (table) => [
+    index("evaluation_scores_result_id_idx").using("hash", table.resultId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.resultId],
+      foreignColumns: [evaluationResults.id],
+      name: "evaluation_scores_result_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("evaluation_results_names_unique").on(table.resultId, table.name),
+  ]
+);
 
-export const events = pgTable("events", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  spanId: uuid("span_id").notNull(),
-  timestamp: timestamp({ withTimezone: true, mode: 'string' }).notNull(),
-  name: text().notNull(),
-  attributes: jsonb().default({}).notNull(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  index("events_span_id_project_id_idx").using("btree", table.spanId.asc().nullsLast().op("uuid_ops"), table.projectId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.spanId, table.projectId],
-    foreignColumns: [spans.spanId, spans.projectId],
-    name: "events_span_id_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const events = pgTable(
+  "events",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    spanId: uuid("span_id").notNull(),
+    timestamp: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    name: text().notNull(),
+    attributes: jsonb().default({}).notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    index("events_span_id_project_id_idx").using(
+      "btree",
+      table.spanId.asc().nullsLast().op("uuid_ops"),
+      table.projectId.asc().nullsLast().op("uuid_ops")
+    ),
+    foreignKey({
+      columns: [table.spanId, table.projectId],
+      foreignColumns: [spans.spanId, spans.projectId],
+      name: "events_span_id_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const renderTemplates = pgTable("render_templates", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  projectId: uuid("project_id").defaultRandom().notNull(),
-  code: text().notNull(),
-  name: text().notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "render_templates_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const renderTemplates = pgTable(
+  "render_templates",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    code: text().notNull(),
+    name: text().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "render_templates_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const evaluationResults = pgTable("evaluation_results", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  evaluationId: uuid("evaluation_id").notNull(),
-  data: jsonb().notNull(),
-  target: jsonb().default({}).notNull(),
-  executorOutput: jsonb("executor_output"),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexInBatch: bigint("index_in_batch", { mode: "number" }),
-  traceId: uuid("trace_id").notNull(),
-  index: integer().default(0).notNull(),
-}, (table) => [
-  index("evaluation_results_evaluation_id_idx").using("btree", table.evaluationId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.evaluationId],
-    foreignColumns: [evaluations.id],
-    name: "evaluation_results_evaluation_id_fkey1"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const evaluationResults = pgTable(
+  "evaluation_results",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    evaluationId: uuid("evaluation_id").notNull(),
+    data: jsonb().notNull(),
+    target: jsonb().default({}).notNull(),
+    executorOutput: jsonb("executor_output"),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    indexInBatch: bigint("index_in_batch", { mode: "number" }),
+    traceId: uuid("trace_id").notNull(),
+    index: integer().default(0).notNull(),
+  },
+  (table) => [
+    index("evaluation_results_evaluation_id_idx").using("btree", table.evaluationId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.evaluationId],
+      foreignColumns: [evaluations.id],
+      name: "evaluation_results_evaluation_id_fkey1",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const labelClasses = pgTable("label_classes", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  projectId: uuid("project_id").notNull(),
-  description: text(),
-  evaluatorRunnableGraph: jsonb("evaluator_runnable_graph"),
-  pipelineVersionId: uuid("pipeline_version_id"),
-  color: text().default('rgb(190, 194, 200)').notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "label_classes_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("label_classes_project_id_id_key").on(table.id, table.projectId),
-  unique("label_classes_name_project_id_unique").on(table.name, table.projectId),
-]);
+export const labelClasses = pgTable(
+  "label_classes",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").notNull(),
+    description: text(),
+    evaluatorRunnableGraph: jsonb("evaluator_runnable_graph"),
+    pipelineVersionId: uuid("pipeline_version_id"),
+    color: text().default("rgb(190, 194, 200)").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "label_classes_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("label_classes_project_id_id_key").on(table.id, table.projectId),
+    unique("label_classes_name_project_id_unique").on(table.name, table.projectId),
+  ]
+);
 
-export const labels = pgTable("labels", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  classId: uuid("class_id").notNull(),
-  spanId: uuid("span_id").notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  userId: uuid("user_id").defaultRandom(),
-  labelSource: labelSource("label_source").default('MANUAL').notNull(),
-  reasoning: text(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.classId, table.projectId],
-    foreignColumns: [labelClasses.id, labelClasses.projectId],
-    name: "labels_class_id_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("labels_span_id_class_id_key").on(table.classId, table.spanId),
-  unique("labels_span_id_class_id_user_id_key").on(table.classId, table.spanId, table.userId),
-]);
+export const labels = pgTable(
+  "labels",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    classId: uuid("class_id").notNull(),
+    spanId: uuid("span_id").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    userId: uuid("user_id").defaultRandom(),
+    labelSource: labelSource("label_source").default("MANUAL").notNull(),
+    reasoning: text(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.classId, table.projectId],
+      foreignColumns: [labelClasses.id, labelClasses.projectId],
+      name: "labels_class_id_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("labels_span_id_class_id_key").on(table.classId, table.spanId),
+    unique("labels_span_id_class_id_user_id_key").on(table.classId, table.spanId, table.userId),
+  ]
+);
 
-export const userCookies = pgTable("user_cookies", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  userId: uuid("user_id").notNull(),
-  cookies: text().notNull(),
-  nonce: text().notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "user_cookies_user_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const agentChats = pgTable(
+  "agent_chats",
+  {
+    sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
+    chatName: text("chat_name").default("New chat").notNull(),
+    userId: uuid("user_id").notNull(),
+    machineStatus: agentMachineStatus("machine_status").default("not_started"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    agentStatus: text("agent_status").default("idle").notNull(),
+  },
+  (table) => [
+    index("agent_chats_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
+    index("agent_chats_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
+    index("agent_chats_user_id_idx").using("hash", table.userId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "agent_chats_user_id_fkey",
+    }),
+    foreignKey({
+      columns: [table.sessionId],
+      foreignColumns: [agentSessions.sessionId],
+      name: "agent_chats_session_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const traces = pgTable("traces", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  sessionId: text("session_id"),
-  metadata: jsonb(),
-  projectId: uuid("project_id").notNull(),
-  endTime: timestamp("end_time", { withTimezone: true, mode: 'string' }),
-  startTime: timestamp("start_time", { withTimezone: true, mode: 'string' }),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  totalTokenCount: bigint("total_token_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  cost: doublePrecision().default(sql`'0'`).notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  traceType: traceType("trace_type").default('DEFAULT').notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  inputTokenCount: bigint("input_token_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  outputTokenCount: bigint("output_token_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  inputCost: doublePrecision("input_cost").default(sql`'0'`).notNull(),
-  outputCost: doublePrecision("output_cost").default(sql`'0'`).notNull(),
-  hasBrowserSession: boolean("has_browser_session"),
-  topSpanId: uuid("top_span_id"),
-  agentSessionId: uuid("agent_session_id"),
-}, (table) => [
-  index("trace_metadata_gin_idx").using("gin", table.metadata.asc().nullsLast().op("jsonb_ops")),
-  index("traces_id_project_id_start_time_times_not_null_idx").using("btree", table.id.asc().nullsLast().op("timestamptz_ops"), table.projectId.asc().nullsLast().op("uuid_ops"), table.startTime.desc().nullsFirst().op("timestamptz_ops")).where(sql`((start_time IS NOT NULL) AND (end_time IS NOT NULL))`),
-  index("traces_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
-  index("traces_project_id_trace_type_start_time_end_time_idx").using("btree", table.projectId.asc().nullsLast().op("timestamptz_ops"), table.startTime.asc().nullsLast().op("uuid_ops"), table.endTime.asc().nullsLast().op("timestamptz_ops")).where(sql`((trace_type = 'DEFAULT'::trace_type) AND (start_time IS NOT NULL) AND (end_time IS NOT NULL))`),
-  index("traces_session_id_idx").using("btree", table.sessionId.asc().nullsLast().op("text_ops")),
-  index("traces_start_time_end_time_idx").using("btree", table.startTime.asc().nullsLast().op("timestamptz_ops"), table.endTime.asc().nullsLast().op("timestamptz_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "new_traces_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const agentMessages = pgTable(
+  "agent_messages",
+  {
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    sessionId: uuid("session_id").notNull(),
+    messageType: agentMessageType("message_type").notNull(),
+    content: jsonb().default({}),
+    traceId: uuid("trace_id"),
+  },
+  (table) => [
+    index("agent_messages_session_id_created_at_idx").using(
+      "btree",
+      table.createdAt.asc().nullsLast().op("timestamptz_ops"),
+      table.sessionId.asc().nullsLast().op("timestamptz_ops")
+    ),
+    foreignKey({
+      columns: [table.sessionId],
+      foreignColumns: [agentSessions.sessionId],
+      name: "agent_messages_session_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const agentSessions = pgTable("agent_sessions", {
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
-  cdpUrl: text("cdp_url"),
-  vncUrl: text("vnc_url"),
-  machineId: text("machine_id"),
-  state: text(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  agentStatus: text("agent_status").default('idle').notNull(),
-}, (table) => [
-  index("agent_sessions_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
-  index("agent_sessions_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
-]);
+export const traces = pgTable(
+  "traces",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    sessionId: text("session_id"),
+    metadata: jsonb(),
+    projectId: uuid("project_id").notNull(),
+    endTime: timestamp("end_time", { withTimezone: true, mode: "string" }),
+    startTime: timestamp("start_time", { withTimezone: true, mode: "string" }),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    totalTokenCount: bigint("total_token_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    cost: doublePrecision()
+      .default(sql`'0'`)
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    traceType: traceType("trace_type").default("DEFAULT").notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    inputTokenCount: bigint("input_token_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    outputTokenCount: bigint("output_token_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    inputCost: doublePrecision("input_cost")
+      .default(sql`'0'`)
+      .notNull(),
+    outputCost: doublePrecision("output_cost")
+      .default(sql`'0'`)
+      .notNull(),
+    hasBrowserSession: boolean("has_browser_session"),
+    topSpanId: uuid("top_span_id"),
+    agentSessionId: uuid("agent_session_id"),
+  },
+  (table) => [
+    index("trace_metadata_gin_idx").using("gin", table.metadata.asc().nullsLast().op("jsonb_ops")),
+    index("traces_id_project_id_start_time_times_not_null_idx")
+      .using(
+        "btree",
+        table.id.asc().nullsLast().op("uuid_ops"),
+        table.projectId.asc().nullsLast().op("timestamptz_ops"),
+        table.startTime.asc().nullsLast().op("timestamptz_ops")
+      )
+      .where(sql`((start_time IS NOT NULL) AND (end_time IS NOT NULL))`),
+    index("traces_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
+    index("traces_project_id_trace_type_start_time_end_time_idx")
+      .using(
+        "btree",
+        table.projectId.asc().nullsLast().op("uuid_ops"),
+        table.startTime.asc().nullsLast().op("timestamptz_ops"),
+        table.endTime.asc().nullsLast().op("uuid_ops")
+      )
+      .where(sql`((trace_type = 'DEFAULT'::trace_type) AND (start_time IS NOT NULL) AND (end_time IS NOT NULL))`),
+    index("traces_session_id_idx").using("btree", table.sessionId.asc().nullsLast().op("text_ops")),
+    index("traces_start_time_end_time_idx").using(
+      "btree",
+      table.startTime.asc().nullsLast().op("timestamptz_ops"),
+      table.endTime.asc().nullsLast().op("timestamptz_ops")
+    ),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "new_traces_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const agentMessages = pgTable("agent_messages", {
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  sessionId: uuid("session_id").notNull(),
-  messageType: agentMessageType("message_type").notNull(),
-  content: jsonb().default({}),
-  traceId: uuid("trace_id"),
-}, (table) => [
-  index("agent_messages_session_id_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops"), table.sessionId.asc().nullsLast().op("timestamptz_ops")),
-  foreignKey({
-    columns: [table.sessionId],
-    foreignColumns: [agentSessions.sessionId],
-    name: "agent_messages_session_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const agentSessions = pgTable(
+  "agent_sessions",
+  {
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    sessionId: uuid("session_id").primaryKey().notNull(),
+    cdpUrl: text("cdp_url"),
+    vncUrl: text("vnc_url"),
+    machineId: text("machine_id"),
+    state: text(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    agentStatus: text("agent_status").default("idle").notNull(),
+  },
+  (table) => [
+    index("agent_sessions_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
+    index("agent_sessions_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
+  ]
+);
 
-export const agentChats = pgTable("agent_chats", {
-  sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
-  chatName: text("chat_name").default('New chat').notNull(),
-  userId: uuid("user_id").notNull(),
-  machineStatus: agentMachineStatus("machine_status").default('not_started'),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-  index("agent_chats_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
-  index("agent_chats_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
-  index("agent_chats_user_id_idx").using("hash", table.userId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "agent_chats_user_id_fkey"
-  }),
-  foreignKey({
-    columns: [table.sessionId],
-    foreignColumns: [agentSessions.sessionId],
-    name: "agent_chats_session_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const userCookies = pgTable(
+  "user_cookies",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    userId: uuid("user_id").notNull(),
+    cookies: text().notNull(),
+    nonce: text().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "user_cookies_user_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const userUsage = pgTable("user_usage", {
-  userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexChatMessageCount: bigint("index_chat_message_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexChatMessageCountSinceReset: bigint("index_chat_message_count_since_reset", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  prevIndexChatMessageCount: bigint("prev_index_chat_message_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  resetTime: timestamp("reset_time", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  resetReason: text("reset_reason").default('signup').notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "user_usage_user_id_fkey"
-  }),
-]);
+export const users = pgTable(
+  "users",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    email: text().notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    tierId: bigint("tier_id", { mode: "number" })
+      .default(sql`'1'`)
+      .notNull(),
+    subscriptionId: text("subscription_id"),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.tierId],
+      foreignColumns: [userSubscriptionTiers.id],
+      name: "users_tier_id_fkey",
+    }),
+    unique("users_email_key").on(table.email),
+  ]
+);
+
+export const userUsage = pgTable(
+  "user_usage",
+  {
+    userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    indexChatMessageCount: bigint("index_chat_message_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    indexChatMessageCountSinceReset: bigint("index_chat_message_count_since_reset", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    prevIndexChatMessageCount: bigint("prev_index_chat_message_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    resetTime: timestamp("reset_time", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    resetReason: text("reset_reason").default("signup").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "user_usage_user_id_fkey",
+    }),
+  ]
+);
 
 export const userSubscriptionTiers = pgTable("user_subscription_tiers", {
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  id: bigint({ mode: "number" }).primaryKey().generatedByDefaultAsIdentity({ name: "user_subscription_tiers_id_seq", startWith: 1, increment: 1, minValue: 1, maxValue: 9223372036854775807, cache: 1 }),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  id: bigint({ mode: "number" })
+    .primaryKey()
+    .generatedByDefaultAsIdentity({
+      name: "user_subscription_tiers_id_seq",
+      startWith: 1,
+      increment: 1,
+      minValue: 1,
+      maxValue: 9223372036854775807,
+      cache: 1,
+    }),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   name: text().notNull(),
-  stripeProductId: text("stripe_product_id").default('').notNull(),
+  stripeProductId: text("stripe_product_id").default("").notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
   indexChatMessages: bigint("index_chat_messages", { mode: "number" }).default(sql`'0'`),
 });
 
-export const machines = pgTable("machines", {
-  id: uuid().defaultRandom().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "machines_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  primaryKey({ columns: [table.id, table.projectId], name: "machines_pkey" }),
-]);
+export const machines = pgTable(
+  "machines",
+  {
+    id: uuid().defaultRandom().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "machines_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    primaryKey({ columns: [table.id, table.projectId], name: "machines_pkey" }),
+  ]
+);
 
-export const datapointToSpan = pgTable("datapoint_to_span", {
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  datapointId: uuid("datapoint_id").notNull(),
-  spanId: uuid("span_id").notNull(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.datapointId],
-    foreignColumns: [datasetDatapoints.id],
-    name: "datapoint_to_span_datapoint_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  foreignKey({
-    columns: [table.spanId, table.projectId],
-    foreignColumns: [spans.spanId, spans.projectId],
-    name: "datapoint_to_span_span_id_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  primaryKey({ columns: [table.datapointId, table.spanId, table.projectId], name: "datapoint_to_span_pkey" }),
-]);
+export const datapointToSpan = pgTable(
+  "datapoint_to_span",
+  {
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    datapointId: uuid("datapoint_id").notNull(),
+    spanId: uuid("span_id").notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.datapointId],
+      foreignColumns: [datasetDatapoints.id],
+      name: "datapoint_to_span_datapoint_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    foreignKey({
+      columns: [table.spanId, table.projectId],
+      foreignColumns: [spans.spanId, spans.projectId],
+      name: "datapoint_to_span_span_id_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    primaryKey({ columns: [table.datapointId, table.spanId, table.projectId], name: "datapoint_to_span_pkey" }),
+  ]
+);
 
-export const spans = pgTable("spans", {
-  spanId: uuid("span_id").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  parentSpanId: uuid("parent_span_id"),
-  name: text().notNull(),
-  attributes: jsonb(),
-  input: jsonb(),
-  output: jsonb(),
-  spanType: spanType("span_type").notNull(),
-  startTime: timestamp("start_time", { withTimezone: true, mode: 'string' }).notNull(),
-  endTime: timestamp("end_time", { withTimezone: true, mode: 'string' }).notNull(),
-  traceId: uuid("trace_id").notNull(),
-  inputPreview: text("input_preview"),
-  outputPreview: text("output_preview"),
-  projectId: uuid("project_id").notNull(),
-  inputUrl: text("input_url"),
-  outputUrl: text("output_url"),
-}, (table) => [
-  index("span_path_idx").using("btree", sql`(attributes -> 'lmnr.span.path'::text)`),
-  index("spans_project_id_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
-  index("spans_project_id_trace_id_start_time_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops"), table.traceId.asc().nullsLast().op("uuid_ops"), table.startTime.asc().nullsLast().op("uuid_ops")),
-  index("spans_root_project_id_start_time_end_time_trace_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops"), table.startTime.asc().nullsLast().op("timestamptz_ops"), table.endTime.asc().nullsLast().op("uuid_ops"), table.traceId.asc().nullsLast().op("timestamptz_ops")).where(sql`(parent_span_id IS NULL)`),
-  index("spans_start_time_end_time_idx").using("btree", table.startTime.asc().nullsLast().op("timestamptz_ops"), table.endTime.asc().nullsLast().op("timestamptz_ops")),
-  index("spans_trace_id_idx").using("btree", table.traceId.asc().nullsLast().op("uuid_ops")),
-  index("spans_trace_id_start_time_idx").using("btree", table.traceId.asc().nullsLast().op("uuid_ops"), table.startTime.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "spans_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  primaryKey({ columns: [table.spanId, table.projectId], name: "spans_pkey" }),
-  unique("unique_span_id_project_id").on(table.spanId, table.projectId),
-]);
+export const spans = pgTable(
+  "spans",
+  {
+    spanId: uuid("span_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    parentSpanId: uuid("parent_span_id"),
+    name: text().notNull(),
+    attributes: jsonb(),
+    input: jsonb(),
+    output: jsonb(),
+    spanType: spanType("span_type").notNull(),
+    startTime: timestamp("start_time", { withTimezone: true, mode: "string" }).notNull(),
+    endTime: timestamp("end_time", { withTimezone: true, mode: "string" }).notNull(),
+    traceId: uuid("trace_id").notNull(),
+    inputPreview: text("input_preview"),
+    outputPreview: text("output_preview"),
+    projectId: uuid("project_id").notNull(),
+    inputUrl: text("input_url"),
+    outputUrl: text("output_url"),
+  },
+  (table) => [
+    index("span_path_idx").using("btree", sql`(attributes -> 'lmnr.span.path'::text)`),
+    index("spans_project_id_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
+    index("spans_project_id_trace_id_start_time_idx").using(
+      "btree",
+      table.projectId.asc().nullsLast().op("timestamptz_ops"),
+      table.traceId.asc().nullsLast().op("timestamptz_ops"),
+      table.startTime.asc().nullsLast().op("timestamptz_ops")
+    ),
+    index("spans_root_project_id_start_time_end_time_trace_id_idx")
+      .using(
+        "btree",
+        table.projectId.asc().nullsLast().op("timestamptz_ops"),
+        table.startTime.asc().nullsLast().op("timestamptz_ops"),
+        table.endTime.asc().nullsLast().op("timestamptz_ops"),
+        table.traceId.asc().nullsLast().op("uuid_ops")
+      )
+      .where(sql`(parent_span_id IS NULL)`),
+    index("spans_start_time_end_time_idx").using(
+      "btree",
+      table.startTime.asc().nullsLast().op("timestamptz_ops"),
+      table.endTime.asc().nullsLast().op("timestamptz_ops")
+    ),
+    index("spans_trace_id_idx").using("btree", table.traceId.asc().nullsLast().op("uuid_ops")),
+    index("spans_trace_id_start_time_idx").using(
+      "btree",
+      table.traceId.asc().nullsLast().op("uuid_ops"),
+      table.startTime.asc().nullsLast().op("uuid_ops")
+    ),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "spans_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    primaryKey({ columns: [table.spanId, table.projectId], name: "spans_pkey" }),
+    unique("unique_span_id_project_id").on(table.spanId, table.projectId),
+  ]
+);

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -1,7 +1,9 @@
 import { createClient } from "@supabase/supabase-js";
 
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from "@/lib/const";
+
 export const createSupabaseClient = (accessToken: string) =>
-  createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+  createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
     global: {
       headers: {
         Authorization: `Bearer ${accessToken}`,

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -1,0 +1,13 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const createSupabaseClient = (accessToken: string) =>
+  createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+    realtime: {
+      accessToken: () => Promise.resolve(accessToken),
+    },
+  });


### PR DESCRIPTION
- real time updates on sessions in chat sidebar
- supabase client with .evn variables
- migration on `agent_chats` table
- update `agent_chats` table in agent worker in app-server
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add real-time updates for chat sessions using Supabase and update database schema and frontend components accordingly.
> 
>   - **Real-time Updates**:
>     - Implement real-time updates for chat sessions in `AgentSidebar` using Supabase.
>     - Subscribe to `agent_chats` table changes and update session data accordingly.
>   - **Database**:
>     - Add `agent_status` column to `agent_chats` table with default 'idle' in `0028_futuristic_blonde_phantom.sql`.
>     - Update `update_agent_chat_status()` in `agent_chats.rs` to modify `agent_status`.
>   - **Frontend**:
>     - Modify `AgentSidebar` to use `supabaseClient` for real-time updates.
>     - Update `route.ts` to include `agentStatus` in session data.
>     - Add `supabaseAccessToken` to `ChatUser` in `layout.tsx` and `pricing-context.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for c44ebd89039921a2e6400f1600fbdc637d597be8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->