### PR TITLE
show seconds in traces tables

### DIFF
--- a/frontend/components/client-timestamp-formatter.tsx
+++ b/frontend/components/client-timestamp-formatter.tsx
@@ -3,7 +3,9 @@ import { useEffect, useState } from 'react';
 import {
   convertToLocalTimeWithMillis,
   formatTimestamp,
-  TIME_MILLISECONDS_FORMAT
+  formatTimestampWithSeconds,
+  TIME_MILLISECONDS_FORMAT,
+  TIME_SECONDS_FORMAT
 } from '@/lib/utils';
 
 // This component is a client-side only component that will format a timestamp
@@ -22,6 +24,8 @@ export default function ClientTimestampFormatter({
   useEffect(() => {
     if (format === TIME_MILLISECONDS_FORMAT) {
       setFormattedTimestamp(convertToLocalTimeWithMillis(timestamp));
+    } else if (format === TIME_SECONDS_FORMAT) {
+      setFormattedTimestamp(formatTimestampWithSeconds(timestamp));
     } else {
       setFormattedTimestamp(formatTimestamp(timestamp));
     }

--- a/frontend/components/traces/sessions-table/columns.tsx
+++ b/frontend/components/traces/sessions-table/columns.tsx
@@ -6,7 +6,7 @@ import { SessionRow } from "@/components/traces/sessions-table/index";
 import { ColumnFilter } from "@/components/ui/datatable-filter/utils";
 import Mono from "@/components/ui/mono";
 import { SessionPreview, Trace } from "@/lib/traces/types";
-import { getDurationString } from "@/lib/utils";
+import { getDurationString, TIME_SECONDS_FORMAT } from "@/lib/utils";
 
 export const columns: ColumnDef<SessionRow, any>[] = [
   {
@@ -38,8 +38,9 @@ export const columns: ColumnDef<SessionRow, any>[] = [
   {
     accessorFn: (row) => row.data.startTime,
     header: "Start time",
-    cell: (row) => <ClientTimestampFormatter timestamp={String(row.getValue())} />,
+    cell: (row) => <ClientTimestampFormatter timestamp={String(row.getValue())} format={TIME_SECONDS_FORMAT} />,
     id: "start_time",
+    size: 150,
   },
   {
     accessorFn: (row) => {

--- a/frontend/components/traces/spans-table/columns.tsx
+++ b/frontend/components/traces/spans-table/columns.tsx
@@ -8,6 +8,7 @@ import { ColumnFilter } from "@/components/ui/datatable-filter/utils";
 import Mono from "@/components/ui/mono";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Span, SpanType } from "@/lib/traces/types";
+import { TIME_SECONDS_FORMAT } from "@/lib/utils";
 
 const renderCost = (val: any) => {
   if (val === null || val === undefined) {
@@ -147,9 +148,9 @@ export const columns: ColumnDef<Span, any>[] = [
   {
     accessorFn: (row) => row.startTime,
     header: "Timestamp",
-    cell: (row) => <ClientTimestampFormatter timestamp={String(row.getValue())} />,
+    cell: (row) => <ClientTimestampFormatter timestamp={String(row.getValue())} format={TIME_SECONDS_FORMAT} />,
     id: "start_time",
-    size: 125,
+    size: 150,
   },
   {
     accessorFn: (row) => {

--- a/frontend/components/traces/traces-table/columns.tsx
+++ b/frontend/components/traces/traces-table/columns.tsx
@@ -11,6 +11,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { SpanType, Trace } from "@/lib/traces/types";
 import { isStringDateOld } from "@/lib/traces/utils";
+import { TIME_SECONDS_FORMAT } from "@/lib/utils";
 
 const renderCost = (val: any) => {
   if (val == null) {
@@ -92,9 +93,9 @@ export const columns: ColumnDef<Trace, any>[] = [
   {
     accessorFn: (row) => row.startTime,
     header: "Timestamp",
-    cell: (row) => <ClientTimestampFormatter timestamp={String(row.getValue())} />,
+    cell: (row) => <ClientTimestampFormatter timestamp={String(row.getValue())} format={TIME_SECONDS_FORMAT} />,
     id: "start_time",
-    size: 125,
+    size: 150,
   },
   {
     accessorFn: (row) => {

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -7,6 +7,7 @@ import { GroupByInterval } from "./clickhouse/modifiers";
 import { ChatMessageContentPart } from "./types";
 
 export const TIME_MILLISECONDS_FORMAT = "timeMilliseconds";
+export const TIME_SECONDS_FORMAT = "timeSeconds";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -99,6 +100,11 @@ export function formatTimestamp(timestampStr: string): string {
   return innerFormatTimestamp(date);
 }
 
+export function formatTimestampWithSeconds(timestampStr: string): string {
+  const date = new Date(timestampStr);
+  return innerFormatTimestamp(date, TIME_SECONDS_FORMAT);
+}
+
 export function formatTimestampFromSeconds(seconds: number): string {
   const date = new Date(seconds * 1000);
   return innerFormatTimestamp(date);
@@ -136,8 +142,9 @@ function innerFormatTimestampWithInterval(date: Date, interval: GroupByInterval)
 }
 
 // Note that the formatted time is calculated for local time
-function innerFormatTimestamp(date: Date): string {
+function innerFormatTimestamp(date: Date, format?: string): string {
   const timeOptions: Intl.DateTimeFormatOptions = {
+    ...(format === TIME_SECONDS_FORMAT ? { second: "2-digit" } : {}),
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for displaying seconds in timestamp formatting across traces tables.
> 
>   - **Behavior**:
>     - `ClientTimestampFormatter` in `client-timestamp-formatter.tsx` now supports `TIME_SECONDS_FORMAT` to display seconds in timestamps.
>     - Updated `sessions-table/columns.tsx`, `spans-table/columns.tsx`, and `traces-table/columns.tsx` to use `TIME_SECONDS_FORMAT` for timestamp columns.
>   - **Utils**:
>     - Added `TIME_SECONDS_FORMAT` constant and `formatTimestampWithSeconds()` function in `utils.ts`.
>     - Modified `innerFormatTimestamp()` in `utils.ts` to handle `TIME_SECONDS_FORMAT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3ac5ac0ed5ff0affd9eb9b8001a25a0a74776539. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->