### PR TITLE
persistent delivery mode

### DIFF
--- a/app-server/src/mq/rabbit.rs
+++ b/app-server/src/mq/rabbit.rs
@@ -175,7 +175,7 @@ impl MessageQueueTrait for RabbitMQ {
                     routing_key,
                     BasicPublishOptions::default(),
                     message,
-                    BasicProperties::default(),
+                    BasicProperties::default().with_delivery_mode(2),
                 )
                 .await
             {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets message delivery mode to persistent in `publish()` method of `RabbitMQ` to ensure message durability.
> 
>   - **Behavior**:
>     - Sets message delivery mode to persistent (2) in `publish()` method of `RabbitMQ` in `rabbit.rs`. This ensures messages are saved to disk and not lost on broker crash.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 92322d4105e0d21c7caddcf321ace3c3219c3ae4. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->