### PR TITLE
consumer port defaults to 8002

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -155,10 +155,11 @@ fn main() -> anyhow::Result<()> {
         .parse()
         .unwrap_or(8001);
 
-    // Default to the same port as the HTTP server. Should only be overriden for testing,
-    // when producer and consumer-only are run on the same machine.
+    // Default to the port 8002. Usually is different from the HTTP and gRPC ports,
+    // to avoid conflicts, when producer and consumer are run on the same machine
+    // in the dual mode.
     let consumer_port: u16 = env::var("CONSUMER_PORT")
-        .unwrap_or(port.to_string())
+        .unwrap_or(String::from("8002"))
         .parse()
         .unwrap_or(8002);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets default `CONSUMER_PORT` to `8002` (no longer mirrors HTTP port) and updates inline documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a4db4866f63060140224b0328f78af833c1e3c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default `consumer_port` to 8002 in `main.rs` to avoid conflicts in dual mode.
> 
>   - **Behavior**:
>     - Default `consumer_port` changed to 8002 in `main.rs` to avoid conflicts with HTTP and gRPC ports when running producer and consumer on the same machine.
>     - Updated comment to reflect the new default port and its purpose.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3a4db4866f63060140224b0328f78af833c1e3c7. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->