### PR TITLE
quickfix: parse only specific columns from the filter

### DIFF
--- a/frontend/app/api/projects/[projectId]/sessions/route.ts
+++ b/frontend/app/api/projects/[projectId]/sessions/route.ts
@@ -20,7 +20,15 @@ export async function GET(req: NextRequest, props: { params: Promise<{ projectId
 
   let urlParamFilters: FilterDef[] = [];
   try {
-    urlParamFilters = req.nextUrl.searchParams.getAll("filter").map((f) => JSON.parse(f) as FilterDef);
+    urlParamFilters = req.nextUrl.searchParams.getAll("filter").map((f) => {
+      const urlParamFilter = JSON.parse(f) as FilterDef;
+      // Only keep the column, operator and value from the URL param
+      return {
+        column: urlParamFilter.column,
+        operator: urlParamFilter.operator,
+        value: urlParamFilter.value,
+      };
+    });
   } catch (e) {
     urlParamFilters = [];
   }

--- a/frontend/app/api/projects/[projectId]/spans/route.ts
+++ b/frontend/app/api/projects/[projectId]/spans/route.ts
@@ -90,7 +90,14 @@ export async function GET(req: NextRequest, props: { params: Promise<{ projectId
 
   let urlParamFilters: FilterDef[] = [];
   try {
-    urlParamFilters = req.nextUrl.searchParams.getAll("filter").map((f) => JSON.parse(f) as FilterDef);
+    urlParamFilters = req.nextUrl.searchParams.getAll("filter").map((f) => {
+      const urlParamFilter = JSON.parse(f) as FilterDef;
+      return {
+        column: urlParamFilter.column,
+        operator: urlParamFilter.operator,
+        value: urlParamFilter.value,
+      };
+    });
   } catch (e) {
     urlParamFilters = [];
   }

--- a/frontend/app/api/projects/[projectId]/traces/[traceId]/spans/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/[traceId]/spans/route.ts
@@ -21,7 +21,14 @@ export async function GET(
 
   const urlParamFilters = (() => {
     try {
-      const rawFilters = req.nextUrl.searchParams.getAll("filter").map((f) => JSON.parse(f) as FilterDef);
+      const rawFilters = req.nextUrl.searchParams.getAll("filter").map((f) => {
+        const urlParamFilter = JSON.parse(f) as FilterDef;
+        return {
+          column: urlParamFilter.column,
+          operator: urlParamFilter.operator,
+          value: urlParamFilter.value,
+        };
+      });
       return Array.isArray(rawFilters) ? rawFilters : [];
     } catch {
       return [];

--- a/frontend/app/api/projects/[projectId]/traces/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/route.ts
@@ -37,7 +37,14 @@ export async function GET(req: NextRequest, props: { params: Promise<{ projectId
 
   let urlParamFilters: FilterDef[] = [];
   try {
-    urlParamFilters = req.nextUrl.searchParams.getAll("filter").map((f) => JSON.parse(f) as FilterDef);
+    urlParamFilters = req.nextUrl.searchParams.getAll("filter").map((f) => {
+      const urlParamFilter = JSON.parse(f) as FilterDef;
+      return {
+        column: urlParamFilter.column,
+        operator: urlParamFilter.operator,
+        value: urlParamFilter.value,
+      };
+    });
   } catch (e) {
     urlParamFilters = [];
   }

--- a/frontend/lib/actions/evaluations/index.ts
+++ b/frontend/lib/actions/evaluations/index.ts
@@ -56,7 +56,11 @@ export const DeleteEvaluationsSchema = z.object({
 export async function getEvaluations(input: z.infer<typeof GetEvaluationsSchema>) {
   const { projectId, groupId, pageSize, pageNumber, search, filters } = input;
 
-  const urlParamFilters: FilterDef[] = compact(filters);
+  const urlParamFilters: FilterDef[] = compact(filters).map((filter) => ({
+    column: filter.column,
+    operator: filter.operator,
+    value: filter.value,
+  }));
 
   const baseFilters: SQL[] = [eq(evaluations.projectId, projectId)];
   if (groupId) {

--- a/frontend/lib/clickhouse/spans.ts
+++ b/frontend/lib/clickhouse/spans.ts
@@ -51,12 +51,12 @@ export const getSpanMetricsOverTime = async (
           ${groupBy},
           ${getMetricColumn(metric, aggregation)}
       ) as value,
-                       ${chRoundTime}(start_time) as time
-                     FROM spans
-                     WHERE
-                       project_id = {projectId: UUID}
-                       AND ${groupBy} != {nullValue: String}
-                       AND span_type in {types: Array(UInt8)}`;
+      ${chRoundTime}(start_time) as time
+    FROM spans
+    WHERE
+      project_id = {projectId: UUID}
+      AND ${groupBy} != {nullValue: String}
+      AND span_type in {types: Array(UInt8)}`;
   const query = addTimeRangeToQuery(baseQuery, timeRange, "time");
 
   let groupByStatement: string;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor filter parsing to only include specific columns (`column`, `operator`, `value`) across multiple API routes and utility functions.
> 
>   - **Filter Parsing**:
>     - In `route.ts` files for `sessions`, `spans`, `traces`, and `traces/[traceId]/spans`, filters are now parsed to only include `column`, `operator`, and `value`.
>     - In `index.ts`, `getEvaluations()` function now maps filters to only include `column`, `operator`, and `value`.
>   - **Miscellaneous**:
>     - Minor formatting changes in `spans.ts` for SQL query alignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for b7bcecc36ea2d59cf28ac0e7468c617c3906e834. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->