### PR TITLE
fix: delete project api keys from cache on project deletion

### DIFF
--- a/app-server/src/traces/limits.rs
+++ b/app-server/src/traces/limits.rs
@@ -7,10 +7,10 @@ use uuid::Uuid;
 
 use crate::{
     cache::{
-        keys::{PROJECT_CACHE_KEY, WORKSPACE_LIMITS_CACHE_KEY},
         Cache, CacheTrait,
+        keys::{PROJECT_CACHE_KEY, WORKSPACE_LIMITS_CACHE_KEY},
     },
-    db::{self, projects::Project, stats::WorkspaceLimitsExceeded, DB},
+    db::{self, DB, projects::Project, stats::WorkspaceLimitsExceeded},
 };
 
 pub async fn get_workspace_limit_exceeded_by_project_id(
@@ -74,7 +74,7 @@ async fn get_workspace_id_for_project_id(
         Ok(Some(project)) => Ok(project.workspace_id),
         Ok(None) | Err(_) => {
             let project = db::projects::get_project(&db.pool, &project_id).await?;
-            let _ = cache.insert::<Project>(&cache_key, project.clone()).await?;
+            let _ = cache.insert::<Project>(&cache_key, project.clone()).await;
             Ok(project.workspace_id)
         }
     }

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -103,8 +103,7 @@ pub async fn record_span_to_db(
         .with_initial_interval(std::time::Duration::from_millis(500))
         .with_multiplier(1.5)
         .with_randomization_factor(0.5)
-        .with_max_interval(std::time::Duration::from_secs(1 * 60))
-        .with_max_elapsed_time(Some(std::time::Duration::from_secs(5 * 60)))
+        .with_max_elapsed_time(Some(std::time::Duration::from_secs(10)))
         .build();
     backoff::future::retry(exponential_backoff, insert_span)
         .await

--- a/frontend/lib/actions/project/index.ts
+++ b/frontend/lib/actions/project/index.ts
@@ -25,7 +25,7 @@ export async function deleteProject(input: z.infer<typeof DeleteProjectSchema>) 
   } catch (error) {
     // In order to avoid blocking backend requests, we fail this operation
     // and don't proceed with project deletion.
-    throw new Error("Failed to delete project api keys from cache");
+    throw new Error("Failed to delete project api keys from cache: " + (error instanceof Error ? error.message : String(error)));
   }
 
   await db.delete(projects).where(eq(projects.id, projectId));

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -100,3 +100,5 @@ class CacheManager {
 }
 
 export const cache = new CacheManager();
+
+export const PROJECT_API_KEY_CACHE_KEY = "project_api_key";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure project API keys are deleted from cache on project deletion in `index.ts`, with error logging and new cache key constant.
> 
>   - **Behavior**:
>     - `deleteProject` in `index.ts` now deletes project API keys from cache before deleting the project from the database.
>     - Logs errors if API key deletion from cache fails.
>   - **Functions**:
>     - Adds `deleteProjectApiKeysFromCache` in `index.ts` to handle cache key deletion.
>   - **Constants**:
>     - Adds `PROJECT_API_KEY_CACHE_KEY` in `cache.ts` for consistent cache key usage.
>   - **Misc**:
>     - Removes unused result handling in `get_workspace_id_for_project_id` in `limits.rs`.
>     - Changes max elapsed time for backoff in `record_span_to_db` in `utils.rs` from 5 minutes to 10 seconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for baa26efb30496e356dca8c4b1ae7dea4e15fbb85. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->