### PR TITLE
reject very large payloads before pushing to MQ

### DIFF
--- a/app-server/src/evaluators/mod.rs
+++ b/app-server/src/evaluators/mod.rs
@@ -271,7 +271,7 @@ pub async fn push_to_evaluators_queue(
     } else {
         queue
             .publish(
-                &serde_json::to_vec(&message)?,
+                &mq_message,
                 EVALUATORS_EXCHANGE,
                 EVALUATORS_ROUTING_KEY,
             )

--- a/app-server/src/language_model/chat_message.rs
+++ b/app-server/src/language_model/chat_message.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
+    mq::utils::mq_max_payload,
     storage::{Storage, StorageTrait},
     utils::is_url,
 };
@@ -447,6 +448,15 @@ impl ChatMessageContentPart {
                     let key = crate::storage::create_key(project_id, &None);
                     let data = crate::storage::base64_to_bytes(&image.data)?;
                     let media_type = image.media_type.clone();
+                    if data.len() >= mq_max_payload() {
+                        log::warn!(
+                            "[STORAGE] MQ payload limit exceeded (image). Project ID: [{}], payload size: [{}]",
+                            project_id,
+                            data.len()
+                        );
+                        // Leave intact in case of error
+                        return Ok(self.clone());
+                    }
                     let url = storage.store(data, &key).await?;
                     Ok(ChatMessageContentPart::ImageUrl(ChatMessageImageUrl {
                         url,
@@ -462,6 +472,15 @@ impl ChatMessageContentPart {
                 };
                 let key = crate::storage::create_key(project_id, &file_extension);
                 let data = crate::storage::base64_to_bytes(&document.source.data)?;
+                if data.len() >= mq_max_payload() {
+                    log::warn!(
+                        "[STORAGE] MQ payload limit exceeded (document). Project ID: [{}], payload size: [{}]",
+                        project_id,
+                        data.len()
+                    );
+                    // Leave intact in case of error
+                    return Ok(self.clone());
+                }
                 let url = storage.store(data, &key).await?;
                 Ok(ChatMessageContentPart::DocumentUrl(
                     ChatMessageDocumentUrl {
@@ -474,6 +493,15 @@ impl ChatMessageContentPart {
                 if let Some(base64_data) = raw_base64_from_data_url(&image_url.url) {
                     let data = crate::storage::base64_to_bytes(base64_data)?;
                     let key = crate::storage::create_key(project_id, &None);
+                    if data.len() >= mq_max_payload() {
+                        log::warn!(
+                            "[STORAGE] MQ payload limit exceeded (image url). Project ID: [{}], payload size: [{}]",
+                            project_id,
+                            data.len()
+                        );
+                        // Leave intact in case of error
+                        return Ok(self.clone());
+                    }
                     let url = storage.store(data, &key).await?;
                     Ok(ChatMessageContentPart::ImageUrl(ChatMessageImageUrl {
                         url,
@@ -486,6 +514,15 @@ impl ChatMessageContentPart {
             }
             ChatMessageContentPart::ImageRawBytes(image) => {
                 let key = crate::storage::create_key(project_id, &None);
+                if image.image.len() >= mq_max_payload() {
+                    log::warn!(
+                        "[STORAGE] MQ payload limit exceeded (image raw bytes/aisdk). Project ID: [{}], payload size: [{}]",
+                        project_id,
+                        image.image.len()
+                    );
+                    // Leave intact in case of error
+                    return Ok(self.clone());
+                }
                 let url = storage.store(image.image.clone(), &key).await?;
                 Ok(ChatMessageContentPart::ImageUrl(ChatMessageImageUrl {
                     url,

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -544,7 +544,7 @@ fn main() -> anyhow::Result<()> {
                     }
 
                     App::new()
-                    .wrap( ErrorHandlers::new()
+                        .wrap( ErrorHandlers::new()
                             .handler(StatusCode::BAD_REQUEST, |res: dev::ServiceResponse| {
                                 log::error!("Bad request: {:?}", res.response().body());
                                 Ok(ErrorHandlerResponse::Response(res.map_into_left_body()))

--- a/app-server/src/mq/mod.rs
+++ b/app-server/src/mq/mod.rs
@@ -5,6 +5,7 @@ use lapin::{
 };
 pub mod rabbit;
 pub mod tokio_mpsc;
+pub mod utils;
 
 use rabbit::{RabbitMQ, RabbitMQDelivery, RabbitMQReceiver};
 use tokio_mpsc::{TokioMpscDelivery, TokioMpscQueue, TokioMpscReceiver};

--- a/app-server/src/mq/utils.rs
+++ b/app-server/src/mq/utils.rs
@@ -1,13 +1,13 @@
 use crate::features::{Feature, is_feature_enabled};
 
-const DEFAULT_MQ_MAX_PAYLOAD: usize = 1024 * 1024 * 50; // 50MB
+const DEFAULT_RABBITMQ_MAX_PAYLOAD: usize = 1024 * 1024 * 50; // 50MB
 
 pub fn mq_max_payload() -> usize {
     if is_feature_enabled(Feature::RabbitMQ) {
-        let limit = std::env::var("MQ_MAX_PAYLOAD")
+        let limit = std::env::var("RABBITMQ_MAX_PAYLOAD")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_MQ_MAX_PAYLOAD);
+            .unwrap_or(DEFAULT_RABBITMQ_MAX_PAYLOAD);
         limit
     } else {
         usize::MAX

--- a/app-server/src/mq/utils.rs
+++ b/app-server/src/mq/utils.rs
@@ -1,0 +1,15 @@
+use crate::features::{Feature, is_feature_enabled};
+
+const DEFAULT_MQ_MAX_PAYLOAD: usize = 1024 * 1024 * 50; // 50MB
+
+pub fn mq_max_payload() -> usize {
+    if is_feature_enabled(Feature::RabbitMQ) {
+        let limit = std::env::var("MQ_MAX_PAYLOAD")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_MQ_MAX_PAYLOAD);
+        limit
+    } else {
+        usize::MAX
+    }
+}

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -74,7 +74,7 @@ pub async fn create_span(
 
     if mq_message.len() >= mq_max_payload() {
         log::warn!(
-            "MQ payload limit exceeded. Project ID: [{}], payload size: [{}]",
+            "[SPANS ROUTE] MQ payload limit exceeded. Project ID: [{}], payload size: [{}]",
             project_id,
             mq_message.len()
         );

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -12,7 +12,7 @@ use crate::{
         events::Event,
         spans::{Span, SpanType},
     },
-    mq::{MessageQueue, MessageQueueTrait},
+    mq::{MessageQueue, MessageQueueTrait, utils::mq_max_payload},
     routes::types::ResponseResult,
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
 };
@@ -70,19 +70,24 @@ pub async fn create_span(
     let events: Vec<Event> = vec![];
 
     let rabbitmq_span_message = RabbitMqSpanMessage { span, events };
+    let mq_message = serde_json::to_vec(&vec![rabbitmq_span_message]).unwrap();
 
-    spans_message_queue
-        .publish(
-            &serde_json::to_vec(&vec![rabbitmq_span_message]).unwrap(),
-            OBSERVATIONS_EXCHANGE,
-            OBSERVATIONS_ROUTING_KEY,
-        )
-        .await
-        .map_err(|e| {
-            log::error!("Failed to publish span to queue: {:?}", e);
-            anyhow::anyhow!("Failed to publish span")
-        })?;
-
+    if mq_message.len() >= mq_max_payload() {
+        log::warn!(
+            "MQ payload limit exceeded. Project ID: [{}], payload size: [{}]",
+            project_id,
+            mq_message.len()
+        );
+        // Don't return error for now, skip publishing
+    } else {
+        spans_message_queue
+            .publish(&mq_message, OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY)
+            .await
+            .map_err(|e| {
+                log::error!("Failed to publish span to queue: {:?}", e);
+                anyhow::anyhow!("Failed to publish span")
+            })?;
+    }
     let response = CreateSpanResponse { span_id, trace_id };
 
     Ok(HttpResponse::Ok().json(response))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Rejects large payloads before pushing to MQ, logging warnings if size exceeds limit, and skips publishing without error.
> 
>   - **Behavior**:
>     - Rejects large payloads before pushing to MQ in `create_session_event()` in `browser_sessions.rs`, `push_to_evaluators_queue()` in `evaluators/mod.rs`, and `create_span()` in `routes/spans.rs`.
>     - Logs a warning if payload size exceeds `mq_max_payload()` limit.
>     - Skips publishing if payload is too large, without returning an error.
>   - **Utilities**:
>     - Adds `mq_max_payload()` in `mq/utils.rs` to determine max payload size, configurable via `RABBITMQ_MAX_PAYLOAD` environment variable.
>   - **Storage**:
>     - In `store_media()` in `chat_message.rs`, checks payload size before storing media, logs warning if size exceeds limit.
>     - In `store_payloads()` in `spans.rs`, checks input/output size, logs warning if size exceeds limit, stores in storage if necessary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for dbd08f489ed0400353f2e61c306aaed4998de0e0. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->