### PR TITLE
allow langchain tool call messages to not have ids

### DIFF
--- a/app-server/src/traces/provider/langchain.rs
+++ b/app-server/src/traces/provider/langchain.rs
@@ -689,7 +689,6 @@ mod tests {
             tool_call_id: None,
         };
 
-        // Should return an error because tool call ID is required
         let result = message_to_langchain_format(message);
         assert!(result.is_ok());
         assert!(result.unwrap()["tool_calls"].as_array().unwrap()[0]["id"] == "");
@@ -1301,9 +1300,9 @@ mod tests {
     #[test]
     fn test_span_remains_intact_on_both_conversion_errors() {
         let invalid_input_messages = vec![ChatMessage {
-            role: "tool".to_string(),
+            role: "invalid_role".to_string(),
             content: ChatMessageContent::Text("Tool response".to_string()),
-            tool_call_id: None, // Missing required tool_call_id
+            tool_call_id: None,
         }];
 
         let invalid_output_messages = vec![ChatMessage {
@@ -1332,15 +1331,15 @@ mod tests {
     fn test_span_partial_conversion_success_still_leaves_intact() {
         // Test case where input conversion succeeds but output fails
         let valid_input_messages = vec![ChatMessage {
-            role: "unknown".to_string(),
+            role: "user".to_string(),
             content: ChatMessageContent::Text("Valid input".to_string()),
             tool_call_id: None,
         }];
 
         let invalid_output_messages = vec![ChatMessage {
-            role: "tool".to_string(),
+            role: "invalid_role".to_string(),
             content: ChatMessageContent::Text("Tool response".to_string()),
-            tool_call_id: None, // Missing required tool_call_id
+            tool_call_id: None,
         }];
 
         let original_input = serde_json::to_value(&valid_input_messages).unwrap();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Allow optional tool call IDs in LangChain messages, defaulting to an empty string if not provided, and update tests accordingly.
> 
>   - **Behavior**:
>     - Allow `tool_call_id` to be optional in `convert_tool_message()` and `tool_calls_from_content_parts()` in `langchain.rs`, defaulting to an empty string if not provided.
>     - Log a warning when `tool_call_id` is missing, using `DEFAULT_TOOL_CALL_ID`.
>   - **Tests**:
>     - Update tests in `langchain.rs` to check for default empty `tool_call_id` when not provided.
>     - Remove assertions expecting errors for missing `tool_call_id` in `test_tool_message_without_tool_call_id_default()` and `test_assistant_tool_call_without_id_default()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 9cbc5d3d526a688e6862a0473a7c47807e717131. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->