### PR TITLE
quorum queues

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -182,6 +182,11 @@ fn main() -> anyhow::Result<()> {
     let queue: Arc<MessageQueue> = if let (Some(publisher_conn), Some(consumer_conn)) = (publisher_connection.as_ref(), consumer_connection.as_ref()) {
         runtime_handle.block_on(async {
             let channel = publisher_conn.create_channel().await.unwrap();
+            
+            // Create quorum queue arguments (reused for all queues)
+            let mut quorum_queue_args = FieldTable::default();
+            quorum_queue_args.insert("x-queue-type".into(), lapin::types::AMQPValue::LongString("quorum".into()));
+            
             // Register queues
             // ==== 3.1 Spans message queue ====
             channel
@@ -204,7 +209,7 @@ fn main() -> anyhow::Result<()> {
                         durable: true,
                         ..Default::default()
                     },
-                    FieldTable::default(),
+                    quorum_queue_args.clone(),
                 )
                 .await
                 .unwrap();
@@ -230,7 +235,7 @@ fn main() -> anyhow::Result<()> {
                         durable: true,
                         ..Default::default()
                     },
-                    FieldTable::default(),
+                    quorum_queue_args.clone(),
                 )
                 .await
                 .unwrap();
@@ -256,7 +261,7 @@ fn main() -> anyhow::Result<()> {
                         durable: true,
                         ..Default::default()
                     },
-                    FieldTable::default(),
+                    quorum_queue_args.clone(),
                 )
                 .await
                 .unwrap();
@@ -282,7 +287,7 @@ fn main() -> anyhow::Result<()> {
                         durable: true,
                         ..Default::default()
                     },
-                    FieldTable::default(),
+                    quorum_queue_args.clone(),
                 )
                 .await
                 .unwrap();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces quorum queues in `main.rs` by setting `x-queue-type` to `quorum` for multiple message queues.
> 
>   - **Behavior**:
>     - Introduces quorum queues by setting `x-queue-type` to `quorum` in `main.rs`.
>     - Applies quorum queue settings to `OBSERVATIONS_QUEUE`, `BROWSER_SESSIONS_QUEUE`, `EVALUATORS_QUEUE`, and `PAYLOADS_QUEUE`.
>   - **Code**:
>     - Creates `quorum_queue_args` in `main.rs` to define quorum queue settings.
>     - Replaces `FieldTable::default()` with `quorum_queue_args.clone()` for queue declarations in `main.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d9e8047674c4240bcb4ff46f7726376e8a4d58e6. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->