### PR TITLE
add an alias for ai sdk v4 tool args; update tests to catch

### DIFF
--- a/app-server/src/language_model/chat_message.rs
+++ b/app-server/src/language_model/chat_message.rs
@@ -260,6 +260,7 @@ pub struct InstrumentationChatMessageDocument {
 pub struct InstrumentationChatMessageAISDKToolCall {
     pub tool_name: String,
     pub tool_call_id: Option<String>,
+    #[serde(alias = "args")] // In AI SDK v4 it used to be called "args"
     pub input: Option<serde_json::Value>,
 }
 

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -2889,21 +2889,6 @@ mod tests {
             _ => panic!("Expected content part list for assistant message"),
         };
         assert_eq!(assistant_message_content.len(), 2);
-        assert!(matches!(
-            assistant_message_content[0],
-            ChatMessageContentPart::ToolCall(_)
-        ));
-        assert!(matches!(
-            assistant_message_content[1],
-            ChatMessageContentPart::ToolCall(_)
-        ));
-
-        let assistant_message = &child_input_messages[2];
-        let assistant_message_content = match &assistant_message.content {
-            ChatMessageContent::ContentPartList(parts) => parts,
-            _ => panic!("Expected content part list for assistant message"),
-        };
-        assert_eq!(assistant_message_content.len(), 2);
 
         for part in assistant_message_content {
             match part {

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -2564,7 +2564,8 @@ mod tests {
         let parent_span_id = Uuid::new_v4();
         let child_span_id = Uuid::new_v4();
         let trace_id = Uuid::new_v4();
-        let key = if is_v4 { "result" } else { "output" };
+        let output_key = if is_v4 { "result" } else { "output" };
+        let input_key = if is_v4 { "args" } else { "input" };
 
         // Create parent span (ai.generateText) - has DEFAULT span type
         let parent_attributes = HashMap::from([
@@ -2581,12 +2582,12 @@ mod tests {
                         "messages":[
                             {"role":"user","content":"What is the weather and time in SF?"},
                             {"role":"assistant","content":[
-                                {"type":"tool-call","toolCallId":"call_9oYyi7pB9xSW5ceOmcWnERiS","toolName":"get_weather","args":{"location":"San Francisco, CA"}},
-                                {"type":"tool-call","toolCallId":"call_K9NDZ4DGgxbiy4HIL5IDNjiS","toolName":"get_time","args":{"location":"San Francisco, CA"}}
+                                {"type":"tool-call","toolCallId":"call_9oYyi7pB9xSW5ceOmcWnERiS","toolName":"get_weather",input_key:{"location":"San Francisco, CA"}},
+                                {"type":"tool-call","toolCallId":"call_K9NDZ4DGgxbiy4HIL5IDNjiS","toolName":"get_time",input_key:{"location":"San Francisco, CA"}}
                             ]},
                             {"role":"tool","content":[
-                                {"type":"tool-result","toolCallId":"call_9oYyi7pB9xSW5ceOmcWnERiS","toolName":"get_weather",key:"Sunny as always!"},
-                                {"type":"tool-result","toolCallId":"call_K9NDZ4DGgxbiy4HIL5IDNjiS","toolName":"get_time",key:"12:00 PM"}
+                                {"type":"tool-result","toolCallId":"call_9oYyi7pB9xSW5ceOmcWnERiS","toolName":"get_weather",output_key:"Sunny as always!"},
+                                {"type":"tool-result","toolCallId":"call_K9NDZ4DGgxbiy4HIL5IDNjiS","toolName":"get_time",output_key:"12:00 PM"}
                             ]}
                         ]
                     }).to_string(),
@@ -2666,12 +2667,12 @@ mod tests {
                         json!({"role":"system","content":"You are a helpful assistant."}),
                         json!({"role":"user","content":[{"type":"text","text":"What is the weather and time in SF?"}]}),
                         json!({"role":"assistant","content":[
-                            {"type":"tool-call","toolCallId":"call_D2fRbvPAs1s4C9fd60l9diSk","toolName":"get_weather","args":{"location":"San Francisco, CA"}},
-                            {"type":"tool-call","toolCallId":"call_mB9nVqiW5NlbtFtBi06Gzr5F","toolName":"get_time","args":{"location":"San Francisco, CA"}}
+                            {"type":"tool-call","toolCallId":"call_D2fRbvPAs1s4C9fd60l9diSk","toolName":"get_weather",input_key:{"location":"San Francisco, CA"}},
+                            {"type":"tool-call","toolCallId":"call_mB9nVqiW5NlbtFtBi06Gzr5F","toolName":"get_time",input_key:{"location":"San Francisco, CA"}}
                         ]}),
                         json!({"role":"tool","content":[
-                            {"type":"tool-result","toolCallId":"call_D2fRbvPAs1s4C9fd60l9diSk","toolName":"get_weather",key:"Sunny as always!"},
-                            {"type":"tool-result","toolCallId":"call_mB9nVqiW5NlbtFtBi06Gzr5F","toolName":"get_time",key:"12:00 PM"}]})
+                            {"type":"tool-result","toolCallId":"call_D2fRbvPAs1s4C9fd60l9diSk","toolName":"get_weather",output_key:"Sunny as always!"},
+                            {"type":"tool-result","toolCallId":"call_mB9nVqiW5NlbtFtBi06Gzr5F","toolName":"get_time",output_key:"12:00 PM"}]})
                     ])
                     .to_string()
                 ),
@@ -2896,6 +2897,25 @@ mod tests {
             assistant_message_content[1],
             ChatMessageContentPart::ToolCall(_)
         ));
+
+        let assistant_message = &child_input_messages[2];
+        let assistant_message_content = match &assistant_message.content {
+            ChatMessageContent::ContentPartList(parts) => parts,
+            _ => panic!("Expected content part list for assistant message"),
+        };
+        assert_eq!(assistant_message_content.len(), 2);
+
+        for part in assistant_message_content {
+            match part {
+                ChatMessageContentPart::ToolCall(tool_call) => {
+                    assert_eq!(
+                        tool_call.arguments,
+                        Some(json!({"location":"San Francisco, CA"}))
+                    );
+                }
+                _ => panic!("Expected tool call for assistant message"),
+            }
+        }
 
         let tool_message = &child_input_messages[3];
         let tool_message_content = match &tool_message.content {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add alias for `input` field in `InstrumentationChatMessageAISDKToolCall` for AI SDK v4 compatibility and update tests accordingly.
> 
>   - **Behavior**:
>     - Add `#[serde(alias = "args")]` to `input` field in `InstrumentationChatMessageAISDKToolCall` in `chat_message.rs` for backward compatibility with AI SDK v4.
>   - **Tests**:
>     - Update `test_aisdk_tool_results()` in `spans.rs` to use `input_key` and `output_key` variables for handling both v4 and v5 field names.
>     - Modify assertions in `test_aisdk_tool_results()` to check for correct parsing of tool call arguments and results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3a0dda70f3f0021d971bbc53ae095a8d7c333c4e. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->