### PR TITLE
various small changes that improve stop-agent

### DIFF
--- a/app-server/src/agent_manager/channel.rs
+++ b/app-server/src/agent_manager/channel.rs
@@ -4,12 +4,12 @@ use dashmap::DashMap;
 use tokio::{sync::mpsc, task::AbortHandle};
 use uuid::Uuid;
 
-use super::types::WorkerStreamChunk;
+use super::types::RunAgentResponseStreamChunk;
 
 const CHANNEL_CAPACITY: usize = 100;
 
-type AgentSender = mpsc::Sender<Result<WorkerStreamChunk>>;
-pub type AgentReceiver = mpsc::Receiver<Result<WorkerStreamChunk>>;
+type AgentSender = mpsc::Sender<Result<RunAgentResponseStreamChunk>>;
+pub type AgentReceiver = mpsc::Receiver<Result<RunAgentResponseStreamChunk>>;
 
 struct AgentChannelState {
     sender: AgentSender,
@@ -114,7 +114,7 @@ impl AgentManagerWorkers {
     pub async fn try_publish(
         &self,
         session_id: Uuid,
-        chunk: Result<WorkerStreamChunk>,
+        chunk: Result<RunAgentResponseStreamChunk>,
     ) -> Result<()> {
         // Completely remove the state first to avoid deadlocks
         let Some(state) = self.workers.remove(&session_id) else {

--- a/app-server/src/agent_manager/types.rs
+++ b/app-server/src/agent_manager/types.rs
@@ -82,10 +82,6 @@ impl Into<AgentOutput> for AgentOutputGrpc {
     }
 }
 
-pub enum WorkerStreamChunk {
-    AgentChunk(RunAgentResponseStreamChunk),
-}
-
 #[derive(Serialize, Clone)]
 #[serde(tag = "chunkType", rename_all = "camelCase")]
 pub enum RunAgentResponseStreamChunk {

--- a/app-server/src/agent_manager/types.rs
+++ b/app-server/src/agent_manager/types.rs
@@ -84,11 +84,6 @@ impl Into<AgentOutput> for AgentOutputGrpc {
 
 pub enum WorkerStreamChunk {
     AgentChunk(RunAgentResponseStreamChunk),
-    ControlChunk(ControlChunk),
-}
-
-pub enum ControlChunk {
-    Stop,
 }
 
 #[derive(Serialize, Clone)]

--- a/app-server/src/agent_manager/worker.rs
+++ b/app-server/src/agent_manager/worker.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use super::{
     channel::AgentManagerWorkers,
     cookies,
-    types::{ModelProvider, RunAgentResponseStreamChunk, WorkerStreamChunk},
+    types::{ModelProvider, RunAgentResponseStreamChunk},
     AgentManager, AgentManagerTrait,
 };
 use crate::db::{self, agent_messages::MessageType, DB};
@@ -105,7 +105,7 @@ pub async fn run_agent_worker(
                 // To avoid dropping the chunk, we retry sending it a couple times with a small delay.
                 let mut retry_count = 0;
                 while worker_channel
-                    .try_publish(session_id, Ok(WorkerStreamChunk::AgentChunk(chunk.clone())))
+                    .try_publish(session_id, Ok(chunk.clone()))
                     .await
                     .is_err()
                 {

--- a/app-server/src/agent_manager/worker.rs
+++ b/app-server/src/agent_manager/worker.rs
@@ -116,7 +116,6 @@ pub async fn run_agent_worker(
                     }
                 }
                 if matches!(chunk, RunAgentResponseStreamChunk::FinalOutput(_)) {
-                    dbg!("ending session");
                     if let Err(e) =
                         db::agent_chats::update_agent_chat_status(&db.pool, "idle", &session_id)
                             .await

--- a/app-server/src/api/v1/agent.rs
+++ b/app-server/src/api/v1/agent.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::agent_manager::channel::AgentManagerWorkers;
-use crate::agent_manager::types::{RunAgentResponseStreamChunk, WorkerStreamChunk};
+use crate::agent_manager::types::RunAgentResponseStreamChunk;
 use crate::agent_manager::worker::{run_agent_worker, RunAgentWorkerOptions};
 use crate::agent_manager::{types::ModelProvider, AgentManager, AgentManagerTrait};
 use crate::cache::Cache;
@@ -115,7 +115,7 @@ pub async fn run_agent_manager(
             let _drop_guard = drop_sender;
             while let Some(message) = receiver.recv().await {
                 match message {
-                    Ok(WorkerStreamChunk::AgentChunk(agent_chunk)) => {
+                    Ok(agent_chunk) => {
                         if let Err(e) =
                             db::stats::add_agent_steps_to_project_usage_stats(&pool, &project_api_key.project_id, 1)
                                 .await

--- a/app-server/src/api/v1/agent.rs
+++ b/app-server/src/api/v1/agent.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::agent_manager::channel::AgentManagerWorkers;
-use crate::agent_manager::types::{ControlChunk, RunAgentResponseStreamChunk, WorkerStreamChunk};
+use crate::agent_manager::types::{RunAgentResponseStreamChunk, WorkerStreamChunk};
 use crate::agent_manager::worker::{run_agent_worker, RunAgentWorkerOptions};
 use crate::agent_manager::{types::ModelProvider, AgentManager, AgentManagerTrait};
 use crate::cache::Cache;
@@ -76,8 +76,14 @@ pub async fn run_agent_manager(
     let session_id = Uuid::new_v4();
 
     let worker_states_clone = worker_states.clone();
+    let pool = db.pool.clone();
     tokio::spawn(async move {
         let _ = drop_guard.await;
+
+        if let Err(e) = db::agent_chats::update_agent_chat_status(&pool, "idle", &session_id).await
+        {
+            log::error!("Error updating agent chat: {}", e);
+        }
         worker_states_clone.stop_session(session_id).await;
     });
 
@@ -90,10 +96,11 @@ pub async fn run_agent_manager(
             return_screenshots: request.return_screenshots,
         };
         let pool = db.pool.clone();
-        tokio::spawn(async move {
+        let worker_states_clone = worker_states.clone();
+        let handle = tokio::spawn(async move {
             run_agent_worker(
                 agent_manager.clone(),
-                worker_states.as_ref().clone(),
+                worker_states_clone.as_ref().clone(),
                 db.clone(),
                 session_id,
                 None,
@@ -103,6 +110,7 @@ pub async fn run_agent_manager(
             )
             .await;
         });
+        worker_states.insert_abort_handle(session_id, handle.abort_handle());
         let stream = async_stream::stream! {
             let _drop_guard = drop_sender;
             while let Some(message) = receiver.recv().await {
@@ -124,9 +132,6 @@ pub async fn run_agent_manager(
                                 yield anyhow::Ok(agent_chunk.into());
                             }
                         }
-                    }
-                    Ok(WorkerStreamChunk::ControlChunk(ControlChunk::Stop)) => {
-                        break;
                     }
                     Err(e) => {
                         log::error!("Error running agent: {}", e);

--- a/app-server/src/db/agent_chats.rs
+++ b/app-server/src/db/agent_chats.rs
@@ -4,16 +4,14 @@ use uuid::Uuid;
 pub async fn update_agent_chat_status(
     pool: &PgPool,
     agent_status: &str,
-    updated_at: chrono::DateTime<chrono::Utc>,
     session_id: &Uuid,
 ) -> anyhow::Result<()> {
     sqlx::query(
         "UPDATE agent_chats
-        SET agent_status = $1, updated_at = $2
-        WHERE session_id = $3",
+        SET agent_status = $1, updated_at = now()
+        WHERE session_id = $2",
     )
     .bind(agent_status)
-    .bind(updated_at)
     .bind(session_id)
     .execute(pool)
     .await?;

--- a/app-server/src/routes/agent.rs
+++ b/app-server/src/routes/agent.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::agent_manager::channel::AgentManagerWorkers;
-use crate::agent_manager::types::{RunAgentResponseStreamChunk, WorkerStreamChunk};
+use crate::agent_manager::types::RunAgentResponseStreamChunk;
 use crate::agent_manager::worker::{run_agent_worker, RunAgentWorkerOptions};
 use crate::db;
 use crate::routes::types::ResponseResult;
@@ -93,7 +93,7 @@ pub async fn run_agent_manager(
     let stream = async_stream::stream! {
         while let Some(message) = receiver.recv().await {
             match message {
-                Ok(WorkerStreamChunk::AgentChunk(agent_chunk)) => {
+                Ok(agent_chunk) => {
                     match agent_chunk {
                         RunAgentResponseStreamChunk::FinalOutput(_) => {
                             yield anyhow::Ok(agent_chunk.into());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improved stop-agent functionality by removing unused code, adding abort handles, and updating agent chat statuses across multiple files.
> 
>   - **Behavior**:
>     - Removed `WorkerStreamChunk` and `ControlChunk` enums from `types.rs`.
>     - Updated `try_publish()` and `stop_session()` in `channel.rs` to handle `RunAgentResponseStreamChunk` directly.
>     - Added abort handle management in `insert_abort_handle()` and `stop_session()` in `channel.rs`.
>     - Updated `run_agent_worker()` in `worker.rs` to handle final output and errors by updating agent chat status to "idle".
>     - Updated `run_agent_manager()` in `agent.rs` to handle streaming and non-streaming requests with abort handles.
>   - **Database**:
>     - Modified `update_agent_chat_status()` in `agent_chats.rs` to remove `updated_at` parameter and use `now()` in SQL query.
>   - **Misc**:
>     - Removed unnecessary imports and reordered imports in `worker.rs` and `agent.rs`.
>     - Added error logging for database operations in `worker.rs` and `agent.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 8074398fa21de62c1a7e26ab4b9751e54c5b7385. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->