### PR TITLE
feat: add session replay LAM-514

### DIFF
--- a/frontend/app/api/browser-sessions/events/route.ts
+++ b/frontend/app/api/browser-sessions/events/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     return new Response(JSON.stringify({ error: "Failed to fetch events." }), {
-      status: 400,
+      status: 500,
     });
   }
 }

--- a/frontend/app/api/browser-sessions/events/route.ts
+++ b/frontend/app/api/browser-sessions/events/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+
+import { clickhouseClient } from "@/lib/clickhouse/client";
+
+export async function GET(request: NextRequest) {
+  const traceId = request.nextUrl.searchParams.get("traceId");
+
+  if (!traceId) {
+    return new Response(JSON.stringify({ error: "traceId is required" }), {
+      status: 400,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const res = await clickhouseClient.query({
+    query: `
+      SELECT 
+        trace_id,
+        timestamp,
+        event_type,
+        base64Encode(data) as data
+      FROM browser_session_events
+      WHERE trace_id = {traceId: UUID}
+      ORDER BY timestamp ASC`,
+    format: "JSONEachRow",
+    query_params: {
+      traceId: traceId,
+    },
+  });
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      controller.enqueue("["); // Start JSON array
+
+      let isFirst = true;
+      const resultStream = res.stream();
+
+      try {
+        for await (const row of resultStream) {
+          if (!isFirst) {
+            controller.enqueue(",");
+          }
+          controller.enqueue(JSON.stringify(row));
+          isFirst = false;
+        }
+
+        controller.enqueue("]"); // End JSON array
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}

--- a/frontend/app/chat/layout.tsx
+++ b/frontend/app/chat/layout.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { PropsWithChildren } from "react";
 
-import PricingProvider from "@/components/chat/pricing-context";
+import SessionProvider from "@/components/chat/session-context";
 import { AgentSidebar } from "@/components/chat/side-bar";
 import { ChatUser } from "@/components/chat/types";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
@@ -44,10 +44,10 @@ export default async function Layout({ children }: PropsWithChildren) {
 
   return (
     <SidebarProvider style={sidebarRef}>
-      <PricingProvider user={chatUser}>
+      <SessionProvider user={chatUser}>
         <AgentSidebar />
         <SidebarInset>{children}</SidebarInset>
-      </PricingProvider>
+      </SessionProvider>
     </SidebarProvider>
   );
 }

--- a/frontend/components/chat/browser-window.tsx
+++ b/frontend/components/chat/browser-window.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { ChevronLeft } from "lucide-react";
 import { usePathname } from "next/navigation";
 import useSWR from "swr";
 
+import { usePricingContext } from "@/components/chat/pricing-context";
+import SessionPlayer from "@/components/chat/session-player";
 import { AgentSession } from "@/components/chat/types";
 import { Button } from "@/components/ui/button";
 import { useSidebar } from "@/components/ui/sidebar";
@@ -17,6 +20,8 @@ const BrowserWindow = ({ onControl, isControlled }: BrowserWindowProps) => {
   const pathname = usePathname();
   const sessionId = pathname.split("/")?.[2];
   const { setOpen } = useSidebar();
+  const { traceId, handleTraceId, browserSessionRef } = usePricingContext();
+
   const { data } = useSWR<Pick<AgentSession, "vncUrl" | "machineStatus">>(
     () => (sessionId ? `/api/agent-sessions/${sessionId}` : null),
     swrFetcher,
@@ -30,41 +35,59 @@ const BrowserWindow = ({ onControl, isControlled }: BrowserWindowProps) => {
 
   return (
     <>
-      <div
-        className={cn(
-          "z-50 bg-background rounded-lg w-full flex flex-col transition-all duration-300 aspect-[4/3]",
-          isBrowserActive
-            ? "max-w-md sm:max-w-sm md:max-w-md xl:max-w-3xl 2xl:max-w-[60%] sm:px-4 md:px-8 lg:px-12"
-            : "max-w-0",
-          {
-            "!max-w-full left-0 right-0 top-0 bottom-0 p-4": isControlled,
-          }
-        )}
-      >
+      {traceId ? (
         <div
           className={cn(
-            "relative flex items-center justify-center rounded-md overflow-hidden aspect-[4/3]",
-            isControlled ? "mx-auto h-full" : "w-full my-auto"
+            "z-50 bg-background rounded-lg w-full flex flex-col transition-all duration-300 aspect-[4/3]",
+            "max-w-md sm:max-w-sm md:max-w-md xl:max-w-3xl 2xl:max-w-[60%] p-2"
           )}
         >
-          <iframe src={data?.vncUrl} className="w-full h-full rounded-md bg-transparent aspect-[4/3]" />
-          {!isControlled && <div className="absolute z-50 w-full h-full bg-transparent" />}
-        </div>
-        {isControlled && (
-          <div className="mx-auto mt-4">
-            <Button
-              className="w-fit mx-auto"
-              onClick={() => {
-                onControl();
-                setOpen(false);
-              }}
-            >
-              {" "}
-              Give control back
-            </Button>
+          <Button onClick={() => handleTraceId("")} className="self-start mt-4" variant="outline">
+            <ChevronLeft className="mr-1 -ml-2 size-4" size={16} />
+            Back
+          </Button>
+
+          <div className="my-auto">
+            <SessionPlayer ref={browserSessionRef} traceId={traceId} onTimelineChange={() => {}} />
           </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div
+          className={cn(
+            "z-50 bg-background rounded-lg w-full flex flex-col transition-all duration-300 aspect-[4/3]",
+            isBrowserActive
+              ? "max-w-md sm:max-w-sm md:max-w-md xl:max-w-3xl 2xl:max-w-[60%] sm:px-4 md:px-8 lg:px-12"
+              : "max-w-0",
+            {
+              "!max-w-full left-0 right-0 top-0 bottom-0 p-4": isControlled,
+            }
+          )}
+        >
+          <div
+            className={cn(
+              "relative flex items-center justify-center rounded-md overflow-hidden aspect-[4/3]",
+              isControlled ? "mx-auto h-full" : "w-full my-auto"
+            )}
+          >
+            <iframe src={data?.vncUrl} className="w-full h-full rounded-md bg-transparent aspect-[4/3]" />
+            {!isControlled && <div className="absolute z-50 w-full h-full bg-transparent" />}
+          </div>
+          {isControlled && (
+            <div className="mx-auto mt-4">
+              <Button
+                className="w-fit mx-auto"
+                onClick={() => {
+                  onControl();
+                  setOpen(false);
+                }}
+              >
+                {" "}
+                Give control back
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/frontend/components/chat/browser-window.tsx
+++ b/frontend/components/chat/browser-window.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft } from "lucide-react";
 import { usePathname } from "next/navigation";
 import useSWR from "swr";
 
-import { usePricingContext } from "@/components/chat/pricing-context";
+import { useSessionContext } from "@/components/chat/session-context";
 import SessionPlayer from "@/components/chat/session-player";
 import { AgentSession } from "@/components/chat/types";
 import { Button } from "@/components/ui/button";
@@ -20,7 +20,7 @@ const BrowserWindow = ({ onControl, isControlled }: BrowserWindowProps) => {
   const pathname = usePathname();
   const sessionId = pathname.split("/")?.[2];
   const { setOpen } = useSidebar();
-  const { traceId, handleTraceId, browserSessionRef } = usePricingContext();
+  const { traceId, handleTraceId, browserSessionRef, currentTime } = useSessionContext();
 
   const { data } = useSWR<Pick<AgentSession, "vncUrl" | "machineStatus">>(
     () => (sessionId ? `/api/agent-sessions/${sessionId}` : null),
@@ -48,7 +48,12 @@ const BrowserWindow = ({ onControl, isControlled }: BrowserWindowProps) => {
           </Button>
 
           <div className="my-auto">
-            <SessionPlayer ref={browserSessionRef} traceId={traceId} onTimelineChange={() => {}} />
+            <SessionPlayer
+              defaultTime={currentTime}
+              ref={browserSessionRef}
+              traceId={traceId}
+              onTimelineChange={() => {}}
+            />
           </div>
         </div>
       ) : (

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -1,56 +1,77 @@
 import { AnimatePresence, motion } from "framer-motion";
+import { Play } from "lucide-react";
 import Image from "next/image";
 
 import logo from "@/assets/logo/icon.svg";
 import { Markdown } from "@/components/chat/markdown";
+import { usePricingContext } from "@/components/chat/pricing-context";
 import { ChatMessage } from "@/components/chat/types";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface MessageProps {
   message: ChatMessage;
 }
 
-const Message = ({ message }: MessageProps) => (
-  <AnimatePresence>
-    <motion.div
-      className="w-full mx-auto max-w-3xl px-4 group/message"
-      initial={{ y: 5, opacity: 0 }}
-      animate={{ y: 0, opacity: 1 }}
-      data-type={message.messageType}
-    >
-      <div
-        className={cn(
-          "flex gap-4 mb-6",
-          "group-data-[type=user]/message:ml-auto group-data-[type=user]/message:w-fit group-data-[type=user]/message:max-w-2xl",
-          "group-data-[type=step]/message:mb-2",
-          "group-data-[type=step]/message:ml-12"
-        )}
+const Message = ({ message }: MessageProps) => {
+  const { handleTraceId, browserSessionRef } = usePricingContext();
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="w-full mx-auto max-w-3xl px-4 group/message"
+        initial={{ y: 5, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        data-type={message.messageType}
       >
-        {message.messageType === "assistant" && (
-          <div className="h-fit w-fit p-2 flex items-center rounded-full justify-center ring-1 shrink-0 ring-border bg-background">
-            <Image className="-mr-px" alt="logo" src={logo} width={16} />
-          </div>
-        )}
-
-        {"text" in message.content ? (
-          <div className="flex flex-col gap-2 items-start">
-            <div
-              className={cn("flex flex-col gap-4", {
-                "text-primary-foreground px-3 py-2 rounded-l-xl rounded-tr-xl bg-secondary":
-                  message.messageType === "user",
-              })}
-            >
-              <Markdown>{message.content.text}</Markdown>
+        <div
+          className={cn(
+            "flex gap-4 mb-6",
+            "group-data-[type=user]/message:ml-auto group-data-[type=user]/message:w-fit group-data-[type=user]/message:max-w-2xl",
+            "group-data-[type=step]/message:mb-2",
+            "group-data-[type=step]/message:ml-12"
+          )}
+        >
+          {message.messageType === "assistant" && (
+            <div className="h-fit w-fit p-2 flex items-center rounded-full justify-center ring-1 shrink-0 ring-border bg-background">
+              <Image className="-mr-px" alt="logo" src={logo} width={16} />
             </div>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-4 text-secondary-foreground">
-            <Markdown>{message.content.summary}</Markdown>
-          </div>
-        )}
-      </div>
-    </motion.div>
-  </AnimatePresence>
-);
+          )}
+          {"text" in message.content ? (
+            <div className="flex flex-col gap-2 items-start">
+              <div
+                className={cn("flex flex-col gap-4", {
+                  "text-primary-foreground px-3 py-2 rounded-l-xl rounded-tr-xl bg-secondary":
+                    message.messageType === "user",
+                })}
+              >
+                <Markdown>{message.content.text}</Markdown>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4 text-secondary-foreground">
+              <Markdown>{message.content.summary}</Markdown>
+            </div>
+          )}
+          {message.messageType !== "user" && (
+            <Button
+              className={cn("p-1 rounded-full ml-auto h-fit w-fit", "invisible group-hover/message:visible")}
+              onClick={() => {
+                handleTraceId(message.traceId);
+                if (message.messageType === "assistant") {
+                  browserSessionRef.current?.goto(0, true);
+                } else {
+                  browserSessionRef.current?.goto(new Date(message.createdAt).getTime(), false);
+                }
+              }}
+              variant="secondary"
+            >
+              <Play size={12} className="size-3" />
+            </Button>
+          )}
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};
 
 export default Message;

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 
 import logo from "@/assets/logo/icon.svg";
 import { Markdown } from "@/components/chat/markdown";
-import { usePricingContext } from "@/components/chat/pricing-context";
+import { useSessionContext } from "@/components/chat/session-context";
 import { ChatMessage } from "@/components/chat/types";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -14,7 +14,7 @@ interface MessageProps {
 }
 
 const Message = ({ message }: MessageProps) => {
-  const { handleTraceId, browserSessionRef } = usePricingContext();
+  const { handleTraceId, browserSessionRef, handleCurrentTime } = useSessionContext();
   return (
     <AnimatePresence>
       <motion.div
@@ -58,8 +58,9 @@ const Message = ({ message }: MessageProps) => {
               onClick={() => {
                 handleTraceId(message.traceId);
                 if (message.messageType === "assistant") {
-                  browserSessionRef.current?.goto(0, true);
+                  handleCurrentTime(0);
                 } else {
+                  handleCurrentTime(new Date(message.createdAt).getTime());
                   browserSessionRef.current?.goto(new Date(message.createdAt).getTime(), false);
                 }
               }}

--- a/frontend/components/chat/multimodal-input.tsx
+++ b/frontend/components/chat/multimodal-input.tsx
@@ -3,7 +3,7 @@ import { ArrowUp, StopCircleIcon, X } from "lucide-react";
 import { KeyboardEvent, memo, MouseEvent, useEffect, useMemo, useRef, useState } from "react";
 
 import ModelSelect from "@/components/chat/model-select";
-import { usePricingContext } from "@/components/chat/pricing-context";
+import { useSessionContext } from "@/components/chat/session-context";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -30,7 +30,7 @@ const MultimodalInput = ({
   onModelStateChange,
 }: MultimodalInputProps) => {
   const [isHidden, setIsHidden] = useState(true);
-  const { handleOpen, user } = usePricingContext();
+  const { handleOpen, user } = useSessionContext();
 
   const isPro = useMemo(() => user?.userSubscriptionTier.trim().toLowerCase() !== "free", [user]);
 

--- a/frontend/components/chat/pricing-context.tsx
+++ b/frontend/components/chat/pricing-context.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { SupabaseClient } from "@supabase/supabase-js";
-import { createContext, PropsWithChildren, RefObject, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, PropsWithChildren, RefObject, useContext, useMemo, useRef, useState } from "react";
 
 import ChatPricing from "@/components/chat/chat-pricing";
 import { SessionPlayerHandle } from "@/components/chat/session-player";
@@ -50,9 +50,6 @@ const PricingProvider = ({ children, user }: PropsWithChildren<{ user: ChatUser 
     [client, open, traceId, user]
   );
 
-  useEffect(() => {
-    setTraceId(undefined);
-  }, []);
   return (
     <PricingContext.Provider value={value}>
       <Dialog open={open} onOpenChange={setOpen}>

--- a/frontend/components/chat/session-context.tsx
+++ b/frontend/components/chat/session-context.tsx
@@ -9,35 +9,40 @@ import { ChatUser } from "@/components/chat/types";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { createSupabaseClient } from "@/lib/supabase";
 
-type PricingContextType = {
+type SessionContextType = {
   open: boolean;
   handleOpen: (open: boolean) => void;
   user?: ChatUser;
+  currentTime?: number;
+  handleCurrentTime: (time?: number) => void;
   supabaseClient?: SupabaseClient;
   traceId?: string;
   handleTraceId: (id?: string) => void;
   browserSessionRef: RefObject<SessionPlayerHandle | null>;
 };
 
-const PricingContext = createContext<PricingContextType>({
+const SessionContext = createContext<SessionContextType>({
   open: false,
   handleOpen: () => {},
   user: undefined,
+  currentTime: undefined,
+  handleCurrentTime: () => {},
   supabaseClient: undefined,
   traceId: undefined,
   handleTraceId: () => {},
   browserSessionRef: { current: null },
 });
 
-export const usePricingContext = () => useContext(PricingContext);
+export const useSessionContext = () => useContext(SessionContext);
 
-const PricingProvider = ({ children, user }: PropsWithChildren<{ user: ChatUser }>) => {
+const SessionProvider = ({ children, user }: PropsWithChildren<{ user: ChatUser }>) => {
   const [open, setOpen] = useState(false);
   const [traceId, setTraceId] = useState<string | undefined>(undefined);
+  const [currentTime, setCurrentTime] = useState<number | undefined>(undefined);
   const client = createSupabaseClient(user.supabaseAccessToken);
   const browserSessionRef = useRef<SessionPlayerHandle>(null);
 
-  const value = useMemo<PricingContextType>(
+  const value = useMemo<SessionContextType>(
     () => ({
       open,
       handleOpen: setOpen,
@@ -46,12 +51,14 @@ const PricingProvider = ({ children, user }: PropsWithChildren<{ user: ChatUser 
       traceId,
       handleTraceId: setTraceId,
       browserSessionRef,
+      currentTime,
+      handleCurrentTime: setCurrentTime,
     }),
-    [client, open, traceId, user]
+    [client, currentTime, open, traceId, user]
   );
 
   return (
-    <PricingContext.Provider value={value}>
+    <SessionContext.Provider value={value}>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTitle className="hidden">Upgrade your plan</DialogTitle>
         <DialogContent className="max-w-[60vw] min-h-[80vh]">
@@ -59,8 +66,8 @@ const PricingProvider = ({ children, user }: PropsWithChildren<{ user: ChatUser 
         </DialogContent>
       </Dialog>
       {children}
-    </PricingContext.Provider>
+    </SessionContext.Provider>
   );
 };
 
-export default PricingProvider;
+export default SessionProvider;

--- a/frontend/components/chat/session-player.tsx
+++ b/frontend/components/chat/session-player.tsx
@@ -148,6 +148,10 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(({ tra
       setCurrentTime(0);
       setTotalDuration(0);
       setSpeed(1);
+      if (playerRef.current) {
+        playerRef.current.destroy();
+        playerRef.current = null;
+      }
       getEvents();
     }
   }, [traceId]);
@@ -190,6 +194,13 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(({ tra
     } catch (e) {
       console.error("Error initializing player:", e);
     }
+
+    return () => {
+      if (playerRef.current) {
+        playerRef.current.destroy();
+        playerRef.current = null;
+      }
+    };
   }, [events]);
 
   useEffect(() => {

--- a/frontend/components/chat/session-player.tsx
+++ b/frontend/components/chat/session-player.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import "rrweb-player/dist/style.css";
+
+import { PauseIcon, PlayIcon } from "@radix-ui/react-icons";
+import { Loader2 } from "lucide-react";
+import pako from "pako";
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import rrwebPlayer from "rrweb-player";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { formatSecondsToMinutesAndSeconds } from "@/lib/utils";
+
+interface SessionPlayerProps {
+  traceId: string;
+  onTimelineChange: (time: number) => void;
+}
+
+interface Event {
+  data: any;
+  timestamp: number;
+  type: number;
+}
+
+export interface SessionPlayerHandle {
+  goto: (time: number, relative: boolean) => void;
+}
+
+const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(({ traceId, onTimelineChange }, ref) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const playerContainerRef = useRef<HTMLDivElement | null>(null);
+  const playerRef = useRef<any>(null);
+  const [events, setEvents] = useState<Event[]>([]);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [totalDuration, setTotalDuration] = useState(0);
+  const [speed, setSpeed] = useState(1);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const [startTime, setStartTime] = useState(0);
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Add resize observer effect
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width } = entry.contentRect;
+        setDimensions({ width, height: (width * 3) / 4 - 48 }); // Subtract header height (48px)
+      }
+    });
+
+    resizeObserver.observe(containerRef.current);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  const getEvents = async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/browser-sessions/events?traceId=${traceId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error("No reader available");
+
+      const chunks: Uint8Array[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      const blob = new Blob(chunks, { type: "application/json" });
+      const text = await blob.text();
+
+      let batchEvents = [];
+      try {
+        batchEvents = JSON.parse(text);
+      } catch (e) {
+        console.error("Error parsing events:", e);
+        setIsLoading(false);
+        setEvents([]);
+        return;
+      }
+
+      const events = batchEvents.flatMap((batch: any) =>
+        batch.map((data: any) => {
+          const parsedEvent = JSON.parse(data.text);
+          const base64DecodedData = atob(parsedEvent.data);
+          let decompressedData = null;
+
+          try {
+            const encodedData = new Uint8Array(base64DecodedData.split("").map((c: any) => c.charCodeAt(0)));
+            decompressedData = pako.ungzip(encodedData, { to: "string" });
+          } catch (e) {
+            // old non-compressed events
+            decompressedData = base64DecodedData;
+          }
+
+          const event = {
+            ...parsedEvent,
+            data: JSON.parse(decompressedData),
+          };
+
+          return {
+            data: event.data,
+            timestamp: new Date(event.timestamp + "Z").getTime(),
+            type: parseInt(event.event_type),
+          };
+        })
+      );
+
+      setEvents(events);
+    } catch (e) {
+      console.error("Error processing events:", e);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (traceId) {
+      setEvents([]);
+      setIsPlaying(false);
+      setCurrentTime(0);
+      setTotalDuration(0);
+      setSpeed(1);
+      getEvents();
+    }
+  }, [traceId]);
+
+  useEffect(() => {
+    if (!events?.length || !playerContainerRef.current) return;
+
+    try {
+      playerRef.current = new rrwebPlayer({
+        target: playerContainerRef.current,
+        props: {
+          autoPlay: false,
+          skipInactive: false,
+          events,
+          showController: false,
+          mouseTail: false,
+          width: dimensions.width,
+          height: dimensions.height,
+          speed,
+        },
+      });
+      const startTime = events[0].timestamp;
+      setStartTime(startTime);
+
+      const duration = (events[events.length - 1].timestamp - events[0].timestamp) / 1000;
+      setTotalDuration(duration);
+
+      playerRef.current.addEventListener("ui-update-player-state", (event: any) => {
+        if (event.payload === "playing") {
+          setIsPlaying(true);
+        } else if (event.payload === "paused") {
+          setIsPlaying(false);
+        }
+      });
+
+      playerRef.current.addEventListener("ui-update-current-time", (event: any) => {
+        setCurrentTime(event.payload / 1000);
+        onTimelineChange(startTime + event.payload);
+      });
+    } catch (e) {
+      console.error("Error initializing player:", e);
+    }
+  }, [events]);
+
+  useEffect(() => {
+    if (playerRef.current) {
+      playerRef.current.$set({
+        width: dimensions.width,
+        height: dimensions.height,
+        speed,
+      });
+      playerRef.current.triggerResize();
+    }
+  }, [dimensions.width, dimensions.height]);
+
+  useEffect(() => {
+    if (playerRef.current) {
+      playerRef.current.setSpeed(speed);
+    }
+  }, [speed]);
+
+  const handlePlayPause = () => {
+    if (playerRef.current) {
+      try {
+        if (isPlaying) {
+          setIsPlaying(false);
+          playerRef.current.pause();
+        } else {
+          setIsPlaying(true);
+          playerRef.current.play();
+        }
+      } catch (e) {
+        console.error("Error in play/pause:", e);
+      }
+    }
+  };
+
+  const handleTimelineChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const time = parseFloat(e.target.value);
+    setCurrentTime(time);
+
+    const wasPlaying = isPlaying;
+    if (wasPlaying && playerRef.current) {
+      playerRef.current.pause();
+    }
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      if (playerRef.current) {
+        playerRef.current.goto(time * 1000);
+        if (wasPlaying) {
+          requestAnimationFrame(() => {
+            playerRef.current.play();
+          });
+        }
+      }
+    }, 50);
+  };
+
+  const handleSpeedChange = (newSpeed: number) => {
+    setSpeed(newSpeed);
+  };
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      goto: (timestamp: number, relative: boolean = false) => {
+        if (playerRef.current) {
+          if (relative) {
+            setCurrentTime(timestamp);
+            playerRef.current.goto(timestamp * 1000);
+          } else {
+            const relativeTimeInSeconds = (timestamp - startTime) / 1000;
+            setCurrentTime(relativeTimeInSeconds);
+            playerRef.current.goto(relativeTimeInSeconds * 1000);
+          }
+        }
+      },
+    }),
+    [startTime]
+  );
+
+  return (
+    <>
+      <style jsx global>{`
+        .rr-player {
+          background-color: transparent !important;
+          border-radius: 6px;
+        }
+
+        .replayer-wrapper {
+          background-color: transparent !important;
+          border: 1px solid gray !important;
+        }
+
+        .rr-controller {
+          background-color: transparent !important;
+          color: white !important;
+          text-color: white !important;
+        }
+
+        /* Using the provided cursor SVG with white outline */
+        .replayer-mouse {
+          width: 30px !important;
+          height: 42px !important;
+          background-image: url("data:image/svg+xml,%3Csvg width='15' height='21' viewBox='0 0 15 21' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.21818 14.9087L5.05222 14.9637L4.92773 15.0865L0.75 19.2069V1.84143L13.2192 14.6096H6.24066H6.11948L6.00446 14.6477L5.21818 14.9087Z' fill='black' stroke='white' stroke-width='1.5'/%3E%3C/svg%3E") !important;
+          background-size: contain !important;
+          background-repeat: no-repeat !important;
+          background-color: transparent !important;
+          margin-left: -1px !important;
+          margin-top: -1px !important;
+          transition: all 0.2s ease-in-out !important;
+        }
+
+        @keyframes bounce {
+          0%,
+          100% {
+            transform: scale(1);
+          }
+          50% {
+            transform: scale(1.4);
+          }
+        }
+
+        .replayer-mouse.active {
+          animation: bounce 0.3s ease-in-out !important;
+        }
+      `}</style>
+      <div className="relative flex flex-col w-full h-full rounded border overflow-hidden" ref={containerRef}>
+        {isLoading && (
+          <div className="flex w-full text-center gap-2 items-center justify-center -mt-12 aspect-[4/3]">
+            <Loader2 className="animate-spin w-4 h-4" /> Loading browser session...
+          </div>
+        )}
+        {!isLoading && events.length === 0 && (
+          <div className="flex text-center w-full h-full gap-2 items-center justify-center -mt-12 aspect-[4/3]">
+            No browser session was recorded. This might be due to an outdated SDK version.
+          </div>
+        )}
+        {!isLoading && events.length > 0 && <div className="" ref={playerContainerRef} />}
+        <div className="flex flex-row items-center justify-center gap-2 px-2">
+          <button onClick={handlePlayPause} className="text-white py-1 rounded">
+            {isPlaying ? <PauseIcon strokeWidth={1.5} /> : <PlayIcon strokeWidth={1.5} />}
+          </button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex items-center text-white py-1 px-2 rounded text-sm">
+              {speed}x
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {[1, 2, 4, 8].map((speedOption) => (
+                <DropdownMenuItem key={speedOption} onClick={() => handleSpeedChange(speedOption)}>
+                  {speedOption}x
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <input
+            type="range"
+            className="flex-grow cursor-pointer"
+            min="0"
+            step="0.1"
+            max={totalDuration || 0}
+            value={currentTime || 0}
+            onChange={handleTimelineChange}
+          />
+          <span className="font-mono">
+            {formatSecondsToMinutesAndSeconds(currentTime || 0)}/{formatSecondsToMinutesAndSeconds(totalDuration || 0)}
+          </span>
+        </div>
+      </div>
+    </>
+  );
+});
+
+SessionPlayer.displayName = "SessionPlayer";
+
+export default SessionPlayer;

--- a/frontend/components/chat/session-player.tsx
+++ b/frontend/components/chat/session-player.tsx
@@ -149,7 +149,7 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(({ tra
       setTotalDuration(0);
       setSpeed(1);
       if (playerRef.current) {
-        playerRef.current.destroy();
+        playerRef.current.$destroy();
         playerRef.current = null;
       }
       getEvents();
@@ -197,7 +197,7 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(({ tra
 
     return () => {
       if (playerRef.current) {
-        playerRef.current.destroy();
+        playerRef.current.$destroy();
         playerRef.current = null;
       }
     };

--- a/frontend/components/chat/session-player.tsx
+++ b/frontend/components/chat/session-player.tsx
@@ -71,6 +71,10 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(({ tra
         },
       });
 
+      if (!res.ok) {
+        return;
+      }
+
       const reader = res.body?.getReader();
       if (!reader) throw new Error("No reader available");
 
@@ -277,7 +281,6 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(({ tra
         .rr-controller {
           background-color: transparent !important;
           color: white !important;
-          text-color: white !important;
         }
 
         /* Using the provided cursor SVG with white outline */
@@ -338,6 +341,7 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(({ tra
           </DropdownMenu>
 
           <input
+            aria-label="Timeline slider"
             type="range"
             className="flex-grow cursor-pointer"
             min="0"

--- a/frontend/components/chat/side-bar.tsx
+++ b/frontend/components/chat/side-bar.tsx
@@ -7,7 +7,7 @@ import { useParams, usePathname, useRouter } from "next/navigation";
 import { FocusEvent, KeyboardEventHandler, memo, MouseEvent, useEffect, useRef, useState } from "react";
 import useSWR, { useSWRConfig } from "swr";
 
-import { usePricingContext } from "@/components/chat/pricing-context";
+import { useSessionContext } from "@/components/chat/session-context";
 import AgentSidebarFooter from "@/components/chat/sidebar-footer";
 import { AgentSession } from "@/components/chat/types";
 import {
@@ -37,7 +37,7 @@ import { cn, swrFetcher } from "@/lib/utils";
 export function AgentSidebar() {
   const router = useRouter();
   const { toggleSidebar, state } = useSidebar();
-  const { user, supabaseClient, handleTraceId } = usePricingContext();
+  const { user, supabaseClient, handleTraceId } = useSessionContext();
   const pathname = usePathname();
   const [sessionId, setSessionId] = useState<string | null>(null);
 
@@ -246,7 +246,11 @@ const PureChatItem = ({
           </div>
         ) : (
           <Link className="overflow-hidden" href={`/chat/${chat.sessionId}`} key={chat.sessionId} passHref>
-            <AnimatedText animate={Boolean(chat?.isNew)} text={chat.chatName} />
+            <AnimatedText
+              loading={chat.agentStatus === "working"}
+              animate={Boolean(chat?.isNew)}
+              text={chat.chatName}
+            />
             {chat.agentStatus === "working" && <Loader2 className="animate-spin duration-[3000ms]" />}
           </Link>
         )}
@@ -286,9 +290,9 @@ const PureChatItem = ({
 };
 
 const wrapperClassName =
-  "flex w-fit items-center justify-center whitespace-nowrap [&>span]:inline-block [&>span]:w-[calc(var(--sidebar-width)-theme(spacing.20))] [&>span]:truncate";
+  "flex w-fit items-center justify-center whitespace-nowrap [&>span]:inline-block [&>span]:truncate [&>span]:w-[calc(var(--sidebar-width)-theme(spacing.12))]";
 
-const AnimatedText = ({ text, animate }: { text: string; animate: boolean }) => {
+const AnimatedText = ({ text, animate, loading }: { text: string; animate: boolean; loading: boolean }) => {
   if (animate) {
     return (
       <motion.div
@@ -299,14 +303,20 @@ const AnimatedText = ({ text, animate }: { text: string; animate: boolean }) => 
           delay: 0.3,
           ease: "easeOut",
         }}
-        className={wrapperClassName}
+        className={cn(wrapperClassName, {
+          "[&>span]:w-[calc(var(--sidebar-width)-theme(spacing.20))]": loading,
+        })}
       >
         <span title={text}>{text}</span>
       </motion.div>
     );
   }
   return (
-    <span className={wrapperClassName}>
+    <span
+      className={cn(wrapperClassName, {
+        "[&>span]:w-[calc(var(--sidebar-width)-theme(spacing.20))]": loading,
+      })}
+    >
       <span title={text}>{text}</span>
     </span>
   );

--- a/frontend/components/chat/side-bar.tsx
+++ b/frontend/components/chat/side-bar.tsx
@@ -37,7 +37,7 @@ import { cn, swrFetcher } from "@/lib/utils";
 export function AgentSidebar() {
   const router = useRouter();
   const { toggleSidebar, state } = useSidebar();
-  const { user, supabaseClient } = usePricingContext();
+  const { user, supabaseClient, handleTraceId } = usePricingContext();
   const pathname = usePathname();
   const [sessionId, setSessionId] = useState<string | null>(null);
 
@@ -50,6 +50,7 @@ export function AgentSidebar() {
   const { data, isLoading, mutate } = useSWR<AgentSession[]>("/api/agent-sessions", swrFetcher, { fallbackData: [] });
 
   const handleNewChat = () => {
+    handleTraceId(undefined);
     router.push("/chat");
     router.refresh();
   };
@@ -120,7 +121,12 @@ export function AgentSidebar() {
                 <SidebarMenu>
                   <AnimatePresence mode="popLayout">
                     {data?.map((chat) => (
-                      <ChatItem key={chat.sessionId} chat={chat} isActive={chat.sessionId === sessionId} />
+                      <ChatItem
+                        handleTraceId={handleTraceId}
+                        key={chat.sessionId}
+                        chat={chat}
+                        isActive={chat.sessionId === sessionId}
+                      />
                     ))}
                   </AnimatePresence>
                 </SidebarMenu>
@@ -134,7 +140,15 @@ export function AgentSidebar() {
   );
 }
 
-const PureChatItem = ({ chat, isActive }: { chat: AgentSession; isActive: boolean }) => {
+const PureChatItem = ({
+  chat,
+  isActive,
+  handleTraceId,
+}: {
+  chat: AgentSession;
+  handleTraceId: (id?: string) => void;
+  isActive: boolean;
+}) => {
   const [isEditing, setIsEditing] = useState(false);
   const router = useRouter();
   const params = useParams();
@@ -211,7 +225,12 @@ const PureChatItem = ({ chat, isActive }: { chat: AgentSession; isActive: boolea
   }, [isEditing]);
 
   return (
-    <SidebarMenuItem>
+    <SidebarMenuItem
+      onClick={(e) => {
+        e.stopPropagation();
+        handleTraceId(undefined);
+      }}
+    >
       <SidebarMenuButton className="group !pr-0" asChild isActive={isActive}>
         {isEditing ? (
           <div className="pr-2">
@@ -235,7 +254,7 @@ const PureChatItem = ({ chat, isActive }: { chat: AgentSession; isActive: boolea
       {!isEditing && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <SidebarMenuAction className="mr-2 hover:bg-transparent">
+            <SidebarMenuAction showOnHover className="mr-2 hover:bg-transparent">
               <MoreHorizontalIcon />
             </SidebarMenuAction>
           </DropdownMenuTrigger>

--- a/frontend/components/chat/sidebar-footer.tsx
+++ b/frontend/components/chat/sidebar-footer.tsx
@@ -2,7 +2,7 @@ import { ChevronsUpDown } from "lucide-react";
 import Link from "next/link";
 import { signOut } from "next-auth/react";
 
-import { usePricingContext } from "@/components/chat/pricing-context";
+import { useSessionContext } from "@/components/chat/session-context";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -18,7 +18,7 @@ import { ChatUser } from "./types";
 const AgentSidebarFooter = ({ user }: { user?: ChatUser }) => {
   const { state } = useSidebar();
 
-  const { handleOpen } = usePricingContext();
+  const { handleOpen } = useSessionContext();
   return (
     <SidebarFooter>
       <SidebarMenu className="overflow-hidden">

--- a/frontend/components/chat/types.ts
+++ b/frontend/components/chat/types.ts
@@ -40,8 +40,9 @@ export interface ChatMessage {
   id: string;
   sessionId: string;
   messageType: "step" | "assistant" | "user";
+  traceId?: string;
   content: ChatMessageContent;
-  createdAt?: string;
+  createdAt: string;
 }
 
 export interface TabInfo {
@@ -94,11 +95,15 @@ export interface StepChunkContent {
   messageId: string; // UUID
   actionResult: ActionResult;
   summary: string;
+  traceId?: string;
+  createdAt: string;
 }
 
 export interface FinalOutputChunkContent {
   messageId: string; // UUID
+  traceId?: string;
   content: AgentOutput;
+  createdAt: string;
 }
 
 export interface StreamAgentRequest {

--- a/frontend/components/chat/use-agent-chat.tsx
+++ b/frontend/components/chat/use-agent-chat.tsx
@@ -113,7 +113,9 @@ export function useAgentChat({
                   summary: chunk.summary,
                   actionResult: chunk.actionResult,
                 },
+                traceId: chunk.traceId,
                 sessionId: id,
+                createdAt: chunk.createdAt,
               };
               setMessages((messages) => [...messages, stepMessage]);
             } else if (chunk.chunkType === "finalOutput") {
@@ -124,7 +126,9 @@ export function useAgentChat({
                   text: chunk.content.result.content ?? "-",
                   actionResult: chunk.content.result,
                 },
+                traceId: chunk.traceId,
                 sessionId: id,
+                createdAt: chunk.createdAt,
               };
               setMessages((messages) => [...messages, finalMessage]);
 
@@ -177,6 +181,8 @@ export function useAgentChat({
                 actionResult: chunk.actionResult,
               },
               sessionId: id,
+              traceId: chunk.traceId,
+              createdAt: chunk.createdAt,
             };
             setMessages((messages) => [...messages, stepMessage]);
           } else if (chunk.chunkType === "finalOutput") {
@@ -188,6 +194,8 @@ export function useAgentChat({
                 actionResult: chunk.content.result,
               },
               sessionId: id,
+              traceId: chunk.traceId,
+              createdAt: chunk.createdAt,
             };
             setMessages((messages) => [...messages, finalMessage]);
 


### PR DESCRIPTION
- add session replay to chat
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR adds session replay functionality to the chat application, including a new API endpoint, session player, and context, while updating various components for integration.
> 
>   - **Session Replay**:
>     - Add `GET` endpoint in `route.ts` to fetch session events from `browser_session_events` table using `traceId`.
>     - Introduce `SessionPlayer` in `session-player.tsx` to replay session events with play, pause, and speed control.
>     - Add `SessionContext` in `session-context.tsx` to manage session state, replacing `PricingContext`.
>   - **UI Integration**:
>     - Update `layout.tsx` to use `SessionProvider`.
>     - Modify `browser-window.tsx` to display `SessionPlayer` when `traceId` is present.
>     - Add play button in `message.tsx` to trigger session replay.
>     - Update `multimodal-input.tsx` to use `SessionContext`.
>     - Adjust `side-bar.tsx` and `sidebar-footer.tsx` to integrate session management.
>   - **Data Handling**:
>     - Extend `ChatMessage` and related types in `types.ts` to include `traceId` and `createdAt`.
>     - Update `use-agent-chat.tsx` to handle new message properties and session replay logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 5c3deb9d857de439ea791815ba963435f5627f2f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->