### PR TITLE
control rabbitmq with separate feature flag

### DIFF
--- a/app-server/src/features/mod.rs
+++ b/app-server/src/features/mod.rs
@@ -12,6 +12,7 @@ pub enum Feature {
     AgentManager,
     /// Evaluators
     Evaluators,
+    RabbitMQ,
 }
 
 pub fn is_feature_enabled(feature: Feature) -> bool {
@@ -32,5 +33,6 @@ pub fn is_feature_enabled(feature: Feature) -> bool {
             // && env::var("ENVIRONMENT") == Ok("PRODUCTION".to_string())
         }
         Feature::Evaluators => env::var("ONLINE_EVALUATORS_SECRET_KEY").is_ok(),
+        Feature::RabbitMQ => env::var("RABBITMQ_URL").is_ok(),
     }
 }

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -158,7 +158,7 @@ fn main() -> anyhow::Result<()> {
     let db = Arc::new(db::DB::new(pool));
 
     // === 3. Message queues ===
-    let (publisher_connection, consumer_connection) = if is_feature_enabled(Feature::FullBuild) {
+    let (publisher_connection, consumer_connection) = if is_feature_enabled(Feature::RabbitMQ) {
         let rabbitmq_url = env::var("RABBITMQ_URL").expect("RABBITMQ_URL must be set");
         runtime_handle.block_on(async {
             let publisher_conn = Arc::new(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `RabbitMQ` feature flag to control RabbitMQ connections via environment variable `RABBITMQ_URL`.
> 
>   - **Feature Flags**:
>     - Add `RabbitMQ` to `Feature` enum in `features/mod.rs`.
>     - `is_feature_enabled()` now checks `RABBITMQ_URL` for `RabbitMQ` feature.
>   - **Main Functionality**:
>     - Change feature flag check from `FullBuild` to `RabbitMQ` in `main.rs` for RabbitMQ connections.
>     - RabbitMQ connections are established only if `RabbitMQ` feature is enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for a2cd5d52c863e798dbabd8fc19561982c575ae76. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->