### PR TITLE
update tracing config to always log to console

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -115,9 +115,7 @@ fn main() -> anyhow::Result<()> {
         drop(_sentry_guard);
     }
 
-    if is_feature_enabled(Feature::Tracing) {
-        instrumentation::setup_tracing();
-    }
+    instrumentation::setup_tracing(is_feature_enabled(Feature::Tracing));
 
     let http_payload_limit: usize = env::var("HTTP_PAYLOAD_LIMIT")
         .unwrap_or(String::from("5242880")) // default to 5MB


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor tracing setup to always log to console and conditionally initialize OpenTelemetry based on feature flag.
> 
>   - **Behavior**:
>     - `setup_tracing` in `mod.rs` now accepts a `bool` parameter `enable_otel` to conditionally initialize OpenTelemetry.
>     - Always logs to console using `tracing_subscriber::fmt::layer()` regardless of `enable_otel`.
>   - **Main Function**:
>     - Updated `main.rs` to call `setup_tracing` with `is_feature_enabled(Feature::Tracing)` to control OpenTelemetry initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 474c3a97eeb409af9cd511079b3c2e426186241c. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->