### PR TITLE
fix duplicate insert into evaluation_datapoints

### DIFF
--- a/app-server/src/api/v1/browser_sessions.rs
+++ b/app-server/src/api/v1/browser_sessions.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use actix_web::{HttpResponse, options, post, web};
+use actix_web::{HttpResponse, post, web};
 use serde::{Deserialize, Deserializer, Serialize};
 use uuid::Uuid;
 
@@ -42,7 +42,7 @@ where
 pub struct RRWebEvent {
     #[serde(rename = "type")]
     pub event_type: u8,
-    pub timestamp: i64,
+    pub timestamp: f64, // milliseconds
     #[serde(deserialize_with = "deserialize_data")]
     pub data: Vec<u8>,
 }
@@ -64,19 +64,6 @@ pub struct EventBatch {
     pub source: Option<String>,
     #[serde(default)]
     pub sdk_version: Option<String>,
-}
-
-#[options("events")]
-async fn options_handler() -> ResponseResult {
-    Ok(HttpResponse::Ok()
-        .insert_header(("Access-Control-Allow-Origin", "*"))
-        .insert_header(("Access-Control-Allow-Methods", "POST, OPTIONS"))
-        .insert_header((
-            "Access-Control-Allow-Headers",
-            "Authorization, Content-Type, Content-Encoding, Accept",
-        ))
-        .insert_header(("Access-Control-Max-Age", "86400"))
-        .finish())
 }
 
 #[post("events")]

--- a/app-server/src/ch/browser_events.rs
+++ b/app-server/src/ch/browser_events.rs
@@ -12,7 +12,8 @@ pub struct BrowserEventCHRow<'a> {
     pub session_id: Uuid,
     #[serde(with = "clickhouse::serde::uuid")]
     pub trace_id: Uuid,
-    pub timestamp: i64,
+    // This column is DateTime64(3, 'UTC'), we assume that the timestamp is in milliseconds
+    pub timestamp: u64,
     pub event_type: u8,
     pub data: &'a [u8],
     #[serde(with = "clickhouse::serde::uuid")]
@@ -47,7 +48,7 @@ pub async fn insert_browser_events(
                 event_id: Uuid::new_v4(),
                 session_id: event_batch.session_id,
                 trace_id: event_batch.trace_id,
-                timestamp: event.timestamp,
+                timestamp: event.timestamp.abs() as u64,
                 event_type: event.event_type,
                 data: &event.data,
                 project_id: project_id,

--- a/app-server/src/ch/evaluation_datapoints.rs
+++ b/app-server/src/ch/evaluation_datapoints.rs
@@ -57,6 +57,17 @@ pub async fn insert_evaluation_datapoints(
         return Ok(());
     }
 
+    // The function is called twice - on datapoint creation and on datapoint update
+    // We check if there any scores to only insert datapoints once
+    let num_scores = evaluation_datapoints
+        .iter()
+        .map(|point| point.scores.len())
+        .sum::<usize>();
+
+    if num_scores == 0 {
+        return Ok(());
+    }
+
     let ch_insert = clickhouse.insert("evaluation_datapoints");
     match ch_insert {
         Ok(mut ch_insert) => {

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -565,7 +565,6 @@ fn main() -> anyhow::Result<()> {
                         .app_data(web::Data::new(sql_query_engine_client.clone()))
                         .service(
                             web::scope("/v1/browser-sessions")
-                                .service(api::v1::browser_sessions::options_handler)
                                 .service(
                                     web::scope("")
                                         .wrap(project_auth.clone())


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes duplicate insertion in `evaluation_datapoints` and improves timestamp handling in `browser_sessions.rs` and `browser_events.rs`.
> 
>   - **Behavior**:
>     - Prevents duplicate insertions in `insert_evaluation_datapoints()` by checking if there are any scores before inserting.
>     - Removes `options_handler` from `browser_sessions.rs` as it was unused.
>   - **Data Handling**:
>     - Changes `timestamp` type from `i64` to `f64` in `RRWebEvent` in `browser_sessions.rs` to handle milliseconds.
>     - Converts `timestamp` to `u64` in `BrowserEventCHRow` in `browser_events.rs` and ensures it is positive.
>   - **Misc**:
>     - Removes `options` import from `browser_sessions.rs`.
>     - Removes `options_handler` service registration in `main.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for c834793cf870359d4c1a26b5417b450af15b2571. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->