### PR TITLE
fix: readonly code highlighter, small sidebar fixes

### DIFF
--- a/frontend/components/project/project-sidebar.tsx
+++ b/frontend/components/project/project-sidebar.tsx
@@ -4,7 +4,7 @@ import { Book, Database, FlaskConical, LayoutGrid, Pen, PlayCircle, Rows4, Setti
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import smallLogo from "@/assets/logo/icon.svg";
 import fullLogo from "@/assets/logo/logo.svg";
@@ -32,7 +32,7 @@ interface ProjectSidebarProps {
 export default function ProjectSidebar({ workspaceId, projectId, isFreeTier }: ProjectSidebarProps) {
   const pathname = usePathname();
   const { open, openMobile } = useSidebar();
-  const [showStarCard, setShowStarCard] = useState<boolean>(false);
+  const [showStarCard, setShowStarCard] = useState(false);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -42,53 +42,58 @@ export default function ProjectSidebar({ workspaceId, projectId, isFreeTier }: P
   }, []);
 
   useEffect(() => {
-    localStorage.setItem("showStarCard", JSON.stringify(showStarCard));
+    if (typeof window !== "undefined") {
+      localStorage.setItem("showStarCard", JSON.stringify(showStarCard));
+    }
   }, [showStarCard]);
 
-  const allOptions = [
-    {
-      name: "dashboard",
-      href: `/project/${projectId}/dashboard`,
-      icon: LayoutGrid,
-      current: false,
-    },
-    {
-      name: "traces",
-      href: `/project/${projectId}/traces`,
-      icon: Rows4,
-      current: false,
-    },
-    {
-      name: "evaluations",
-      href: `/project/${projectId}/evaluations`,
-      icon: FlaskConical,
-      current: false,
-    },
-    {
-      name: "datasets",
-      href: `/project/${projectId}/datasets`,
-      icon: Database,
-      current: false,
-    },
-    {
-      name: "queues",
-      href: `/project/${projectId}/labeling-queues`,
-      icon: Pen,
-      current: false,
-    },
-    {
-      name: "playgrounds",
-      href: `/project/${projectId}/playgrounds`,
-      icon: PlayCircle,
-      current: false,
-    },
-    {
-      name: "settings",
-      href: `/project/${projectId}/settings`,
-      icon: Settings,
-      current: false,
-    },
-  ];
+  const allOptions = useMemo(
+    () => [
+      {
+        name: "dashboard",
+        href: `/project/${projectId}/dashboard`,
+        icon: LayoutGrid,
+        current: false,
+      },
+      {
+        name: "traces",
+        href: `/project/${projectId}/traces`,
+        icon: Rows4,
+        current: false,
+      },
+      {
+        name: "evaluations",
+        href: `/project/${projectId}/evaluations`,
+        icon: FlaskConical,
+        current: false,
+      },
+      {
+        name: "datasets",
+        href: `/project/${projectId}/datasets`,
+        icon: Database,
+        current: false,
+      },
+      {
+        name: "queues",
+        href: `/project/${projectId}/labeling-queues`,
+        icon: Pen,
+        current: false,
+      },
+      {
+        name: "playgrounds",
+        href: `/project/${projectId}/playgrounds`,
+        icon: PlayCircle,
+        current: false,
+      },
+      {
+        name: "settings",
+        href: `/project/${projectId}/settings`,
+        icon: Settings,
+        current: false,
+      },
+    ],
+    [projectId]
+  );
 
   return (
     <Sidebar className="border-r" collapsible="icon">

--- a/frontend/components/traces/chat-message-list-tab.tsx
+++ b/frontend/components/traces/chat-message-list-tab.tsx
@@ -57,6 +57,7 @@ const ContentParts = ({ contentParts, presetKey }: ContentPartsProps) => {
         case "text":
           return (
             <CodeHighlighter
+              readOnly
               collapsible
               value={contentPart.text}
               presetKey={presetKey}


### PR DESCRIPTION
- readonly code highlighter in spans
- small improvements in sidebar of projects
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize sidebar performance and make code highlighter read-only.
> 
>   - **Sidebar Improvements**:
>     - Use `useMemo` for `allOptions` in `project-sidebar.tsx` to optimize performance.
>     - Ensure `localStorage` operations in `project-sidebar.tsx` are only executed in the browser environment.
>   - **Code Highlighter**:
>     - Add `readOnly` prop to `CodeHighlighter` in `chat-message-list-tab.tsx` to prevent editing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 59940fc68a31c044281379988fed77a7bb753bb4. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->