### PR TITLE
fix: unwrap receiver to panic

### DIFF
--- a/app-server/src/evaluators/mod.rs
+++ b/app-server/src/evaluators/mod.rs
@@ -61,20 +61,14 @@ pub async fn inner_process_evaluators(
     client: Arc<reqwest::Client>,
     python_online_evaluator_url: &str,
 ) {
-    let mut receiver = match queue
+    let mut receiver = queue
         .get_receiver(
             EVALUATORS_QUEUE,
             EVALUATORS_EXCHANGE,
             EVALUATORS_ROUTING_KEY,
         )
         .await
-    {
-        Ok(receiver) => receiver,
-        Err(e) => {
-            log::error!("Failed to get receiver for evaluator queue: {:?}", e);
-            return;
-        }
-    };
+        .unwrap();
 
     while let Some(delivery) = receiver.receive().await {
         if let Err(e) = delivery {


### PR DESCRIPTION
- unwrap receiver to prevent infinite loop
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Unwraps receiver in `inner_process_evaluators()` to prevent infinite loop on failure in `mod.rs`.
> 
>   - **Behavior**:
>     - Unwraps the receiver in `inner_process_evaluators()` in `mod.rs` to prevent an infinite loop when failing to get the receiver for the evaluator queue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for e2b0867faaaf6e076b541c22b8dee36461367aa0. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->