### PR TITLE
update usage cache for browser events

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -562,7 +562,9 @@ fn main() -> anyhow::Result<()> {
 
                     for _ in 0..num_browser_events_workers_per_thread {
                         tokio::spawn(process_browser_events(
+                            db_for_http.clone(),
                             clickhouse.clone(),
+                            cache_for_http.clone(),
                             mq_for_http.clone(),
                         ));
                     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update browser events processing to include usage limits cache updates and modify related functions.
> 
>   - **Behavior**:
>     - `process_browser_events` in `mod.rs` now updates usage limits cache after inserting browser events.
>     - `insert_browser_events` in `browser_events.rs` returns the number of bytes written.
>   - **Functions**:
>     - `process_browser_events` and `inner_process_browser_events` in `mod.rs` now take `db` and `cache` as parameters.
>     - `update_workspace_limit_exceeded_by_project_id` called in `inner_process_browser_events` to update cache.
>   - **Misc**:
>     - Update `main.rs` to pass `db` and `cache` to `process_browser_events`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 5da753299c60fd79a96ec16b1e54818511582b32. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->