### PR TITLE
feat: span level error LAM-645

### DIFF
--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -64,6 +64,7 @@ pub struct CHSpan {
     pub path: String,
     pub input: String,
     pub output: String,
+    pub status: String,
     #[serde(default)]
     pub size_bytes: u64,
 }
@@ -117,6 +118,7 @@ impl CHSpan {
                 .unwrap_or(String::from("<null>")),
             input: span_input_string,
             output: span_output_string,
+            status: span.status.clone().unwrap_or(String::from("<null>")),
             size_bytes: size_bytes as u64,
         }
     }

--- a/app-server/src/db/spans.rs
+++ b/app-server/src/db/spans.rs
@@ -55,6 +55,7 @@ pub struct Span {
     pub start_time: DateTime<Utc>,
     pub end_time: DateTime<Utc>,
     pub events: Option<Value>,
+    pub status: Option<String>,
     pub labels: Option<Value>,
     pub input_url: Option<String>,
     pub output_url: Option<String>,
@@ -108,6 +109,7 @@ pub async fn record_span(pool: &PgPool, span: &Span, project_id: &Uuid) -> Resul
             output_preview,
             input_url,
             output_url,
+            status,
             project_id
         )
         VALUES(
@@ -125,7 +127,8 @@ pub async fn record_span(pool: &PgPool, span: &Span, project_id: &Uuid) -> Resul
             $12,
             $13,
             $14,
-            $15)
+            $15,
+            $16)
         ON CONFLICT (span_id, project_id) DO UPDATE SET
             trace_id = EXCLUDED.trace_id,
             parent_span_id = EXCLUDED.parent_span_id,
@@ -139,7 +142,8 @@ pub async fn record_span(pool: &PgPool, span: &Span, project_id: &Uuid) -> Resul
             input_preview = EXCLUDED.input_preview,
             output_preview = EXCLUDED.output_preview,
             input_url = EXCLUDED.input_url,
-            output_url = EXCLUDED.output_url
+            output_url = EXCLUDED.output_url,
+            status = EXCLUDED.status
     ",
     )
     .bind(&span.span_id)
@@ -156,6 +160,7 @@ pub async fn record_span(pool: &PgPool, span: &Span, project_id: &Uuid) -> Resul
     .bind(&output_preview)
     .bind(&span.input_url as &Option<String>)
     .bind(&span.output_url as &Option<String>)
+    .bind(&span.status)
     .bind(&project_id)
     .execute(pool)
     .await?;

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -59,6 +59,7 @@ pub async fn create_span(
         span_type: request.span_type.unwrap_or(SpanType::LLM),
         start_time: request.start_time,
         end_time: request.end_time,
+        status: None,
         events: None,
         labels: None,
         input_url: None,

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -202,6 +202,7 @@ pub fn prepare_span_for_recording(
         // Check if it's an exception event
         if event.name == "exception" {
             trace_attributes.set_status("error".to_string());
+            span.status = Some("error".to_string());
         }
     });
 

--- a/clickhouse/001000-initial.sql
+++ b/clickhouse/001000-initial.sql
@@ -24,7 +24,7 @@ CREATE TABLE default.spans
     input_lower String MATERIALIZED lower(input) CODEC(ZSTD(3)),
     output_lower String MATERIALIZED lower(output) CODEC(ZSTD(3)),
     size_bytes UInt64 DEFAULT 0,
-    spans String DEFAULT '<null>'
+    status String DEFAULT '<null>'
 )
 ENGINE = MergeTree()
 ORDER BY (project_id, start_time, trace_id, span_id)

--- a/clickhouse/001000-initial.sql
+++ b/clickhouse/001000-initial.sql
@@ -106,4 +106,4 @@ PRIMARY KEY (project_id, evaluator_id)
 ORDER BY (project_id, evaluator_id, created_at)
 SETTINGS index_granularity = 8192;
 
-ALTER TABLE default.spans ADD COLUMN "status" text;
+ALTER TABLE default.spans ADD COLUMN "status" text DEFAULT '<null>';

--- a/clickhouse/001000-initial.sql
+++ b/clickhouse/001000-initial.sql
@@ -23,7 +23,8 @@ CREATE TABLE default.spans
     -- Add materialized columns for case-insensitive search
     input_lower String MATERIALIZED lower(input) CODEC(ZSTD(3)),
     output_lower String MATERIALIZED lower(output) CODEC(ZSTD(3)),
-    size_bytes UInt64 DEFAULT 0
+    size_bytes UInt64 DEFAULT 0,
+    spans String DEFAULT '<null>'
 )
 ENGINE = MergeTree()
 ORDER BY (project_id, start_time, trace_id, span_id)
@@ -105,5 +106,3 @@ ENGINE = MergeTree()
 PRIMARY KEY (project_id, evaluator_id)
 ORDER BY (project_id, evaluator_id, created_at)
 SETTINGS index_granularity = 8192;
-
-ALTER TABLE default.spans ADD COLUMN "status" text DEFAULT '<null>';

--- a/clickhouse/001000-initial.sql
+++ b/clickhouse/001000-initial.sql
@@ -105,3 +105,5 @@ ENGINE = MergeTree()
 PRIMARY KEY (project_id, evaluator_id)
 ORDER BY (project_id, evaluator_id, created_at)
 SETTINGS index_granularity = 8192;
+
+ALTER TABLE default.spans ADD COLUMN "status" text;

--- a/clickhouse/migrations/0003-span-status.sql
+++ b/clickhouse/migrations/0003-span-status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE default.spans ADD COLUMN "status" text;

--- a/clickhouse/migrations/0003-span-status.sql
+++ b/clickhouse/migrations/0003-span-status.sql
@@ -1,1 +1,1 @@
-ALTER TABLE default.spans ADD COLUMN "status" text;
+ALTER TABLE default.spans ADD COLUMN "status" text DEFAULT '<null>';

--- a/frontend/app/api/projects/[projectId]/traces/[traceId]/spans/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/[traceId]/spans/route.ts
@@ -1,11 +1,12 @@
-import { and, asc, eq, inArray, sql } from 'drizzle-orm';
-import { NextRequest, NextResponse } from 'next/server';
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
 
