### PR TITLE
fix clickhouse import to only be bundled in server

### DIFF
--- a/frontend/app/api/projects/[projectId]/spans/metrics/summary/route.ts
+++ b/frontend/app/api/projects/[projectId]/spans/metrics/summary/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { getSpanMetricsSummary, SpanMetric, SpanMetricGroupBy } from "@/lib/clickhouse/spans";
+import { getSpanMetricsSummary } from "@/lib/clickhouse/spans";
+import { SpanMetric, SpanMetricGroupBy } from "@/lib/clickhouse/types";
 import { AggregationFunction, getTimeRange } from "@/lib/clickhouse/utils";
 
 export async function GET(req: NextRequest, props: { params: Promise<{ projectId: string }> }) {

--- a/frontend/app/api/projects/[projectId]/spans/metrics/time/route.ts
+++ b/frontend/app/api/projects/[projectId]/spans/metrics/time/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { GroupByInterval } from "@/lib/clickhouse/modifiers";
-import { getSpanMetricsOverTime, SpanMetric, SpanMetricGroupBy } from "@/lib/clickhouse/spans";
+import { getSpanMetricsOverTime } from "@/lib/clickhouse/spans";
+import { SpanMetric, SpanMetricGroupBy } from "@/lib/clickhouse/types";
 import { AggregationFunction, getTimeRange } from "@/lib/clickhouse/utils";
 
 export async function GET(req: NextRequest, props: { params: Promise<{ projectId: string }> }) {

--- a/frontend/components/dashboard/dashboard.tsx
+++ b/frontend/components/dashboard/dashboard.tsx
@@ -5,7 +5,7 @@ import { useEffect } from "react";
 
 import { useProjectContext } from "@/contexts/project-context";
 import { GroupByInterval } from "@/lib/clickhouse/modifiers";
-import { SpanMetric, SpanMetricGroupBy } from "@/lib/clickhouse/spans";
+import { SpanMetric, SpanMetricGroupBy } from "@/lib/clickhouse/types";
 import { AggregationFunction } from "@/lib/clickhouse/utils";
 import { getGroupByInterval } from "@/lib/utils";
 

--- a/frontend/components/dashboard/span-stat-chart.tsx
+++ b/frontend/components/dashboard/span-stat-chart.tsx
@@ -8,7 +8,7 @@ import {
   ChartTooltipContent
 } from '@/components/ui/chart';
 import { GroupByInterval } from '@/lib/clickhouse/modifiers';
-import { MetricTimeValue, SpanMetric, SpanMetricGroupBy, SpanMetricType } from '@/lib/clickhouse/spans';
+import { MetricTimeValue, SpanMetric, SpanMetricGroupBy, SpanMetricType } from '@/lib/clickhouse/types';
 import { AggregationFunction } from '@/lib/clickhouse/utils';
 import {
   cn,

--- a/frontend/components/dashboard/span-summary-chart.tsx
+++ b/frontend/components/dashboard/span-summary-chart.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
-import { SpanMetric, SpanMetricGroupBy } from "@/lib/clickhouse/spans";
+import { SpanMetric, SpanMetricGroupBy } from "@/lib/clickhouse/types";
 import { AggregationFunction } from "@/lib/clickhouse/utils";
 import { buildSpansUrl } from "@/lib/traces/utils";
 import { cn, toFixedIfFloat } from "@/lib/utils";

--- a/frontend/lib/clickhouse/spans.ts
+++ b/frontend/lib/clickhouse/spans.ts
@@ -2,6 +2,13 @@ import { clickhouseClient } from "@/lib/clickhouse/client";
 
 import { GroupByInterval, truncateTimeMap } from "./modifiers";
 import {
+  MetricTimeValue,
+  SpanMetric,
+  SpanMetricGroupBy,
+  SpanMetricType,
+  SpanType,
+} from "./types";
+import {
   addTimeRangeToQuery,
   AggregationFunction,
   aggregationFunctionToCh,
@@ -11,44 +18,6 @@ import {
   TimeRange,
 } from "./utils";
 
-export enum SpanMetricGroupBy {
-  Model = "model",
-  Provider = "provider",
-  Path = "path",
-  Name = "name",
-}
-
-// Don't change, must remain consistent with BE
-export enum SpanType {
-  DEFAULT = 0,
-  LLM = 1,
-  PIPELINE = 2,
-  EXECUTOR = 3,
-  EVALUATOR = 4,
-  EVALUATION = 5,
-  TOOL = 6,
-}
-
-export enum SpanMetric {
-  Count = "count",
-  InputCost = "input_cost",
-  OutputCost = "output_cost",
-  TotalCost = "total_cost",
-  Latency = "latency",
-  InputTokens = "input_tokens",
-  OutputTokens = "output_tokens",
-  TotalTokens = "total_tokens",
-}
-
-export type MetricTimeValue<T> = {
-  time: string;
-  value: T;
-};
-
-export type SpanMetricType = {
-  [key: string]: number;
-  timestamp: number; // unix timestamp in seconds
-};
 
 const NULL_VALUE = "<null>";
 

--- a/frontend/lib/clickhouse/types.ts
+++ b/frontend/lib/clickhouse/types.ts
@@ -1,0 +1,38 @@
+export enum SpanMetricGroupBy {
+  Model = "model",
+  Provider = "provider",
+  Path = "path",
+  Name = "name",
+}
+
+// Don't change, must remain consistent with BE
+export enum SpanType {
+  DEFAULT = 0,
+  LLM = 1,
+  PIPELINE = 2,
+  EXECUTOR = 3,
+  EVALUATOR = 4,
+  EVALUATION = 5,
+  TOOL = 6,
+}
+
+export enum SpanMetric {
+  Count = "count",
+  InputCost = "input_cost",
+  OutputCost = "output_cost",
+  TotalCost = "total_cost",
+  Latency = "latency",
+  InputTokens = "input_tokens",
+  OutputTokens = "output_tokens",
+  TotalTokens = "total_tokens",
+}
+
+export type MetricTimeValue<T> = {
+  time: string;
+  value: T;
+};
+
+export type SpanMetricType = {
+  [key: string]: number;
+  timestamp: number; // unix timestamp in seconds
+};

--- a/frontend/lib/clickhouse/utils.ts
+++ b/frontend/lib/clickhouse/utils.ts
@@ -2,11 +2,6 @@ import { clickhouseClient } from "@/lib/clickhouse/client";
 
 import { chStepMap, GroupByInterval, intervalMap, truncateTimeMap } from "./modifiers";
 
-interface TimeBounds {
-  minTime: number;
-  maxTime: number;
-}
-
 const NANOS_PER_MILLISECOND = 1e6;
 
 export const dateToNanoseconds = (date: Date): number => date.getTime() * NANOS_PER_MILLISECOND;

--- a/frontend/lib/traces/utils.ts
+++ b/frontend/lib/traces/utils.ts
@@ -1,4 +1,4 @@
-import { SpanMetricGroupBy } from "../clickhouse/spans";
+import { SpanMetricGroupBy } from "../clickhouse/types";
 import { DatatableFilter } from "../types";
 import { SpanType } from "./types";
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@ai-sdk/openai": "^1.3.16",
     "@ai-sdk/react": "^1.2.9",
     "@aws-sdk/client-s3": "^3.787.0",
-    "@clickhouse/client": "1.11.0",
+    "@clickhouse/client": "^1.11.1",
     "@codemirror/lang-html": "^6.4.9",
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-python": "^6.1.7",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^3.787.0
         version: 3.787.0
       '@clickhouse/client':
-        specifier: 1.11.0
-        version: 1.11.0
+        specifier: ^1.11.1
+        version: 1.11.1
       '@codemirror/lang-html':
         specifier: ^6.4.9
         version: 6.4.9
@@ -702,11 +702,11 @@ packages:
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
-  '@clickhouse/client-common@1.11.0':
-    resolution: {integrity: sha512-O0xbwv7HiMXayokrf5dYIBpjBnYekcOXWz60T1cXLmiZ8vgrfNRCiOpybJkrMXKnw9D0mWCgPUu/rgMY7U1f4g==}
+  '@clickhouse/client-common@1.11.1':
+    resolution: {integrity: sha512-bme0le2yhDSAh13d2fxhSW5ZrNoVqZ3LTyac8jK6hNH0qkksXnjYkLS6KQalPU6NMpffxHmpI4+/Gi2MnX0NCA==}
 
-  '@clickhouse/client@1.11.0':
-    resolution: {integrity: sha512-VYTQfR0y/BtrIDEjuSce1zv85OvHak5sUhZVyNYJzbAgWHy3jFf8Os7FdUSeqyKav0xGGy+2X+dRanTFjI5Oug==}
+  '@clickhouse/client@1.11.1':
+    resolution: {integrity: sha512-u9h++h72SmWystijNqfNvMkfA+5+Y1LNfmLL/odCL3VgI3oyAPP9ubSw/Yrt2zRZkLKehMMD1kuOej0QHbSoBA==}
     engines: {node: '>=16'}
 
   '@codemirror/autocomplete@6.18.6':
@@ -6665,11 +6665,11 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@clickhouse/client-common@1.11.0': {}
+  '@clickhouse/client-common@1.11.1': {}
 
-  '@clickhouse/client@1.11.0':
+  '@clickhouse/client@1.11.1':
     dependencies:
-      '@clickhouse/client-common': 1.11.0
+      '@clickhouse/client-common': 1.11.1
 
   '@codemirror/autocomplete@6.18.6':
     dependencies:


### PR DESCRIPTION
Move types definitions to a separate file, since they are used in both the client and the server.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move type definitions to `types.ts` and update ClickHouse client version.
> 
>   - **Type Definitions**:
>     - Move `SpanMetric`, `SpanMetricGroupBy`, `SpanMetricType`, `SpanType`, and `MetricTimeValue` from `spans.ts` to `types.ts`.
>     - Update imports in `route.ts`, `dashboard.tsx`, `span-stat-chart.tsx`, `span-summary-chart.tsx`, `spans.ts`, and `utils.ts` to reflect new `types.ts` location.
>   - **Dependencies**:
>     - Update `@clickhouse/client` version from `1.11.0` to `^1.11.1` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for a84cf52619785fb90f5d57d7d6cee60a4d3d8695. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->