### PR TITLE
Hobby tier

### DIFF
--- a/frontend/app/checkout/page.tsx
+++ b/frontend/app/checkout/page.tsx
@@ -17,7 +17,7 @@ export default async function CheckoutPage(
   const typeParam = searchParams?.type ?? 'workspace' as 'workspace' | 'user';
   const lookupKey =
     (searchParams?.lookupKey as string) ?? (
-      typeParam === 'workspace' ? 'pro_monthly_2025_02' : 'index_pro_monthly_2025_04'
+      typeParam === 'workspace' ? 'hobby_monthly_2025_04' : 'index_pro_monthly_2025_04'
     );
   const workspaceId = searchParams?.workspaceId as string | undefined;
   const workspaceName = searchParams?.workspaceName as string | undefined;

--- a/frontend/app/webhook/route.ts
+++ b/frontend/app/webhook/route.ts
@@ -142,7 +142,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       const invoice = event.data.object;
       const itemDescriptions = invoice.lines.data.map((line) => {
         const productDescription = line.description ?? '';
-        const lookupKey = line.price?.lookup_key ?? 'pro_monthly_2024_09';
+        const lookupKey = line.price?.lookup_key ?? 'hobby_monthly_2025_04';
         const shortDescription = LOOKUP_KEY_TO_TIER_NAME[lookupKey];
         return {
           productDescription,

--- a/frontend/components/workspace/pricing-dialog.tsx
+++ b/frontend/components/workspace/pricing-dialog.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+// THIS IS A COPY-PASTE FROM THE LANDING PAGE PRICING PAGE
+// MADE IT SO WE DON'T GET GIT CONFLICTS
+// TODO: REFACTOR TO USE THE SAME COMPONENT FOR BOTH
+
+import Link from 'next/link';
+import { usePostHog } from 'posthog-js/react';
+import { useState } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from '@/components/ui/accordion';
+import { Button } from '@/components/ui/button';
+import { Slider } from "@/components/ui/slider";
+
+import PricingCard from '../landing/pricing-card';
+
+const TIER_LINKS = {
+  free: '/projects',
+  hobby: '/checkout?type=workspace&lookupKey=hobby_monthly_2025_04',
+  pro: '/checkout?type=workspace&lookupKey=pro_monthly_2025_04',
+};
+
+interface PricingDialogProps {
+  workspaceTier: string;
+  workspaceId: string;
+  workspaceName: string;
+}
+
+const isTierPaid = (tier: string) => tier.toLowerCase().trim() !== 'free';
+
+export default function PricingDialog({ workspaceTier, workspaceId, workspaceName }: PricingDialogProps) {
+  const posthog = usePostHog();
+  const addWorkspaceToLink = (link: string) => `${link}&workspaceId=${workspaceId}&workspaceName=${workspaceName}`;
+
+  const [spanCount, setSpanCount] = useState(200); // in thousands
+  const [teamMembers, setTeamMembers] = useState(3);
+
+  const calculateProPrice = () => {
+    const basePrice = 50;
+    const additionalSpansCost = spanCount > 200 ? Math.floor((spanCount - 200) / 100 * 5) : 0;
+    const additionalMembersCost = (teamMembers - 3) * 25;
+    return basePrice + additionalSpansCost + additionalMembersCost;
+  };
+
+  const handleQuestionClick = (question: string) => {
+    posthog?.capture('faq_question_clicked', { question });
+  };
+
+  // Add FAQ data
+  const faqItems = [
+    {
+      id: 'span',
+      question: 'What is a span?',
+      answer: 'A span represents a unit of work or operation in your application. In the context of tracing, single LLM call or function tool call is a span. In case of evaluations, executor run and evaluator run are spans.'
+    },
+    {
+      id: 'agent-steps',
+      question: 'What is an agent step?',
+      answer: 'An agent step is a single step of an execution of the Index browser agent when it is called via API.'
+    }
+  ];
+
+  return (
+    <div className="flex flex-col items-center mt-32 w-full h-full">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 md:p-16">
+        <div className="p-8 border rounded-lg flex flex-col space-y-4">
+          <PricingCard
+            className="text-secondary-foreground"
+            title="Free"
+            price="0 / month"
+            features={[
+              '50K spans / month',
+              '15 day data retention',
+              '1 team member',
+              '100 agent steps / month',
+              'Community support',
+            ]}
+          />
+          <Link href={TIER_LINKS.free}>
+            <Button variant="secondary" className="w-full h-10">
+              Get started
+            </Button>
+          </Link>
+        </div>
+        <div className="p-8 border rounded-lg flex flex-col space-y-4">
+          <PricingCard
+            className="text-secondary-foreground"
+            title="Hobby"
+            price="$25 / month"
+            features={[
+              '100k spans / month',
+              '30 day data retention',
+              '2 team members',
+              '1000 agent steps / month',
+              'Community support',
+            ]}
+            subfeatures={[
+              'then $5 per 100k of additional spans',
+              null,
+              null
+            ]}
+          />
+          <Link href={workspaceTier === 'hobby' ? '/checkout/portal' : addWorkspaceToLink(TIER_LINKS.hobby)}>
+            <Button variant="secondary" className="w-full h-10">
+              {workspaceTier === 'hobby' ? 'Manage billing' : 'Get started'}
+            </Button>
+          </Link>
+        </div>
+        <div className="h-full w-full rounded p-8 flex flex-col z-20 border border-primary bg-primary">
+          <PricingCard
+            className="text-white z-20"
+            title="Pro"
+            price={`$${calculateProPrice()} / month`}
+            features={[
+              '200k spans / month included',
+              '90 day data retention',
+              '3 team members included',
+              '3000 agent steps / month',
+              'Private Slack channel',
+            ]}
+            subfeatures={[
+              'then $5 per 100k of additional spans',
+              null,
+              '$25 per additional team member',
+              null
+            ]}
+          />
+          <div className="space-y-4 z-20 flex flex-col">
+            <div className="space-y-2">
+              <div className="text-white">Spans per month {spanCount}k</div>
+              <Slider
+                defaultValue={[200]}
+                max={1000}
+                min={200}
+                step={100}
+                onValueChange={(value) => setSpanCount(value[0])}
+              />
+            </div>
+            <div className="space-y-2">
+              <div className="text-white">Team members {teamMembers}</div>
+              <Slider
+                defaultValue={[3]}
+                max={10}
+                min={3}
+                step={1}
+                onValueChange={(value) => setTeamMembers(value[0])}
+              />
+            </div>
+            <Link href={isTierPaid(workspaceTier) ? '/checkout/portal' : addWorkspaceToLink(TIER_LINKS.pro)} className="w-full z-20">
+              <Button
+                className="h-10 text-base bg-white/90 border-none text-primary hover:bg-white/70 w-full"
+                variant="outline"
+              >
+                {isTierPaid(workspaceTier) ?
+                  (workspaceTier === 'hobby' ? 'Upgrade' : 'Manage billing')
+                  : 'Get started'}
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+      <div className="w-full max-w-3xl mt-16 mb-32 px-4">
+        <h2 className="text-2xl font-bold mb-4 text-center">
+          Frequently Asked Questions
+        </h2>
+        <Accordion type="single" collapsible className="w-full">
+          {faqItems.map((item) => (
+            <AccordionItem key={item.id} value={item.id}>
+              <AccordionTrigger
+                className="text-2xl"
+                onClick={() => handleQuestionClick(item.question)}
+              >
+                {item.question}
+              </AccordionTrigger>
+              <AccordionContent className="text-secondary-foreground">
+                {item.answer}
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </div>
+      <div className="flex-grow"></div>
+    </div >
+  );
+}

--- a/frontend/components/workspace/pricing-dialog.tsx
+++ b/frontend/components/workspace/pricing-dialog.tsx
@@ -1,21 +1,6 @@
-'use client';
-
-// THIS IS A COPY-PASTE FROM THE LANDING PAGE PRICING PAGE
-// MADE IT SO WE DON'T GET GIT CONFLICTS
-// TODO: REFACTOR TO USE THE SAME COMPONENT FOR BOTH
-
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
-import { useState } from "react";
 
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger
-} from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import { Slider } from "@/components/ui/slider";
 
 import PricingCard from '../landing/pricing-card';
 
@@ -34,39 +19,10 @@ interface PricingDialogProps {
 const isTierPaid = (tier: string) => tier.toLowerCase().trim() !== 'free';
 
 export default function PricingDialog({ workspaceTier, workspaceId, workspaceName }: PricingDialogProps) {
-  const posthog = usePostHog();
   const addWorkspaceToLink = (link: string) => `${link}&workspaceId=${workspaceId}&workspaceName=${workspaceName}`;
 
-  const [spanCount, setSpanCount] = useState(200); // in thousands
-  const [teamMembers, setTeamMembers] = useState(3);
-
-  const calculateProPrice = () => {
-    const basePrice = 50;
-    const additionalSpansCost = spanCount > 200 ? Math.floor((spanCount - 200) / 100 * 5) : 0;
-    const additionalMembersCost = (teamMembers - 3) * 25;
-    return basePrice + additionalSpansCost + additionalMembersCost;
-  };
-
-  const handleQuestionClick = (question: string) => {
-    posthog?.capture('faq_question_clicked', { question });
-  };
-
-  // Add FAQ data
-  const faqItems = [
-    {
-      id: 'span',
-      question: 'What is a span?',
-      answer: 'A span represents a unit of work or operation in your application. In the context of tracing, single LLM call or function tool call is a span. In case of evaluations, executor run and evaluator run are spans.'
-    },
-    {
-      id: 'agent-steps',
-      question: 'What is an agent step?',
-      answer: 'An agent step is a single step of an execution of the Index browser agent when it is called via API.'
-    }
-  ];
-
   return (
-    <div className="flex flex-col items-center mt-32 w-full h-full">
+    <div className="flex flex-col items-center w-full h-full">
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 md:p-16">
         <div className="p-8 border rounded-lg flex flex-col space-y-4">
           <PricingCard
@@ -115,7 +71,7 @@ export default function PricingDialog({ workspaceTier, workspaceId, workspaceNam
           <PricingCard
             className="text-white z-20"
             title="Pro"
-            price={`$${calculateProPrice()} / month`}
+            price={'$50 / month'}
             features={[
               '200k spans / month included',
               '90 day data retention',
@@ -131,26 +87,6 @@ export default function PricingDialog({ workspaceTier, workspaceId, workspaceNam
             ]}
           />
           <div className="space-y-4 z-20 flex flex-col">
-            <div className="space-y-2">
-              <div className="text-white">Spans per month {spanCount}k</div>
-              <Slider
-                defaultValue={[200]}
-                max={1000}
-                min={200}
-                step={100}
-                onValueChange={(value) => setSpanCount(value[0])}
-              />
-            </div>
-            <div className="space-y-2">
-              <div className="text-white">Team members {teamMembers}</div>
-              <Slider
-                defaultValue={[3]}
-                max={10}
-                min={3}
-                step={1}
-                onValueChange={(value) => setTeamMembers(value[0])}
-              />
-            </div>
             <Link href={isTierPaid(workspaceTier) ? '/checkout/portal' : addWorkspaceToLink(TIER_LINKS.pro)} className="w-full z-20">
               <Button
                 className="h-10 text-base bg-white/90 border-none text-primary hover:bg-white/70 w-full"
@@ -163,26 +99,6 @@ export default function PricingDialog({ workspaceTier, workspaceId, workspaceNam
             </Link>
           </div>
         </div>
-      </div>
-      <div className="w-full max-w-3xl mt-16 mb-32 px-4">
-        <h2 className="text-2xl font-bold mb-4 text-center">
-          Frequently Asked Questions
-        </h2>
-        <Accordion type="single" collapsible className="w-full">
-          {faqItems.map((item) => (
-            <AccordionItem key={item.id} value={item.id}>
-              <AccordionTrigger
-                className="text-2xl"
-                onClick={() => handleQuestionClick(item.question)}
-              >
-                {item.question}
-              </AccordionTrigger>
-              <AccordionContent className="text-secondary-foreground">
-                {item.answer}
-              </AccordionContent>
-            </AccordionItem>
-          ))}
-        </Accordion>
       </div>
       <div className="flex-grow"></div>
     </div >

--- a/frontend/components/workspace/pricing-dialog.tsx
+++ b/frontend/components/workspace/pricing-dialog.tsx
@@ -5,7 +5,6 @@ import { Button } from '@/components/ui/button';
 import PricingCard from '../landing/pricing-card';
 
 const TIER_LINKS = {
-  free: '/projects',
   hobby: '/checkout?type=workspace&lookupKey=hobby_monthly_2025_04',
   pro: '/checkout?type=workspace&lookupKey=pro_monthly_2025_04',
 };
@@ -37,11 +36,6 @@ export default function PricingDialog({ workspaceTier, workspaceId, workspaceNam
               'Community support',
             ]}
           />
-          <Link href={TIER_LINKS.free}>
-            <Button variant="secondary" className="w-full h-10">
-              Get started
-            </Button>
-          </Link>
         </div>
         <div className="p-8 border rounded-lg flex flex-col space-y-4">
           <PricingCard
@@ -63,7 +57,7 @@ export default function PricingDialog({ workspaceTier, workspaceId, workspaceNam
           />
           <Link href={workspaceTier === 'hobby' ? '/checkout/portal' : addWorkspaceToLink(TIER_LINKS.hobby)}>
             <Button variant="secondary" className="w-full h-10">
-              {workspaceTier === 'hobby' ? 'Manage billing' : 'Get started'}
+              {workspaceTier === 'hobby' ? 'Manage billing' : 'Upgrade to Hobby'}
             </Button>
           </Link>
         </div>
@@ -93,8 +87,8 @@ export default function PricingDialog({ workspaceTier, workspaceId, workspaceNam
                 variant="outline"
               >
                 {isTierPaid(workspaceTier) ?
-                  (workspaceTier === 'hobby' ? 'Upgrade' : 'Manage billing')
-                  : 'Get started'}
+                  (workspaceTier === 'hobby' ? 'Manage billing' : 'Upgrade to Pro')
+                  : 'Upgrade to Pro'}
               </Button>
             </Link>
           </div>

--- a/frontend/components/workspace/workspace-usage.tsx
+++ b/frontend/components/workspace/workspace-usage.tsx
@@ -7,6 +7,8 @@ import { Workspace } from '@/lib/workspaces/types';
 
 import ClientTimestampFormatter from '../client-timestamp-formatter';
 import { Button } from '../ui/button';
+import { Dialog, DialogContent, DialogTitle,DialogTrigger } from '../ui/dialog';
+import PricingDialog from './pricing-dialog';
 
 interface WorkspaceUsageProps {
   workspace: Workspace;
@@ -40,29 +42,21 @@ export default function WorkspaceUsage({
       <div className="flex flex-row space-x-2">
         <div>
           {isOwner &&
-            (workspaceStats.tierName.toLowerCase().trim() === 'free' ? (
-              <Button
-                variant="default"
-                onClick={() =>
-                  router.push(
-                    `/checkout?type=workspace&workspaceId=${workspace.id}&workspaceName=${workspace.name}`
-                  )
-                }
-              >
-                Upgrade
-              </Button>
-            ) : (
-              <Button
-                variant="secondary"
-                onClick={() =>
-                  router.push(
-                    `/checkout/portal?type=workspace&callbackUrl=/workspace/${workspace.id}`
-                  )
-                }
-              >
-                Manage billing
-              </Button>
-            ))}
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button variant="secondary">
+                  {workspaceStats.tierName.toLowerCase().trim() === 'free'
+                    ? 'Upgrade'
+                    : 'Manage billing'
+                  }
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-w-5xl">
+                <DialogTitle>Manage billing</DialogTitle>
+                <PricingDialog workspaceTier={workspaceStats.tierName} workspaceId={workspace.id} workspaceName={workspace.name} />
+              </DialogContent>
+            </Dialog>
+          }
         </div>
       </div>
 

--- a/frontend/components/workspace/workspace-usage.tsx
+++ b/frontend/components/workspace/workspace-usage.tsx
@@ -7,7 +7,7 @@ import { Workspace } from '@/lib/workspaces/types';
 
 import ClientTimestampFormatter from '../client-timestamp-formatter';
 import { Button } from '../ui/button';
-import { Dialog, DialogContent, DialogTitle,DialogTrigger } from '../ui/dialog';
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '../ui/dialog';
 import PricingDialog from './pricing-dialog';
 
 interface WorkspaceUsageProps {
@@ -15,6 +15,24 @@ interface WorkspaceUsageProps {
   workspaceStats: WorkspaceStats;
   isOwner: boolean;
 }
+
+const TIER_SPAN_HINTS = {
+  free: {
+    spans: '50k',
+    steps: '100',
+    isOverageAllowed: false,
+  },
+  hobby: {
+    spans: '100k',
+    steps: '1000',
+    isOverageAllowed: true,
+  },
+  pro: {
+    spans: '200k',
+    steps: '3000',
+    isOverageAllowed: true,
+  },
+};
 
 export default function WorkspaceUsage({
   workspace,
@@ -26,6 +44,15 @@ export default function WorkspaceUsage({
   const spansThisMonth = workspaceStats?.spansThisMonth ?? 0;
   const spansLimit = workspaceStats?.spansLimit ?? 1;
   const resetTime = workspaceStats.resetTime;
+
+  const tierHintInfo = TIER_SPAN_HINTS[workspaceStats.tierName.toLowerCase().trim() as keyof typeof TIER_SPAN_HINTS];
+  const tierHint = `${workspaceStats.tierName} tier comes with ${tierHintInfo.spans} spans and ` +
+    `${tierHintInfo.steps} agent steps included per month.`;
+
+  const tierHintOverages = 'If you exceed this limit, '
+    + (tierHintInfo.isOverageAllowed
+      ? 'you will be charged for overages.'
+      : 'you won\'t be able to send any more spans during current billing cycle.');
 
   return (
     <div className="p-4 flex flex-col space-y-2">
@@ -51,9 +78,13 @@ export default function WorkspaceUsage({
                   }
                 </Button>
               </DialogTrigger>
-              <DialogContent className="max-w-5xl">
-                <DialogTitle>Manage billing</DialogTitle>
-                <PricingDialog workspaceTier={workspaceStats.tierName} workspaceId={workspace.id} workspaceName={workspace.name} />
+              <DialogTitle className="hidden">Manage billing</DialogTitle>
+              <DialogContent className="max-w-[80vw] min-h-[80vh]">
+                <PricingDialog
+                  workspaceTier={workspaceStats.tierName}
+                  workspaceId={workspace.id}
+                  workspaceName={workspace.name}
+                />
               </DialogContent>
             </Dialog>
           }
@@ -61,21 +92,11 @@ export default function WorkspaceUsage({
       </div>
 
       <div className="flex flex-col space-y-1">
-        {workspaceStats.tierName === 'Pro' && (
-          <p className="text-secondary-foreground text-sm mb-2">
-            Pro tier comes with 100K spans included per month. <br />
-            If you exceed this limit, you will be charged for overages.
-          </p>
-        )}
-        {
-          workspaceStats.tierName === 'Free' && (
-            <p className="text-secondary-foreground text-sm mb-2">
-              Free tier comes with 50K spans included per month. <br />
-              If you exceed this limit, you won{"'"}t be able to send <br />
-              any more spans during current billing cycle.
-            </p>
-          )
-        }
+        <p className="text-secondary-foreground text-sm mb-2">
+          {tierHint} <br />
+          {tierHintOverages}
+        </p>
+
         <Label className="mt-2 text-secondary-foreground text-sm">
           Spans used during this billing cycle
         </Label>

--- a/frontend/components/workspace/workspace-usage.tsx
+++ b/frontend/components/workspace/workspace-usage.tsx
@@ -78,10 +78,10 @@ export default function WorkspaceUsage({
                   }
                 </Button>
               </DialogTrigger>
-              <DialogTitle className="hidden">Manage billing</DialogTitle>
+              <DialogTitle className="sr-only">Manage billing</DialogTitle>
               <DialogContent className="max-w-[80vw] min-h-[80vh]">
                 <PricingDialog
-                  workspaceTier={workspaceStats.tierName}
+                  workspaceTier={workspaceStats.tierName.toLowerCase().trim()}
                   workspaceId={workspace.id}
                   workspaceName={workspace.name}
                 />

--- a/frontend/components/workspace/workspace-usage.tsx
+++ b/frontend/components/workspace/workspace-usage.tsx
@@ -71,7 +71,7 @@ export default function WorkspaceUsage({
           {isOwner &&
             <Dialog>
               <DialogTrigger asChild>
-                <Button variant="secondary">
+                <Button variant="default">
                   {workspaceStats.tierName.toLowerCase().trim() === 'free'
                     ? 'Upgrade'
                     : 'Manage billing'

--- a/frontend/components/workspace/workspace-users.tsx
+++ b/frontend/components/workspace/workspace-users.tsx
@@ -93,7 +93,7 @@ export default function WorkspaceUsers({
         <Label>You have {workspaceStats.membersLimit} seat{workspaceStats.membersLimit > 1 ? 's' : ''} in this workspace</Label>
         {isOwner && (
           <div className="flex flex-row gap-4">
-            {workspace.tierName.trim() === 'Pro' && (
+            {workspace.tierName.trim().toLowerCase() === 'pro' && (
               <PurchaseSeatsDialog
                 workspaceId={workspace.id}
                 currentQuantity={workspaceStats.membersLimit}
@@ -103,7 +103,7 @@ export default function WorkspaceUsers({
                 }}
               />
             )}
-            {users.length == workspaceStats.membersLimit ? (
+            {users.length >= workspaceStats.membersLimit ? (
               <TooltipProvider delayDuration={200}>
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/frontend/lib/checkout/utils.ts
+++ b/frontend/lib/checkout/utils.ts
@@ -8,10 +8,9 @@ import { subscriptionTiers, users, userSubscriptionInfo, userUsage, workspaces, 
 const WORKSPACE_LIMITS_CACHE_KEY = "workspace_limits";
 
 export const LOOKUP_KEY_TO_TIER_NAME: Record<string, string> = {
-  pro_monthly_2024_09: 'Laminar Pro tier',
+  hobby_monthly_2025_04: 'Laminar Hobby tier',
   pro_monthly_2025_02: 'Laminar Pro tier',
-  team_monthly_2024_11: 'Laminar Team tier',
-  team_monthly_2025_02: 'Laminar Team tier',
+  pro_monthly_2025_04: 'Laminar Pro tier',
   additional_seat_2024_11: 'Additional seat',
   index_pro_monthly_2025_04: 'Laminar Index Pro tier'
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces 'Hobby' tier to pricing model, updates lookup keys, and modifies billing and subscription logic across multiple components.
> 
>   - **Pricing Model**:
>     - Introduces 'Hobby' tier in `pricing-dialog.tsx` with $25/month, 100k spans, 30-day retention, and 2 team members.
>     - Updates `TIER_LINKS` in `pricing-dialog.tsx` to include 'hobby_monthly_2025_04'.
>   - **Lookup Keys**:
>     - Changes default lookup key to 'hobby_monthly_2025_04' in `page.tsx` and `route.ts`.
>     - Updates `LOOKUP_KEY_TO_TIER_NAME` in `utils.ts` to map 'hobby_monthly_2025_04' to 'Laminar Hobby tier'.
>   - **Subscription Management**:
>     - Adds `PricingDialog` to `workspace-usage.tsx` for managing billing and upgrades.
>     - Updates `workspace-users.tsx` to handle user limits based on tier.
>     - Modifies `manageWorkspaceSubscriptionEvent` and `manageUserSubscriptionEvent` in `utils.ts` to handle new tier logic.
>   - **Miscellaneous**:
>     - Adjusts `workspace-usage.tsx` to display tier-specific span and step limits and overage policies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 1defad2486afc8d5b9d638fca836715efc572b46. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->