### PR TITLE
checkout overage usage products in addition to subscribe

### DIFF
--- a/frontend/app/checkout/page.tsx
+++ b/frontend/app/checkout/page.tsx
@@ -4,9 +4,12 @@ import { getServerSession } from "next-auth";
 import Stripe from "stripe";
 
 import { authOptions } from "@/lib/auth";
-import { getUserSubscriptionInfo } from "@/lib/checkout/utils";
+import { getIdFromStripeObject, getUserSubscriptionInfo } from "@/lib/checkout/utils";
 import { db } from "@/lib/db/drizzle";
 import { users, userSubscriptionInfo } from "@/lib/db/migrations/schema";
+
+const bytesOverageLookupKeyEnding = "_monthly_2025_06_overage_bytes";
+const stepsOverageLookupKeyEnding = "_monthly_2025_06_overage_steps";
 
 export default async function CheckoutPage(props: {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -73,6 +76,15 @@ export default async function CheckoutPage(props: {
     expand: ["data.product"],
   });
 
+  const product = prices.data[0].product;
+
+  const productPrices = await s.prices.list({
+    product: getIdFromStripeObject(product),
+  });
+
+  const bytesOveragePrice = productPrices.data.find((p) => p.lookup_key?.endsWith(bytesOverageLookupKeyEnding));
+  const stepsOveragePrice = productPrices.data.find((p) => p.lookup_key?.endsWith(stepsOverageLookupKeyEnding));
+
   const metadata =
     typeParam === "workspace"
       ? {
@@ -107,6 +119,12 @@ export default async function CheckoutPage(props: {
         price: prices.data.find((p) => p.lookup_key === lookupKey)?.id,
         quantity: 1,
       },
+      ...(bytesOveragePrice ? [{
+        price: bytesOveragePrice?.id,
+      }] : []),
+      ...(stepsOveragePrice ? [{
+        price: stepsOveragePrice?.id,
+      }] : []),
     ],
     mode: "subscription",
     subscription_data: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for overage usage products in `CheckoutPage` by fetching and including additional product prices based on specific lookup keys.
> 
>   - **Behavior**:
>     - Adds support for overage usage products in `CheckoutPage` in `page.tsx`.
>     - Fetches `bytesOveragePrice` and `stepsOveragePrice` using lookup keys ending with `_monthly_2025_06_overage_bytes` and `_monthly_2025_06_overage_steps`.
>     - Includes overage prices in `line_items` if they exist.
>   - **Functions**:
>     - Uses `getIdFromStripeObject` to retrieve product ID for fetching prices.
>   - **Constants**:
>     - Defines `bytesOverageLookupKeyEnding` and `stepsOverageLookupKeyEnding` for identifying overage products.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 87dd2590b27409f040c3287d0cbcff82b46c4809. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->