### PR TITLE
allow parsing output chat messages as content parts

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -938,11 +938,26 @@ fn output_message_from_completion_content(
 
     if tool_calls.is_empty() {
         if let Some(Value::String(s)) = msg_content {
-            Some(ChatMessage {
-                role: msg_role,
-                content: ChatMessageContent::Text(s.clone()),
-                tool_call_id: None,
-            })
+            if let Ok(content) =
+                serde_json::from_str::<Vec<InstrumentationChatMessageContentPart>>(&s)
+            {
+                Some(ChatMessage {
+                    role: msg_role,
+                    content: ChatMessageContent::ContentPartList(
+                        content
+                            .into_iter()
+                            .map(ChatMessageContentPart::from_instrumentation_content_part)
+                            .collect(),
+                    ),
+                    tool_call_id: None,
+                })
+            } else {
+                Some(ChatMessage {
+                    role: msg_role,
+                    content: ChatMessageContent::Text(s.clone()),
+                    tool_call_id: None,
+                })
+            }
         } else {
             None
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `output_message_from_completion_content()` in `spans.rs` to parse JSON strings into `InstrumentationChatMessageContentPart` objects, defaulting to plain text on failure.
> 
>   - **Behavior**:
>     - `output_message_from_completion_content()` in `spans.rs` now parses JSON strings into `InstrumentationChatMessageContentPart` objects.
>     - If parsing fails, defaults to treating content as plain text.
>   - **Functions**:
>     - Modifies `output_message_from_completion_content()` to handle JSON parsing of chat message content.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7d35b2516e011b478654c26a2b7830b9cf8311f6. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->