### PR TITLE
try inferring provider name from span name for old versions of langchain instrumentation

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -44,7 +44,6 @@ use sodiumoxide;
 use std::{
     env,
     io::{self, Error},
-    time::Duration,
     sync::Arc,
     thread::{self, JoinHandle},
 };

--- a/app-server/src/traces/consumer.rs
+++ b/app-server/src/traces/consumer.rs
@@ -231,7 +231,8 @@ async fn process_batch(
 
     for span in &mut spans {
         let span_usage =
-            get_llm_usage_for_span(&mut span.attributes, db.clone(), cache.clone()).await;
+            get_llm_usage_for_span(&mut span.attributes, db.clone(), cache.clone(), &span.name)
+                .await;
 
         // Filter events for this span
         let span_events: Vec<Event> = events

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -238,7 +238,7 @@ impl SpanAttributes {
         }
     }
 
-    pub fn provider_name(&self, span_name: &String) -> Option<String> {
+    pub fn provider_name(&self, span_name: &str) -> Option<String> {
         let name = if let Some(Value::String(provider)) = self.raw_attributes.get(GEN_AI_SYSTEM) {
             // For several versions prior to https://github.com/traceloop/openllmetry/pull/3165
             // and thus before `opentelemetry-instrumentation-langchain` 0.43.1, OpenLLMetry used

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -238,17 +238,36 @@ impl SpanAttributes {
         }
     }
 
-    pub fn provider_name(&self) -> Option<String> {
+    pub fn provider_name(&self, span_name: &String) -> Option<String> {
         let name = if let Some(Value::String(provider)) = self.raw_attributes.get(GEN_AI_SYSTEM) {
-            // Traceloop's auto-instrumentation sends the provider name as "Langchain" and the actual provider
-            // name as an attribute `association_properties.ls_provider`.
-            if provider == "Langchain" {
+            // For several versions prior to https://github.com/traceloop/openllmetry/pull/3165
+            // and thus before `opentelemetry-instrumentation-langchain` 0.43.1, OpenLLMetry used
+            // to send the provider name as "Langchain" and the actual provider.
+
+            // TODO: Since `lmnr 0.7.2` in Python, we have upgraded to OpenLLMetry >= 0.44.0,
+            // which correctly sends the provider name as the actual provider name, so
+            // this logic can be removed in a few months. We should also stop passing
+            // the span name all the way to here when we remove this logic.
+            if provider.to_lowercase().trim() == "langchain" {
+                // In some old versions, they would add an association property `ls_provider`
+                // to the span attributes.
                 let ls_provider = self
                     .raw_attributes
                     .get(format!("{ASSOCIATION_PROPERTIES_PREFIX}.ls_provider").as_str())
                     .and_then(|s| serde_json::from_value(s.clone()).ok());
                 if let Some(ls_provider) = ls_provider {
                     ls_provider
+                } else if span_name.contains(".")
+                    && span_name.to_lowercase().trim().starts_with("chat")
+                {
+                    // If there is no `ls_provider` attribute, we can try to extract the provider
+                    // name from the span name.
+                    span_name
+                        .to_lowercase()
+                        .replacen("chat", "", 1)
+                        .split(".")
+                        .next()
+                        .map(String::from)
                 } else {
                     Some(provider.clone())
                 }

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -37,6 +37,7 @@ pub async fn get_llm_usage_for_span(
     attributes: &mut SpanAttributes,
     db: Arc<DB>,
     cache: Arc<Cache>,
+    span_name: &String,
 ) -> SpanUsage {
     let input_tokens = attributes.input_tokens();
     let output_tokens = attributes.output_tokens();
@@ -48,7 +49,7 @@ pub async fn get_llm_usage_for_span(
     let response_model = attributes.response_model();
     let request_model = attributes.request_model();
     let model_name = response_model.clone().or(attributes.request_model());
-    let provider_name = attributes.provider_name();
+    let provider_name = attributes.provider_name(span_name);
 
     if input_cost.is_some_and(|c| c > 0.0)
         || output_cost.is_some_and(|c| c > 0.0)

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -37,7 +37,7 @@ pub async fn get_llm_usage_for_span(
     attributes: &mut SpanAttributes,
     db: Arc<DB>,
     cache: Arc<Cache>,
-    span_name: &String,
+    span_name: &str,
 ) -> SpanUsage {
     let input_tokens = attributes.input_tokens();
     let output_tokens = attributes.output_tokens();


### PR DESCRIPTION
Read the comment in code. Context: https://discord.com/channels/1212123095423393842/1266089994548678708/1401216965573349557

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Infer provider name from span name for older Langchain instrumentation versions by updating `provider_name()` in `SpanAttributes` and modifying `get_llm_usage_for_span()` to pass `span_name`.
> 
>   - **Behavior**:
>     - Update `provider_name()` in `SpanAttributes` to infer provider name from `span_name` if `ls_provider` attribute is missing and `span_name` starts with "chat".
>     - Modify `get_llm_usage_for_span()` in `utils.rs` to pass `span_name` to `provider_name()`.
>   - **Code Changes**:
>     - Update `process_batch()` in `consumer.rs` to pass `span.name` to `get_llm_usage_for_span()`.
>     - Remove unused `Duration` import from `main.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for f03b232f143b48ae5e76181130ecbe1368c7e6d9. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->