### PR TITLE
remove provider == anthropic check on getting cache tokens

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -129,9 +129,8 @@ impl SpanAttributes {
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
 
-        let regular_input_tokens = (total_input_tokens - (cache_write_tokens + cache_read_tokens)).max(0);
-        let cache_write_tokens = cache_write_tokens;
-        let cache_read_tokens = cache_read_tokens;
+        let regular_input_tokens =
+            (total_input_tokens - (cache_write_tokens + cache_read_tokens)).max(0);
 
         InputTokens {
             regular_input_tokens,

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -118,34 +118,25 @@ impl SpanAttributes {
                 0
             };
 
-        if self.provider_name() == Some("anthropic".to_string()) {
-            let cache_write_tokens = self
-                .attributes
-                .get(GEN_AI_CACHE_WRITE_INPUT_TOKENS)
-                .and_then(|v| v.as_i64())
-                .unwrap_or(0);
-            let cache_read_tokens = self
-                .attributes
-                .get(GEN_AI_CACHE_READ_INPUT_TOKENS)
-                .and_then(|v| v.as_i64())
-                .unwrap_or(0);
+        let cache_write_tokens = self
+            .attributes
+            .get(GEN_AI_CACHE_WRITE_INPUT_TOKENS)
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let cache_read_tokens = self
+            .attributes
+            .get(GEN_AI_CACHE_READ_INPUT_TOKENS)
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
 
-            let regular_input_tokens =
-                total_input_tokens - (cache_write_tokens + cache_read_tokens);
-            let cache_write_tokens = cache_write_tokens;
-            let cache_read_tokens = cache_read_tokens;
+        let regular_input_tokens = total_input_tokens - (cache_write_tokens + cache_read_tokens);
+        let cache_write_tokens = cache_write_tokens;
+        let cache_read_tokens = cache_read_tokens;
 
-            InputTokens {
-                regular_input_tokens,
-                cache_write_tokens,
-                cache_read_tokens,
-            }
-        } else {
-            InputTokens {
-                regular_input_tokens: total_input_tokens,
-                cache_write_tokens: 0,
-                cache_read_tokens: 0,
-            }
+        InputTokens {
+            regular_input_tokens,
+            cache_write_tokens,
+            cache_read_tokens,
         }
     }
 

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -129,7 +129,7 @@ impl SpanAttributes {
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
 
-        let regular_input_tokens = total_input_tokens - (cache_write_tokens + cache_read_tokens);
+        let regular_input_tokens = (total_input_tokens - (cache_write_tokens + cache_read_tokens)).max(0);
         let cache_write_tokens = cache_write_tokens;
         let cache_read_tokens = cache_read_tokens;
 


### PR DESCRIPTION
This is safe, because we do `.unwrap_or(0)` at the end any way
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove provider name check for 'anthropic' in `input_tokens()` in `spans.rs`, simplifying token calculation logic.
> 
>   - **Behavior**:
>     - Removed provider name check for 'anthropic' in `input_tokens()` in `spans.rs`.
>     - Simplified token calculation logic by removing unnecessary conditional branching.
>   - **Token Calculation**:
>     - `regular_input_tokens` now calculated as `total_input_tokens - (cache_write_tokens + cache_read_tokens)`, ensuring non-negative values with `.max(0)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 42b29a27e5ba366422c635fb900c5e6081a020d7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->