### PR TITLE
fix: reference our model id, default thinking

### DIFF
--- a/frontend/components/playground/messages/params-popover.tsx
+++ b/frontend/components/playground/messages/params-popover.tsx
@@ -3,6 +3,7 @@ import { SlidersHorizontal } from "lucide-react";
 import { Controller, useFormContext } from "react-hook-form";
 
 import ReasoningField from "@/components/playground/messages/reasoning-field";
+import { defaultMaxTokens, defaultTemperature } from "@/components/playground/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -14,9 +15,6 @@ import { cn } from "@/lib/utils";
 interface ParamsPopoverProps {
   className?: string;
 }
-
-const defaultMaxTokens = 1024;
-const defaultTemperature = 1;
 
 const ParamsPopover = ({ className }: ParamsPopoverProps) => {
   const { control, watch } = useFormContext<PlaygroundForm>();

--- a/frontend/components/playground/types.ts
+++ b/frontend/components/playground/types.ts
@@ -150,7 +150,7 @@ export const providers: { provider: Provider; models: LanguageModel[] }[] = [
         id: "anthropic:claude-opus-4-20250514:thinking",
         name: "claude-opus-4-20250514",
         label: "Claude 4 Opus (Thinking)",
-      }
+      },
     ],
   },
   {
@@ -167,7 +167,7 @@ export const providers: { provider: Provider; models: LanguageModel[] }[] = [
         label: "Gemini 1.5 Pro",
       },
       {
-        id: "gemini:gemini-2.5-flash-preview-05-20",
+        id: "gemini:gemini-2.5-flash-preview-05-20:thinking",
         name: "gemini-2.5-flash-preview-05-20",
         label: "Gemini 2.5 Flash Preview",
       },
@@ -177,14 +177,9 @@ export const providers: { provider: Provider; models: LanguageModel[] }[] = [
         label: "Gemini 2.5 Pro Experimental",
       },
       {
-        id: "gemini:gemini-2.5-pro-preview-05-06",
-        name: "gemini-2.5-pro-preview-05-06",
-        label: "Gemini 2.5 Pro Preview",
-      },
-      {
         id: "gemini:gemini-2.5-pro-preview-05-06:thinking",
         name: "gemini-2.5-pro-preview-05-06",
-        label: "Gemini 2.5 Pro Preview (Thinking)",
+        label: "Gemini 2.5 Pro Preview",
       },
     ],
   },

--- a/frontend/components/playground/utils.tsx
+++ b/frontend/components/playground/utils.tsx
@@ -58,6 +58,9 @@ export const envVarsToIconMap: Record<EnvVars, ReactNode> = {
   [EnvVars.GOOGLE_SEARCH_API_KEY]: <IconGoogle />,
 };
 
+export const defaultMaxTokens = 65536;
+export const defaultTemperature = 1;
+
 export const getDefaultThinkingModelProviderOptions = <P extends Provider, K extends string>(
   value: `${P}:${K}`
 ): ProviderOptions => {
@@ -229,8 +232,8 @@ export const getPlaygroundConfig = (
     modelId: foundModel ? foundModel : "openai:gpt-4o-mini",
     tools: parsedTools,
     toolChoice: parsedToolChoice || (parsedTools ? "auto" : undefined),
-    maxTokens: get(span, ["attributes", "gen_ai.request.max_tokens"]) as number | undefined,
-    temperature: get(span, ["attributes", "gen_ai.request.temperature"]) as number | undefined,
+    maxTokens: get(span, ["attributes", "gen_ai.request.max_tokens"], defaultMaxTokens),
+    temperature: get(span, ["attributes", "gen_ai.request.temperature"], defaultTemperature),
   };
 
   return pickBy(result, (value) => value !== undefined) as typeof result;


### PR DESCRIPTION
- reference our model id
- default thinking gemini
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update model ID references and default values for max tokens and temperature in `ParamsPopover` and `getPlaygroundConfig`.
> 
>   - **Model ID Reference**:
>     - Update model ID reference in `getPlaygroundConfig()` in `utils.tsx` to use `foundModel` directly.
>     - Change model IDs for Gemini models in `types.ts` to include `:thinking` suffix.
>   - **Default Values**:
>     - Move `defaultMaxTokens` and `defaultTemperature` to `utils.tsx` and import them in `params-popover.tsx`.
>     - Update default values in `ParamsPopover` component for max tokens and temperature sliders.
>   - **Misc**:
>     - Remove unused `provider` variable in `getPlaygroundConfig()` in `utils.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for b25facba52e4d5f64c89259d15d57246b4690ac4. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->