### PR TITLE
fix datapoint count by counting from clickhouse

### DIFF
--- a/clickhouse-profiles-config.xml
+++ b/clickhouse-profiles-config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <profiles>
+        <default>
+            <date_time_input_format replace="replace">best_effort</date_time_input_format>
+        </default>
+    </profiles>
+</clickhouse>

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -26,6 +26,9 @@ services:
       - type: volume
         source: clickhouse-logs
         target: /var/log/clickhouse-server/
+      - type: bind
+        source: ./clickhouse-profiles-config.xml
+        target: /etc/clickhouse-server/users.d/lmnr.xml
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -25,6 +25,9 @@ services:
       - type: volume
         source: clickhouse-logs
         target: /var/log/clickhouse-server/
+      - type: bind
+        source: ./clickhouse-profiles-config.xml
+        target: /etc/clickhouse-server/users.d/lmnr.xml
     environment:
         CLICKHOUSE_USER: ${CLICKHOUSE_USER}
         CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}

--- a/docker-compose-local-dev-full.yml
+++ b/docker-compose-local-dev-full.yml
@@ -29,6 +29,9 @@ services:
       - type: volume
         source: clickhouse-logs
         target: /var/log/clickhouse-server/
+      - type: bind
+        source: ./clickhouse-profiles-config.xml
+        target: /etc/clickhouse-server/users.d/lmnr.xml
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -35,6 +35,9 @@ services:
       - type: volume
         source: clickhouse-logs
         target: /var/log/clickhouse-server/
+      - type: bind
+        source: ./clickhouse-profiles-config.xml
+        target: /etc/clickhouse-server/users.d/lmnr.xml
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       - type: volume
         source: clickhouse-logs
         target: /var/log/clickhouse-server/
+      - type: bind
+        source: ./clickhouse-profiles-config.xml
+        target: /etc/clickhouse-server/users.d/lmnr.xml
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}

--- a/frontend/lib/clickhouse/datapoints.ts
+++ b/frontend/lib/clickhouse/datapoints.ts
@@ -236,6 +236,10 @@ export const createDatapoints = async (
     table: 'datapoints',
     values: rows,
     format: 'JSONEachRow',
+    clickhouse_settings: {
+      wait_for_async_insert: 1,
+      async_insert: 1,
+    }
   });
 
   await insert;

--- a/frontend/lib/dataset/types.ts
+++ b/frontend/lib/dataset/types.ts
@@ -2,7 +2,6 @@ export interface Dataset {
   id: string;
   createdAt?: string;
   name: string;
-  indexedOn: string | null;
 }
 
 export interface DatasetInfo extends Dataset {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change datapoint counting to use ClickHouse queries and update Docker Compose for new ClickHouse configuration.
> 
>   - **Behavior**:
>     - Modify `GET` function in `route.ts` to count datapoints using ClickHouse query instead of SQL subquery.
>     - Add ClickHouse configuration file `clickhouse-profiles-config.xml` for date-time input format.
>   - **Docker Compose**:
>     - Bind `clickhouse-profiles-config.xml` in `docker-compose-full.yml`, `docker-compose-local-build.yml`, `docker-compose-local-dev-full.yml`, `docker-compose-local-dev.yml`, and `docker-compose.yml` to `/etc/clickhouse-server/users.d/lmnr.xml`.
>   - **Misc**:
>     - Remove `indexedOn` from `Dataset` interface in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 2d9e5f49a45e9289a9b503bc7f9bfb57f54c9748. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->