### PR TITLE
datapoints insert api

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -581,6 +581,7 @@ fn main() -> anyhow::Result<()> {
                                 .wrap(project_auth.clone())
                                 .service(api::v1::traces::process_traces)
                                 .service(api::v1::datasets::get_datapoints)
+                                .service(api::v1::datasets::create_datapoints)
                                 .service(api::v1::metrics::process_metrics)
                                 .service(api::v1::browser_sessions::create_session_event)
                                 .service(api::v1::evals::init_eval)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `create_datapoints` API endpoint to insert datapoints into datasets and handle ClickHouse insertion.
> 
>   - **API Changes**:
>     - Add `create_datapoints` POST endpoint in `datasets.rs` to insert datapoints into datasets.
>     - Define `CreateDatapointsRequest` and `CreateDatapointRequest` structs for request deserialization.
>   - **Datapoint Insertion**:
>     - Implement `insert_datapoints` in `datapoints.rs` to handle ClickHouse insertion.
>     - Add `from_datapoint` method in `CHDatapoint` for conversion from `Datapoint`.
>   - **Main Application**:
>     - Register `create_datapoints` service in `main.rs` under the `/v1` scope.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 44bc0c2d86d58b75b82c564855d5e91fadaaccd5. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->