### PR TITLE
don't join array elems in clickhouse insert

### DIFF
--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -1,13 +1,11 @@
 use anyhow::Result;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use uuid::Uuid;
 
 use crate::{
     db::spans::{Span, SpanType},
     traces::spans::SpanUsage,
-    utils::json_value_to_string,
 };
 
 use super::utils::chrono_to_nanoseconds;
@@ -74,17 +72,17 @@ impl CHSpan {
         let user_id = span.attributes.user_id();
         let path = span.attributes.flat_path();
 
-        let span_input_string = json_value_to_string(
-            span.input
-                .as_ref()
-                .unwrap_or(&Value::String(String::from(""))),
-        );
+        let span_input_string = span
+            .input
+            .as_ref()
+            .map(|input| input.to_string())
+            .unwrap_or(String::new());
 
-        let span_output_string = json_value_to_string(
-            span.output
-                .as_ref()
-                .unwrap_or(&Value::String(String::from(""))),
-        );
+        let span_output_string = span
+            .output
+            .as_ref()
+            .map(|output| output.to_string())
+            .unwrap_or(String::new());
 
         CHSpan {
             span_id: span.span_id,

--- a/app-server/src/utils/mod.rs
+++ b/app-server/src/utils/mod.rs
@@ -3,11 +3,6 @@ use serde_json::Value;
 pub fn json_value_to_string(v: &Value) -> String {
     match v {
         Value::String(s) => s.to_string(),
-        Value::Array(a) => a
-            .iter()
-            .map(json_value_to_string)
-            .collect::<Vec<_>>()
-            .join(", "),
         _ => v.to_string(),
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplify JSON handling in Clickhouse inserts by removing array element joining in `json_value_to_string`.
> 
>   - **Behavior**:
>     - `CHSpan::from_db_span` in `spans.rs` now converts `span.input` and `span.output` to strings directly using `to_string()`.
>     - Removed joining of array elements in `json_value_to_string` in `utils/mod.rs`.
>   - **Functions**:
>     - Removed `json_value_to_string` usage from `spans.rs`.
>     - Simplified `json_value_to_string` in `utils/mod.rs` by removing array handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 991d2b532a5bb8cff2e0f9962691a265baf216e5. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->