### PR TITLE
exclude healthcheck path from actix logs

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -512,7 +512,7 @@ fn main() -> anyhow::Result<()> {
                     }
 
                     App::new()
-                        .wrap(Logger::default())
+                        .wrap(Logger::default().exclude("/health"))
                         .wrap(NormalizePath::trim())
                         .app_data(JsonConfig::default().limit(http_payload_limit))
                         .app_data(PayloadConfig::new(http_payload_limit))


### PR DESCRIPTION
This is called very frequently by `kube-probe`, so it creates a lot of noise in logs. And if this endpoint stops responding, we will probably be able to debug by looking at other symptoms
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude `/health` path from Actix logs in `main.rs` to reduce noise from frequent health checks.
> 
>   - **Logging**:
>     - Exclude `/health` path from Actix logs in `main.rs` to reduce noise from frequent `kube-probe` health checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d000fb7506b6e333bbf7adba882389d29b140919. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->