### PR TITLE
fix: don't query project labels if none on span

### DIFF
--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -133,10 +133,13 @@ pub async fn record_labels_to_db_and_ch(
     span: &Span,
     project_id: &Uuid,
 ) -> anyhow::Result<()> {
+    let labels = span.get_attributes().labels();
+    if labels.is_empty() {
+        return Ok(());
+    }
+
     let project_labels =
         db::labels::get_label_classes_by_project_id(&db.pool, *project_id, None).await?;
-
-    let labels = span.get_attributes().labels();
 
     for label_name in labels {
         let label_class = project_labels.iter().find(|l| l.name == label_name);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add early return in `record_labels_to_db_and_ch` in `utils.rs` to skip database queries if `span` has no labels.
> 
>   - **Behavior**:
>     - In `record_labels_to_db_and_ch` in `utils.rs`, added a check to return early if `span` has no labels, preventing unnecessary database queries.
>   - **Misc**:
>     - Minor formatting change: moved `labels` variable declaration to after the early return check in `record_labels_to_db_and_ch`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for be03ee7d89ee6906ac1c466282f64993bef99f7c. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->