### PR TITLE
configurable retries for summaries

### DIFF
--- a/frontend/app/api/projects/[projectId]/traces/[traceId]/agent/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/[traceId]/agent/route.ts
@@ -9,14 +9,12 @@ export async function POST(req: Request, props: { params: Promise<{ projectId: s
   const traceId = params.traceId;
 
   try {
-    const { messages, traceStartTime, traceEndTime } = await req.json();
+    const { messages } = await req.json();
 
     const parseResult = ChatMessageSchema.safeParse({
       traceId,
       projectId,
       messages,
-      traceStartTime,
-      traceEndTime,
     });
 
     if (!parseResult.success) {

--- a/frontend/app/api/projects/[projectId]/traces/[traceId]/agent/summary/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/[traceId]/agent/summary/route.ts
@@ -1,22 +1,15 @@
 import { observe } from '@lmnr-ai/lmnr';
 import { prettifyError } from 'zod/v4';
 
-import { generateOrGetTraceSummary, TraceSummaryRequestSchema } from '@/lib/actions/trace/agent/summary';
+import { generateOrGetTraceSummary, GenerateTraceSummaryRequestSchema } from '@/lib/actions/trace/agent/summary';
 
 export async function POST(req: Request, props: { params: Promise<{ projectId: string, traceId: string }> }) {
   const params = await props.params;
   const projectId = params.projectId;
   const traceId = params.traceId;
 
-  const { traceStartTime, traceEndTime }: {
-    traceStartTime: string,
-    traceEndTime: string
-  } = await req.json();
-
-  const parseResult = TraceSummaryRequestSchema.safeParse({
+  const parseResult = GenerateTraceSummaryRequestSchema.safeParse({
     traceId,
-    traceStartTime,
-    traceEndTime,
     projectId,
   });
 

--- a/frontend/components/project/project-sidebar.tsx
+++ b/frontend/components/project/project-sidebar.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
+import DiscordLogo from "@/assets/logo/discord";
 import smallLogo from "@/assets/logo/icon.svg";
 import fullLogo from "@/assets/logo/logo.svg";
 import { Button } from "@/components/ui/button";
@@ -230,9 +231,9 @@ export default function ProjectSidebar({
           </div>
         )}
       </SidebarContent>
-      <SidebarFooter className="bg-background p-4 gap-4">
+      <SidebarFooter className="bg-background p-4 gap-1">
         <Link
-          href="https://docs.lmnr.ai"
+          href="https://discord.gg/nNFUUDAKub"
           target="_blank"
           rel="noopener noreferrer"
           className={cn(
@@ -240,8 +241,20 @@ export default function ProjectSidebar({
             open || openMobile ? "" : "justify-center"
           )}
         >
+          <DiscordLogo className="w-5 h-5" />
+          {open || openMobile ? <span className="text-sm">Support</span> : null}
+        </Link>
+        <Link
+          href="https://docs.lmnr.ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "h-8 text-secondary-foreground flex items-center gap-2 mb-4",
+            open || openMobile ? "" : "justify-center"
+          )}
+        >
           <Book size={16} />
-          {open || openMobile ? <span className="text-sm">Docs</span> : null}
+          {open || openMobile ? <span className="text-sm ml-1">Docs</span> : null}
         </Link>
         <AvatarMenu showDetails={open || openMobile} />
       </SidebarFooter>

--- a/frontend/components/user/avatar-menu.tsx
+++ b/frontend/components/user/avatar-menu.tsx
@@ -19,7 +19,7 @@ export default function AvatarMenu({ showDetails }: AvatarMenuProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost">
+        <Button variant="ghost" className="justify-start px-0">
           <div className="flex items-center justify-start gap-2">
             {imageUrl && imageUrl !== "" ? (
               <Image
@@ -32,7 +32,7 @@ export default function AvatarMenu({ showDetails }: AvatarMenuProps) {
             ) : (
               <div className="w-6 h-6 bg-slate-500 rounded-full cursor-pointer" />
             )}
-            {showDetails && <span className="text-xs truncate text-muted-foreground min-w-0">{email}</span>}
+            {showDetails && <span className="text-xs truncate whitespace-nowrap text-muted-foreground max-w-32">{email}</span>}
           </div>
         </Button>
       </DropdownMenuTrigger>

--- a/frontend/lib/actions/trace/agent/index.ts
+++ b/frontend/lib/actions/trace/agent/index.ts
@@ -7,8 +7,6 @@ import { convertToLocalTimeWithMillis } from "@/lib/utils";
 import { getFullTraceSpans, getSpansData, getTraceStructure } from "./spans";
 
 export const GetTraceStructureSchema = z.object({
-  startTime: z.iso.datetime(),
-  endTime: z.iso.datetime(),
   projectId: z.string(),
   traceId: z.string(),
 });
@@ -69,4 +67,4 @@ export const getFullTraceForSummary = async (input: z.infer<typeof GetTraceStruc
 };
 
 // Re-export summary functionality
-export { generateOrGetTraceSummary as generateTraceSummary, TraceSummaryRequestSchema as TraceSummarySchema } from './summary';
+export { generateOrGetTraceSummary as generateTraceSummary, GenerateTraceSummaryRequestSchema as TraceSummarySchema } from './summary';

--- a/frontend/lib/actions/trace/agent/messages.ts
+++ b/frontend/lib/actions/trace/agent/messages.ts
@@ -1,5 +1,5 @@
 import { tool } from 'ai';
-import { and, desc,eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from '@/lib/db/drizzle';
@@ -20,8 +20,6 @@ export const ChatMessageSchema = z.object({
       callProviderMetadata: z.any().optional(),
     })).optional(),
   })).describe('The conversation messages'),
-  traceStartTime: z.iso.datetime().describe('Start time of the trace'),
-  traceEndTime: z.iso.datetime().describe('End time of the trace'),
 });
 
 export const GetChatMessagesSchema = z.object({

--- a/frontend/lib/actions/trace/agent/spans.ts
+++ b/frontend/lib/actions/trace/agent/spans.ts
@@ -119,7 +119,7 @@ interface SpanStructure {
 };
 
 const fetchFullTraceSpans = async (input: z.infer<typeof GetTraceStructureSchema>): Promise<Span[]> => {
-  const { projectId, traceId, startTime, endTime } = input;
+  const { projectId, traceId } = input;
 
   const spans = await executeQuery({
     projectId,
@@ -149,13 +149,9 @@ const fetchFullTraceSpans = async (input: z.infer<typeof GetTraceStructureSchema
         parent_span_id
       FROM spans
       WHERE trace_id = {trace_id: UUID}
-      AND start_time >= {start_time:DateTime(3)} - interval '1 second'
-      AND start_time <= {end_time:DateTime(3)} + interval '1 second'
       ORDER BY start_time ASC
     `,
     parameters: {
-      start_time: startTime.replace("Z", ""),
-      end_time: endTime.replace("Z", ""),
       trace_id: traceId,
     },
   });
@@ -167,14 +163,10 @@ const fetchFullTraceSpans = async (input: z.infer<typeof GetTraceStructureSchema
     query: `
       SELECT span_id, timestamp, name, attributes FROM events
       WHERE span_id IN {span_ids:Array(UUID)}
-      AND timestamp >= {start_time:DateTime(3)} - interval '1 second'
-      AND timestamp <= {end_time:DateTime(3)} + interval '1 second'
       ORDER BY timestamp ASC
     `,
     parameters: {
       span_ids: Object.keys(spanIdsMap),
-      start_time: startTime.replace("Z", ""),
-      end_time: endTime.replace("Z", ""),
     },
   });
 

--- a/frontend/lib/actions/trace/agent/stream.ts
+++ b/frontend/lib/actions/trace/agent/stream.ts
@@ -10,13 +10,11 @@ import { TraceChatPrompt } from './prompt';
 export const TraceStreamChatSchema = z.object({
   messages: z.array(z.any()).describe('Array of UI messages'),
   traceId: z.string().describe('The trace ID to analyze'),
-  traceStartTime: z.iso.datetime().describe('Start time of the trace'),
-  traceEndTime: z.iso.datetime().describe('End time of the trace'),
   projectId: z.string().describe('The project ID'),
 });
 
 export async function streamTraceChat(input: z.infer<typeof TraceStreamChatSchema>) {
-  const { messages: uiMessages, traceId, traceStartTime, traceEndTime, projectId } = input;
+  const { messages: uiMessages, traceId, projectId } = input;
 
   const chatId = await findOrCreateChatSession(traceId, projectId);
 
@@ -32,16 +30,13 @@ export async function streamTraceChat(input: z.infer<typeof TraceStreamChatSchem
 
   const { summary, status, analysis, analysisPreview } = await generateTraceSummary({
     traceId,
-    traceStartTime,
-    traceEndTime,
     projectId,
+    maxRetries: 5,
   });
 
   const traceStructure = await getTraceStructureAsYAML({
     projectId,
     traceId,
-    startTime: traceStartTime,
-    endTime: traceEndTime
   });
 
   const prompt = TraceChatPrompt
@@ -50,9 +45,10 @@ export async function streamTraceChat(input: z.infer<typeof TraceStreamChatSchem
     .replace('{{analysis}}', analysis);
 
   const result = streamText({
-    model: google('gemini-2.5-flash'),
+    model: google('gemini-2.5-pro'),
     messages: convertToModelMessages(uiMessages as UIMessage[]),
     stopWhen: stepCountIs(10),
+    maxRetries: 5,
     system: prompt,
     tools: {
       getSpansData: tool({
@@ -64,8 +60,6 @@ export async function streamTraceChat(input: z.infer<typeof TraceStreamChatSchem
           const spansData = await getSpansDataAsYAML({
             projectId,
             traceId,
-            startTime: traceStartTime,
-            endTime: traceEndTime
           }, spanIds);
 
           return spansData;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes trace time-window params across backend/frontend, adds configurable retries to summary generation, and updates sidebar/support and minor UI details.
> 
> - **Trace Summaries (Backend + Frontend)**:
>   - Remove `traceStartTime`/`traceEndTime` from summary flow:
>     - Rust: drop times from `TraceSummaryMessage` and `push_to_trace_summary_queue`; update consumer call and internal API payload.
>     - Frontend API: replace `TraceSummaryRequestSchema` with `GenerateTraceSummaryRequestSchema` (no times) in `/api/traces/summary` and project routes; adjust validation and requests.
>     - ClickHouse queries: remove time filters for spans/events and LLM-span check; rely on `traceId` only.
>   - Add configurable retries:
>     - Summary generation accepts `maxRetries` (default 5); internal worker sets `maxRetries: 0` for fire-and-forget; chat stream uses `maxRetries: 5` and upgrades model to `gemini-2.5-pro`.
> - **UI**:
>   - Sidebar: add Discord “Support” link; adjust spacing and Docs label.
>   - Avatar menu: left-align button, refine email truncation.
> - **Misc**:
>   - Minor formatting/cleanup (imports, spacing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 651575d17ebde6d96f2c28600afabcfbccb9b41f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed `traceStartTime` and `traceEndTime` from trace summary logic and added configurable retries for summary generation.
> 
>   - **Behavior**:
>     - Removed `traceStartTime` and `traceEndTime` from `push_to_trace_summary_queue()` in `consumer.rs` and `summary.rs`.
>     - Updated `POST` handlers in `route.ts` files to exclude `traceStartTime` and `traceEndTime`.
>     - Configurable retries added to `generateTraceSummary()` in `summary.ts` with `maxRetries` parameter.
>   - **Schemas**:
>     - Removed `traceStartTime` and `traceEndTime` from `TraceSummaryMessage` and related schemas in `messages.ts` and `summary.ts`.
>     - Renamed `TraceSummaryRequestSchema` to `GenerateTraceSummaryRequestSchema` in `summary.ts`.
>   - **Misc**:
>     - Added Discord support link to `project-sidebar.tsx`.
>     - Minor UI adjustments in `avatar-menu.tsx` and `project-sidebar.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 651575d17ebde6d96f2c28600afabcfbccb9b41f. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->