### PR TITLE
don't fail updates if cancelling a subscription without metadata

### DIFF
--- a/frontend/app/webhook/route.ts
+++ b/frontend/app/webhook/route.ts
@@ -66,7 +66,7 @@ async function handleSubscriptionChange(
       );
       if (subscriptionType === 'workspace') {
         if (!workspaceId) {
-          console.log(`subscription updated event. No workspaceId found.`);
+          console.log(`subscription updated event. No workspaceId found. subscriptionId: ${subscription.id}`);
           continue;
         }
         await manageWorkspaceSubscriptionEvent({

--- a/frontend/app/webhook/route.ts
+++ b/frontend/app/webhook/route.ts
@@ -79,7 +79,7 @@ async function handleSubscriptionChange(
         });
       } else {
         if (!userId) {
-          console.log(`subscription updated event. No userId found.`);
+          console.log(`subscription updated event. No userId found. subscriptionId: ${subscription.id}`);
           continue;
         }
         await manageUserSubscriptionEvent({

--- a/frontend/app/webhook/route.ts
+++ b/frontend/app/webhook/route.ts
@@ -65,6 +65,10 @@ async function handleSubscriptionChange(
         productId
       );
       if (subscriptionType === 'workspace') {
+        if (!workspaceId) {
+          console.log(`subscription updated event. No workspaceId found.`);
+          continue;
+        }
         await manageWorkspaceSubscriptionEvent({
           stripeCustomerId,
           productId,
@@ -74,6 +78,10 @@ async function handleSubscriptionChange(
           cancel: true
         });
       } else {
+        if (!userId) {
+          console.log(`subscription updated event. No userId found.`);
+          continue;
+        }
         await manageUserSubscriptionEvent({
           stripeCustomerId,
           productId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add checks in `handleSubscriptionChange` to prevent failure when `workspaceId` or `userId` is missing during subscription cancellation in `route.ts`.
> 
>   - **Behavior**:
>     - In `handleSubscriptionChange` in `route.ts`, added checks for missing `workspaceId` and `userId` during subscription cancellation.
>     - Logs a message and continues if `workspaceId` or `userId` is missing, preventing failure.
>   - **Logging**:
>     - Logs missing `workspaceId` or `userId` with subscription ID for debugging purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for f2f88f77873f209e76b3ae8fa8c0c9df48ec29ed. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->