### PR TITLE
fix media_type parsing on document

### DIFF
--- a/app-server/src/language_model/chat_message.rs
+++ b/app-server/src/language_model/chat_message.rs
@@ -174,9 +174,10 @@ pub enum InstrumentationChatMessageImageUrl {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
 pub struct InstrumentationChatMessageDocumentBase64 {
-    pub media_type: String, // e.g. "application/pdf"
+    // alias, not rename to allow for both "mediaType" and "media_type"
+    #[serde(alias = "mediaType", default)]
+    pub media_type: Option<String>, // e.g. "application/pdf"
     pub data: String,
 }
 
@@ -246,7 +247,9 @@ impl ChatMessageContentPart {
                     ChatMessageContentPart::Document(ChatMessageDocument {
                         source: ChatMessageDocumentSource {
                             document_type: "base64".to_string(),
-                            media_type: document_source.media_type,
+                            media_type: document_source
+                                .media_type
+                                .unwrap_or("application/octet-stream".to_string()),
                             data: document_source.data,
                         },
                     })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `media_type` parsing in `InstrumentationChatMessageDocumentBase64` to accept both `mediaType` and `media_type`, with a default value.
> 
>   - **Behavior**:
>     - `InstrumentationChatMessageDocumentBase64` now accepts both `mediaType` and `media_type` as input using `#[serde(alias = "mediaType", default)]`.
>     - Defaults `media_type` to `application/octet-stream` in `ChatMessageContentPart::from_instrumentation_content_part()` if not provided.
>   - **Misc**:
>     - Removed `#[serde(rename_all = "camelCase")]` from `InstrumentationChatMessageDocumentBase64`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 9dc95fd019bb6b534c87a2ba034ca25f9b32bc13. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->