### PR TITLE
fix: remove agent manager from docker compose local build

### DIFF
--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -68,8 +68,6 @@ services:
         condition: service_healthy
       clickhouse:
         condition: service_started
-      agent-manager:
-        condition: service_healthy
     environment:
       PORT: 8000
       GRPC_PORT: 8001


### PR DESCRIPTION
Thanks to @itsaphel https://github.com/lmnr-ai/lmnr/pull/807#issuecomment-3307936029
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `agent-manager` dependency from `app-server` in `docker-compose-local-build.yml`.
> 
>   - **Docker Compose Changes**:
>     - Remove `agent-manager` dependency from `app-server` in `docker-compose-local-build.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 0fb927dc88aeb7b558cadc443739d0bd24e218cc. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->