### PR TITLE
feat: disable realtime in presence of filters, search

### DIFF
--- a/frontend/components/traces/traces-table/index.tsx
+++ b/frontend/components/traces/traces-table/index.tsx
@@ -253,7 +253,7 @@ export default function TracesTable() {
       return;
     }
 
-    if (!enableLiveUpdates || filter.length > 0) {
+    if (!enableLiveUpdates || filter.length > 0 || textSearchFilter) {
       supabase.removeAllChannels();
       return;
     }
@@ -301,7 +301,7 @@ export default function TracesTable() {
     return () => {
       channel.unsubscribe();
     };
-  }, [enableLiveUpdates, projectId, isCurrentTimestampIncluded, supabase, filter.length]);
+  }, [enableLiveUpdates, projectId, isCurrentTimestampIncluded, supabase, filter.length, textSearchFilter]);
 
   useEffect(() => {
     if (pastHours || startDate || endDate) {

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -236,6 +236,7 @@ const JsxRenderer = ({
   code,
   data,
   className,
+  // height according to message in span view
   height = 372,
 }: {
   code: string;

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -232,7 +232,17 @@ const parseData = (data: any): any => {
   }
 };
 
-const JsxRenderer = ({ code, data, className }: { code: string; data: any; className?: string }) => {
+const JsxRenderer = ({
+  code,
+  data,
+  className,
+  height = 372,
+}: {
+  code: string;
+  data: any;
+  className?: string;
+  height?: number;
+}) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
@@ -257,6 +267,7 @@ const JsxRenderer = ({ code, data, className }: { code: string; data: any; class
       style={{
         contain: "layout style",
         isolation: "isolate",
+        height,
       }}
       sandbox="allow-scripts allow-same-origin"
       title="Template Preview"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Disable real-time updates in `TracesTable` when filters or search are active, and add a default height prop to `JsxRenderer`.
> 
>   - **Behavior**:
>     - Disable real-time updates in `TracesTable` when `filter` or `textSearchFilter` is active.
>     - Add `height` prop with default value `372` to `JsxRenderer`.
>   - **Code Changes**:
>     - Update dependency array in `useEffect` in `index.tsx` to include `textSearchFilter`.
>     - Modify `if` condition in `index.tsx` to check for `textSearchFilter`.
>     - Add `height` to `JsxRenderer` component props and apply it to `iframe` style.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7d77361859091d1670b917f90f438ee6a511b19b. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->