### PR TITLE
read llm costs from cache, TTL to 24 hours

### DIFF
--- a/app-server/src/db/prices.rs
+++ b/app-server/src/db/prices.rs
@@ -11,7 +11,11 @@ pub struct DBPriceEntry {
     pub additional_prices: Value,
 }
 
-pub async fn get_price(pool: &PgPool, provider: &str, model: &str) -> anyhow::Result<DBPriceEntry> {
+pub async fn get_price(
+    pool: &PgPool,
+    provider: &str,
+    model: &str,
+) -> anyhow::Result<Option<DBPriceEntry>> {
     let price = sqlx::query_as::<_, DBPriceEntry>(
         "SELECT
             provider,
@@ -32,7 +36,7 @@ pub async fn get_price(pool: &PgPool, provider: &str, model: &str) -> anyhow::Re
     )
     .bind(provider)
     .bind(model)
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await?;
 
     Ok(price)

--- a/app-server/src/language_model/costs/mod.rs
+++ b/app-server/src/language_model/costs/mod.rs
@@ -62,7 +62,7 @@ pub async fn estimate_output_cost(
                     );
                     e
                 })
-                .ok()?;
+                .unwrap_or_default()?;
             let price = LLMPriceEntry::from(price);
             let _ = cache
                 .insert_with_ttl::<LLMPriceEntry>(
@@ -101,7 +101,7 @@ pub async fn estimate_input_cost(
                     );
                     e
                 })
-                .ok()?;
+                .unwrap_or_default()?;
             let price = LLMPriceEntry::from(price);
             let _ = cache
                 .insert_with_ttl::<LLMPriceEntry>(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Cache LLM prices with a 24-hour TTL, handle missing prices, and log database fetch errors in `mod.rs` and `prices.rs`.
> 
>   - **Behavior**:
>     - Cache LLM prices with a TTL of 24 hours in `estimate_output_cost()` and `estimate_input_cost()` in `mod.rs`.
>     - Handle missing prices by returning `None` in `get_price()` in `prices.rs`.
>     - Log errors when fetching prices from the database fails in `mod.rs`.
>   - **Functions**:
>     - Change `get_price()` in `prices.rs` to return `Option<DBPriceEntry>` using `fetch_optional()`.
>     - Use `insert_with_ttl()` for cache insertion in `mod.rs`.
>   - **Constants**:
>     - Add `LLM_PRICES_CACHE_TTL_SECONDS` constant in `mod.rs` for 24-hour TTL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 143dc964ac05f67c040a33522374bc0caf38d5de. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 24h TTL to cached LLM prices, switches DB price fetch to optional, and hardens cache/DB error handling in cost estimations.
> 
> - **Caching (LLM prices)**
>   - Introduce `LLM_PRICES_CACHE_TTL_SECONDS` (24h) and use `insert_with_ttl` when caching `LLMPriceEntry`.
>   - Read from cache in both `estimate_output_cost` and `estimate_input_cost` using `cache.get` result handling.
> - **DB**
>   - Change `get_price(pool, provider, model)` to return `anyhow::Result<Option<DBPriceEntry>>` and use `fetch_optional`.
> - **Error handling**
>   - Handle `Ok(None)`/`Err(_)` from cache and log DB retrieval errors before falling back to DB lookup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 143dc964ac05f67c040a33522374bc0caf38d5de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->