### PR TITLE
fix datasets apis to return 404 not 500 on a non-existent dataset name

### DIFF
--- a/app-server/src/api/v1/datasets.rs
+++ b/app-server/src/api/v1/datasets.rs
@@ -36,6 +36,12 @@ async fn get_datapoints(
     let dataset_id =
         db::datasets::get_dataset_id_by_name(&db.pool, &query.name, project_id).await?;
 
+    let Some(dataset_id) = dataset_id else {
+        return Ok(HttpResponse::NotFound().json(serde_json::json!({
+            "error": "Dataset not found"
+        })));
+    };
+
     // Get datapoints from ClickHouse
     let ch_datapoints = ch_datapoints::get_datapoints_paginated(
         clickhouse.clone(),
@@ -105,6 +111,12 @@ async fn create_datapoints(
     // Get dataset metadata from PostgreSQL
     let dataset_id =
         db::datasets::get_dataset_id_by_name(&db.pool, &request.dataset_name, project_id).await?;
+
+    let Some(dataset_id) = dataset_id else {
+        return Ok(HttpResponse::NotFound().json(serde_json::json!({
+            "error": "Dataset not found"
+        })));
+    };
 
     // Convert request datapoints to Datapoint structs
     let datapoints: Vec<Datapoint> = request

--- a/app-server/src/db/datasets.rs
+++ b/app-server/src/db/datasets.rs
@@ -2,15 +2,18 @@ use anyhow::Result;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-pub async fn get_dataset_id_by_name(pool: &PgPool, name: &str, project_id: Uuid) -> Result<Uuid> {
-    let dataset_id =
-        sqlx::query_as::<_, (Uuid,)>("SELECT id FROM datasets WHERE name = $1 AND project_id = $2")
-            .bind(name)
-            .bind(project_id)
-            .fetch_optional(pool)
-            .await?
-            .map(|(id,)| id)
-            .ok_or_else(|| anyhow::anyhow!("Dataset not found"))?;
+pub async fn get_dataset_id_by_name(
+    pool: &PgPool,
+    name: &str,
+    project_id: Uuid,
+) -> Result<Option<Uuid>> {
+    let dataset_id = sqlx::query_scalar::<_, Uuid>(
+        "SELECT id FROM datasets WHERE name = $1 AND project_id = $2",
+    )
+    .bind(name)
+    .bind(project_id)
+    .fetch_optional(pool)
+    .await?;
 
     Ok(dataset_id)
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix datasets APIs to return 404 instead of 500 for non-existent dataset names by updating error handling in `datasets.rs`.
> 
>   - **Behavior**:
>     - `get_datapoints` and `create_datapoints` in `datasets.rs` now return 404 for non-existent dataset names instead of 500.
>     - Error message "Dataset not found" returned in JSON format.
>   - **Database**:
>     - `get_dataset_id_by_name` in `datasets.rs` now returns `Result<Option<Uuid>>` instead of `Result<Uuid>` to handle non-existent datasets.
>   - **Misc**:
>     - No changes to `get_parquet_path` function behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for ead1dd05e3bad623b41b185e09aa5a5264c4a30c. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->