### PR TITLE
remove span count update from postgres

### DIFF
--- a/app-server/src/db/stats.rs
+++ b/app-server/src/db/stats.rs
@@ -19,29 +19,6 @@ pub async fn create_usage_stats_for_workspace(pool: &PgPool, workspace_id: &Uuid
     Ok(())
 }
 
-pub async fn add_spans_to_project_usage_stats(
-    pool: &PgPool,
-    project_id: &Uuid,
-    spans: i64,
-) -> Result<()> {
-    sqlx::query(
-        "UPDATE workspace_usage
-        SET span_count = span_count + $2,
-            span_count_since_reset = span_count_since_reset + $2
-        WHERE workspace_id = (
-            SELECT workspace_id
-            FROM projects
-            WHERE id = $1
-            LIMIT 1)",
-    )
-    .bind(project_id)
-    .bind(spans)
-    .execute(pool)
-    .await?;
-
-    Ok(())
-}
-
 pub async fn increment_project_spans_bytes_ingested(
     pool: &PgPool,
     project_id: &Uuid,

--- a/app-server/src/traces/mod.rs
+++ b/app-server/src/traces/mod.rs
@@ -8,11 +8,8 @@ use crate::{
     cache::Cache,
     ch::{self, spans::CHSpan},
     db::{
-        DB,
-        evaluators::get_evaluators_by_path,
-        events::Event,
-        spans::Span,
-        stats::{add_spans_to_project_usage_stats, increment_project_spans_bytes_ingested},
+        DB, evaluators::get_evaluators_by_path, events::Event, spans::Span,
+        stats::increment_project_spans_bytes_ingested,
     },
     evaluators::push_to_evaluators_queue,
     mq::{MessageQueue, MessageQueueAcker},
@@ -140,13 +137,6 @@ pub async fn process_spans_and_events(
                 0
             }
         };
-
-    if let Err(e) = add_spans_to_project_usage_stats(&db.pool, &project_id, 1).await {
-        log::error!(
-            "Failed to add spans and events to project usage stats: {:?}",
-            e
-        );
-    }
 
     let recorded_events_bytes = match record_events(db.clone(), clickhouse.clone(), &events).await {
         Ok(_) => ingested_bytes.events_bytes,


### PR DESCRIPTION
The query locks out the workspace row on every span insertion and this is on a (very) hot path, so this was slow. We don't use these two fields in any code, only in analytics queries, which we can update later.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `add_spans_to_project_usage_stats` to improve performance by eliminating database locking during span insertion.
> 
>   - **Behavior**:
>     - Removes `add_spans_to_project_usage_stats` function from `stats.rs`.
>     - Removes invocation of `add_spans_to_project_usage_stats` in `process_spans_and_events()` in `mod.rs`.
>   - **Performance**:
>     - Eliminates database locking on workspace row during span insertion, improving performance on hot path.
>   - **Analytics**:
>     - Affected fields are only used in analytics queries, not in application logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for fb1742137df6d3c03873499a2140b9b7756522ec. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->