### PR TITLE
allow CTES in SQL editor

### DIFF
--- a/frontend/lib/sql/transpile.ts
+++ b/frontend/lib/sql/transpile.ts
@@ -98,7 +98,6 @@ class SQLValidator {
       }
       // Transpile the query
       const transpiled = this.transpileQuery(ast, projectId);
-      console.log(transpiled.sql);
       return {
         valid: true,
         sql: transpiled.sql,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Allow CTEs in SQL editor by updating `SQLValidator` to track and handle CTE aliases.
> 
>   - **Behavior**:
>     - Allows CTEs in SQL queries by tracking CTE aliases in `SQLValidator`.
>     - Updates whitelist check to include CTE aliases in `validateAndTranspile()`.
>     - Ensures `project_id` conditions are not applied to CTEs in `processSubqueries()`.
>   - **Classes**:
>     - Adds `withAliases` set to `SQLValidator` to store CTE aliases.
>   - **Functions**:
>     - Modifies `validateAndTranspile()` to populate `withAliases` with CTE names.
>     - Updates `processSubqueries()` to skip `project_id` application for CTEs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 971b3cf4690b6a1e3f9e7d7d69b8334aa4b45f99. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->