### PR TITLE
fix: fix border and default mode

### DIFF
--- a/frontend/components/traces/chat-message-list-tab.tsx
+++ b/frontend/components/traces/chat-message-list-tab.tsx
@@ -90,7 +90,7 @@ const ContentParts = ({ contentParts, presetKey }: ContentPartsProps) => {
   );
 
   return (
-    <div className="flex flex-col w-full">
+    <div className="flex flex-col w-full divide-y">
       {memoizedContentParts.map(({ key, part }) => (
         <div key={key} className="w-full">
           {renderContentPart(part)}
@@ -154,7 +154,7 @@ function PureChatMessageListTab({ messages, presetKey }: ChatMessageListTabProps
                   className="flex flex-col border rounded mb-4"
                 >
                   {message?.role && (
-                    <div className="font-medium text-sm text-secondary-foreground p-2">
+                    <div className="font-medium text-sm text-secondary-foreground p-2 border-b">
                       {message.role.toUpperCase()}
                     </div>
                   )}

--- a/frontend/components/traces/code-highlighter/index.tsx
+++ b/frontend/components/traces/code-highlighter/index.tsx
@@ -29,7 +29,7 @@ interface CodeEditorProps {
   codeEditorClassName?: string;
 }
 
-const defaultMode = "TEXT";
+const defaultMode = "text";
 
 const PureCodeHighlighter = ({
   value,
@@ -84,7 +84,7 @@ const PureCodeHighlighter = ({
   return (
     <div className={cn("w-full h-full flex flex-col border", className)}>
       <div
-        className={cn("bg-background flex items-center pl-2 pr-1 w-full border-t", {
+        className={cn("bg-background flex items-center pl-2 pr-1 w-full rounded-t", {
           "border-b": !isCollapsed,
         })}
       >

--- a/frontend/components/traces/code-highlighter/index.tsx
+++ b/frontend/components/traces/code-highlighter/index.tsx
@@ -128,6 +128,7 @@ const PureCodeHighlighter = ({
         className={cn("flex-grow flex bg-card overflow-auto w-full h-fit", { "h-0": isCollapsed }, codeEditorClassName)}
       >
         <CodeMirror
+          className="w-full"
           onUpdate={onLoad}
           placeholder={placeholder}
           theme={theme}


### PR DESCRIPTION
- fixed default mode for editor
- fixed border between content parts
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes default mode in code editor and adjusts border styling in chat message list tab.
> 
>   - **Behavior**:
>     - Fixes default mode in `PureCodeHighlighter` from `"TEXT"` to `"text"` in `index.tsx`.
>     - Adds `divide-y` class to `ContentParts` in `chat-message-list-tab.tsx` for border between content parts.
>     - Adds `border-b` class to message role div in `PureChatMessageListTab` in `chat-message-list-tab.tsx`.
>   - **Misc**:
>     - Changes `border-t` to `rounded-t` in `index.tsx` for top border styling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 0d2ef27f423b93cca1248bd52d8b67f15c630f42. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->