### PR TITLE
fix limits in browser events

### DIFF
--- a/app-server/src/api/v1/browser_sessions.rs
+++ b/app-server/src/api/v1/browser_sessions.rs
@@ -96,7 +96,7 @@ async fn create_session_event(
         .await?;
 
         if limits_exceeded.bytes_ingested {
-            return Ok(HttpResponse::PaymentRequired().json("Workspace data limit exceeded"));
+            return Ok(HttpResponse::Forbidden().json("Workspace data limit exceeded"));
         }
     }
 

--- a/app-server/src/api/v1/traces.rs
+++ b/app-server/src/api/v1/traces.rs
@@ -47,7 +47,7 @@ pub async fn process_traces(
         .await?;
 
         if limits_exceeded.bytes_ingested {
-            return Ok(HttpResponse::PaymentRequired().json("Workspace data limit exceeded"));
+            return Ok(HttpResponse::Forbidden().json("Workspace data limit exceeded"));
         }
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add feature flag check for usage limits in `create_session_event` to return 403 if exceeded.
> 
>   - **Behavior**:
>     - Add feature flag check for `Feature::UsageLimit` in `create_session_event` in `browser_sessions.rs`.
>     - If `UsageLimit` is enabled and workspace data limit is exceeded, return 403 Forbidden response.
>   - **Dependencies**:
>     - Add `db`, `cache`, and `clickhouse` as parameters to `create_session_event` to support limit checking.
>   - **Imports**:
>     - Import `DB`, `is_feature_enabled`, and `get_workspace_limit_exceeded_by_project_id` in `browser_sessions.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for b52976fda6a8bb517425fbbe5c49163a37be7974. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->