### PR TITLE
if path starts with current span, nullify parent

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use chrono::{TimeZone, Utc};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use uuid::Uuid;
 
 use crate::{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Nullify `parent_span_id` in `record_span_to_db()` if the span is determined to be the top span using `is_top_span()`.
> 
>   - **Behavior**:
>     - In `record_span_to_db()` in `utils.rs`, nullify `parent_span_id` if `is_top_span()` returns true.
>     - `is_top_span()` checks if the span's ID and name match the first elements in `ids_path()` and `path()`.
>   - **Imports**:
>     - Reorder imports in `spans.rs` and `utils.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3609fac4125f22ce26d3d07af0a8125b474ab67a. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->