### PR TITLE
take gen_ai.usage.cost into account as well

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -197,6 +197,14 @@ impl SpanAttributes {
         }
     }
 
+    pub fn total_cost(&mut self) -> Option<f64> {
+        if let Some(Value::Number(n)) = self.raw_attributes.get(GEN_AI_TOTAL_COST) {
+            n.as_f64()
+        } else {
+            None
+        }
+    }
+
     pub fn request_model(&self) -> Option<String> {
         match self.raw_attributes.get(GEN_AI_REQUEST_MODEL) {
             Some(Value::String(s)) => Some(s.clone()),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for `gen_ai.usage.cost` in cost calculations by updating `SpanAttributes` and `get_llm_usage_for_span()`.
> 
>   - **Behavior**:
>     - `total_cost` is now considered in `get_llm_usage_for_span()` in `utils.rs`. If `total_cost` is provided, it is used; otherwise, it is calculated from `input_cost` and `output_cost`.
>   - **Functions**:
>     - Adds `total_cost()` to `SpanAttributes` in `spans.rs` to retrieve `GEN_AI_TOTAL_COST` from attributes.
>     - Updates `get_llm_usage_for_span()` in `utils.rs` to include `total_cost` in cost calculation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 4b7723fbbd642df3ed026a3f869fd89446255409. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->