### PR TITLE
delete datapoints, use body

### DIFF
--- a/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/route.ts
+++ b/frontend/app/api/projects/[projectId]/datasets/[datasetId]/datapoints/route.ts
@@ -66,6 +66,9 @@ export async function POST(
   }
 }
 
+// Note: this endpoint allows a body in a DELETE request, which is not standard
+// but fits our purposes: (1) this is an internal API, (2) passing many
+// datapoint IDs in the URL may break
 export async function DELETE(
   req: NextRequest,
   props: { params: Promise<{ projectId: string; datasetId: string }> }
@@ -73,8 +76,8 @@ export async function DELETE(
   const params = await props.params;
 
   try {
-    const searchParams = req.nextUrl.searchParams;
-    const datapointIds = searchParams.get("datapointIds")?.split(",");
+    const body = await req.json();
+    const datapointIds = body.datapointIds;
 
     if (!datapointIds) {
       return new Response("At least one Datapoint ID is required", { status: 400 });

--- a/frontend/components/dataset/dataset.tsx
+++ b/frontend/components/dataset/dataset.tsx
@@ -121,12 +121,15 @@ export default function Dataset({ dataset, enableDownloadParquet, publicApiBaseU
     async (datapointIds: string[]) => {
       try {
         const response = await fetch(
-          `/api/projects/${projectId}/datasets/${dataset.id}/datapoints` + `?datapointIds=${datapointIds.join(",")}`,
+          `/api/projects/${projectId}/datasets/${dataset.id}/datapoints`,
           {
             method: "DELETE",
             headers: {
               "Content-Type": "application/json",
             },
+            body: JSON.stringify({
+              datapointIds,
+            }),
           }
         );
         if (!response.ok) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify DELETE request to use request body for datapoint IDs in `route.ts` and update `dataset.tsx` accordingly.
> 
>   - **API Changes**:
>     - `DELETE` function in `route.ts` now reads `datapointIds` from the request body instead of URL parameters.
>     - Justification: Internal API, avoids URL length issues with many IDs.
>   - **Component Changes**:
>     - `handleDeleteDatapoints` in `dataset.tsx` updated to send `datapointIds` in the request body.
>     - Adjusts fetch call to match new API expectations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3a3fb179d049b94c9636cc2df5e25d9489083b7e. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->