### PR TITLE
feat: pass speed options

### DIFF
--- a/frontend/components/shared/traces/session-player.tsx
+++ b/frontend/components/shared/traces/session-player.tsx
@@ -33,6 +33,8 @@ export interface SessionPlayerHandle {
   goto: (time: number) => void;
 }
 
+const speedOptions = [1, 2, 4, 8, 16];
+
 const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(
   ({ hasBrowserSession, traceId, onTimelineChange }, ref) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
@@ -147,6 +149,7 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(
         playerRef.current = new rrwebPlayer({
           target: playerContainerRef.current,
           props: {
+            speedOption: speedOptions,
             autoPlay: false,
             skipInactive: false,
             events,
@@ -312,7 +315,7 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(
                 {speed}x
               </DropdownMenuTrigger>
               <DropdownMenuContent>
-                {[1, 2, 4, 8, 16].map((speedOption) => (
+                {speedOptions.map((speedOption) => (
                   <DropdownMenuItem key={speedOption} onClick={() => handleSpeedChange(speedOption)}>
                     {speedOption}x
                   </DropdownMenuItem>

--- a/frontend/components/traces/session-player.tsx
+++ b/frontend/components/traces/session-player.tsx
@@ -39,6 +39,7 @@ export interface SessionPlayerHandle {
   goto: (time: number) => void;
 }
 
+const speedOptions = [1, 2, 4, 8, 16];
 const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(
   ({ hasBrowserSession, traceId, onTimelineChange }, ref) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
@@ -239,6 +240,7 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(
         playerRef.current = new rrwebPlayer({
           target: playerContainerRef.current,
           props: {
+            speedOption: speedOptions,
             autoPlay: false,
             skipInactive: false,
             events,
@@ -411,7 +413,7 @@ const SessionPlayer = forwardRef<SessionPlayerHandle, SessionPlayerProps>(
                 {speed}x
               </DropdownMenuTrigger>
               <DropdownMenuContent>
-                {[1, 2, 4, 8, 16].map((speedOption) => (
+                {speedOptions.map((speedOption) => (
                   <DropdownMenuItem key={speedOption} onClick={() => handleSpeedChange(speedOption)}>
                     {speedOption}x
                   </DropdownMenuItem>


### PR DESCRIPTION
- override default speed options
![Screenshot 2025-07-04 at 1 00 44 PM](https://github.com/user-attachments/assets/61223ac1-6c33-4dfc-8303-b60cae8b727b)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds configurable speed options to session player components in `session-player.tsx` and `shared/session-player.tsx`.
> 
>   - **Behavior**:
>     - Adds `speedOptions` constant to define available speed settings in `session-player.tsx` and `shared/session-player.tsx`.
>     - Passes `speedOptions` to `rrwebPlayer` configuration in `session-player.tsx` and `shared/session-player.tsx`.
>     - Updates speed dropdown to use `speedOptions` in `session-player.tsx` and `shared/session-player.tsx`.
>   - **Misc**:
>     - Minor UI adjustments in `session-player.tsx` and `shared/session-player.tsx` to accommodate speed options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for b8a30f749fc33315b5b7932f613a2bdb01d76125. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->