### PR TITLE
allow for explicit null metadata in eval datapoints

### DIFF
--- a/app-server/src/evaluations/utils.rs
+++ b/app-server/src/evaluations/utils.rs
@@ -24,7 +24,7 @@ pub struct EvaluationDatapointResult {
     #[serde(default)]
     pub target: Value,
     #[serde(default)]
-    pub metadata: HashMap<String, Value>,
+    pub metadata: Option<HashMap<String, Value>>,
     #[serde(default)]
     pub executor_output: Option<Value>,
     #[serde(default)]
@@ -62,7 +62,7 @@ pub fn get_columns_from_points(points: &Vec<EvaluationDatapointResult>) -> Datap
 
     let metadatas = points
         .iter()
-        .map(|point| point.metadata.clone())
+        .map(|point| point.metadata.clone().unwrap_or_default())
         .collect::<Vec<_>>();
 
     let executor_outputs = points


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow `metadata` in `EvaluationDatapointResult` to be null and handle it in `get_columns_from_points()`.
> 
>   - **Behavior**:
>     - `metadata` in `EvaluationDatapointResult` changed to `Option<HashMap<String, Value>>` to allow explicit null values.
>     - `get_columns_from_points()` in `utils.rs` updated to handle null `metadata` by using `unwrap_or_default()`.
>   - **Misc**:
>     - No changes to other fields or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7662751f4d74dbb70d7263ba467d70cee03c8ec6. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->