### PR TITLE
fix: update cache update query to new pricing mode

### DIFF
--- a/frontend/lib/checkout/utils.ts
+++ b/frontend/lib/checkout/utils.ts
@@ -175,10 +175,12 @@ const updateUsageCacheForWorkspace = async (workspaceId: string) => {
   const cacheKey = `${WORKSPACE_LIMITS_CACHE_KEY}:${workspaceId}`;
   const baseQuery = db.$with('workspace_stats').as(
     db.select({
-      tierName: subscriptionTiers.name,
-      stepsLimit: subscriptionTiers.steps,
-      spansThisMonth: workspaceUsage.spanCount,
-      stepsThisMonth: workspaceUsage.stepCount
+      name: subscriptionTiers.name,
+      steps: subscriptionTiers.steps,
+      bytesIngested: subscriptionTiers.bytesIngested,
+      spansBytesIngestedSinceReset: workspaceUsage.spansBytesIngestedSinceReset,
+      browserSessionEventsBytesIngestedSinceReset: workspaceUsage.browserSessionEventsBytesIngestedSinceReset,
+      stepCountSinceReset: workspaceUsage.stepCountSinceReset
     }).from(workspaces)
       .innerJoin(subscriptionTiers, eq(workspaces.tierId, subscriptionTiers.id))
       .innerJoin(workspaceUsage, eq(workspaces.id, workspaceUsage.workspaceId))
@@ -186,12 +188,13 @@ const updateUsageCacheForWorkspace = async (workspaceId: string) => {
   );
 
   const limitExceededRows = await db.with(baseQuery).select({
-    spans: sql`span_count >= spans AND LOWER(TRIM(name)) = 'free'`,
-    steps: sql`step_count >= steps AND LOWER(TRIM(name)) = 'free'`
+    bytesIngested: sql`spans_bytes_ingested_since_reset + browser_session_events_bytes_ingested_since_reset >= bytes_ingested AND LOWER(TRIM(name)) = 'free'`.as('bytesIngested'),
+    steps: sql`step_count_since_reset >= steps AND LOWER(TRIM(name)) = 'free'`.as('steps')
   }).from(baseQuery);
 
   const limitExceeded = {
-    spans: limitExceededRows.length > 0 && !!limitExceededRows[0].spans,
+    // snake_case because the cache key is snake_case
+    bytes_ingested: limitExceededRows.length > 0 && !!limitExceededRows[0].bytesIngested,
     steps: limitExceededRows.length > 0 && !!limitExceededRows[0].steps
   };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `updateUsageCacheForWorkspace` in `utils.ts` to align with new pricing metrics and conditions for limit exceedance.
> 
>   - **Behavior**:
>     - Update `updateUsageCacheForWorkspace` in `utils.ts` to use new pricing metrics: `bytesIngested`, `spansBytesIngestedSinceReset`, `browserSessionEventsBytesIngestedSinceReset`, and `stepCountSinceReset`.
>     - Change limit exceedance conditions to check `bytesIngested` and `steps` against new metrics.
>   - **Misc**:
>     - Rename fields in query: `tierName` to `name`, `stepsLimit` to `steps`, `spansThisMonth` to `spansBytesIngestedSinceReset`, `stepsThisMonth` to `stepCountSinceReset`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 6a069f314090c7405291fafbf5239fa6c95e15ea. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->