### PR TITLE
fix: remove on key down event

### DIFF
--- a/frontend/components/onboarding/create-first-workspace-and-project.tsx
+++ b/frontend/components/onboarding/create-first-workspace-and-project.tsx
@@ -74,11 +74,6 @@ export default function CreateFirstWorkspaceAndProject({ name }: CreateFirstWork
               placeholder="Enter workspace name"
               value={workspaceName}
               onChange={(e) => setWorkspaceName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && workspaceName && projectName && !isLoading) {
-                  handleButtonClick();
-                }
-              }}
             />
           </div>
           <div className="flex flex-col gap-1">
@@ -91,15 +86,11 @@ export default function CreateFirstWorkspaceAndProject({ name }: CreateFirstWork
               placeholder="Enter project name"
               value={projectName}
               onChange={(e) => setProjectName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && workspaceName && projectName && !isLoading) {
-                  handleButtonClick();
-                }
-              }}
             />
           </div>
           <div className="flex justify-end">
             <Button
+              handleEnter
               type="button"
               onClick={handleButtonClick}
               disabled={!workspaceName || !projectName || isLoading}

--- a/frontend/components/settings/trace-summary-settings.tsx
+++ b/frontend/components/settings/trace-summary-settings.tsx
@@ -148,11 +148,6 @@ export default function TraceSummarySettings() {
               placeholder="Enter span name..."
               value={newSpanName}
               onChange={(e) => setNewSpanName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && newSpanName.trim() && !isLoading) {
-                  addSpanName();
-                }
-              }}
               disabled={isLoading}
             />
           </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove input-level Enter handlers and rely on Button `handleEnter` for form submission in onboarding and trace summary settings.
> 
> - **UI**
>   - **Onboarding (`frontend/components/onboarding/create-first-workspace-and-project.tsx`)**:
>     - Remove `onKeyDown` Enter handlers from `workspace-name` and `project-name` inputs.
>     - Enable `handleEnter` on the "Create" `Button` to submit via Enter.
>   - **Trace Summary Settings (`frontend/components/settings/trace-summary-settings.tsx`)**:
>     - Remove `onKeyDown` Enter handler from new span name `Input`; rely on "Add" `Button` with `handleEnter`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10753738eb1b9786d327c5384b8f13a2e6434a7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes Enter key `onKeyDown` event for form submission in `create-first-workspace-and-project.tsx` and `trace-summary-settings.tsx`, relying on button clicks instead.
> 
>   - **Behavior**:
>     - Removes `onKeyDown` event for Enter key in `create-first-workspace-and-project.tsx` and `trace-summary-settings.tsx`, preventing form submission via Enter key.
>     - Adds `handleEnter` prop to `Button` in `create-first-workspace-and-project.tsx` to handle Enter key press.
>   - **Misc**:
>     - Minor refactor in `create-first-workspace-and-project.tsx` and `trace-summary-settings.tsx` to improve code clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 10753738eb1b9786d327c5384b8f13a2e6434a7d. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->