### PR TITLE
durable queues

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -188,7 +188,10 @@ fn main() -> anyhow::Result<()> {
                 .exchange_declare(
                     OBSERVATIONS_EXCHANGE,
                     ExchangeKind::Fanout,
-                    ExchangeDeclareOptions::default(),
+                    ExchangeDeclareOptions {
+                        durable: true,
+                        ..Default::default()
+                    },
                     FieldTable::default(),
                 )
                 .await
@@ -197,7 +200,10 @@ fn main() -> anyhow::Result<()> {
             channel
                 .queue_declare(
                     OBSERVATIONS_QUEUE,
-                    QueueDeclareOptions::default(),
+                    QueueDeclareOptions {
+                        durable: true,
+                        ..Default::default()
+                    },
                     FieldTable::default(),
                 )
                 .await
@@ -208,7 +214,10 @@ fn main() -> anyhow::Result<()> {
                 .exchange_declare(
                     BROWSER_SESSIONS_EXCHANGE,
                     ExchangeKind::Fanout,
-                    ExchangeDeclareOptions::default(),
+                    ExchangeDeclareOptions {
+                        durable: true,
+                        ..Default::default()
+                    },
                     FieldTable::default(),
                 )
                 .await
@@ -217,7 +226,10 @@ fn main() -> anyhow::Result<()> {
             channel
                 .queue_declare(
                     BROWSER_SESSIONS_QUEUE,
-                    QueueDeclareOptions::default(),
+                    QueueDeclareOptions {
+                        durable: true,
+                        ..Default::default()
+                    },
                     FieldTable::default(),
                 )
                 .await
@@ -228,7 +240,10 @@ fn main() -> anyhow::Result<()> {
                 .exchange_declare(
                     EVALUATORS_EXCHANGE,
                     ExchangeKind::Fanout,
-                    ExchangeDeclareOptions::default(),
+                    ExchangeDeclareOptions {
+                        durable: true,
+                        ..Default::default()
+                    },
                     FieldTable::default(),
                 )
                 .await
@@ -237,7 +252,10 @@ fn main() -> anyhow::Result<()> {
             channel
                 .queue_declare(
                     EVALUATORS_QUEUE,
-                    QueueDeclareOptions::default(),
+                    QueueDeclareOptions {
+                        durable: true,
+                        ..Default::default()
+                    },
                     FieldTable::default(),
                 )
                 .await
@@ -248,7 +266,10 @@ fn main() -> anyhow::Result<()> {
                 .exchange_declare(
                     PAYLOADS_EXCHANGE,
                     ExchangeKind::Fanout,
-                    ExchangeDeclareOptions::default(),
+                    ExchangeDeclareOptions {
+                        durable: true,
+                        ..Default::default()
+                    },
                     FieldTable::default(),
                 )
                 .await
@@ -257,7 +278,10 @@ fn main() -> anyhow::Result<()> {
             channel
                 .queue_declare(
                     PAYLOADS_QUEUE,
-                    QueueDeclareOptions::default(),
+                    QueueDeclareOptions {
+                        durable: true,
+                        ..Default::default()
+                    },
                     FieldTable::default(),
                 )
                 .await


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set message queues and exchanges to be durable in `main.rs` to ensure persistence across server restarts.
> 
>   - **Durability**:
>     - Set `durable: true` for `OBSERVATIONS_EXCHANGE` and `OBSERVATIONS_QUEUE` in `main.rs`.
>     - Set `durable: true` for `BROWSER_SESSIONS_EXCHANGE` and `BROWSER_SESSIONS_QUEUE` in `main.rs`.
>     - Set `durable: true` for `EVALUATORS_EXCHANGE` and `EVALUATORS_QUEUE` in `main.rs`.
>     - Set `durable: true` for `PAYLOADS_EXCHANGE` and `PAYLOADS_QUEUE` in `main.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 5bab94e9e5278290160df34d9189af3d553e48c5. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->