### PR TITLE
enable parquets and mq in correct env settings

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -158,7 +158,8 @@ fn main() -> anyhow::Result<()> {
     let db = Arc::new(db::DB::new(pool));
 
     // === 3. Message queues ===
-    let (publisher_connection, consumer_connection) = if is_feature_enabled(Feature::RabbitMQ) {
+    // Only enable RabbitMQ if it is a full build and RabbitMQ Feature (URL) is set
+    let (publisher_connection, consumer_connection) = if is_feature_enabled(Feature::RabbitMQ) && is_feature_enabled(Feature::FullBuild) {
         let rabbitmq_url = env::var("RABBITMQ_URL").expect("RABBITMQ_URL must be set");
         runtime_handle.block_on(async {
             let publisher_conn = Arc::new(

--- a/frontend/app/project/[projectId]/datasets/[datasetId]/page.tsx
+++ b/frontend/app/project/[projectId]/datasets/[datasetId]/page.tsx
@@ -30,5 +30,5 @@ export default async function DatasetPage(props: { params: Promise<{ projectId: 
     return notFound();
   }
 
-  return <Dataset dataset={dataset} />;
+  return <Dataset dataset={dataset} enableDownloadParquet={process.env.DATASET_EXPORT_WORKER_URL !== undefined} />;
 }

--- a/frontend/components/dataset/dataset.tsx
+++ b/frontend/components/dataset/dataset.tsx
@@ -26,6 +26,7 @@ import ManualAddDatapoint from "./manual-add-datapoint-dialog";
 
 interface DatasetProps {
   dataset: DatasetType;
+  enableDownloadParquet?: boolean;
 }
 
 const columns: ColumnDef<Datapoint>[] = [
@@ -52,7 +53,7 @@ const columns: ColumnDef<Datapoint>[] = [
   },
 ];
 
-export default function Dataset({ dataset }: DatasetProps) {
+export default function Dataset({ dataset, enableDownloadParquet }: DatasetProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathName = usePathname();
@@ -184,7 +185,7 @@ export default function Dataset({ dataset }: DatasetProps) {
               <span className="ml-2 truncate flex-1">Add all to labeling queue</span>
             </Badge>
           </AddToLabelingQueuePopover>
-          <DownloadParquetDialog datasetId={dataset.id} />
+          {enableDownloadParquet && <DownloadParquetDialog datasetId={dataset.id} />}
         </div>
       </div>
       <div className="flex-grow">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable RabbitMQ and Parquet download features based on environment settings in backend and frontend.
> 
>   - **Backend**:
>     - In `main.rs`, RabbitMQ connections are now only enabled if both `Feature::RabbitMQ` and `Feature::FullBuild` are enabled.
>   - **Frontend**:
>     - In `page.tsx`, `enableDownloadParquet` prop is passed to `Dataset` component if `DATASET_EXPORT_WORKER_URL` is set.
>     - In `dataset.tsx`, `DownloadParquetDialog` is conditionally rendered based on `enableDownloadParquet` prop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for dce5291caf09136e1945a1f8a56e50cbe8a47fa9. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->