### PR TITLE
fix: add sheet title sr only in pdf renderer

### DIFF
--- a/frontend/components/ui/pdf-renderer.tsx
+++ b/frontend/components/ui/pdf-renderer.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "./button";
 import DownloadButton from "./download-button";
 import { ScrollArea } from "./scroll-area";
-import { Sheet, SheetContent, SheetTrigger } from "./sheet";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "./sheet";
 import { Skeleton } from "./skeleton";
 
 // const options = {
@@ -95,12 +95,11 @@ export default function PdfRenderer({ url, maxWidth, className }: PdfRendererPro
             </Button>
           </SheetTrigger>
           <SheetContent side="right" className="flex flex-col gap-0 min-w-[50vw]">
+            <SheetTitle className="sr-only">Full-screen PDF View</SheetTitle>
             <PdfDocumentContainer
               file={file}
               numPages={numPages}
               onDocumentLoadSuccess={onDocumentLoadSuccess}
-              // TODO: remove pt-8 after we return the sheet to the original state
-              className="pt-8"
             />
           </SheetContent>
         </Sheet>
@@ -147,7 +146,7 @@ function PdfDocumentContainer({
           <Skeleton className="w-full h-12" />
         </div>
       }
-      // options={options}
+    // options={options}
     >
       <ScrollArea className="w-full h-full flex flex-col">
         {Array.from(new Array(numPages), (_el, index) => (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add screen reader-only title to PDF renderer's sheet content for accessibility in `pdf-renderer.tsx`.
> 
>   - **Accessibility**:
>     - Add `SheetTitle` with `sr-only` class to `SheetContent` in `pdf-renderer.tsx` for screen reader accessibility.
>   - **Misc**:
>     - Remove unused `className` from `PdfDocumentContainer` in `pdf-renderer.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 83261f90b2abea94b7130a51e8d9ed50ffc39793. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->