### PR TITLE
prefer manually reported costs over estimations

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -167,7 +167,7 @@ impl SpanAttributes {
         }
     }
 
-    pub fn completion_tokens(&mut self) -> i64 {
+    pub fn output_tokens(&mut self) -> i64 {
         if let Some(Value::Number(n)) = self.raw_attributes.get(GEN_AI_OUTPUT_TOKENS) {
             n.as_i64().unwrap_or(0)
         } else if let Some(Value::Number(n)) = self.raw_attributes.get(GEN_AI_COMPLETION_TOKENS) {
@@ -178,6 +178,22 @@ impl SpanAttributes {
             n
         } else {
             0
+        }
+    }
+
+    pub fn input_cost(&mut self) -> Option<f64> {
+        if let Some(Value::Number(n)) = self.raw_attributes.get(GEN_AI_INPUT_COST) {
+            n.as_f64()
+        } else {
+            None
+        }
+    }
+
+    pub fn output_cost(&mut self) -> Option<f64> {
+        if let Some(Value::Number(n)) = self.raw_attributes.get(GEN_AI_OUTPUT_COST) {
+            n.as_f64()
+        } else {
+            None
         }
     }
 

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -32,7 +32,6 @@ pub async fn get_llm_usage_for_span(
     db: Arc<DB>,
     cache: Arc<Cache>,
 ) -> SpanUsage {
-    dbg!(&attributes);
     let input_tokens = attributes.input_tokens();
     let output_tokens = attributes.output_tokens();
     let total_tokens = input_tokens.total() + output_tokens;
@@ -44,16 +43,16 @@ pub async fn get_llm_usage_for_span(
     let model_name = response_model.clone().or(attributes.request_model());
     let provider_name = attributes.provider_name();
 
-    if input_cost.is_some() || output_cost.is_some() {
+    if input_cost.is_some_and(|c| c > 0.0) || output_cost.is_some_and(|c| c > 0.0) {
         // do not proceed with cost estimation if
         // either input or output cost is reported manually
         return SpanUsage {
             input_tokens: input_tokens.total(),
             output_tokens,
             total_tokens,
-            input_cost: input_cost.unwrap(),
-            output_cost: output_cost.unwrap(),
-            total_cost: input_cost.unwrap() + output_cost.unwrap(),
+            input_cost: input_cost.unwrap_or(0.0),
+            output_cost: output_cost.unwrap_or(0.0),
+            total_cost: input_cost.unwrap_or(0.0) + output_cost.unwrap_or(0.0),
             response_model: response_model.clone(),
             request_model: request_model.clone(),
             provider_name,

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -1,4 +1,7 @@
-use std::{env, str::FromStr, sync::Arc};
+use std::{
+    env,
+    sync::{Arc, LazyLock},
+};
 
 use backoff::ExponentialBackoffBuilder;
 use indexmap::IndexMap;
@@ -24,6 +27,9 @@ use super::{
     attributes::TraceAttributes,
     spans::{SpanAttributes, SpanUsage},
 };
+
+static SKIP_SPAN_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^Runnable[A-Z][A-Za-z]*(?:<[A-Za-z_,]+>)*\.task$").unwrap());
 
 /// Calculate usage for both default and LLM spans
 pub async fn get_llm_usage_for_span(
@@ -154,9 +160,6 @@ pub async fn record_spans_batch(
             })
     };
 
-    // Starting with 0.5 second delay, delay multiplies by random factor between 1 and 2
-    // up to 1 minute and until the total elapsed time is 5 minutes
-    // https://docs.rs/backoff/latest/backoff/default/index.html
     let exponential_backoff = ExponentialBackoffBuilder::new()
         .with_initial_interval(std::time::Duration::from_millis(500))
         .with_multiplier(1.5)
@@ -221,8 +224,7 @@ pub async fn record_labels_to_db_and_ch(
 }
 
 pub fn skip_span_name(name: &str) -> bool {
-    let re = Regex::new(r"^Runnable[A-Z][A-Za-z]*(?:<[A-Za-z_,]+>)*\.task$").unwrap();
-    re.is_match(name)
+    SKIP_SPAN_NAME_REGEX.is_match(name)
 }
 
 fn is_top_span(span: &Span, attributes: &SpanAttributes) -> bool {
@@ -369,7 +371,7 @@ pub fn convert_any_value_to_json_value(
             json!(map)
         }
         opentelemetry_proto_common_v1::any_value::Value::BytesValue(val) => String::from_utf8(val)
-            .map(|s| serde_json::Value::from_str(&s).unwrap_or(serde_json::Value::String(s)))
+            .map(|s| serde_json::from_str::<Value>(&s).unwrap_or(serde_json::Value::String(s)))
             .unwrap_or_default(),
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prefer manually reported costs over estimations in `get_llm_usage_for_span()` and rename `completion_tokens()` to `output_tokens()` in `spans.rs`.
> 
>   - **Behavior**:
>     - In `get_llm_usage_for_span()` in `utils.rs`, prefer manually reported `input_cost` and `output_cost` over estimations. If either cost is manually reported, skip cost estimation.
>   - **Functions**:
>     - Rename `completion_tokens()` to `output_tokens()` in `spans.rs`.
>     - Add `input_cost()` and `output_cost()` methods to `SpanAttributes` in `spans.rs`.
>   - **Misc**:
>     - Optimize regex initialization by using `LazyLock` for `SKIP_SPAN_NAME_REGEX` in `utils.rs`.
>     - Minor change in `convert_any_value_to_json_value()` in `utils.rs` to handle JSON parsing more robustly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3b72cf21863364d11cf3a0ce35062afd2e6ec542. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->