### PR TITLE
refresh cache usages every 16MB

### DIFF
--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -6,3 +6,5 @@ pub const PROJECT_API_KEY_CACHE_KEY: &str = "project_api_key";
 pub const PROJECT_CACHE_KEY: &str = "project";
 pub const WORKSPACE_LIMITS_CACHE_KEY: &str = "workspace_limits";
 pub const PROJECT_EVALUATORS_BY_PATH_CACHE_KEY: &str = "project_evaluators_by_path";
+
+pub const WORKSPACE_PARTIAL_USAGE_CACHE_KEY: &str = "workspace_partial_usage";

--- a/app-server/src/traces/events.rs
+++ b/app-server/src/traces/events.rs
@@ -5,10 +5,11 @@ use crate::{
     db::events::Event,
 };
 
+///
 pub async fn record_events(
     clickhouse: clickhouse::Client,
     event_payloads: &Vec<Event>,
-) -> Result<()> {
+) -> Result<usize> {
     let ch_events = event_payloads
         .iter()
         .map(|e| CHEvent::from_db_event(e))

--- a/app-server/src/traces/limits.rs
+++ b/app-server/src/traces/limits.rs
@@ -9,11 +9,14 @@ use uuid::Uuid;
 use crate::{
     cache::{
         Cache, CacheTrait,
-        keys::{PROJECT_CACHE_KEY, WORKSPACE_LIMITS_CACHE_KEY},
+        keys::{PROJECT_CACHE_KEY, WORKSPACE_LIMITS_CACHE_KEY, WORKSPACE_PARTIAL_USAGE_CACHE_KEY},
     },
     ch,
     db::{self, DB, projects::ProjectWithWorkspaceBillingInfo, stats::WorkspaceLimitsExceeded},
 };
+
+// Threshold in bytes (16MB) - only recompute workspace limits after this much data is written
+const RECOMPUTE_THRESHOLD_BYTES: usize = 16 * 1024 * 1024; // 16MB
 
 pub async fn get_workspace_limit_exceeded_by_project_id(
     db: Arc<DB>,
@@ -56,6 +59,7 @@ pub async fn update_workspace_limit_exceeded_by_project_id(
     clickhouse: clickhouse::Client,
     cache: Arc<Cache>,
     project_id: Uuid,
+    written_bytes: usize,
 ) -> Result<()> {
     tokio::spawn(async move {
         let project_info = get_workspace_info_for_project_id(db.clone(), cache.clone(), project_id)
@@ -74,26 +78,57 @@ pub async fn update_workspace_limit_exceeded_by_project_id(
             return;
         }
 
-        let cache_key = format!("{WORKSPACE_LIMITS_CACHE_KEY}:{workspace_id}");
-        let workspace_limits_exceeded = is_workspace_over_limit(
-            clickhouse,
-            project_info.workspace_project_ids,
-            project_info.bytes_limit,
-            project_info.reset_time,
-        )
-        .await
-        .map_err(|e| {
-            log::error!(
-                "Failed to update workspace limit exceeded for project [{}]: {:?}",
-                project_id,
-                e
-            );
-        })
-        .unwrap();
-        cache
-            .insert::<WorkspaceLimitsExceeded>(&cache_key, workspace_limits_exceeded.clone())
+        let partial_usage_cache_key = format!("{WORKSPACE_PARTIAL_USAGE_CACHE_KEY}:{workspace_id}");
+        let limits_cache_key = format!("{WORKSPACE_LIMITS_CACHE_KEY}:{workspace_id}");
+
+        // Get current partial usage from cache
+        let cache_result = cache.get::<usize>(&partial_usage_cache_key).await;
+
+        // If cache is missing or errored, we should recompute
+        let (current_partial_usage, cache_available) = match cache_result {
+            Ok(Some(value)) => (value, true),
+            Ok(None) | Err(_) => (0, false),
+        };
+
+        let new_partial_usage = current_partial_usage + written_bytes;
+
+        // Recompute if: cache was unavailable, or we've accumulated at least RECOMPUTE_THRESHOLD_BYTES
+        let should_recompute = !cache_available || new_partial_usage >= RECOMPUTE_THRESHOLD_BYTES;
+
+        if should_recompute {
+            // Perform the heavy computation
+            let workspace_limits_exceeded = is_workspace_over_limit(
+                clickhouse,
+                project_info.workspace_project_ids,
+                project_info.bytes_limit,
+                project_info.reset_time,
+            )
             .await
+            .map_err(|e| {
+                log::error!(
+                    "Failed to update workspace limit exceeded for project [{}]: {:?}",
+                    project_id,
+                    e
+                );
+            })
             .unwrap();
+
+            // Update the limits cache
+            let _ = cache
+                .insert::<WorkspaceLimitsExceeded>(
+                    &limits_cache_key,
+                    workspace_limits_exceeded.clone(),
+                )
+                .await;
+
+            // Reset the partial usage counter
+            let _ = cache.insert::<usize>(&partial_usage_cache_key, 0).await;
+        } else {
+            // Just update the partial usage counter
+            let _ = cache
+                .insert::<usize>(&partial_usage_cache_key, new_partial_usage)
+                .await;
+        }
     });
 
     Ok(())


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refresh cache usage every 16MB by updating event recording and workspace limit computation logic.
> 
>   - **Behavior**:
>     - Refresh cache usage every 16MB of data ingested.
>     - `insert_events` in `events.rs` now returns the number of bytes inserted.
>     - `update_workspace_limit_exceeded_by_project_id` in `limits.rs` uses a partial usage cache to decide when to recompute limits.
>   - **Functions**:
>     - `record_events` in `events.rs` updated to return total bytes ingested.
>     - `process_batch` in `consumer.rs` calculates total ingested bytes and updates workspace limits accordingly.
>   - **Constants**:
>     - Added `WORKSPACE_PARTIAL_USAGE_CACHE_KEY` in `keys.rs`.
>     - Defined `RECOMPUTE_THRESHOLD_BYTES` as 16MB in `limits.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for bd5e7de451effd02694d04482655e43b09ab6996. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->