### PR TITLE
lazy queues

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -182,6 +182,17 @@ fn main() -> anyhow::Result<()> {
     let queue: Arc<MessageQueue> = if let (Some(publisher_conn), Some(consumer_conn)) = (publisher_connection.as_ref(), consumer_connection.as_ref()) {
         runtime_handle.block_on(async {
             let channel = publisher_conn.create_channel().await.unwrap();
+            
+            // Create arguments for lazy queues
+            let mut lazy_args = FieldTable::default();
+            lazy_args.insert("x-queue-mode".into(), lapin::types::AMQPValue::LongString("lazy".into()));
+            
+            // Lazy queues should be durable
+            let lazy_options = QueueDeclareOptions {
+                durable: true,
+                ..QueueDeclareOptions::default()
+            };
+            
             // Register queues
             // ==== 3.1 Spans message queue ====
             channel
@@ -197,8 +208,8 @@ fn main() -> anyhow::Result<()> {
             channel
                 .queue_declare(
                     OBSERVATIONS_QUEUE,
-                    QueueDeclareOptions::default(),
-                    FieldTable::default(),
+                    lazy_options,
+                    lazy_args.clone(),
                 )
                 .await
                 .unwrap();
@@ -217,8 +228,8 @@ fn main() -> anyhow::Result<()> {
             channel
                 .queue_declare(
                     BROWSER_SESSIONS_QUEUE,
-                    QueueDeclareOptions::default(),
-                    FieldTable::default(),
+                    lazy_options,
+                    lazy_args.clone(),
                 )
                 .await
                 .unwrap();
@@ -237,8 +248,8 @@ fn main() -> anyhow::Result<()> {
             channel
                 .queue_declare(
                     EVALUATORS_QUEUE,
-                    QueueDeclareOptions::default(),
-                    FieldTable::default(),
+                    lazy_options,
+                    lazy_args.clone(),
                 )
                 .await
                 .unwrap();
@@ -257,8 +268,8 @@ fn main() -> anyhow::Result<()> {
             channel
                 .queue_declare(
                     PAYLOADS_QUEUE,
-                    QueueDeclareOptions::default(),
-                    FieldTable::default(),
+                    lazy_options,
+                    lazy_args.clone(),
                 )
                 .await
                 .unwrap();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify queue declarations in `main.rs` to use durable lazy queues for improved efficiency.
> 
>   - **Behavior**:
>     - Modify queue declaration in `main.rs` to use lazy queues with `x-queue-mode` set to `lazy`.
>     - Ensure queues are durable by setting `durable: true` in `QueueDeclareOptions`.
>   - **Queues**:
>     - Apply lazy queue settings to `OBSERVATIONS_QUEUE`, `BROWSER_SESSIONS_QUEUE`, `EVALUATORS_QUEUE`, and `PAYLOADS_QUEUE`.
>     - Use `lazy_args` and `lazy_options` for queue declarations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for ebb9fcbc91b5dcfb81002b32f22291adb98600af. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->