### PR TITLE
encode non-ascii workspace name for stripe URL

### DIFF
--- a/frontend/app/checkout/page.tsx
+++ b/frontend/app/checkout/page.tsx
@@ -88,9 +88,11 @@ export default async function CheckoutPage(props: {
         type: "user",
       };
 
+  const urlEncodedWorkspaceName = encodeURIComponent(workspaceName ?? "");
+
   const successUrl =
     typeParam === "workspace"
-      ? `${process.env.NEXT_PUBLIC_URL}/workspace/${workspaceId}?sessionId={CHECKOUT_SESSION_ID}&workspaceName=${workspaceName}&lookupKey=${lookupKey}`
+      ? `${process.env.NEXT_PUBLIC_URL}/workspace/${workspaceId}?sessionId={CHECKOUT_SESSION_ID}&workspaceName=${urlEncodedWorkspaceName}&lookupKey=${lookupKey}`
       : `${process.env.NEXT_PUBLIC_URL}/chat?sessionId={CHECKOUT_SESSION_ID}&userId=${userId}&lookupKey=${lookupKey}`;
 
   const cancelUrl =

--- a/frontend/components/workspace/workspace-usage.tsx
+++ b/frontend/components/workspace/workspace-usage.tsx
@@ -49,12 +49,12 @@ export default function WorkspaceUsage({ workspace, workspaceStats, isOwner }: W
 
   const tierHintInfo = TIER_SPAN_HINTS[workspaceStats.tierName.toLowerCase().trim() as keyof typeof TIER_SPAN_HINTS];
   const tierHint =
-    `${workspaceStats.tierName} tier comes with ${tierHintInfo.spans} spans and ` +
-    `${tierHintInfo.steps} agent steps included per month.`;
+    `${workspaceStats.tierName} tier comes with ${tierHintInfo?.spans ?? "unlimited"} spans and ` +
+    `${tierHintInfo?.steps ?? "unlimited"} agent steps included per month.`;
 
   const tierHintOverages =
     "If you exceed this limit, " +
-    (tierHintInfo.isOverageAllowed
+    (tierHintInfo?.isOverageAllowed
       ? "you will be charged for overages."
       : "you won't be able to send any more spans during current billing cycle.");
 


### PR DESCRIPTION
1. Encode workspace name to URL chars, to avoid non-ascii errors
2. Fix for local tier limits if people run local DB with PRODUCTION flag
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Encode non-ASCII workspace names for Stripe URLs and fix tier limit handling for local DB with PRODUCTION flag.
> 
>   - **Behavior**:
>     - Encode `workspaceName` using `encodeURIComponent` in `page.tsx` to handle non-ASCII characters in Stripe URLs.
>     - Modify tier limit handling in `workspace-usage.tsx` to provide default values ("unlimited") for spans and steps if `tierHintInfo` is undefined.
>   - **Misc**:
>     - Adjust conditional checks in `workspace-usage.tsx` to use optional chaining for `tierHintInfo`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 5b210eb489b6e635943bbd3ef77f7faf67500c78. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->