### PR TITLE
small fixes to enable proper clickhouse migrations in main

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,8 @@ CLICKHOUSE_PASSWORD=ch_passwd
 POSTGRES_PORT=5433
 # must be exactly 32 bytes (64 hex characters)
 AEAD_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+# could be any value
+NEXTAUTH_SECRET=0123456789abcdef0123456789abcdef
 
 
 # Uncomment and set these to override the default exposed ports.

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -31,8 +31,8 @@ services:
         source: ./clickhouse-profiles-config.xml
         target: /etc/clickhouse-server/users.d/lmnr.xml
     environment:
-        CLICKHOUSE_USER: ${CLICKHOUSE_USER}
-        CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
     ulimits:
       nofile:
         soft: 262144

--- a/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/download/[format]/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/download/[format]/route.ts
@@ -62,10 +62,10 @@ export async function GET(
 
   const datapoints = chDatapoints.map(datapoint => ({
     ...datapoint,
-    scores: tryParseJson(datapoint.scores) as Record<string, number | null> || datapoint.scores,
-    data: tryParseJson(datapoint.data) || datapoint.data,
-    target: tryParseJson(datapoint.target) || datapoint.target,
-    executorOutput: tryParseJson(datapoint.executorOutput) || datapoint.executorOutput,
+    scores: tryParseJson(datapoint.scores) as Record<string, number | null> ?? datapoint.scores,
+    data: tryParseJson(datapoint.data) ?? datapoint.data,
+    target: tryParseJson(datapoint.target) ?? datapoint.target,
+    executorOutput: tryParseJson(datapoint.executorOutput) ?? datapoint.executorOutput,
   }));
 
   const flattenedResults = datapoints.map(result => {

--- a/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/download/[format]/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/[evaluationId]/download/[format]/route.ts
@@ -62,10 +62,10 @@ export async function GET(
 
   const datapoints = chDatapoints.map(datapoint => ({
     ...datapoint,
-    scores: tryParseJson(datapoint.scores) as Record<string, number | null>,
-    data: tryParseJson(datapoint.data),
-    target: tryParseJson(datapoint.target),
-    executorOutput: tryParseJson(datapoint.executorOutput),
+    scores: tryParseJson(datapoint.scores) as Record<string, number | null> || datapoint.scores,
+    data: tryParseJson(datapoint.data) || datapoint.data,
+    target: tryParseJson(datapoint.target) || datapoint.target,
+    executorOutput: tryParseJson(datapoint.executorOutput) || datapoint.executorOutput,
   }));
 
   const flattenedResults = datapoints.map(result => {

--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -42,7 +42,7 @@ export async function register() {
 
       const initializeClickHouse = async () => {
         try {
-          const { clickhouseClient } = await import("@/lib/clickhouse/client.js");
+          const { clickhouseClient } = await import("@/lib/clickhouse/client.ts");
           const { readFileSync, readdirSync } = await import("fs");
           const { join } = await import("path");
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix JSON parsing fallback and import path for ClickHouse migrations, and correct indentation in Docker Compose file.
> 
>   - **Behavior**:
>     - Fix JSON parsing fallback in `route.ts` by adding nullish coalescing to `tryParseJson()` results.
>   - **Imports**:
>     - Change import path from `client.js` to `client.ts` in `instrumentation.ts`.
>   - **Misc**:
>     - Fix indentation in `docker-compose-local-build.yml` for `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7a5854a8421dee1dcd1f2719e023524d7e63c6b2. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->