### PR TITLE
fix: asterisk alias replacement in auto join

### DIFF
--- a/frontend/lib/sql/join.ts
+++ b/frontend/lib/sql/join.ts
@@ -389,16 +389,20 @@ const applyJoins = (node: Select, rule: AutoJoinRule): void => {
         if (column.expr.type === 'column_ref') {
           const columnRef = column.expr as ColumnRefItem;
           if (typeof columnRef.column === 'string') {
-            newAs = newAs ?? columnRef.column;
+            const columnName = columnRef.column;
+            newAs = newAs ?? (columnName !== '*' ? columnName : null);
           } else {
-            newAs = newAs ?? (columnRef.column.expr?.value as string);
+            const columnName = columnRef.column.expr?.value as string;
+            newAs = newAs ?? (columnName !== '*' ? columnName : null);
           }
         } else if (column.expr.type === 'expr') {
           const innerColumnRef = (column.expr as unknown as ColumnRefExpr).expr as ColumnRefItem;
           if (typeof innerColumnRef.column === 'string') {
-            newAs = newAs ?? innerColumnRef.column;
+            const columnName = innerColumnRef.column;
+            newAs = newAs ?? (columnName !== '*' ? columnName : null);
           } else {
-            newAs = newAs ?? (innerColumnRef.column.expr?.value as string);
+            const columnName = innerColumnRef.column.expr?.value as string;
+            newAs = newAs ?? (columnName !== '*' ? columnName : null);
           }
         }
         return {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of asterisk ('*') column references in `applyJoins` in `join.ts` to prevent alias assignment.
> 
>   - **Behavior**:
>     - In `applyJoins` in `join.ts`, ensure `newAs` is set to null for asterisk ('*') column references.
>     - Handles both direct and nested column references.
>   - **Misc**:
>     - Refactor to use `columnName` variable for clarity in `applyJoins`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 6f2c28e09f6c63683f4fc6029e8c65659c75ddae. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->