### PR TITLE
fix: disc progress bar, update trace in drawer

### DIFF
--- a/frontend/components/traces/share-trace-button.tsx
+++ b/frontend/components/traces/share-trace-button.tsx
@@ -11,7 +11,15 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { useToast } from "@/lib/hooks/use-toast";
 import { Trace } from "@/lib/traces/types";
 
-const ShareTraceButton = ({ trace, projectId }: { trace: Pick<Trace, "id" | "visibility">; projectId: string }) => {
+const ShareTraceButton = ({
+  trace,
+  projectId,
+  refetch,
+}: {
+  trace: Pick<Trace, "id" | "visibility">;
+  projectId: string;
+  refetch?: () => void;
+}) => {
   const traceId = trace.id;
   const router = useRouter();
 
@@ -31,7 +39,11 @@ const ShareTraceButton = ({ trace, projectId }: { trace: Pick<Trace, "id" | "vis
         toast({
           title: "Trace privacy updated.",
         });
-        router.refresh();
+        if (refetch) {
+          refetch();
+        } else {
+          router.refresh();
+        }
       } else {
         const text = await res.json();
         toast({ variant: "destructive", title: "Error", description: text });

--- a/frontend/components/traces/trace-view.tsx
+++ b/frontend/components/traces/trace-view.tsx
@@ -90,25 +90,24 @@ export default function TraceView({ traceId, onClose, propsTrace, fullScreen = f
   const [collapsedSpans, setCollapsedSpans] = useState<Set<string>>(new Set());
   const [browserSessionTime, setBrowserSessionTime] = useState<number | null>(null);
 
-  const handleFetchTrace = useCallback(() => {
+  const handleFetchTrace = useCallback(async () => {
     try {
-      const fetchTrace = async () => {
-        const trace = await fetch(`/api/projects/${projectId}/traces/${traceId}`);
-        return await trace.json();
-      };
-
       if (propsTrace) {
         setTrace(propsTrace);
       } else {
-        fetchTrace().then((trace) => {
-          setTrace(trace);
-          if (trace.hasBrowserSession) {
-            setShowBrowserSession(true);
-          }
-        });
+        const trace = await fetch(`/api/projects/${projectId}/traces/${traceId}`);
+        const traceData = await trace.json();
+        setTrace(traceData);
+        if (traceData.hasBrowserSession) {
+          setShowBrowserSession(true);
+        }
       }
     } catch (e) {
-      toast({ variant: "destructive", title: "Error", description: "Failed to load trace. Please try again." });
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Failed to load trace. Please try again.",
+      });
     }
   }, [projectId, propsTrace, toast, traceId]);
 

--- a/frontend/components/traces/trace-view.tsx
+++ b/frontend/components/traces/trace-view.tsx
@@ -95,8 +95,16 @@ export default function TraceView({ traceId, onClose, propsTrace, fullScreen = f
       if (propsTrace) {
         setTrace(propsTrace);
       } else {
-        const trace = await fetch(`/api/projects/${projectId}/traces/${traceId}`);
-        const traceData = await trace.json();
+        const response = await fetch(`/api/projects/${projectId}/traces/${traceId}`);
+        if (!response.ok) {
+          toast({
+            variant: "destructive",
+            title: "Error",
+            description: "Failed to load trace. Please try again.",
+          });
+          return;
+        }
+        const traceData = await response.json();
         setTrace(traceData);
         if (traceData.hasBrowserSession) {
           setShowBrowserSession(true);

--- a/frontend/components/workspace/workspace-usage.tsx
+++ b/frontend/components/workspace/workspace-usage.tsx
@@ -147,8 +147,8 @@ interface UsageProgressDiscProps {
 }
 
 const UsageProgressDisc = ({ maxValue, value, data, dataKey }: UsageProgressDiscProps) => {
-  const endAngle = -90;
-  const startAngle = endAngle + (Math.min(value, maxValue) / maxValue) * 360;
+  const startAngle = 90;
+  const endAngle = startAngle - (Math.min(value, maxValue) / maxValue) * 360;
 
   return (
     <ChartContainer config={{}} className="aspect-square h-16 w-16">


### PR DESCRIPTION
- fixed disc progress bar for usage in workspaces
- fixed refetch of trace on update
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes disc progress bar in `workspace-usage.tsx` and updates trace refetch logic in `trace-view.tsx`.
> 
>   - **Trace Update**:
>     - `ShareTraceButton` in `share-trace-button.tsx` now accepts an optional `refetch` function to update trace data after visibility change.
>     - `TraceView` in `trace-view.tsx` uses `handleFetchTrace` to refetch trace data, improving error handling with toasts.
>   - **Disc Progress Bar**:
>     - Corrects `startAngle` and `endAngle` calculations in `UsageProgressDisc` in `workspace-usage.tsx` for accurate display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 82702694f71a681eddceb0c76b7278135717b680. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->