### PR TITLE
fix workspace stats for empty workspace

### DIFF
--- a/frontend/lib/actions/workspaces/index.ts
+++ b/frontend/lib/actions/workspaces/index.ts
@@ -23,9 +23,18 @@ export const getWorkspaceUsage = async (workspaceId: string): Promise<WorkspaceU
     },
   });
 
-  if (projectIds.length === 0 || !resetTime) {
+  if (!resetTime) {
     throw new Error("Workspace not found");
   }
+
+  if (projectIds.length === 0) {
+    return {
+      spansBytesIngested: 0,
+      browserSessionEventsBytesIngested: 0,
+      resetTime: new Date(resetTime.resetTime),
+    };
+  }
+
 
   const resetTimeDate = new Date(resetTime.resetTime);
 

--- a/frontend/lib/usage/workspace-stats.ts
+++ b/frontend/lib/usage/workspace-stats.ts
@@ -5,7 +5,6 @@ import {
   membersOfWorkspaces,
   subscriptionTiers,
   workspaces,
-  workspaceUsage,
 } from "@/lib/db/migrations/schema";
 
 import { getWorkspaceUsage } from "../actions/workspaces";
@@ -30,10 +29,9 @@ export async function getWorkspaceStats(workspaceId: string): Promise<WorkspaceS
       storageLimit: subscriptionTiers.storageMib,
       bytesLimit: subscriptionTiers.bytesIngested,
     })
-    .from(workspaceUsage)
-    .innerJoin(workspaces, eq(workspaces.id, workspaceUsage.workspaceId))
+    .from(workspaces)
     .innerJoin(subscriptionTiers, eq(subscriptionTiers.id, workspaces.tierId))
-    .where(eq(workspaceUsage.workspaceId, workspaceId))
+    .where(eq(workspaces.id, workspaceId))
     .limit(1);
 
   if (!limitsRows[0]) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of empty workspaces in `getWorkspaceUsage` and simplify query in `getWorkspaceStats`.
> 
>   - **Behavior**:
>     - `getWorkspaceUsage` in `index.ts` now returns zero usage stats for workspaces with no projects instead of throwing an error.
>     - Simplifies query in `getWorkspaceStats` in `workspace-stats.ts` by removing `workspaceUsage` table join.
>   - **Error Handling**:
>     - Throws error only if `resetTime` is not found in `getWorkspaceUsage`.
>   - **Misc**:
>     - Removes unused import of `workspaceUsage` in `workspace-stats.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 39c4b6317bce72d2c4bed2bed2a22a48b1f37ad7. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->