-import { searchSpans } from '@/lib/clickhouse/spans';
-import { SpanSearchType } from '@/lib/clickhouse/types';
-import { TimeRange } from '@/lib/clickhouse/utils';
-import { db } from '@/lib/db/drizzle';
-import { events, spans } from '@/lib/db/migrations/schema'; export async function GET(
+import { searchSpans } from "@/lib/clickhouse/spans";
+import { SpanSearchType } from "@/lib/clickhouse/types";
+import { TimeRange } from "@/lib/clickhouse/utils";
+import { db } from "@/lib/db/drizzle";
+import { events, spans } from "@/lib/db/migrations/schema";
+export async function GET(
   req: NextRequest,
   props: { params: Promise<{ projectId: string; traceId: string }> }
 ): Promise<Response> {
@@ -16,63 +17,68 @@ import { events, spans } from '@/lib/db/migrations/schema'; export async functio
   const searchType = req.nextUrl.searchParams.getAll("searchIn");
   let searchSpanIds: string[] = [];
   if (searchQuery) {
-    const timeRange = { pastHours: 'all' } as TimeRange;
+    const timeRange = { pastHours: "all" } as TimeRange;
     const searchResult = await searchSpans({
       projectId,
       searchQuery,
       timeRange,
       traceId,
-      searchType: searchType as SpanSearchType[]
+      searchType: searchType as SpanSearchType[],
     });
 
     searchSpanIds = Array.from(searchResult.spanIds);
   }
 
-  const spanEventsQuery = db.$with('span_events').as(
-    db.select({
-      spanId: events.spanId,
-      projectId: events.projectId,
-      events: sql`jsonb_agg(jsonb_build_object(
+  const spanEventsQuery = db.$with("span_events").as(
+    db
+      .select({
+        spanId: events.spanId,
+        projectId: events.projectId,
+        events: sql`jsonb_agg(jsonb_build_object(
         'id', events.id,
         'spanId', events.span_id,
         'timestamp', events.timestamp,
         'name', events.name,
         'attributes', events.attributes
-      ))`.as('events')
-    })
+      ))`.as("events"),
+      })
       .from(events)
       .where(
         and(
           eq(events.projectId, projectId),
           // This check may seem redundant because there is a join statement below,
           // but it makes much wiser use of indexes and is much faster (up to 1000x in theory)
-          inArray(events.spanId, sql`(SELECT span_id FROM spans
+          inArray(
+            events.spanId,
+            sql`(SELECT span_id FROM spans
             WHERE project_id = ${projectId} AND trace_id = ${traceId}
             ${searchSpanIds.length > 0 ? sql`AND span_id IN ${searchSpanIds}` : sql``}
-          )`)
+          )`
+          )
         )
       )
       .groupBy(events.spanId, events.projectId)
   );
 
-  const spanItems = await db.with(spanEventsQuery).select({
-    // inputs and outputs are ignored on purpose
-    spanId: spans.spanId,
-    startTime: spans.startTime,
-    endTime: spans.endTime,
-    traceId: spans.traceId,
-    parentSpanId: spans.parentSpanId,
-    name: spans.name,
-    attributes: spans.attributes,
-    spanType: spans.spanType,
-    events: sql`COALESCE(${spanEventsQuery.events}, '[]'::jsonb)`.as('events'),
-  })
+  const spanItems = await db
+    .with(spanEventsQuery)
+    .select({
+      // inputs and outputs are ignored on purpose
+      spanId: spans.spanId,
+      startTime: spans.startTime,
+      endTime: spans.endTime,
+      traceId: spans.traceId,
+      parentSpanId: spans.parentSpanId,
+      name: spans.name,
+      attributes: spans.attributes,
+      spanType: spans.spanType,
+      status: spans.status,
+      events: sql`COALESCE(${spanEventsQuery.events}, '[]'::jsonb)`.as("events"),
+    })
     .from(spans)
-    .leftJoin(spanEventsQuery,
-      and(
-        eq(spans.spanId, spanEventsQuery.spanId),
-        eq(spans.projectId, spanEventsQuery.projectId)
-      )
+    .leftJoin(
+      spanEventsQuery,
+      and(eq(spans.spanId, spanEventsQuery.spanId), eq(spans.projectId, spanEventsQuery.projectId))
     )
     .where(
       and(
@@ -85,8 +91,10 @@ import { events, spans } from '@/lib/db/migrations/schema'; export async functio
 
   // For now we flatten the span tree in the front-end if there is a search query,
   // so we explicitly set the parentSpanId to null
-  return NextResponse.json(spanItems.map((span) => ({
-    ...span,
-    parentSpanId: searchSpanIds.length > 0 ? null : span.parentSpanId,
-  })));
+  return NextResponse.json(
+    spanItems.map((span) => ({
+      ...span,
+      parentSpanId: searchSpanIds.length > 0 ? null : span.parentSpanId,
+    }))
+  );
 }

--- a/frontend/components/traces/error-card.tsx
+++ b/frontend/components/traces/error-card.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight, CircleAlert } from "lucide-react";
-import { useState } from "react";
+import { memo, useState } from "react";
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ErrorEventAttributes } from "@/lib/types";
@@ -19,22 +19,20 @@ const ErrorCard = ({ attributes }: ErrorCardProps) => {
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <div className="border bg-card rounded-md text-destructive">
-        <CollapsibleTrigger className="w-full p-2 text-left rounded-md">
-          <div className="flex items-start gap-2">
-            <CircleAlert className="w-4 h-4" />
-            <div className="flex flex-1 items-center justify-between">
-              <div>
-                <h3 className="font-medium text-xs">{errorType || "Exception occurred"}</h3>
-                {errorMessage && (
-                  <p className="text-xs mt-0.5">
-                    {isOpen ? errorMessage : `${errorMessage.substring(0, 60)}${errorMessage.length > 60 ? "..." : ""}`}
-                  </p>
-                )}
-              </div>
-              <div className="text-muted-foreground ml-2">
-                {isOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-              </div>
+      <div className="border bg-card rounded-md text-destructive max-h-48 overflow-y-auto">
+        <CollapsibleTrigger className="flex items-start gap-2 w-full p-2 text-left rounded-md">
+          <CircleAlert className="w-4 h-4" />
+          <div className="flex flex-1 items-center justify-between">
+            <div>
+              <h3 className="font-medium text-xs">{errorType || "Exception occurred"}</h3>
+              {errorMessage && (
+                <p className="text-xs mt-0.5">
+                  {isOpen ? errorMessage : `${errorMessage.substring(0, 60)}${errorMessage.length > 60 ? "..." : ""}`}
+                </p>
+              )}
+            </div>
+            <div className="text-muted-foreground ml-2">
+              {isOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
             </div>
           </div>
         </CollapsibleTrigger>
@@ -48,23 +46,17 @@ const ErrorCard = ({ attributes }: ErrorCardProps) => {
             </div>
           )}
           {traceLines.length > 0 && (
-            <div>
+            <>
               <p className="text-muted-foreground text-xs mb-1">Stack trace:</p>
               <div className="space-y-0.5">
-                {traceLines.slice(0, isOpen ? traceLines.length : 3).map((line, index) => (
+                {traceLines.map((line, index) => (
                   <div key={index} className="flex items-start gap-1.5">
                     <div className="w-1 h-1 bg-red-500 rounded-full mt-1.5 flex-shrink-0"></div>
                     <span className="text-xs font-mono break-all">{line.trim()}</span>
                   </div>
                 ))}
-                {!isOpen && traceLines.length > 3 && (
-                  <div className="flex items-start gap-1.5">
-                    <div className="w-1 h-1 bg-red-500 rounded-full mt-1.5 flex-shrink-0"></div>
-                    <span className="text-xs italic">{traceLines.length - 3} more lines...</span>
-                  </div>
-                )}
               </div>
-            </div>
+            </>
           )}
         </CollapsibleContent>
       </div>
@@ -72,4 +64,4 @@ const ErrorCard = ({ attributes }: ErrorCardProps) => {
   );
 };
 
-export default ErrorCard;
+export default memo(ErrorCard);

--- a/frontend/components/traces/error-card.tsx
+++ b/frontend/components/traces/error-card.tsx
@@ -1,0 +1,75 @@
+import { ChevronDown, ChevronRight, CircleAlert } from "lucide-react";
+import { useState } from "react";
+
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { ErrorEventAttributes } from "@/lib/types";
+
+interface ErrorCardProps {
+  attributes: ErrorEventAttributes;
+}
+
+const ErrorCard = ({ attributes }: ErrorCardProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const errorType = attributes["exception.type"];
+  const errorMessage = attributes["exception.message"];
+  const errorTrace = attributes["exception.stacktrace"];
+
+  const traceLines = errorTrace?.split("\n").filter((line) => line.trim()) || [];
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div className="border bg-card rounded-md text-destructive">
+        <CollapsibleTrigger className="w-full p-2 text-left rounded-md">
+          <div className="flex items-start gap-2">
+            <CircleAlert className="w-4 h-4" />
+            <div className="flex flex-1 items-center justify-between">
+              <div>
+                <h3 className="font-medium text-xs">{errorType || "Exception occurred"}</h3>
+                {errorMessage && (
+                  <p className="text-xs mt-0.5">
+                    {isOpen ? errorMessage : `${errorMessage.substring(0, 60)}${errorMessage.length > 60 ? "..." : ""}`}
+                  </p>
+                )}
+              </div>
+              <div className="text-muted-foreground ml-2">
+                {isOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+              </div>
+            </div>
+          </div>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="px-2 pb-2 ml-6">
+          {errorMessage && (
+            <div className="mb-2">
+              <p className="text-muted-foreground text-xs mb-1">Full error details:</p>
+              <div className="bg-muted rounded-sm p-2 border">
+                <pre className="text-xs text-foreground whitespace-pre-wrap font-mono">{errorMessage}</pre>
+              </div>
+            </div>
+          )}
+          {traceLines.length > 0 && (
+            <div>
+              <p className="text-muted-foreground text-xs mb-1">Stack trace:</p>
+              <div className="space-y-0.5">
+                {traceLines.slice(0, isOpen ? traceLines.length : 3).map((line, index) => (
+                  <div key={index} className="flex items-start gap-1.5">
+                    <div className="w-1 h-1 bg-red-500 rounded-full mt-1.5 flex-shrink-0"></div>
+                    <span className="text-xs font-mono break-all">{line.trim()}</span>
+                  </div>
+                ))}
+                {!isOpen && traceLines.length > 3 && (
+                  <div className="flex items-start gap-1.5">
+                    <div className="w-1 h-1 bg-red-500 rounded-full mt-1.5 flex-shrink-0"></div>
+                    <span className="text-xs italic">{traceLines.length - 3} more lines...</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+};
+
+export default ErrorCard;

--- a/frontend/components/traces/span-card.tsx
+++ b/frontend/components/traces/span-card.tsx
@@ -90,6 +90,7 @@ export function SpanCard({
             containerWidth={SQUARE_SIZE}
             containerHeight={SQUARE_SIZE}
             size={SQUARE_ICON_SIZE}
+            status={span.status}
             className={cn("min-w-[22px]", { "text-muted-foreground bg-muted ": span.pending })}
           />
           <div

--- a/frontend/components/traces/span-type-icon.tsx
+++ b/frontend/components/traces/span-type-icon.tsx
@@ -1,4 +1,4 @@
-import { Activity, ArrowRight, Bolt, Braces, Gauge, MessageCircleMore } from "lucide-react";
+import { Activity, ArrowRight, Bolt, Braces, CircleAlert, Gauge, MessageCircleMore } from "lucide-react";
 
 import { SpanType } from "@/lib/traces/types";
 import { SPAN_TYPE_TO_COLOR } from "@/lib/traces/utils";
@@ -11,6 +11,7 @@ interface SpanTypeIconProps {
   size?: number;
   className?: string;
   iconClassName?: string;
+  status?: string;
 }
 
 const DEFAULT_CONTAINER_SIZE = 22;
@@ -23,22 +24,41 @@ export default function SpanTypeIcon({
   size = DEFAULT_ICON_SIZE,
   className,
   iconClassName,
+  status,
 }: SpanTypeIconProps) {
+  const renderIcon = () => {
+    if (status === "error") {
+      return <CircleAlert className={iconClassName} size={size} />;
+    }
+
+    switch (spanType) {
+      case SpanType.DEFAULT:
+        return <Braces className={iconClassName} size={size} />;
+      case SpanType.LLM:
+        return <MessageCircleMore className={iconClassName} size={size} />;
+      case SpanType.EXECUTOR:
+        return <Activity className={iconClassName} size={size} />;
+      case SpanType.EVALUATOR:
+        return <ArrowRight className={iconClassName} size={size} />;
+      case SpanType.EVALUATION:
+        return <Gauge className={iconClassName} size={size} />;
+      case SpanType.TOOL:
+        return <Bolt className={iconClassName} size={size} />;
+      default:
+        return <Braces className={iconClassName} size={size} />;
+    }
+  };
+
   return (
     <div
       className={cn("flex items-center justify-center z-10 rounded", className)}
       style={{
-        backgroundColor: SPAN_TYPE_TO_COLOR[spanType],
+        backgroundColor: status === "error" ? "rgba(204, 51, 51, 1)" : SPAN_TYPE_TO_COLOR[spanType], // Red background for errors
         width: containerWidth,
         height: containerHeight,
       }}
     >
-      {spanType === SpanType.DEFAULT && <Braces className={iconClassName} size={size} />}
-      {spanType === SpanType.LLM && <MessageCircleMore className={iconClassName} size={size} />}
-      {spanType === SpanType.EXECUTOR && <Activity className={iconClassName} size={size} />}
-      {spanType === SpanType.EVALUATOR && <ArrowRight className={iconClassName} size={size} />}
-      {spanType === SpanType.EVALUATION && <Gauge className={iconClassName} size={size} />}
-      {spanType === SpanType.TOOL && <Bolt className={iconClassName} size={size} />}
+      {renderIcon()}
     </div>
   );
 }

--- a/frontend/components/traces/span-view.tsx
+++ b/frontend/components/traces/span-view.tsx
@@ -10,6 +10,7 @@ import LabelsContextProvider from "@/components/labels/labels-context";
 import LabelsList from "@/components/labels/labels-list";
 import LabelsTrigger from "@/components/labels/labels-trigger";
 import AddToLabelingQueuePopover from "@/components/traces/add-to-labeling-queue-popover";
+import ErrorCard from "@/components/traces/error-card";
 import ExportSpansPopover from "@/components/traces/export-spans-popover";
 import SpanInput from "@/components/traces/span-input";
 import SpanOutput from "@/components/traces/span-output";
@@ -19,6 +20,7 @@ import { useProjectContext } from "@/contexts/project-context";
 import { Event } from "@/lib/events/types";
 import { useToast } from "@/lib/hooks/use-toast";
 import { Span, SpanType } from "@/lib/traces/types";
+import { ErrorEventAttributes } from "@/lib/types";
 import { swrFetcher } from "@/lib/utils";
 
 import Formatter from "../ui/formatter";
@@ -48,6 +50,11 @@ export function SpanView({ spanId }: SpanViewProps) {
       });
     }
   };
+
+  const errorEventAttributes = useMemo(
+    () => cleanedEvents?.find((e) => e.name === "exception")?.attributes as ErrorEventAttributes,
+    [cleanedEvents]
+  );
 
   if (isLoading || !span) {
     return (
@@ -126,6 +133,7 @@ export function SpanView({ spanId }: SpanViewProps) {
               <LabelsList />
               <EvaluatorScoresList spanId={spanId} />
             </LabelsContextProvider>
+            {errorEventAttributes && <ErrorCard attributes={errorEventAttributes} />}
           </div>
           <TabsList className="border-none text-sm px-4">
             <TabsTrigger value="span-input" className="truncate">

--- a/frontend/components/traces/trace-view/index.tsx
+++ b/frontend/components/traces/trace-view/index.tsx
@@ -139,9 +139,10 @@ export default function TraceView({ traceId, onClose, propsTrace, fullScreen = f
         setSpans(spans);
 
         const spanIdFromUrl = searchParams.get("spanId");
-        const spanToSelect = spanIdFromUrl ? spans.find((span: Span) => span.spanId === spanIdFromUrl) ?? spans[0] : spans[0];
+        const spanToSelect = spanIdFromUrl
+          ? (spans.find((span: Span) => span.spanId === spanIdFromUrl) ?? spans[0])
+          : spans[0];
         setSelectedSpan(spanToSelect);
-
       } catch (e) {
         console.error(e);
       } finally {
@@ -329,7 +330,7 @@ export default function TraceView({ traceId, onClose, propsTrace, fullScreen = f
       if (typeof window !== "undefined") {
         localStorage.setItem("trace-view:tree-view-width", treeViewWidth.toString());
       }
-    } catch (e) { }
+    } catch (e) {}
   }, [treeViewWidth]);
 
   const isLoading = !trace || (isSpansLoading && isTraceLoading);

--- a/frontend/components/traces/trace-view/timeline-element.tsx
+++ b/frontend/components/traces/trace-view/timeline-element.tsx
@@ -71,9 +71,7 @@ const TimelineElement = ({
     const textContent = (
       <>
         {segment.span.name}{" "}
-        <span className="text-white/70">
-          {getDurationString(segment.span.startTime, segment.span.endTime)}
-        </span>
+        <span className="text-white/70">{getDurationString(segment.span.startTime, segment.span.endTime)}</span>
       </>
     );
 
@@ -160,7 +158,8 @@ const TimelineElement = ({
         ref={blockRef}
         className="rounded relative z-20 flex items-center"
         style={{
-          backgroundColor: SPAN_TYPE_TO_COLOR[segment.span.spanType],
+          backgroundColor:
+            segment.span.status === "error" ? "rgba(204, 51, 51, 1)" : SPAN_TYPE_TO_COLOR[segment.span.spanType],
           marginLeft: segment.left + "%",
           width: `max(${segment.width}%, 2px)`,
           height: 24,

--- a/frontend/components/traces/trace-view/utils.ts
+++ b/frontend/components/traces/trace-view/utils.ts
@@ -73,6 +73,7 @@ export const enrichSpansWithPending = (existingSpans: Span[]): Span[] => {
           inputUrl: null,
           outputUrl: null,
           pending: true,
+          status: span.status,
         } as Span;
         pendingSpans.set(spanId, pendingSpan);
       }

--- a/frontend/lib/db/migrations/0042_violet_jamie_braddock.sql
+++ b/frontend/lib/db/migrations/0042_violet_jamie_braddock.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "spans" ADD COLUMN "status" text;--> statement-breakpoint

--- a/frontend/lib/db/migrations/meta/0042_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0042_snapshot.json
@@ -1,0 +1,4061 @@
+{
+  "id": "6a158042-7597-48da-a63b-c354a95e814c",
+  "prevId": "440cdd0c-9f65-42fd-9edb-5077d4a333a8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_chats": {
+      "name": "agent_chats",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_name": {
+          "name": "chat_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_status": {
+          "name": "machine_status",
+          "type": "agent_machine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agent_status": {
+          "name": "agent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        }
+      },
+      "indexes": {
+        "agent_chats_created_at_idx": {
+          "name": "agent_chats_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_updated_at_idx": {
+          "name": "agent_chats_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_user_id_idx": {
+          "name": "agent_chats_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chats_user_id_fkey": {
+          "name": "agent_chats_user_id_fkey",
+          "tableFrom": "agent_chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_chats_session_id_fkey": {
+          "name": "agent_chats_session_id_fkey",
+          "tableFrom": "agent_chats",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_messages": {
+      "name": "agent_messages",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "agent_message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_messages_session_id_created_at_idx": {
+          "name": "agent_messages_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_messages_session_id_fkey": {
+          "name": "agent_messages_session_id_fkey",
+          "tableFrom": "agent_messages",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cdp_url": {
+          "name": "cdp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vnc_url": {
+          "name": "vnc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agent_status": {
+          "name": "agent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        }
+      },
+      "indexes": {
+        "agent_sessions_created_at_idx": {
+          "name": "agent_sessions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_updated_at_idx": {
+          "name": "agent_sessions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datapoint_to_span": {
+      "name": "datapoint_to_span",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "datapoint_id": {
+          "name": "datapoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datapoint_to_span_datapoint_id_fkey": {
+          "name": "datapoint_to_span_datapoint_id_fkey",
+          "tableFrom": "datapoint_to_span",
+          "tableTo": "dataset_datapoints",
+          "columnsFrom": [
+            "datapoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "datapoint_to_span_span_id_project_id_fkey": {
+          "name": "datapoint_to_span_span_id_project_id_fkey",
+          "tableFrom": "datapoint_to_span",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "span_id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "datapoint_to_span_pkey": {
+          "name": "datapoint_to_span_pkey",
+          "columns": [
+            "datapoint_id",
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_datapoints": {
+      "name": "dataset_datapoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_on": {
+          "name": "indexed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "index_in_batch": {
+          "name": "index_in_batch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dataset_datapoints_dataset_id_fkey": {
+          "name": "dataset_datapoints_dataset_id_fkey",
+          "tableFrom": "dataset_datapoints",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "indexed_on": {
+          "name": "indexed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "datasets_project_id_hash_idx": {
+          "name": "datasets_project_id_hash_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_datasets_project_id_fkey": {
+          "name": "public_datasets_project_id_fkey",
+          "tableFrom": "datasets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "executor_output": {
+          "name": "executor_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_in_batch": {
+          "name": "index_in_batch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "evaluation_results_evaluation_id_idx": {
+          "name": "evaluation_results_evaluation_id_idx",
+          "columns": [
+            {
+              "expression": "evaluation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_evaluation_id_fkey1": {
+          "name": "evaluation_results_evaluation_id_fkey1",
+          "tableFrom": "evaluation_results",
+          "tableTo": "evaluations",
+          "columnsFrom": [
+            "evaluation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_scores": {
+      "name": "evaluation_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "evaluation_scores_result_id_idx": {
+          "name": "evaluation_scores_result_id_idx",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_scores_result_id_fkey": {
+          "name": "evaluation_scores_result_id_fkey",
+          "tableFrom": "evaluation_scores",
+          "tableTo": "evaluation_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evaluation_results_names_unique": {
+          "name": "evaluation_results_names_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "result_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluations": {
+      "name": "evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {
+        "evaluations_project_id_hash_idx": {
+          "name": "evaluations_project_id_hash_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluations_project_id_fkey1": {
+          "name": "evaluations_project_id_fkey1",
+          "tableFrom": "evaluations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluator_scores": {
+      "name": "evaluator_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evaluator_id": {
+          "name": "evaluator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluator_scores_project_id_fkey": {
+          "name": "evaluator_scores_project_id_fkey",
+          "tableFrom": "evaluator_scores",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluator_span_paths": {
+      "name": "evaluator_span_paths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evaluator_id": {
+          "name": "evaluator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_path": {
+          "name": "span_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluator_span_paths_evaluator_id_fkey": {
+          "name": "evaluator_span_paths_evaluator_id_fkey",
+          "tableFrom": "evaluator_span_paths",
+          "tableTo": "evaluators",
+          "columnsFrom": [
+            "evaluator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluator_span_paths_project_id_fkey": {
+          "name": "evaluator_span_paths_project_id_fkey",
+          "tableFrom": "evaluator_span_paths",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluators": {
+      "name": "evaluators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluator_type": {
+          "name": "evaluator_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluators_project_id_fkey": {
+          "name": "evaluators_project_id_fkey",
+          "tableFrom": "evaluators",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "events_span_id_project_id_idx": {
+          "name": "events_span_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "span_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_span_id_project_id_fkey": {
+          "name": "events_span_id_project_id_fkey",
+          "tableFrom": "events",
+          "tableTo": "spans",
+          "columnsFrom": [
+            "span_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "span_id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_classes": {
+      "name": "label_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluator_runnable_graph": {
+          "name": "evaluator_runnable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_version_id": {
+          "name": "pipeline_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rgb(190, 194, 200)'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_classes_project_id_fkey": {
+          "name": "label_classes_project_id_fkey",
+          "tableFrom": "label_classes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_classes_project_id_id_key": {
+          "name": "label_classes_project_id_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "label_classes_name_project_id_unique": {
+          "name": "label_classes_name_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_classes_for_path": {
+      "name": "label_classes_for_path",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_class_id": {
+          "name": "label_class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "autoeval_labels_project_id_fkey": {
+          "name": "autoeval_labels_project_id_fkey",
+          "tableFrom": "label_classes_for_path",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_project_id_path_label_class": {
+          "name": "unique_project_id_path_label_class",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "path",
+            "label_class_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeling_queue_items": {
+      "name": "labeling_queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labelling_queue_items_queue_id_fkey": {
+          "name": "labelling_queue_items_queue_id_fkey",
+          "tableFrom": "labeling_queue_items",
+          "tableTo": "labeling_queues",
+          "columnsFrom": [
+            "queue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeling_queues": {
+      "name": "labeling_queues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labeling_queues_project_id_fkey": {
+          "name": "labeling_queues_project_id_fkey",
+          "tableFrom": "labeling_queues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "label_source": {
+          "name": "label_source",
+          "type": "label_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MANUAL'"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labels_class_id_project_id_fkey": {
+          "name": "labels_class_id_project_id_fkey",
+          "tableFrom": "labels",
+          "tableTo": "label_classes",
+          "columnsFrom": [
+            "class_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_span_id_class_id_key": {
+          "name": "labels_span_id_class_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "class_id",
+            "span_id"
+          ]
+        },
+        "labels_span_id_class_id_user_id_key": {
+          "name": "labels_span_id_class_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "class_id",
+            "span_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_prices": {
+      "name": "llm_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_price_per_million": {
+          "name": "input_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_price_per_million": {
+          "name": "output_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_cached_price_per_million": {
+          "name": "input_cached_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_prices": {
+          "name": "additional_prices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "machines_project_id_fkey": {
+          "name": "machines_project_id_fkey",
+          "tableFrom": "machines",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "machines_pkey": {
+          "name": "machines_pkey",
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members_of_workspaces": {
+      "name": "members_of_workspaces",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_role": {
+          "name": "member_role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        }
+      },
+      "indexes": {
+        "members_of_workspaces_user_id_idx": {
+          "name": "members_of_workspaces_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_of_workspaces_user_id_fkey": {
+          "name": "members_of_workspaces_user_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "public_members_of_workspaces_workspace_id_fkey": {
+          "name": "public_members_of_workspaces_workspace_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_of_workspaces_user_workspace_unique": {
+          "name": "members_of_workspaces_user_workspace_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_templates": {
+      "name": "pipeline_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "runnable_graph": {
+          "name": "runnable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "displayable_graph": {
+          "name": "displayable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "number_of_nodes": {
+          "name": "number_of_nodes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "display_group": {
+          "name": "display_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'build'"
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_versions": {
+      "name": "pipeline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayable_graph": {
+          "name": "displayable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runnable_graph": {
+          "name": "runnable_graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline_type": {
+          "name": "pipeline_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipelines": {
+      "name": "pipelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "python_requirements": {
+          "name": "python_requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "pipelines_name_project_id_idx": {
+          "name": "pipelines_name_project_id_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipelines_project_id_idx": {
+          "name": "pipelines_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipelines_project_id_fkey": {
+          "name": "pipelines_project_id_fkey",
+          "tableFrom": "pipelines",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_project_id_pipeline_name": {
+          "name": "unique_project_id_pipeline_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playgrounds": {
+      "name": "playgrounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_messages": {
+          "name": "prompt_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[{\"role\":\"user\",\"content\":\"\"}]'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1024
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playgrounds_project_id_fkey": {
+          "name": "playgrounds_project_id_fkey",
+          "tableFrom": "playgrounds",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_api_keys": {
+      "name": "project_api_keys",
+      "schema": "",
+      "columns": {
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shorthand": {
+          "name": "shorthand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {
+        "project_api_keys_hash_idx": {
+          "name": "project_api_keys_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_project_api_keys_project_id_fkey": {
+          "name": "public_project_api_keys_project_id_fkey",
+          "tableFrom": "project_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_workspace_id_idx": {
+          "name": "projects_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_fkey": {
+          "name": "projects_workspace_id_fkey",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_api_keys": {
+      "name": "provider_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hex": {
+          "name": "nonce_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_api_keys_project_id_fkey": {
+          "name": "provider_api_keys_project_id_fkey",
+          "tableFrom": "provider_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_templates": {
+      "name": "render_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "render_templates_project_id_fkey": {
+          "name": "render_templates_project_id_fkey",
+          "tableFrom": "render_templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spans": {
+      "name": "spans",
+      "schema": "",
+      "columns": {
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parent_span_id": {
+          "name": "parent_span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "span_type": {
+          "name": "span_type",
+          "type": "span_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_preview": {
+          "name": "input_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_preview": {
+          "name": "output_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_url": {
+          "name": "input_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_url": {
+          "name": "output_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "span_path_idx": {
+          "name": "span_path_idx",
+          "columns": [
+            {
+              "expression": "((attributes -> 'lmnr.span.path'::text))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_partial_evaluator_trace_id_project_id_start_time_span_id_": {
+          "name": "spans_partial_evaluator_trace_id_project_id_start_time_span_id_",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "span_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(span_type = 'EVALUATOR'::span_type)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_partial_executor_trace_id_project_id_start_time_span_id_i": {
+          "name": "spans_partial_executor_trace_id_project_id_start_time_span_id_i",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "span_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(span_type = 'EXECUTOR'::span_type)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_project_id_created_at_idx": {
+          "name": "spans_project_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_project_id_idx": {
+          "name": "spans_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "spans_project_id_start_time_idx": {
+          "name": "spans_project_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_project_id_trace_id_start_time_idx": {
+          "name": "spans_project_id_trace_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_root_project_id_start_time_end_time_trace_id_idx": {
+          "name": "spans_root_project_id_start_time_end_time_trace_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(parent_span_id IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_start_time_end_time_idx": {
+          "name": "spans_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_trace_id_idx": {
+          "name": "spans_trace_id_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spans_trace_id_start_time_idx": {
+          "name": "spans_trace_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spans_project_id_fkey": {
+          "name": "spans_project_id_fkey",
+          "tableFrom": "spans",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "spans_pkey": {
+          "name": "spans_pkey",
+          "columns": [
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_span_id_project_id": {
+          "name": "unique_span_id_project_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "span_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "subscription_tiers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_mib": {
+          "name": "storage_mib",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_retention_days": {
+          "name": "log_retention_days",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "members_per_workspace": {
+          "name": "members_per_workspace",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "steps": {
+          "name": "steps",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "spans": {
+          "name": "spans",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_span_price": {
+          "name": "extra_span_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_step_price": {
+          "name": "extra_step_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "bytes_ingested": {
+          "name": "bytes_ingested",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_byte_price": {
+          "name": "extra_byte_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.target_pipeline_versions": {
+      "name": "target_pipeline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline_version_id": {
+          "name": "pipeline_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "target_pipeline_versions_pipeline_id_fkey": {
+          "name": "target_pipeline_versions_pipeline_id_fkey",
+          "tableFrom": "target_pipeline_versions",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "target_pipeline_versions_pipeline_version_id_fkey": {
+          "name": "target_pipeline_versions_pipeline_version_id_fkey",
+          "tableFrom": "target_pipeline_versions",
+          "tableTo": "pipeline_versions",
+          "columnsFrom": [
+            "pipeline_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pipeline_id": {
+          "name": "unique_pipeline_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pipeline_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traces": {
+      "name": "traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_token_count": {
+          "name": "total_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trace_type": {
+          "name": "trace_type",
+          "type": "trace_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DEFAULT'"
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "input_cost": {
+          "name": "input_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_cost": {
+          "name": "output_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "has_browser_session": {
+          "name": "has_browser_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_span_id": {
+          "name": "top_span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trace_metadata_gin_idx": {
+          "name": "trace_metadata_gin_idx",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "traces_id_project_id_start_time_times_not_null_idx": {
+          "name": "traces_id_project_id_start_time_times_not_null_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "((start_time IS NOT NULL) AND (end_time IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_project_id_idx": {
+          "name": "traces_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_project_id_trace_type_start_time_end_time_idx": {
+          "name": "traces_project_id_trace_type_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "((trace_type = 'DEFAULT'::trace_type) AND (start_time IS NOT NULL) AND (end_time IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_session_id_idx": {
+          "name": "traces_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_start_time_end_time_idx": {
+          "name": "traces_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_traces_project_id_fkey": {
+          "name": "new_traces_project_id_fkey",
+          "tableFrom": "traces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cookies": {
+      "name": "user_cookies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cookies": {
+          "name": "cookies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_cookies_user_id_fkey": {
+          "name": "user_cookies_user_id_fkey",
+          "tableFrom": "user_cookies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscription_info": {
+      "name": "user_subscription_info",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_subscription_info_stripe_customer_id_idx": {
+          "name": "user_subscription_info_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscription_info_fkey": {
+          "name": "user_subscription_info_fkey",
+          "tableFrom": "user_subscription_info",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscription_tiers": {
+      "name": "user_subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "user_subscription_tiers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "index_chat_messages": {
+          "name": "index_chat_messages",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_usage": {
+      "name": "user_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "index_chat_message_count": {
+          "name": "index_chat_message_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "index_chat_message_count_since_reset": {
+          "name": "index_chat_message_count_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "prev_index_chat_message_count": {
+          "name": "prev_index_chat_message_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "reset_time": {
+          "name": "reset_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reset_reason": {
+          "name": "reset_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signup'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_usage_user_id_fkey": {
+          "name": "user_usage_user_id_fkey",
+          "tableFrom": "user_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_tier_id_fkey": {
+          "name": "users_tier_id_fkey",
+          "tableFrom": "users",
+          "tableTo": "user_subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_invitations_workspace_id_fkey": {
+          "name": "workspace_invitations_workspace_id_fkey",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_workspace_id_email_key": {
+          "name": "workspace_invitations_workspace_id_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_usage": {
+      "name": "workspace_usage",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "span_count": {
+          "name": "span_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "span_count_since_reset": {
+          "name": "span_count_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "prev_span_count": {
+          "name": "prev_span_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "step_count": {
+          "name": "step_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "step_count_since_reset": {
+          "name": "step_count_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "prev_step_count": {
+          "name": "prev_step_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "reset_time": {
+          "name": "reset_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reset_reason": {
+          "name": "reset_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signup'"
+        },
+        "bytes_ingested": {
+          "name": "bytes_ingested",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "bytes_ingested_since_reset": {
+          "name": "bytes_ingested_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "prev_bytes_ingested": {
+          "name": "prev_bytes_ingested",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "spans_bytes_ingested": {
+          "name": "spans_bytes_ingested",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "spans_bytes_ingested_since_reset": {
+          "name": "spans_bytes_ingested_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "browser_session_events_bytes_ingested": {
+          "name": "browser_session_events_bytes_ingested",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "browser_session_events_bytes_ingested_since_reset": {
+          "name": "browser_session_events_bytes_ingested_since_reset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_usage_workspace_id_fkey": {
+          "name": "user_usage_workspace_id_fkey",
+          "tableFrom": "workspace_usage",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_usage_workspace_id_key": {
+          "name": "user_usage_workspace_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_seats": {
+          "name": "additional_seats",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_tier_id_fkey": {
+          "name": "workspaces_tier_id_fkey",
+          "tableFrom": "workspaces",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_machine_status": {
+      "name": "agent_machine_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "running",
+        "paused",
+        "stopped"
+      ]
+    },
+    "public.agent_message_type": {
+      "name": "agent_message_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "step",
+        "error"
+      ]
+    },
+    "public.label_source": {
+      "name": "label_source",
+      "schema": "public",
+      "values": [
+        "MANUAL",
+        "AUTO",
+        "CODE"
+      ]
+    },
+    "public.span_type": {
+      "name": "span_type",
+      "schema": "public",
+      "values": [
+        "DEFAULT",
+        "LLM",
+        "PIPELINE",
+        "EXECUTOR",
+        "EVALUATOR",
+        "EVALUATION",
+        "TOOL"
+      ]
+    },
+    "public.trace_type": {
+      "name": "trace_type",
+      "schema": "public",
+      "values": [
+        "DEFAULT",
+        "EVENT",
+        "EVALUATION",
+        "PLAYGROUND"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1748615661679,
       "tag": "0041_silent_midnight",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1748853622534,
+      "tag": "0042_violet_jamie_braddock",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/db/migrations/relations.ts
+++ b/frontend/lib/db/migrations/relations.ts
@@ -2,143 +2,141 @@ import { relations } from "drizzle-orm/relations";
 
 import { agentChats, agentMessages, agentSessions, apiKeys, datapointToSpan,datasetDatapoints, datasets, evaluationResults, evaluations, evaluationScores, evaluators, evaluatorScores, evaluatorSpanPaths, events, labelClasses, labelClassesForPath, labelingQueueItems, labelingQueues, labels, machines, membersOfWorkspaces, pipelines, pipelineVersions, playgrounds, projectApiKeys, projects, providerApiKeys, renderTemplates, spans, subscriptionTiers, targetPipelineVersions, traces, userCookies, users, userSubscriptionInfo, userSubscriptionTiers, userUsage, workspaceInvitations, workspaces, workspaceUsage } from "./schema";
 
-export const agentChatsRelations = relations(agentChats, ({one}) => ({
-  agentSession: one(agentSessions, {
-    fields: [agentChats.sessionId],
-    references: [agentSessions.sessionId]
-  }),
-  user: one(users, {
-    fields: [agentChats.userId],
-    references: [users.id]
-  }),
-}));
-
-export const agentSessionsRelations = relations(agentSessions, ({many}) => ({
-  agentChats: many(agentChats),
-  agentMessages: many(agentMessages),
-}));
-
-export const usersRelations = relations(users, ({one, many}) => ({
-  agentChats: many(agentChats),
-  userUsages: many(userUsage),
-  userCookies: many(userCookies),
-  apiKeys: many(apiKeys),
-  userSubscriptionTier: one(userSubscriptionTiers, {
-    fields: [users.tierId],
-    references: [userSubscriptionTiers.id]
-  }),
-  userSubscriptionInfos: many(userSubscriptionInfo),
-  membersOfWorkspaces: many(membersOfWorkspaces),
-}));
-
-export const userUsageRelations = relations(userUsage, ({one}) => ({
-  user: one(users, {
-    fields: [userUsage.userId],
-    references: [users.id]
-  }),
-}));
-
-export const evaluatorsRelations = relations(evaluators, ({one, many}) => ({
+export const datasetsRelations = relations(datasets, ({one, many}) => ({
   project: one(projects, {
-    fields: [evaluators.projectId],
+    fields: [datasets.projectId],
     references: [projects.id]
   }),
-  evaluatorSpanPaths: many(evaluatorSpanPaths),
+  datasetDatapoints: many(datasetDatapoints),
 }));
 
 export const projectsRelations = relations(projects, ({one, many}) => ({
-  evaluators: many(evaluators),
-  evaluatorScores: many(evaluatorScores),
-  evaluatorSpanPaths: many(evaluatorSpanPaths),
-  renderTemplates: many(renderTemplates),
-  labelClasses: many(labelClasses),
-  labelClassesForPaths: many(labelClassesForPath),
-  labelingQueues: many(labelingQueues),
   datasets: many(datasets),
-  traces: many(traces),
   workspace: one(workspaces, {
     fields: [projects.workspaceId],
     references: [workspaces.id]
   }),
-  providerApiKeys: many(providerApiKeys),
+  labelClassesForPaths: many(labelClassesForPath),
   pipelines: many(pipelines),
-  evaluations: many(evaluations),
   projectApiKeys: many(projectApiKeys),
+  providerApiKeys: many(providerApiKeys),
+  labelingQueues: many(labelingQueues),
+  evaluations: many(evaluations),
+  renderTemplates: many(renderTemplates),
+  labelClasses: many(labelClasses),
+  evaluatorScores: many(evaluatorScores),
+  evaluators: many(evaluators),
+  evaluatorSpanPaths: many(evaluatorSpanPaths),
   playgrounds: many(playgrounds),
+  traces: many(traces),
   machines: many(machines),
   spans: many(spans),
 }));
 
-export const userCookiesRelations = relations(userCookies, ({one}) => ({
-  user: one(users, {
-    fields: [userCookies.userId],
-    references: [users.id]
+export const datasetDatapointsRelations = relations(datasetDatapoints, ({one, many}) => ({
+  dataset: one(datasets, {
+    fields: [datasetDatapoints.datasetId],
+    references: [datasets.id]
   }),
-}));
-
-export const evaluatorScoresRelations = relations(evaluatorScores, ({one}) => ({
-  project: one(projects, {
-    fields: [evaluatorScores.projectId],
-    references: [projects.id]
-  }),
-}));
-
-export const evaluatorSpanPathsRelations = relations(evaluatorSpanPaths, ({one}) => ({
-  evaluator: one(evaluators, {
-    fields: [evaluatorSpanPaths.evaluatorId],
-    references: [evaluators.id]
-  }),
-  project: one(projects, {
-    fields: [evaluatorSpanPaths.projectId],
-    references: [projects.id]
-  }),
-}));
-
-export const workspaceInvitationsRelations = relations(workspaceInvitations, ({one}) => ({
-  workspace: one(workspaces, {
-    fields: [workspaceInvitations.workspaceId],
-    references: [workspaces.id]
-  }),
+  datapointToSpans: many(datapointToSpan),
 }));
 
 export const workspacesRelations = relations(workspaces, ({one, many}) => ({
-  workspaceInvitations: many(workspaceInvitations),
   projects: many(projects),
+  membersOfWorkspaces: many(membersOfWorkspaces),
   subscriptionTier: one(subscriptionTiers, {
     fields: [workspaces.tierId],
     references: [subscriptionTiers.id]
   }),
-  membersOfWorkspaces: many(membersOfWorkspaces),
+  workspaceInvitations: many(workspaceInvitations),
   workspaceUsages: many(workspaceUsage),
 }));
 
-export const renderTemplatesRelations = relations(renderTemplates, ({one}) => ({
+export const labelClassesForPathRelations = relations(labelClassesForPath, ({one}) => ({
   project: one(projects, {
-    fields: [renderTemplates.projectId],
+    fields: [labelClassesForPath.projectId],
     references: [projects.id]
   }),
 }));
 
-export const labelingQueueItemsRelations = relations(labelingQueueItems, ({one}) => ({
-  labelingQueue: one(labelingQueues, {
-    fields: [labelingQueueItems.queueId],
-    references: [labelingQueues.id]
+export const membersOfWorkspacesRelations = relations(membersOfWorkspaces, ({one}) => ({
+  user: one(users, {
+    fields: [membersOfWorkspaces.userId],
+    references: [users.id]
+  }),
+  workspace: one(workspaces, {
+    fields: [membersOfWorkspaces.workspaceId],
+    references: [workspaces.id]
+  }),
+}));
+
+export const usersRelations = relations(users, ({one, many}) => ({
+  membersOfWorkspaces: many(membersOfWorkspaces),
+  userSubscriptionInfos: many(userSubscriptionInfo),
+  apiKeys: many(apiKeys),
+  userCookies: many(userCookies),
+  userUsages: many(userUsage),
+  agentChats: many(agentChats),
+  userSubscriptionTier: one(userSubscriptionTiers, {
+    fields: [users.tierId],
+    references: [userSubscriptionTiers.id]
+  }),
+}));
+
+export const subscriptionTiersRelations = relations(subscriptionTiers, ({many}) => ({
+  workspaces: many(workspaces),
+}));
+
+export const pipelinesRelations = relations(pipelines, ({one, many}) => ({
+  project: one(projects, {
+    fields: [pipelines.projectId],
+    references: [projects.id]
+  }),
+  targetPipelineVersions: many(targetPipelineVersions),
+}));
+
+export const projectApiKeysRelations = relations(projectApiKeys, ({one}) => ({
+  project: one(projects, {
+    fields: [projectApiKeys.projectId],
+    references: [projects.id]
+  }),
+}));
+
+export const providerApiKeysRelations = relations(providerApiKeys, ({one}) => ({
+  project: one(projects, {
+    fields: [providerApiKeys.projectId],
+    references: [projects.id]
+  }),
+}));
+
+export const targetPipelineVersionsRelations = relations(targetPipelineVersions, ({one}) => ({
+  pipeline: one(pipelines, {
+    fields: [targetPipelineVersions.pipelineId],
+    references: [pipelines.id]
+  }),
+  pipelineVersion: one(pipelineVersions, {
+    fields: [targetPipelineVersions.pipelineVersionId],
+    references: [pipelineVersions.id]
+  }),
+}));
+
+export const pipelineVersionsRelations = relations(pipelineVersions, ({many}) => ({
+  targetPipelineVersions: many(targetPipelineVersions),
+}));
+
+export const userSubscriptionInfoRelations = relations(userSubscriptionInfo, ({one}) => ({
+  user: one(users, {
+    fields: [userSubscriptionInfo.userId],
+    references: [users.id]
   }),
 }));
 
 export const labelingQueuesRelations = relations(labelingQueues, ({one, many}) => ({
-  labelingQueueItems: many(labelingQueueItems),
   project: one(projects, {
     fields: [labelingQueues.projectId],
     references: [projects.id]
   }),
-}));
-
-export const agentMessagesRelations = relations(agentMessages, ({one}) => ({
-  agentSession: one(agentSessions, {
-    fields: [agentMessages.sessionId],
-    references: [agentSessions.sessionId]
-  }),
+  labelingQueueItems: many(labelingQueueItems),
 }));
 
 export const apiKeysRelations = relations(apiKeys, ({one}) => ({
@@ -148,12 +146,27 @@ export const apiKeysRelations = relations(apiKeys, ({one}) => ({
   }),
 }));
 
-export const labelClassesRelations = relations(labelClasses, ({one, many}) => ({
+export const evaluationsRelations = relations(evaluations, ({one, many}) => ({
   project: one(projects, {
-    fields: [labelClasses.projectId],
+    fields: [evaluations.projectId],
     references: [projects.id]
   }),
-  labels: many(labels),
+  evaluationResults: many(evaluationResults),
+}));
+
+export const evaluationScoresRelations = relations(evaluationScores, ({one}) => ({
+  evaluationResult: one(evaluationResults, {
+    fields: [evaluationScores.resultId],
+    references: [evaluationResults.id]
+  }),
+}));
+
+export const evaluationResultsRelations = relations(evaluationResults, ({one, many}) => ({
+  evaluationScores: many(evaluationScores),
+  evaluation: one(evaluations, {
+    fields: [evaluationResults.evaluationId],
+    references: [evaluations.id]
+  }),
 }));
 
 export const eventsRelations = relations(events, ({one}) => ({
@@ -172,127 +185,19 @@ export const spansRelations = relations(spans, ({one, many}) => ({
   }),
 }));
 
-export const labelClassesForPathRelations = relations(labelClassesForPath, ({one}) => ({
+export const renderTemplatesRelations = relations(renderTemplates, ({one}) => ({
   project: one(projects, {
-    fields: [labelClassesForPath.projectId],
+    fields: [renderTemplates.projectId],
     references: [projects.id]
   }),
 }));
 
-export const evaluationScoresRelations = relations(evaluationScores, ({one}) => ({
-  evaluationResult: one(evaluationResults, {
-    fields: [evaluationScores.resultId],
-    references: [evaluationResults.id]
-  }),
-}));
-
-export const evaluationResultsRelations = relations(evaluationResults, ({one, many}) => ({
-  evaluationScores: many(evaluationScores),
-  evaluation: one(evaluations, {
-    fields: [evaluationResults.evaluationId],
-    references: [evaluations.id]
-  }),
-}));
-
-export const datasetsRelations = relations(datasets, ({one, many}) => ({
+export const labelClassesRelations = relations(labelClasses, ({one, many}) => ({
   project: one(projects, {
-    fields: [datasets.projectId],
+    fields: [labelClasses.projectId],
     references: [projects.id]
   }),
-  datasetDatapoints: many(datasetDatapoints),
-}));
-
-export const tracesRelations = relations(traces, ({one}) => ({
-  project: one(projects, {
-    fields: [traces.projectId],
-    references: [projects.id]
-  }),
-}));
-
-export const userSubscriptionTiersRelations = relations(userSubscriptionTiers, ({many}) => ({
-  users: many(users),
-}));
-
-export const targetPipelineVersionsRelations = relations(targetPipelineVersions, ({one}) => ({
-  pipeline: one(pipelines, {
-    fields: [targetPipelineVersions.pipelineId],
-    references: [pipelines.id]
-  }),
-  pipelineVersion: one(pipelineVersions, {
-    fields: [targetPipelineVersions.pipelineVersionId],
-    references: [pipelineVersions.id]
-  }),
-}));
-
-export const pipelinesRelations = relations(pipelines, ({one, many}) => ({
-  targetPipelineVersions: many(targetPipelineVersions),
-  project: one(projects, {
-    fields: [pipelines.projectId],
-    references: [projects.id]
-  }),
-}));
-
-export const pipelineVersionsRelations = relations(pipelineVersions, ({many}) => ({
-  targetPipelineVersions: many(targetPipelineVersions),
-}));
-
-export const providerApiKeysRelations = relations(providerApiKeys, ({one}) => ({
-  project: one(projects, {
-    fields: [providerApiKeys.projectId],
-    references: [projects.id]
-  }),
-}));
-
-export const subscriptionTiersRelations = relations(subscriptionTiers, ({many}) => ({
-  workspaces: many(workspaces),
-}));
-
-export const userSubscriptionInfoRelations = relations(userSubscriptionInfo, ({one}) => ({
-  user: one(users, {
-    fields: [userSubscriptionInfo.userId],
-    references: [users.id]
-  }),
-}));
-
-export const datasetDatapointsRelations = relations(datasetDatapoints, ({one, many}) => ({
-  dataset: one(datasets, {
-    fields: [datasetDatapoints.datasetId],
-    references: [datasets.id]
-  }),
-  datapointToSpans: many(datapointToSpan),
-}));
-
-export const evaluationsRelations = relations(evaluations, ({one, many}) => ({
-  evaluationResults: many(evaluationResults),
-  project: one(projects, {
-    fields: [evaluations.projectId],
-    references: [projects.id]
-  }),
-}));
-
-export const membersOfWorkspacesRelations = relations(membersOfWorkspaces, ({one}) => ({
-  user: one(users, {
-    fields: [membersOfWorkspaces.userId],
-    references: [users.id]
-  }),
-  workspace: one(workspaces, {
-    fields: [membersOfWorkspaces.workspaceId],
-    references: [workspaces.id]
-  }),
-}));
-
-export const projectApiKeysRelations = relations(projectApiKeys, ({one}) => ({
-  project: one(projects, {
-    fields: [projectApiKeys.projectId],
-    references: [projects.id]
-  }),
-}));
-
-export const workspaceUsageRelations = relations(workspaceUsage, ({one}) => ({
-  workspace: one(workspaces, {
-    fields: [workspaceUsage.workspaceId],
-    references: [workspaces.id]
-  }),
+  labels: many(labels),
 }));
 
 export const labelsRelations = relations(labels, ({one}) => ({
@@ -302,10 +207,105 @@ export const labelsRelations = relations(labels, ({one}) => ({
   }),
 }));
 
+export const agentMessagesRelations = relations(agentMessages, ({one}) => ({
+  agentSession: one(agentSessions, {
+    fields: [agentMessages.sessionId],
+    references: [agentSessions.sessionId]
+  }),
+}));
+
+export const agentSessionsRelations = relations(agentSessions, ({many}) => ({
+  agentMessages: many(agentMessages),
+  agentChats: many(agentChats),
+}));
+
+export const userCookiesRelations = relations(userCookies, ({one}) => ({
+  user: one(users, {
+    fields: [userCookies.userId],
+    references: [users.id]
+  }),
+}));
+
+export const userUsageRelations = relations(userUsage, ({one}) => ({
+  user: one(users, {
+    fields: [userUsage.userId],
+    references: [users.id]
+  }),
+}));
+
+export const agentChatsRelations = relations(agentChats, ({one}) => ({
+  user: one(users, {
+    fields: [agentChats.userId],
+    references: [users.id]
+  }),
+  agentSession: one(agentSessions, {
+    fields: [agentChats.sessionId],
+    references: [agentSessions.sessionId]
+  }),
+}));
+
+export const workspaceInvitationsRelations = relations(workspaceInvitations, ({one}) => ({
+  workspace: one(workspaces, {
+    fields: [workspaceInvitations.workspaceId],
+    references: [workspaces.id]
+  }),
+}));
+
+export const userSubscriptionTiersRelations = relations(userSubscriptionTiers, ({many}) => ({
+  users: many(users),
+}));
+
+export const evaluatorScoresRelations = relations(evaluatorScores, ({one}) => ({
+  project: one(projects, {
+    fields: [evaluatorScores.projectId],
+    references: [projects.id]
+  }),
+}));
+
+export const evaluatorsRelations = relations(evaluators, ({one, many}) => ({
+  project: one(projects, {
+    fields: [evaluators.projectId],
+    references: [projects.id]
+  }),
+  evaluatorSpanPaths: many(evaluatorSpanPaths),
+}));
+
+export const evaluatorSpanPathsRelations = relations(evaluatorSpanPaths, ({one}) => ({
+  evaluator: one(evaluators, {
+    fields: [evaluatorSpanPaths.evaluatorId],
+    references: [evaluators.id]
+  }),
+  project: one(projects, {
+    fields: [evaluatorSpanPaths.projectId],
+    references: [projects.id]
+  }),
+}));
+
 export const playgroundsRelations = relations(playgrounds, ({one}) => ({
   project: one(projects, {
     fields: [playgrounds.projectId],
     references: [projects.id]
+  }),
+}));
+
+export const labelingQueueItemsRelations = relations(labelingQueueItems, ({one}) => ({
+  labelingQueue: one(labelingQueues, {
+    fields: [labelingQueueItems.queueId],
+    references: [labelingQueues.id]
+  }),
+}));
+
+export const tracesRelations = relations(traces, ({one}) => ({
+  project: one(projects, {
+    fields: [traces.projectId],
+    references: [projects.id]
+  }),
+}));
+
+export const workspaceUsageRelations = relations(workspaceUsage, ({one}) => ({
+  workspace: one(workspaces, {
+    fields: [workspaceUsage.workspaceId],
+    references: [workspaces.id]
   }),
 }));
 

--- a/frontend/lib/db/migrations/schema.ts
+++ b/frontend/lib/db/migrations/schema.ts
@@ -1,270 +1,40 @@
 import { sql } from "drizzle-orm";
-import { bigint, boolean, doublePrecision, foreignKey, index, integer, jsonb, pgEnum,pgPolicy, pgTable, primaryKey, real, text, timestamp, unique, uuid } from "drizzle-orm/pg-core";
+import {
+  bigint,
+  boolean,
+  doublePrecision,
+  foreignKey,
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from "drizzle-orm/pg-core";
 
-export const agentMachineStatus = pgEnum("agent_machine_status", ['not_started', 'running', 'paused', 'stopped']);
-export const agentMessageType = pgEnum("agent_message_type", ['user', 'assistant', 'step', 'error']);
-export const labelSource = pgEnum("label_source", ['MANUAL', 'AUTO', 'CODE']);
-export const spanType = pgEnum("span_type", ['DEFAULT', 'LLM', 'PIPELINE', 'EXECUTOR', 'EVALUATOR', 'EVALUATION', 'TOOL']);
-export const traceType = pgEnum("trace_type", ['DEFAULT', 'EVENT', 'EVALUATION', 'PLAYGROUND']);
-export const workspaceRole = pgEnum("workspace_role", ['member', 'owner']);
-
-
-export const agentChats = pgTable("agent_chats", {
-  sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
-  chatName: text("chat_name").default('New chat').notNull(),
-  userId: uuid("user_id").notNull(),
-  machineStatus: agentMachineStatus("machine_status").default('not_started'),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  agentStatus: text("agent_status").default('idle').notNull(),
-}, (table) => [
-  index("agent_chats_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
-  index("agent_chats_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
-  index("agent_chats_user_id_idx").using("hash", table.userId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.sessionId],
-    foreignColumns: [agentSessions.sessionId],
-    name: "agent_chats_session_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "agent_chats_user_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  pgPolicy("select_by_next_api_key", { as: "permissive", for: "select", to: ["authenticated"], using: sql`is_user_id_accessible_for_api_key(api_key(), user_id)` }),
+export const agentMachineStatus = pgEnum("agent_machine_status", ["not_started", "running", "paused", "stopped"]);
+export const agentMessageType = pgEnum("agent_message_type", ["user", "assistant", "step", "error"]);
+export const labelSource = pgEnum("label_source", ["MANUAL", "AUTO", "CODE"]);
+export const spanType = pgEnum("span_type", [
+  "DEFAULT",
+  "LLM",
+  "PIPELINE",
+  "EXECUTOR",
+  "EVALUATOR",
+  "EVALUATION",
+  "TOOL",
 ]);
-
-export const userUsage = pgTable("user_usage", {
-  userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexChatMessageCount: bigint("index_chat_message_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexChatMessageCountSinceReset: bigint("index_chat_message_count_since_reset", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  prevIndexChatMessageCount: bigint("prev_index_chat_message_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  resetTime: timestamp("reset_time", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  resetReason: text("reset_reason").default('signup').notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "user_usage_user_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
-
-export const userSubscriptionTiers = pgTable("user_subscription_tiers", {
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  id: bigint({ mode: "number" }).primaryKey().generatedByDefaultAsIdentity({ name: "user_subscription_tiers_id_seq", startWith: 1, increment: 1, minValue: 1, maxValue: 9223372036854775807, cache: 1 }),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  stripeProductId: text("stripe_product_id").default('').notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexChatMessages: bigint("index_chat_messages", { mode: "number" }).default(sql`'0'`),
-});
-
-export const evaluators = pgTable("evaluators", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  projectId: uuid("project_id").notNull(),
-  name: text().notNull(),
-  evaluatorType: text("evaluator_type").notNull(),
-  definition: jsonb().default({}),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "evaluators_project_id_fkey"
-  }).onDelete("cascade"),
-]);
-
-export const userCookies = pgTable("user_cookies", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  userId: uuid("user_id").notNull(),
-  cookies: text().notNull(),
-  nonce: text().notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "user_cookies_user_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
-
-export const evaluatorScores = pgTable("evaluator_scores", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  evaluatorId: uuid("evaluator_id").notNull(),
-  spanId: uuid("span_id").notNull(),
-  score: doublePrecision().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "evaluator_scores_project_id_fkey"
-  }).onDelete("cascade"),
-]);
-
-export const evaluatorSpanPaths = pgTable("evaluator_span_paths", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  evaluatorId: uuid("evaluator_id").notNull(),
-  spanPath: jsonb("span_path").default({}),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.evaluatorId],
-    foreignColumns: [evaluators.id],
-    name: "evaluator_span_paths_evaluator_id_fkey"
-  }).onDelete("cascade"),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "evaluator_span_paths_project_id_fkey"
-  }).onDelete("cascade"),
-]);
-
-export const workspaceInvitations = pgTable("workspace_invitations", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  workspaceId: uuid("workspace_id").defaultRandom().notNull(),
-  email: text().default('').notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.workspaceId],
-    foreignColumns: [workspaces.id],
-    name: "workspace_invitations_workspace_id_fkey"
-  }).onDelete("cascade"),
-]);
-
-export const renderTemplates = pgTable("render_templates", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  projectId: uuid("project_id").defaultRandom().notNull(),
-  code: text().notNull(),
-  name: text().notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "render_templates_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
-
-export const labelingQueueItems = pgTable("labeling_queue_items", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  queueId: uuid("queue_id").defaultRandom().notNull(),
-  metadata: jsonb().default({}),
-  payload: jsonb().default({}),
-}, (table) => [
-  foreignKey({
-    columns: [table.queueId],
-    foreignColumns: [labelingQueues.id],
-    name: "labelling_queue_items_queue_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
-
-export const agentSessions = pgTable("agent_sessions", {
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
-  cdpUrl: text("cdp_url"),
-  vncUrl: text("vnc_url"),
-  machineId: text("machine_id"),
-  state: text(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  agentStatus: text("agent_status").default('idle').notNull(),
-}, (table) => [
-  index("agent_sessions_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
-  index("agent_sessions_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
-]);
-
-export const agentMessages = pgTable("agent_messages", {
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  sessionId: uuid("session_id").notNull(),
-  content: jsonb().default({}),
-  messageType: agentMessageType("message_type").notNull(),
-  traceId: uuid("trace_id"),
-}, (table) => [
-  index("agent_messages_session_id_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops"), table.sessionId.asc().nullsLast().op("timestamptz_ops")),
-  foreignKey({
-    columns: [table.sessionId],
-    foreignColumns: [agentSessions.sessionId],
-    name: "agent_messages_session_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
-
-export const apiKeys = pgTable("api_keys", {
-  apiKey: text("api_key").primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  userId: uuid("user_id").notNull(),
-  name: text().default('default').notNull(),
-}, (table) => [
-  index("api_keys_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "api_keys_user_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  pgPolicy("Enable insert for authenticated users only", { as: "permissive", for: "all", to: ["service_role"], using: sql`true`, withCheck: sql`true` }),
-]);
-
-export const labelClasses = pgTable("label_classes", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  projectId: uuid("project_id").notNull(),
-  description: text(),
-  evaluatorRunnableGraph: jsonb("evaluator_runnable_graph"),
-  pipelineVersionId: uuid("pipeline_version_id"),
-  color: text().default('rgb(190, 194, 200)').notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "label_classes_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("label_classes_project_id_id_key").on(table.id, table.projectId),
-  unique("label_classes_name_project_id_unique").on(table.name, table.projectId),
-]);
-
-export const events = pgTable("events", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  timestamp: timestamp({ withTimezone: true, mode: 'string' }).notNull(),
-  name: text().notNull(),
-  attributes: jsonb().default({}).notNull(),
-  spanId: uuid("span_id").notNull(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  index("events_span_id_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops"), table.spanId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.spanId, table.projectId],
-    foreignColumns: [spans.spanId, spans.projectId],
-    name: "events_span_id_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
-
-export const labelClassesForPath = pgTable("label_classes_for_path", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  projectId: uuid("project_id").defaultRandom().notNull(),
-  path: text().notNull(),
-  labelClassId: uuid("label_class_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "autoeval_labels_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("unique_project_id_path_label_class").on(table.projectId, table.path, table.labelClassId),
-]);
+export const traceType = pgEnum("trace_type", ["DEFAULT", "EVENT", "EVALUATION", "PLAYGROUND"]);
+export const workspaceRole = pgEnum("workspace_role", ["member", "owner"]);
 
 export const llmPrices = pgTable("llm_prices", {
   id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   provider: text().notNull(),
   model: text().notNull(),
   inputPricePerMillion: doublePrecision("input_price_per_million").notNull(),
@@ -275,489 +45,1112 @@ export const llmPrices = pgTable("llm_prices", {
 
 export const pipelineTemplates = pgTable("pipeline_templates", {
   id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   runnableGraph: jsonb("runnable_graph").default({}).notNull(),
   displayableGraph: jsonb("displayable_graph").default({}).notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
   numberOfNodes: bigint("number_of_nodes", { mode: "number" }).notNull(),
-  name: text().default('').notNull(),
-  description: text().default('').notNull(),
-  displayGroup: text("display_group").default('build').notNull(),
+  name: text().default("").notNull(),
+  description: text().default("").notNull(),
+  displayGroup: text("display_group").default("build").notNull(),
   ordinal: integer().default(500).notNull(),
 });
 
-export const evaluationScores = pgTable("evaluation_scores", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  resultId: uuid("result_id").defaultRandom().notNull(),
-  name: text().default('').notNull(),
-  score: doublePrecision().notNull(),
-  labelId: uuid("label_id"),
-}, (table) => [
-  index("evaluation_scores_result_id_idx").using("hash", table.resultId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.resultId],
-    foreignColumns: [evaluationResults.id],
-    name: "evaluation_scores_result_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("evaluation_results_names_unique").on(table.resultId, table.name),
-]);
+export const datasets = pgTable(
+  "datasets",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    indexedOn: text("indexed_on"),
+  },
+  (table) => [
+    index("datasets_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "public_datasets_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const labelingQueues = pgTable("labeling_queues", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "labeling_queues_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const datasetDatapoints = pgTable(
+  "dataset_datapoints",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    datasetId: uuid("dataset_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    data: jsonb().notNull(),
+    indexedOn: text("indexed_on"),
+    target: jsonb().default({}),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    indexInBatch: bigint("index_in_batch", { mode: "number" }),
+    metadata: jsonb().default({}),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.datasetId],
+      foreignColumns: [datasets.id],
+      name: "dataset_datapoints_dataset_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const datasets = pgTable("datasets", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  projectId: uuid("project_id").defaultRandom().notNull(),
-  indexedOn: text("indexed_on"),
-}, (table) => [
-  index("datasets_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "public_datasets_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const projects = pgTable(
+  "projects",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+  },
+  (table) => [
+    index("projects_workspace_id_idx").using("btree", table.workspaceId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "projects_workspace_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const traces = pgTable("traces", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  sessionId: text("session_id"),
-  metadata: jsonb(),
-  projectId: uuid("project_id").notNull(),
-  endTime: timestamp("end_time", { withTimezone: true, mode: 'string' }),
-  startTime: timestamp("start_time", { withTimezone: true, mode: 'string' }),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  totalTokenCount: bigint("total_token_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  cost: doublePrecision().default(sql`'0'`).notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  traceType: traceType("trace_type").default('DEFAULT').notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  inputTokenCount: bigint("input_token_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  outputTokenCount: bigint("output_token_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  inputCost: doublePrecision("input_cost").default(sql`'0'`).notNull(),
-  outputCost: doublePrecision("output_cost").default(sql`'0'`).notNull(),
-  hasBrowserSession: boolean("has_browser_session"),
-  topSpanId: uuid("top_span_id"),
-  agentSessionId: uuid("agent_session_id"),
-  visibility: text().default(''),
-  status: text(),
-  userId: text("user_id"),
-}, (table) => [
-  index("trace_metadata_gin_idx").using("gin", table.metadata.asc().nullsLast().op("jsonb_ops")),
-  index("traces_id_project_id_start_time_times_not_null_idx").using("btree", table.id.asc().nullsLast().op("timestamptz_ops"), table.projectId.asc().nullsLast().op("timestamptz_ops"), table.startTime.desc().nullsFirst().op("uuid_ops")).where(sql`((start_time IS NOT NULL) AND (end_time IS NOT NULL))`),
-  index("traces_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
-  index("traces_project_id_trace_type_start_time_end_time_idx").using("btree", table.projectId.asc().nullsLast().op("timestamptz_ops"), table.startTime.asc().nullsLast().op("timestamptz_ops"), table.endTime.asc().nullsLast().op("timestamptz_ops")).where(sql`((trace_type = 'DEFAULT'::trace_type) AND (start_time IS NOT NULL) AND (end_time IS NOT NULL))`),
-  index("traces_session_id_idx").using("btree", table.sessionId.asc().nullsLast().op("text_ops")),
-  index("traces_start_time_end_time_idx").using("btree", table.startTime.asc().nullsLast().op("timestamptz_ops"), table.endTime.asc().nullsLast().op("timestamptz_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "new_traces_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  pgPolicy("select_by_next_api_key", { as: "permissive", for: "select", to: ["anon", "authenticated"], using: sql`is_project_id_accessible_for_api_key(api_key(), project_id)` }),
-]);
+export const labelClassesForPath = pgTable(
+  "label_classes_for_path",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    path: text().notNull(),
+    labelClassId: uuid("label_class_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "autoeval_labels_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("unique_project_id_path_label_class").on(table.projectId, table.path, table.labelClassId),
+  ]
+);
 
-export const users = pgTable("users", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  email: text().notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  tierId: bigint("tier_id", { mode: "number" }).default(sql`'1'`).notNull(),
-  subscriptionId: text("subscription_id"),
-  avatarUrl: text("avatar_url"),
-}, (table) => [
-  foreignKey({
-    columns: [table.tierId],
-    foreignColumns: [userSubscriptionTiers.id],
-    name: "users_tier_id_fkey"
-  }),
-  unique("users_email_key").on(table.email),
-  pgPolicy("Enable insert for authenticated users only", { as: "permissive", for: "insert", to: ["service_role"], withCheck: sql`true` }),
-]);
+export const membersOfWorkspaces = pgTable(
+  "members_of_workspaces",
+  {
+    workspaceId: uuid("workspace_id").notNull(),
+    userId: uuid("user_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    memberRole: workspaceRole("member_role").default("owner").notNull(),
+  },
+  (table) => [
+    index("members_of_workspaces_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "members_of_workspaces_user_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "public_members_of_workspaces_workspace_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("members_of_workspaces_user_workspace_unique").on(table.workspaceId, table.userId),
+  ]
+);
 
-export const targetPipelineVersions = pgTable("target_pipeline_versions", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  pipelineId: uuid("pipeline_id").notNull(),
-  pipelineVersionId: uuid("pipeline_version_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.pipelineId],
-    foreignColumns: [pipelines.id],
-    name: "target_pipeline_versions_pipeline_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  foreignKey({
-    columns: [table.pipelineVersionId],
-    foreignColumns: [pipelineVersions.id],
-    name: "target_pipeline_versions_pipeline_version_id_fkey"
-  }),
-  unique("unique_pipeline_id").on(table.pipelineId),
-]);
+export const workspaces = pgTable(
+  "workspaces",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    tierId: bigint("tier_id", { mode: "number" })
+      .default(sql`'1'`)
+      .notNull(),
+    subscriptionId: text("subscription_id"),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    additionalSeats: bigint("additional_seats", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.tierId],
+      foreignColumns: [subscriptionTiers.id],
+      name: "workspaces_tier_id_fkey",
+    }).onUpdate("cascade"),
+  ]
+);
+
+export const pipelines = pgTable(
+  "pipelines",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    projectId: uuid("project_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    visibility: text().default("PRIVATE").notNull(),
+    pythonRequirements: text("python_requirements").default("").notNull(),
+  },
+  (table) => [
+    index("pipelines_name_project_id_idx").using(
+      "btree",
+      table.name.asc().nullsLast().op("text_ops"),
+      table.projectId.asc().nullsLast().op("uuid_ops")
+    ),
+    index("pipelines_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "pipelines_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("unique_project_id_pipeline_name").on(table.projectId, table.name),
+  ]
+);
+
+export const projectApiKeys = pgTable(
+  "project_api_keys",
+  {
+    value: text().default("").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text(),
+    projectId: uuid("project_id").notNull(),
+    shorthand: text().default("").notNull(),
+    hash: text().default("").notNull(),
+    id: uuid().defaultRandom().primaryKey().notNull(),
+  },
+  (table) => [
+    index("project_api_keys_hash_idx").using("hash", table.hash.asc().nullsLast().op("text_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "public_project_api_keys_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const providerApiKeys = pgTable(
+  "provider_api_keys",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    nonceHex: text("nonce_hex").notNull(),
+    value: text().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "provider_api_keys_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const targetPipelineVersions = pgTable(
+  "target_pipeline_versions",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    pipelineId: uuid("pipeline_id").notNull(),
+    pipelineVersionId: uuid("pipeline_version_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.pipelineId],
+      foreignColumns: [pipelines.id],
+      name: "target_pipeline_versions_pipeline_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    foreignKey({
+      columns: [table.pipelineVersionId],
+      foreignColumns: [pipelineVersions.id],
+      name: "target_pipeline_versions_pipeline_version_id_fkey",
+    }),
+    unique("unique_pipeline_id").on(table.pipelineId),
+  ]
+);
+
+export const userSubscriptionInfo = pgTable(
+  "user_subscription_info",
+  {
+    userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    stripeCustomerId: text("stripe_customer_id").notNull(),
+    activated: boolean().default(false).notNull(),
+  },
+  (table) => [
+    index("user_subscription_info_stripe_customer_id_idx").using(
+      "btree",
+      table.stripeCustomerId.asc().nullsLast().op("text_ops")
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "user_subscription_info_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
 export const subscriptionTiers = pgTable("subscription_tiers", {
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  id: bigint({ mode: "number" }).primaryKey().generatedByDefaultAsIdentity({ name: "subscription_tiers_id_seq", startWith: 1, increment: 1, minValue: 1, maxValue: 9223372036854775807, cache: 1 }),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  id: bigint({ mode: "number" })
+    .primaryKey()
+    .generatedByDefaultAsIdentity({
+      name: "subscription_tiers_id_seq",
+      startWith: 1,
+      increment: 1,
+      minValue: 1,
+      maxValue: 9223372036854775807,
+      cache: 1,
+    }),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   name: text().notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
   storageMib: bigint("storage_mib", { mode: "number" }).notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
   logRetentionDays: bigint("log_retention_days", { mode: "number" }).notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  membersPerWorkspace: bigint("members_per_workspace", { mode: "number" }).default(sql`'-1'`).notNull(),
-  stripeProductId: text("stripe_product_id").default('').notNull(),
+  membersPerWorkspace: bigint("members_per_workspace", { mode: "number" })
+    .default(sql`'-1'`)
+    .notNull(),
+  stripeProductId: text("stripe_product_id").default("").notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  steps: bigint({ mode: "number" }).default(sql`'0'`).notNull(),
+  steps: bigint({ mode: "number" })
+    .default(sql`'0'`)
+    .notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  spans: bigint({ mode: "number" }).default(sql`'0'`).notNull(),
-  extraSpanPrice: doublePrecision("extra_span_price").default(sql`'0'`).notNull(),
-  extraStepPrice: doublePrecision("extra_step_price").default(sql`'0'`).notNull(),
+  spans: bigint({ mode: "number" })
+    .default(sql`'0'`)
+    .notNull(),
+  extraSpanPrice: doublePrecision("extra_span_price")
+    .default(sql`'0'`)
+    .notNull(),
+  extraStepPrice: doublePrecision("extra_step_price")
+    .default(sql`'0'`)
+    .notNull(),
   // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  bytesIngested: bigint("bytes_ingested", { mode: "number" }).default(sql`'0'`).notNull(),
-  extraBytePrice: doublePrecision("extra_byte_price").default(sql`'0'`).notNull(),
+  bytesIngested: bigint("bytes_ingested", { mode: "number" })
+    .default(sql`'0'`)
+    .notNull(),
+  extraBytePrice: doublePrecision("extra_byte_price")
+    .default(sql`'0'`)
+    .notNull(),
 });
 
-export const projects = pgTable("projects", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  workspaceId: uuid("workspace_id").notNull(),
-}, (table) => [
-  index("projects_workspace_id_idx").using("btree", table.workspaceId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.workspaceId],
-    foreignColumns: [workspaces.id],
-    name: "projects_workspace_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const labelingQueues = pgTable(
+  "labeling_queues",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "labeling_queues_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const providerApiKeys = pgTable("provider_api_keys", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  projectId: uuid("project_id").defaultRandom().notNull(),
-  nonceHex: text("nonce_hex").notNull(),
-  value: text().notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "provider_api_keys_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const apiKeys = pgTable(
+  "api_keys",
+  {
+    apiKey: text("api_key").primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    userId: uuid("user_id").notNull(),
+    name: text().default("default").notNull(),
+  },
+  (table) => [
+    index("api_keys_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "api_keys_user_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const workspaces = pgTable("workspaces", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  tierId: bigint("tier_id", { mode: "number" }).default(sql`'1'`).notNull(),
-  subscriptionId: text("subscription_id"),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  additionalSeats: bigint("additional_seats", { mode: "number" }).default(sql`'0'`).notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.tierId],
-    foreignColumns: [subscriptionTiers.id],
-    name: "workspaces_tier_id_fkey"
-  }).onUpdate("cascade"),
-]);
-
-export const userSubscriptionInfo = pgTable("user_subscription_info", {
-  userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  stripeCustomerId: text("stripe_customer_id").notNull(),
-  activated: boolean().default(false).notNull(),
-}, (table) => [
-  index("user_subscription_info_stripe_customer_id_idx").using("btree", table.stripeCustomerId.asc().nullsLast().op("text_ops")),
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "user_subscription_info_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
-
-export const pipelines = pgTable("pipelines", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  projectId: uuid("project_id").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text().notNull(),
-  visibility: text().default('PRIVATE').notNull(),
-  pythonRequirements: text("python_requirements").default('').notNull(),
-}, (table) => [
-  index("pipelines_name_project_id_idx").using("btree", table.name.asc().nullsLast().op("text_ops"), table.projectId.asc().nullsLast().op("uuid_ops")),
-  index("pipelines_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "pipelines_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("unique_project_id_pipeline_name").on(table.projectId, table.name),
-]);
-
-export const datasetDatapoints = pgTable("dataset_datapoints", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  datasetId: uuid("dataset_id").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  data: jsonb().notNull(),
-  indexedOn: text("indexed_on"),
-  target: jsonb().default({}),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexInBatch: bigint("index_in_batch", { mode: "number" }),
-  metadata: jsonb().default({}),
-}, (table) => [
-  foreignKey({
-    columns: [table.datasetId],
-    foreignColumns: [datasets.id],
-    name: "dataset_datapoints_dataset_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
-
-export const evaluationResults = pgTable("evaluation_results", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  evaluationId: uuid("evaluation_id").notNull(),
-  data: jsonb().notNull(),
-  target: jsonb().default({}).notNull(),
-  executorOutput: jsonb("executor_output"),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexInBatch: bigint("index_in_batch", { mode: "number" }),
-  traceId: uuid("trace_id").notNull(),
-  index: integer().default(0).notNull(),
-  metadata: jsonb(),
-}, (table) => [
-  index("evaluation_results_evaluation_id_idx").using("btree", table.evaluationId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.evaluationId],
-    foreignColumns: [evaluations.id],
-    name: "evaluation_results_evaluation_id_fkey1"
-  }).onUpdate("cascade").onDelete("cascade"),
-  pgPolicy("select_by_next_api_key", { as: "permissive", for: "select", to: ["anon", "authenticated"], using: sql`is_evaluation_id_accessible_for_api_key(api_key(), evaluation_id)` }),
-]);
-
-export const evaluations = pgTable("evaluations", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  projectId: uuid("project_id").notNull(),
-  name: text().notNull(),
-  groupId: text("group_id").default('default').notNull(),
-}, (table) => [
-  index("evaluations_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "evaluations_project_id_fkey1"
-  }).onUpdate("cascade").onDelete("cascade"),
-  pgPolicy("select_by_next_api_key", { as: "permissive", for: "select", to: ["anon", "authenticated"], using: sql`is_evaluation_id_accessible_for_api_key(api_key(), id)` }),
-]);
-
-export const membersOfWorkspaces = pgTable("members_of_workspaces", {
-  workspaceId: uuid("workspace_id").notNull(),
-  userId: uuid("user_id").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  memberRole: workspaceRole("member_role").default('owner').notNull(),
-}, (table) => [
-  index("members_of_workspaces_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.userId],
-    foreignColumns: [users.id],
-    name: "members_of_workspaces_user_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  foreignKey({
-    columns: [table.workspaceId],
-    foreignColumns: [workspaces.id],
-    name: "public_members_of_workspaces_workspace_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("members_of_workspaces_user_workspace_unique").on(table.workspaceId, table.userId),
-]);
+export const evaluations = pgTable(
+  "evaluations",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").notNull(),
+    name: text().notNull(),
+    groupId: text("group_id").default("default").notNull(),
+  },
+  (table) => [
+    index("evaluations_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "evaluations_project_id_fkey1",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
 export const pipelineVersions = pgTable("pipeline_versions", {
   id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   pipelineId: uuid("pipeline_id").notNull(),
   displayableGraph: jsonb("displayable_graph").notNull(),
   runnableGraph: jsonb("runnable_graph").notNull(),
   pipelineType: text("pipeline_type").notNull(),
   name: text().notNull(),
-}, (table) => [
-  pgPolicy("all_actions_by_next_api_key", { as: "permissive", for: "all", to: ["anon", "authenticated"], using: sql`is_pipeline_id_accessible_for_api_key(api_key(), pipeline_id)` }),
-]);
+});
 
-export const projectApiKeys = pgTable("project_api_keys", {
-  value: text().default('').notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  name: text(),
-  projectId: uuid("project_id").notNull(),
-  shorthand: text().default('').notNull(),
-  hash: text().default('').notNull(),
-  id: uuid().defaultRandom().primaryKey().notNull(),
-}, (table) => [
-  index("project_api_keys_hash_idx").using("hash", table.hash.asc().nullsLast().op("text_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "public_project_api_keys_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+export const evaluationScores = pgTable(
+  "evaluation_scores",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    resultId: uuid("result_id").defaultRandom().notNull(),
+    name: text().default("").notNull(),
+    score: doublePrecision().notNull(),
+    labelId: uuid("label_id"),
+  },
+  (table) => [
+    index("evaluation_scores_result_id_idx").using("hash", table.resultId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.resultId],
+      foreignColumns: [evaluationResults.id],
+      name: "evaluation_scores_result_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("evaluation_results_names_unique").on(table.resultId, table.name),
+  ]
+);
 
-export const workspaceUsage = pgTable("workspace_usage", {
-  workspaceId: uuid("workspace_id").defaultRandom().primaryKey().notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  spanCount: bigint("span_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  spanCountSinceReset: bigint("span_count_since_reset", { mode: "number" }).default(sql`'0'`).notNull(),
-  resetTime: timestamp("reset_time", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  resetReason: text("reset_reason").default('signup').notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  stepCount: bigint("step_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  prevStepCount: bigint("prev_step_count", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  stepCountSinceReset: bigint("step_count_since_reset", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  bytesIngested: bigint("bytes_ingested", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  bytesIngestedSinceReset: bigint("bytes_ingested_since_reset", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  spansBytesIngested: bigint("spans_bytes_ingested", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  spansBytesIngestedSinceReset: bigint("spans_bytes_ingested_since_reset", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  browserSessionEventsBytesIngested: bigint("browser_session_events_bytes_ingested", { mode: "number" }).default(sql`'0'`).notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  browserSessionEventsBytesIngestedSinceReset: bigint("browser_session_events_bytes_ingested_since_reset", { mode: "number" }).default(sql`'0'`).notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.workspaceId],
-    foreignColumns: [workspaces.id],
-    name: "user_usage_workspace_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("user_usage_workspace_id_key").on(table.workspaceId),
-]);
+export const events = pgTable(
+  "events",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    spanId: uuid("span_id").notNull(),
+    timestamp: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    name: text().notNull(),
+    attributes: jsonb().default({}).notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    index("events_span_id_project_id_idx").using(
+      "btree",
+      table.spanId.asc().nullsLast().op("uuid_ops"),
+      table.projectId.asc().nullsLast().op("uuid_ops")
+    ),
+    foreignKey({
+      columns: [table.spanId, table.projectId],
+      foreignColumns: [spans.spanId, spans.projectId],
+      name: "events_span_id_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const labels = pgTable("labels", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  classId: uuid("class_id").notNull(),
-  spanId: uuid("span_id").notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  userId: uuid("user_id").defaultRandom(),
-  labelSource: labelSource("label_source").default('MANUAL').notNull(),
-  reasoning: text(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.classId, table.projectId],
-    foreignColumns: [labelClasses.id, labelClasses.projectId],
-    name: "labels_class_id_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  unique("labels_span_id_class_id_user_id_key").on(table.classId, table.spanId, table.userId),
-  unique("labels_span_id_class_id_key").on(table.classId, table.spanId),
-]);
+export const renderTemplates = pgTable(
+  "render_templates",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    code: text().notNull(),
+    name: text().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "render_templates_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const playgrounds = pgTable("playgrounds", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+export const labelClasses = pgTable(
+  "label_classes",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").notNull(),
+    description: text(),
+    evaluatorRunnableGraph: jsonb("evaluator_runnable_graph"),
+    pipelineVersionId: uuid("pipeline_version_id"),
+    color: text().default("rgb(190, 194, 200)").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "label_classes_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("label_classes_project_id_id_key").on(table.id, table.projectId),
+    unique("label_classes_name_project_id_unique").on(table.name, table.projectId),
+  ]
+);
+
+export const labels = pgTable(
+  "labels",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    classId: uuid("class_id").notNull(),
+    spanId: uuid("span_id").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    userId: uuid("user_id").defaultRandom(),
+    labelSource: labelSource("label_source").default("MANUAL").notNull(),
+    reasoning: text(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.classId, table.projectId],
+      foreignColumns: [labelClasses.id, labelClasses.projectId],
+      name: "labels_class_id_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("labels_span_id_class_id_key").on(table.classId, table.spanId),
+    unique("labels_span_id_class_id_user_id_key").on(table.classId, table.spanId, table.userId),
+  ]
+);
+
+export const agentMessages = pgTable(
+  "agent_messages",
+  {
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    sessionId: uuid("session_id").notNull(),
+    messageType: agentMessageType("message_type").notNull(),
+    content: jsonb().default({}),
+    traceId: uuid("trace_id"),
+  },
+  (table) => [
+    index("agent_messages_session_id_created_at_idx").using(
+      "btree",
+      table.createdAt.asc().nullsLast().op("timestamptz_ops"),
+      table.sessionId.asc().nullsLast().op("timestamptz_ops")
+    ),
+    foreignKey({
+      columns: [table.sessionId],
+      foreignColumns: [agentSessions.sessionId],
+      name: "agent_messages_session_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const agentSessions = pgTable(
+  "agent_sessions",
+  {
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
+    cdpUrl: text("cdp_url"),
+    vncUrl: text("vnc_url"),
+    machineId: text("machine_id"),
+    state: text(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    agentStatus: text("agent_status").default("idle").notNull(),
+  },
+  (table) => [
+    index("agent_sessions_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
+    index("agent_sessions_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
+  ]
+);
+
+export const userCookies = pgTable(
+  "user_cookies",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    userId: uuid("user_id").notNull(),
+    cookies: text().notNull(),
+    nonce: text().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "user_cookies_user_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const userUsage = pgTable(
+  "user_usage",
+  {
+    userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    indexChatMessageCount: bigint("index_chat_message_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    indexChatMessageCountSinceReset: bigint("index_chat_message_count_since_reset", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    prevIndexChatMessageCount: bigint("prev_index_chat_message_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    resetTime: timestamp("reset_time", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    resetReason: text("reset_reason").default("signup").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "user_usage_user_id_fkey",
+    }),
+  ]
+);
+
+export const userSubscriptionTiers = pgTable("user_subscription_tiers", {
+  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+  id: bigint({ mode: "number" })
+    .primaryKey()
+    .generatedByDefaultAsIdentity({
+      name: "user_subscription_tiers_id_seq",
+      startWith: 1,
+      increment: 1,
+      minValue: 1,
+      maxValue: 9223372036854775807,
+      cache: 1,
+    }),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   name: text().notNull(),
-  projectId: uuid("project_id").notNull(),
-  promptMessages: jsonb("prompt_messages").default([{ "role": "user", "content": "" }]).notNull(),
-  modelId: text("model_id").default('').notNull(),
-  outputSchema: text("output_schema"),
-  maxTokens: integer("max_tokens").default(1024),
-  temperature: real().default(sql`'1'`),
-  providerOptions: jsonb("provider_options").default({}),
-  toolChoice: jsonb("tool_choice").default("none"),
-  tools: jsonb().default({}),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "playgrounds_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-]);
+  stripeProductId: text("stripe_product_id").default("").notNull(),
+  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+  indexChatMessages: bigint("index_chat_messages", { mode: "number" }).default(sql`'0'`),
+});
 
-export const machines = pgTable("machines", {
-  id: uuid().defaultRandom().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "machines_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  primaryKey({ columns: [table.id, table.projectId], name: "machines_pkey" }),
-]);
+export const agentChats = pgTable(
+  "agent_chats",
+  {
+    sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
+    chatName: text("chat_name").default("New chat").notNull(),
+    userId: uuid("user_id").notNull(),
+    machineStatus: agentMachineStatus("machine_status").default("not_started"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    agentStatus: text("agent_status").default("idle").notNull(),
+  },
+  (table) => [
+    index("agent_chats_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
+    index("agent_chats_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
+    index("agent_chats_user_id_idx").using("hash", table.userId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "agent_chats_user_id_fkey",
+    }),
+    foreignKey({
+      columns: [table.sessionId],
+      foreignColumns: [agentSessions.sessionId],
+      name: "agent_chats_session_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
 
-export const datapointToSpan = pgTable("datapoint_to_span", {
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  datapointId: uuid("datapoint_id").notNull(),
-  spanId: uuid("span_id").notNull(),
-  projectId: uuid("project_id").notNull(),
-}, (table) => [
-  foreignKey({
-    columns: [table.datapointId],
-    foreignColumns: [datasetDatapoints.id],
-    name: "datapoint_to_span_datapoint_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  foreignKey({
-    columns: [table.spanId, table.projectId],
-    foreignColumns: [spans.spanId, spans.projectId],
-    name: "datapoint_to_span_span_id_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  primaryKey({ columns: [table.datapointId, table.spanId, table.projectId], name: "datapoint_to_span_pkey" }),
-]);
+export const workspaceInvitations = pgTable(
+  "workspace_invitations",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    workspaceId: uuid("workspace_id").defaultRandom().notNull(),
+    email: text().default("").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "workspace_invitations_workspace_id_fkey",
+    }).onDelete("cascade"),
+    unique("workspace_invitations_workspace_id_email_key").on(table.workspaceId, table.email),
+  ]
+);
 
-export const spans = pgTable("spans", {
-  spanId: uuid("span_id").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  parentSpanId: uuid("parent_span_id"),
-  name: text().notNull(),
-  attributes: jsonb(),
-  input: jsonb(),
-  output: jsonb(),
-  spanType: spanType("span_type").notNull(),
-  startTime: timestamp("start_time", { withTimezone: true, mode: 'string' }).notNull(),
-  endTime: timestamp("end_time", { withTimezone: true, mode: 'string' }).notNull(),
-  traceId: uuid("trace_id").notNull(),
-  inputPreview: text("input_preview"),
-  outputPreview: text("output_preview"),
-  projectId: uuid("project_id").notNull(),
-  inputUrl: text("input_url"),
-  outputUrl: text("output_url"),
-}, (table) => [
-  index("span_path_idx").using("btree", sql`((attributes -> 'lmnr.span.path'::text))`),
-  index("spans_partial_evaluator_trace_id_project_id_start_time_span_id_").using("btree", table.traceId.asc().nullsLast().op("uuid_ops"), table.projectId.asc().nullsLast().op("uuid_ops"), table.startTime.asc().nullsLast().op("timestamptz_ops"), table.spanId.asc().nullsLast().op("uuid_ops")).where(sql`(span_type = 'EVALUATOR'::span_type)`),
-  index("spans_partial_executor_trace_id_project_id_start_time_span_id_i").using("btree", table.traceId.asc().nullsLast().op("timestamptz_ops"), table.projectId.asc().nullsLast().op("uuid_ops"), table.startTime.asc().nullsLast().op("uuid_ops"), table.spanId.asc().nullsLast().op("timestamptz_ops")).where(sql`(span_type = 'EXECUTOR'::span_type)`),
-  index("spans_project_id_created_at_idx").using("btree", table.projectId.asc().nullsLast().op("timestamptz_ops"), table.createdAt.asc().nullsLast().op("uuid_ops")),
-  index("spans_project_id_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
-  index("spans_project_id_start_time_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops"), table.startTime.asc().nullsLast().op("uuid_ops")),
-  index("spans_project_id_trace_id_start_time_idx").using("btree", table.projectId.asc().nullsLast().op("timestamptz_ops"), table.traceId.asc().nullsLast().op("uuid_ops"), table.startTime.asc().nullsLast().op("timestamptz_ops")),
-  index("spans_root_project_id_start_time_end_time_trace_id_idx").using("btree", table.projectId.asc().nullsLast().op("timestamptz_ops"), table.startTime.asc().nullsLast().op("timestamptz_ops"), table.endTime.asc().nullsLast().op("uuid_ops"), table.traceId.asc().nullsLast().op("uuid_ops")).where(sql`(parent_span_id IS NULL)`),
-  index("spans_start_time_end_time_idx").using("btree", table.startTime.asc().nullsLast().op("timestamptz_ops"), table.endTime.asc().nullsLast().op("timestamptz_ops")),
-  index("spans_trace_id_idx").using("btree", table.traceId.asc().nullsLast().op("uuid_ops")),
-  index("spans_trace_id_start_time_idx").using("btree", table.traceId.asc().nullsLast().op("uuid_ops"), table.startTime.asc().nullsLast().op("uuid_ops")),
-  foreignKey({
-    columns: [table.projectId],
-    foreignColumns: [projects.id],
-    name: "spans_project_id_fkey"
-  }).onUpdate("cascade").onDelete("cascade"),
-  primaryKey({ columns: [table.spanId, table.projectId], name: "spans_pkey" }),
-  unique("unique_span_id_project_id").on(table.spanId, table.projectId),
-  pgPolicy("select_by_next_api_key", { as: "permissive", for: "select", to: ["public"], using: sql`is_project_id_accessible_for_api_key(api_key(), project_id)` }),
-]);
+export const users = pgTable(
+  "users",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    email: text().notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    tierId: bigint("tier_id", { mode: "number" })
+      .default(sql`'1'`)
+      .notNull(),
+    subscriptionId: text("subscription_id"),
+    avatarUrl: text("avatar_url"),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.tierId],
+      foreignColumns: [userSubscriptionTiers.id],
+      name: "users_tier_id_fkey",
+    }),
+    unique("users_email_key").on(table.email),
+  ]
+);
+
+export const evaluatorScores = pgTable(
+  "evaluator_scores",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    evaluatorId: uuid("evaluator_id").notNull(),
+    projectId: uuid("project_id").notNull(),
+    spanId: uuid("span_id").notNull(),
+    score: doublePrecision().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "evaluator_scores_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const evaluators = pgTable(
+  "evaluators",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    projectId: uuid("project_id").notNull(),
+    name: text().notNull(),
+    evaluatorType: text("evaluator_type").notNull(),
+    definition: jsonb().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "evaluators_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const evaluatorSpanPaths = pgTable(
+  "evaluator_span_paths",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    evaluatorId: uuid("evaluator_id").notNull(),
+    projectId: uuid("project_id").notNull(),
+    spanPath: jsonb("span_path").default({}),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.evaluatorId],
+      foreignColumns: [evaluators.id],
+      name: "evaluator_span_paths_evaluator_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "evaluator_span_paths_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const playgrounds = pgTable(
+  "playgrounds",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").notNull(),
+    promptMessages: jsonb("prompt_messages")
+      .default([{ role: "user", content: "" }])
+      .notNull(),
+    modelId: text("model_id").default("").notNull(),
+    outputSchema: text("output_schema"),
+    tools: jsonb().default({}),
+    toolChoice: jsonb("tool_choice").default("none"),
+    maxTokens: integer("max_tokens").default(1024),
+    temperature: doublePrecision().default(1),
+    providerOptions: jsonb("provider_options").default({}),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "playgrounds_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const labelingQueueItems = pgTable(
+  "labeling_queue_items",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    queueId: uuid("queue_id").defaultRandom().notNull(),
+    metadata: jsonb().default({}),
+    payload: jsonb().default({}),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.queueId],
+      foreignColumns: [labelingQueues.id],
+      name: "labelling_queue_items_queue_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const traces = pgTable(
+  "traces",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    sessionId: text("session_id"),
+    metadata: jsonb(),
+    projectId: uuid("project_id").notNull(),
+    endTime: timestamp("end_time", { withTimezone: true, mode: "string" }),
+    startTime: timestamp("start_time", { withTimezone: true, mode: "string" }),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    totalTokenCount: bigint("total_token_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    cost: doublePrecision()
+      .default(sql`'0'`)
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    traceType: traceType("trace_type").default("DEFAULT").notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    inputTokenCount: bigint("input_token_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    outputTokenCount: bigint("output_token_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    inputCost: doublePrecision("input_cost")
+      .default(sql`'0'`)
+      .notNull(),
+    outputCost: doublePrecision("output_cost")
+      .default(sql`'0'`)
+      .notNull(),
+    hasBrowserSession: boolean("has_browser_session"),
+    topSpanId: uuid("top_span_id"),
+    agentSessionId: uuid("agent_session_id"),
+    visibility: text().default(""),
+    status: text(),
+    userId: text("user_id"),
+  },
+  (table) => [
+    index("trace_metadata_gin_idx").using("gin", table.metadata.asc().nullsLast().op("jsonb_ops")),
+    index("traces_id_project_id_start_time_times_not_null_idx")
+      .using(
+        "btree",
+        table.id.asc().nullsLast().op("uuid_ops"),
+        table.projectId.asc().nullsLast().op("timestamptz_ops"),
+        table.startTime.asc().nullsLast().op("timestamptz_ops")
+      )
+      .where(sql`((start_time IS NOT NULL) AND (end_time IS NOT NULL))`),
+    index("traces_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
+    index("traces_project_id_trace_type_start_time_end_time_idx")
+      .using(
+        "btree",
+        table.projectId.asc().nullsLast().op("uuid_ops"),
+        table.startTime.asc().nullsLast().op("timestamptz_ops"),
+        table.endTime.asc().nullsLast().op("uuid_ops")
+      )
+      .where(sql`((trace_type = 'DEFAULT'::trace_type) AND (start_time IS NOT NULL) AND (end_time IS NOT NULL))`),
+    index("traces_session_id_idx").using("btree", table.sessionId.asc().nullsLast().op("text_ops")),
+    index("traces_start_time_end_time_idx").using(
+      "btree",
+      table.startTime.asc().nullsLast().op("timestamptz_ops"),
+      table.endTime.asc().nullsLast().op("timestamptz_ops")
+    ),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "new_traces_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const evaluationResults = pgTable(
+  "evaluation_results",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    evaluationId: uuid("evaluation_id").notNull(),
+    data: jsonb().notNull(),
+    target: jsonb().default({}).notNull(),
+    executorOutput: jsonb("executor_output"),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    indexInBatch: bigint("index_in_batch", { mode: "number" }),
+    traceId: uuid("trace_id").notNull(),
+    index: integer().default(0).notNull(),
+    metadata: jsonb(),
+  },
+  (table) => [
+    index("evaluation_results_evaluation_id_idx").using("btree", table.evaluationId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.evaluationId],
+      foreignColumns: [evaluations.id],
+      name: "evaluation_results_evaluation_id_fkey1",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const workspaceUsage = pgTable(
+  "workspace_usage",
+  {
+    workspaceId: uuid("workspace_id").defaultRandom().primaryKey().notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    spanCount: bigint("span_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    spanCountSinceReset: bigint("span_count_since_reset", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    prevSpanCount: bigint("prev_span_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    stepCount: bigint("step_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    stepCountSinceReset: bigint("step_count_since_reset", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    prevStepCount: bigint("prev_step_count", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    resetTime: timestamp("reset_time", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    resetReason: text("reset_reason").default("signup").notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    bytesIngested: bigint("bytes_ingested", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    bytesIngestedSinceReset: bigint("bytes_ingested_since_reset", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    prevBytesIngested: bigint("prev_bytes_ingested", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    spansBytesIngested: bigint("spans_bytes_ingested", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    spansBytesIngestedSinceReset: bigint("spans_bytes_ingested_since_reset", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    browserSessionEventsBytesIngested: bigint("browser_session_events_bytes_ingested", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    browserSessionEventsBytesIngestedSinceReset: bigint("browser_session_events_bytes_ingested_since_reset", {
+      mode: "number",
+    })
+      .default(sql`'0'`)
+      .notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "user_usage_workspace_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("user_usage_workspace_id_key").on(table.workspaceId),
+  ]
+);
+
+export const machines = pgTable(
+  "machines",
+  {
+    id: uuid().defaultRandom().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "machines_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    primaryKey({ columns: [table.id, table.projectId], name: "machines_pkey" }),
+  ]
+);
+
+export const datapointToSpan = pgTable(
+  "datapoint_to_span",
+  {
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    datapointId: uuid("datapoint_id").notNull(),
+    spanId: uuid("span_id").notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.datapointId],
+      foreignColumns: [datasetDatapoints.id],
+      name: "datapoint_to_span_datapoint_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    foreignKey({
+      columns: [table.spanId, table.projectId],
+      foreignColumns: [spans.spanId, spans.projectId],
+      name: "datapoint_to_span_span_id_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    primaryKey({ columns: [table.datapointId, table.spanId, table.projectId], name: "datapoint_to_span_pkey" }),
+  ]
+);
+
+export const spans = pgTable(
+  "spans",
+  {
+    spanId: uuid("span_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    parentSpanId: uuid("parent_span_id"),
+    name: text().notNull(),
+    attributes: jsonb(),
+    input: jsonb(),
+    output: jsonb(),
+    spanType: spanType("span_type").notNull(),
+    startTime: timestamp("start_time", { withTimezone: true, mode: "string" }).notNull(),
+    endTime: timestamp("end_time", { withTimezone: true, mode: "string" }).notNull(),
+    traceId: uuid("trace_id").notNull(),
+    inputPreview: text("input_preview"),
+    outputPreview: text("output_preview"),
+    projectId: uuid("project_id").notNull(),
+    inputUrl: text("input_url"),
+    outputUrl: text("output_url"),
+    status: text(),
+  },
+  (table) => [
+    index("span_path_idx").using("btree", sql`((attributes -> 'lmnr.span.path'::text))`),
+    index("spans_partial_evaluator_trace_id_project_id_start_time_span_id_")
+      .using(
+        "btree",
+        table.traceId.asc().nullsLast().op("timestamptz_ops"),
+        table.projectId.asc().nullsLast().op("timestamptz_ops"),
+        table.startTime.asc().nullsLast().op("uuid_ops"),
+        table.spanId.asc().nullsLast().op("uuid_ops")
+      )
+      .where(sql`(span_type = 'EVALUATOR'::span_type)`),
+    index("spans_partial_executor_trace_id_project_id_start_time_span_id_i")
+      .using(
+        "btree",
+        table.traceId.asc().nullsLast().op("uuid_ops"),
+        table.projectId.asc().nullsLast().op("timestamptz_ops"),
+        table.startTime.asc().nullsLast().op("uuid_ops"),
+        table.spanId.asc().nullsLast().op("uuid_ops")
+      )
+      .where(sql`(span_type = 'EXECUTOR'::span_type)`),
+    index("spans_project_id_created_at_idx").using(
+      "btree",
+      table.projectId.asc().nullsLast().op("uuid_ops"),
+      table.createdAt.asc().nullsLast().op("uuid_ops")
+    ),
+    index("spans_project_id_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
+    index("spans_project_id_start_time_idx").using(
+      "btree",
+      table.projectId.asc().nullsLast().op("timestamptz_ops"),
+      table.startTime.asc().nullsLast().op("uuid_ops")
+    ),
+    index("spans_project_id_trace_id_start_time_idx").using(
+      "btree",
+      table.projectId.asc().nullsLast().op("timestamptz_ops"),
+      table.traceId.asc().nullsLast().op("timestamptz_ops"),
+      table.startTime.asc().nullsLast().op("uuid_ops")
+    ),
+    index("spans_root_project_id_start_time_end_time_trace_id_idx")
+      .using(
+        "btree",
+        table.projectId.asc().nullsLast().op("uuid_ops"),
+        table.startTime.asc().nullsLast().op("uuid_ops"),
+        table.endTime.asc().nullsLast().op("timestamptz_ops"),
+        table.traceId.asc().nullsLast().op("uuid_ops")
+      )
+      .where(sql`(parent_span_id IS NULL)`),
+    index("spans_start_time_end_time_idx").using(
+      "btree",
+      table.startTime.asc().nullsLast().op("timestamptz_ops"),
+      table.endTime.asc().nullsLast().op("timestamptz_ops")
+    ),
+    index("spans_trace_id_idx").using("btree", table.traceId.asc().nullsLast().op("uuid_ops")),
+    index("spans_trace_id_start_time_idx").using(
+      "btree",
+      table.traceId.asc().nullsLast().op("uuid_ops"),
+      table.startTime.asc().nullsLast().op("uuid_ops")
+    ),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "spans_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    primaryKey({ columns: [table.spanId, table.projectId], name: "spans_pkey" }),
+    unique("unique_span_id_project_id").on(table.spanId, table.projectId),
+  ]
+);

--- a/frontend/lib/traces/types.ts
+++ b/frontend/lib/traces/types.ts
@@ -49,6 +49,7 @@ export type Span = {
   inputUrl: string | null;
   outputUrl: string | null;
   pending?: boolean;
+  status?: string;
 };
 
 export type Trace = {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -132,3 +132,9 @@ export const DownloadFormat = {
 } as const;
 
 export type DownloadFormat = (typeof DownloadFormat)[keyof typeof DownloadFormat];
+
+export interface ErrorEventAttributes {
+  "exception.message": string;
+  "exception.stacktrace": string;
+  "exception.type": string;
+}


### PR DESCRIPTION
- added span status and set to error if error
- added ui to display error on span view
- added ui to display error item in timeline/tree view of spans
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add span-level error handling by introducing a `status` field to spans, updating both backend and frontend to reflect error statuses.
> 
>   - **Backend**:
>     - Add `status` field to `CHSpan` in `ch/spans.rs` and `record_span()` in `db/spans.rs`.
>     - Update ClickHouse schema in `001000-initial.sql` and `0003-span-status.sql` to include `status` column.
>     - Modify `prepare_span_for_recording()` in `traces/utils.rs` to set `status` to 'error' for exception events.
>   - **Frontend**:
>     - Add `ErrorCard` component in `error-card.tsx` to display error details.
>     - Update `span-card.tsx` and `span-type-icon.tsx` to reflect span status visually.
>     - Modify `span-view.tsx` to include error details in span view.
>     - Update `timeline-element.tsx` in `trace-view` to show error status in timeline.
>   - **Database**:
>     - Add `status` column to `spans` table in `0042_violet_jamie_braddock.sql`.
>     - Update `relations.ts` and `schema.ts` to reflect new `status` field in spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 26dac079c7e891bf26c5622f16db849532836fdb. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->