### PR TITLE
use single interface for all queues

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -169,11 +169,11 @@ fn main() -> anyhow::Result<()> {
 
     let connection_for_health = connection.clone(); // Clone before moving into HttpServer
 
-    // ==== 3.1 Spans message queue ====
-    let spans_message_queue: Arc<MessageQueue> = if let Some(connection) = connection.as_ref() {
+    let queue: Arc<MessageQueue> = if let Some(connection) = connection.as_ref() {
         runtime_handle.block_on(async {
             let channel = connection.create_channel().await.unwrap();
-
+            // Register queues
+            // ==== 3.1 Spans message queue ====
             channel
                 .exchange_declare(
                     OBSERVATIONS_EXCHANGE,
@@ -193,28 +193,7 @@ fn main() -> anyhow::Result<()> {
                 .await
                 .unwrap();
 
-            let max_channel_pool_size = env::var("RABBITMQ_MAX_CHANNEL_POOL_SIZE")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(64);
-
-            log::info!("RabbitMQ span channels: {}", max_channel_pool_size);
-
-            let rabbit_mq = mq::rabbit::RabbitMQ::new(connection.clone(), max_channel_pool_size);
-            Arc::new(rabbit_mq.into())
-        })
-    } else {
-        log::info!("Using tokio mpsc span queue");
-        Arc::new(mq::tokio_mpsc::TokioMpscQueue::new().into())
-    };
-
-    // ==== 3.2 Browser events message queue ====
-    let browser_events_message_queue: Arc<MessageQueue> = if let Some(connection) =
-        connection.as_ref()
-    {
-        runtime_handle.block_on(async {
-            let channel = connection.create_channel().await.unwrap();
-
+            // ==== 3.2 Browser events message queue ====
             channel
                 .exchange_declare(
                     BROWSER_SESSIONS_EXCHANGE,
@@ -234,30 +213,7 @@ fn main() -> anyhow::Result<()> {
                 .await
                 .unwrap();
 
-            let max_channel_pool_size = env::var("RABBITMQ_MAX_CHANNEL_POOL_SIZE")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(64);
-
-            log::info!(
-                "RabbitMQ browser events channels: {}",
-                max_channel_pool_size
-            );
-
-            let rabbit_mq = mq::rabbit::RabbitMQ::new(connection.clone(), max_channel_pool_size);
-            Arc::new(rabbit_mq.into())
-        })
-    } else {
-        log::info!("Using tokio mpsc browser events queue");
-        Arc::new(mq::tokio_mpsc::TokioMpscQueue::new().into())
-    };
-
-    // ==== 3.3 Evaluators message queue ====
-    let evaluators_message_queue: Arc<MessageQueue> = if let Some(connection) = connection.as_ref()
-    {
-        runtime_handle.block_on(async {
-            let channel = connection.create_channel().await.unwrap();
-
+            // ==== 3.3 Evaluators message queue ====
             channel
                 .exchange_declare(
                     EVALUATORS_EXCHANGE,
@@ -282,14 +238,22 @@ fn main() -> anyhow::Result<()> {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(64);
 
-            log::info!("RabbitMQ evaluators channels: {}", max_channel_pool_size);
+            log::info!("RabbitMQ channels: {}", max_channel_pool_size);
 
             let rabbit_mq = mq::rabbit::RabbitMQ::new(connection.clone(), max_channel_pool_size);
             Arc::new(rabbit_mq.into())
         })
     } else {
-        log::info!("Using tokio mpsc evaluators queue");
-        Arc::new(mq::tokio_mpsc::TokioMpscQueue::new().into())
+        let queue = mq::tokio_mpsc::TokioMpscQueue::new();
+        // register queues
+        // ==== 3.1 Spans message queue ====
+        queue.register_queue(OBSERVATIONS_EXCHANGE, OBSERVATIONS_QUEUE);
+        // ==== 3.2 Browser events message queue ====
+        queue.register_queue(BROWSER_SESSIONS_EXCHANGE, BROWSER_SESSIONS_QUEUE);
+        // ==== 3.3 Evaluators message queue ====
+        queue.register_queue(EVALUATORS_EXCHANGE, EVALUATORS_QUEUE);
+        log::info!("Using tokio mpsc queue");
+        Arc::new(queue.into())
     };
 
     // ==== 3.4 Agent worker message queue ====
@@ -298,7 +262,7 @@ fn main() -> anyhow::Result<()> {
     let runtime_handle_for_http = runtime_handle.clone();
     let db_for_http = db.clone();
     let cache_for_http = cache.clone();
-    let spans_mq_for_http = spans_message_queue.clone();
+    let mq_for_http = queue.clone();
 
     // == HTTP server and listener workers ==
     let http_server_handle = thread::Builder::new()
@@ -456,8 +420,7 @@ fn main() -> anyhow::Result<()> {
                         tokio::spawn(process_queue_spans(
                             db_for_http.clone(),
                             cache_for_http.clone(),
-                            spans_mq_for_http.clone(),
-                            evaluators_message_queue.clone(),
+                            mq_for_http.clone(),
                             clickhouse.clone(),
                             storage.clone(),
                         ));
@@ -467,7 +430,7 @@ fn main() -> anyhow::Result<()> {
                         tokio::spawn(process_browser_events(
                             db_for_http.clone(),
                             clickhouse.clone(),
-                            browser_events_message_queue.clone(),
+                            mq_for_http.clone(),
                         ));
                     }
 
@@ -475,7 +438,7 @@ fn main() -> anyhow::Result<()> {
                         tokio::spawn(process_evaluators(
                             db_for_http.clone(),
                             clickhouse.clone(),
-                            evaluators_message_queue.clone(),
+                            mq_for_http.clone(),
                             evaluator_client.clone(),
                             python_online_evaluator_url.clone(),
                         ));
@@ -488,13 +451,11 @@ fn main() -> anyhow::Result<()> {
                         .app_data(PayloadConfig::new(http_payload_limit))
                         .app_data(web::Data::from(cache_for_http.clone()))
                         .app_data(web::Data::from(db_for_http.clone()))
-                        .app_data(web::Data::new(spans_mq_for_http.clone()))
+                        .app_data(web::Data::new(mq_for_http.clone()))
                         .app_data(web::Data::new(clickhouse.clone()))
                         .app_data(web::Data::new(name_generator.clone()))
                         .app_data(web::Data::new(storage.clone()))
                         .app_data(web::Data::new(machine_manager.clone()))
-                        .app_data(web::Data::new(browser_events_message_queue.clone()))
-                        .app_data(web::Data::new(evaluators_message_queue.clone()))
                         .app_data(web::Data::new(agent_manager_workers.clone()))
                         .app_data(web::Data::new(connection_for_health.clone()))
                         .app_data(web::Data::new(browser_agent.clone()))
@@ -570,7 +531,7 @@ fn main() -> anyhow::Result<()> {
                 let process_traces_service = ProcessTracesService::new(
                     db.clone(),
                     cache.clone(),
-                    spans_message_queue.clone(),
+                    queue.clone(),
                 );
 
                 Server::builder()

--- a/app-server/src/mq/rabbit.rs
+++ b/app-server/src/mq/rabbit.rs
@@ -1,10 +1,10 @@
 use deadpool::managed::{Manager, Pool, PoolError, RecycleError};
 use futures_util::StreamExt;
 use lapin::{
+    BasicProperties, Channel, Connection, Consumer,
     acker::Acker,
     options::{BasicConsumeOptions, BasicPublishOptions, QueueBindOptions},
     types::FieldTable,
-    BasicProperties, Channel, Connection, Consumer,
 };
 use std::sync::Arc;
 

--- a/app-server/src/mq/tokio_mpsc.rs
+++ b/app-server/src/mq/tokio_mpsc.rs
@@ -5,8 +5,8 @@ use super::{
 use dashmap::DashMap;
 use std::sync::Arc;
 use tokio::sync::{
-    mpsc::{self, Receiver, Sender},
     Mutex,
+    mpsc::{self, Receiver, Sender},
 };
 
 const CHANNEL_CAPACITY: usize = 100;
@@ -52,6 +52,11 @@ impl TokioMpscQueue {
 
     fn key(&self, exchange: &str, routing_key: &str) -> String {
         format!("{}:-:{}", exchange, routing_key)
+    }
+
+    pub fn register_queue(&self, exchange: &str, routing_key: &str) {
+        let key = self.key(exchange, routing_key);
+        self.senders.entry(key).or_default();
     }
 }
 

--- a/app-server/src/traces/consumer.rs
+++ b/app-server/src/traces/consumer.rs
@@ -21,7 +21,6 @@ pub async fn process_queue_spans(
     db: Arc<DB>,
     cache: Arc<Cache>,
     queue: Arc<MessageQueue>,
-    evaluators_queue: Arc<MessageQueue>,
     clickhouse: clickhouse::Client,
     storage: Arc<Storage>,
 ) {
@@ -30,7 +29,6 @@ pub async fn process_queue_spans(
             db.clone(),
             cache.clone(),
             queue.clone(),
-            evaluators_queue.clone(),
             clickhouse.clone(),
             storage.clone(),
         )
@@ -43,7 +41,6 @@ async fn inner_process_queue_spans(
     db: Arc<DB>,
     cache: Arc<Cache>,
     queue: Arc<MessageQueue>,
-    evaluators_queue: Arc<MessageQueue>,
     clickhouse: clickhouse::Client,
     storage: Arc<Storage>,
 ) {
@@ -142,7 +139,7 @@ async fn inner_process_queue_spans(
             clickhouse.clone(),
             cache.clone(),
             acker,
-            evaluators_queue.clone(),
+            queue.clone(),
         )
         .await;
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor to use a single message queue interface for spans, browser events, and evaluators in `main.rs`, and update `TokioMpscQueue` and `process_queue_spans()` accordingly.
> 
>   - **Behavior**:
>     - Refactor `main.rs` to use a single `queue` interface for spans, browser events, and evaluators message queues.
>     - Register queues in `TokioMpscQueue` using `register_queue()` for spans, browser events, and evaluators.
>     - Update `process_queue_spans()` in `consumer.rs` to use the unified `queue` interface.
>   - **Functions**:
>     - Add `register_queue()` to `TokioMpscQueue` in `tokio_mpsc.rs` for queue registration.
>   - **Misc**:
>     - Remove redundant message queue variables in `main.rs` and replace with a single `queue` variable.
>     - Minor logging adjustments in `main.rs` and `consumer.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for eca210e51c93a2abf4d25c47ebbd406b75242bed. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->