### PR TITLE
fix: rollback clickhouse dep

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@ai-sdk/openai": "^1.3.16",
     "@ai-sdk/react": "^1.2.9",
     "@aws-sdk/client-s3": "^3.787.0",
-    "@clickhouse/client": "^1.11.1",
+    "@clickhouse/client": "1.11.0",
     "@codemirror/lang-html": "^6.4.9",
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-python": "^6.1.7",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^3.787.0
         version: 3.787.0
       '@clickhouse/client':
-        specifier: ^1.11.1
-        version: 1.11.1
+        specifier: 1.11.0
+        version: 1.11.0
       '@codemirror/lang-html':
         specifier: ^6.4.9
         version: 6.4.9
@@ -702,11 +702,11 @@ packages:
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
-  '@clickhouse/client-common@1.11.1':
-    resolution: {integrity: sha512-bme0le2yhDSAh13d2fxhSW5ZrNoVqZ3LTyac8jK6hNH0qkksXnjYkLS6KQalPU6NMpffxHmpI4+/Gi2MnX0NCA==}
+  '@clickhouse/client-common@1.11.0':
+    resolution: {integrity: sha512-O0xbwv7HiMXayokrf5dYIBpjBnYekcOXWz60T1cXLmiZ8vgrfNRCiOpybJkrMXKnw9D0mWCgPUu/rgMY7U1f4g==}
 
-  '@clickhouse/client@1.11.1':
-    resolution: {integrity: sha512-u9h++h72SmWystijNqfNvMkfA+5+Y1LNfmLL/odCL3VgI3oyAPP9ubSw/Yrt2zRZkLKehMMD1kuOej0QHbSoBA==}
+  '@clickhouse/client@1.11.0':
+    resolution: {integrity: sha512-VYTQfR0y/BtrIDEjuSce1zv85OvHak5sUhZVyNYJzbAgWHy3jFf8Os7FdUSeqyKav0xGGy+2X+dRanTFjI5Oug==}
     engines: {node: '>=16'}
 
   '@codemirror/autocomplete@6.18.6':
@@ -6665,11 +6665,11 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@clickhouse/client-common@1.11.1': {}
+  '@clickhouse/client-common@1.11.0': {}
 
-  '@clickhouse/client@1.11.1':
+  '@clickhouse/client@1.11.0':
     dependencies:
-      '@clickhouse/client-common': 1.11.1
+      '@clickhouse/client-common': 1.11.0
 
   '@codemirror/autocomplete@6.18.6':
     dependencies:


### PR DESCRIPTION
- rollback clickhouse to stable version
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rollback `@clickhouse/client` version to `1.11.0` in `frontend/package.json`.
> 
>   - **Dependencies**:
>     - Rollback `@clickhouse/client` version from `^1.11.1` to `1.11.0` in `frontend/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 0323e9b9cbdbf8b9152e957d6b86abe14c4d77e3. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->