### PR TITLE
fix old migration in place to unblock initialize script

### DIFF
--- a/frontend/lib/db/migrations/0046_talented_frog_thor.sql
+++ b/frontend/lib/db/migrations/0046_talented_frog_thor.sql
@@ -16,8 +16,6 @@ ALTER TABLE "label_classes" DROP COLUMN "description";--> statement-breakpoint
 ALTER TABLE "label_classes" DROP COLUMN "evaluator_runnable_graph";--> statement-breakpoint
 ALTER TABLE "label_classes" DROP COLUMN "pipeline_version_id";--> statement-breakpoint
 ALTER TABLE "labels" DROP COLUMN "reasoning";--> statement-breakpoint
-ALTER TABLE "subscription_tiers" DROP COLUMN "spans";--> statement-breakpoint
-ALTER TABLE "subscription_tiers" DROP COLUMN "extra_span_price";--> statement-breakpoint
 ALTER TABLE "workspace_usage" DROP COLUMN "prev_span_count";--> statement-breakpoint
 ALTER TABLE "workspace_usage" DROP COLUMN "prev_step_count";--> statement-breakpoint
 ALTER TABLE "workspace_usage" DROP COLUMN "bytes_ingested";--> statement-breakpoint

--- a/frontend/lib/db/migrations/meta/0046_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0046_snapshot.json
@@ -2948,6 +2948,20 @@
           "primaryKey": false,
           "notNull": true,
           "default": "'0'"
+        },
+        "spans": {
+          "name": "spans",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_span_price": {
+          "name": "extra_span_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
         }
       },
       "indexes": {},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes migration by removing `DROP COLUMN` statements and restoring columns in `subscription_tiers`.
> 
>   - **Migration Fix**:
>     - Removed `DROP COLUMN` statements for `spans` and `extra_span_price` in `0046_talented_frog_thor.sql`.
>     - Added `spans` and `extra_span_price` columns back to `subscription_tiers` in `0046_snapshot.json` with default values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for d9ac3b6a8c0185c94cec08cbbd45e3387b03037b. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->