### PR TITLE
highlight selected trace in session; fix duration

### DIFF
--- a/frontend/components/traces/sessions-table/columns.tsx
+++ b/frontend/components/traces/sessions-table/columns.tsx
@@ -114,7 +114,7 @@ export const columns: ColumnDef<SessionRow, any>[] = [
         return getDurationString(row.startTime, row.endTime);
       }
 
-      return row.duration.toFixed(3) + "s";
+      return row.duration.toFixed(2) + "s";
     },
     header: "Duration",
     size: 100,

--- a/frontend/components/traces/sessions-table/index.tsx
+++ b/frontend/components/traces/sessions-table/index.tsx
@@ -210,7 +210,7 @@ function SessionsTableContent() {
         data={sessions}
         getRowId={(session) => get(session, ["id"], session.sessionId)}
         onRowClick={handleRowClick}
-        focusedRowId={searchParams.get("sessionId")}
+        focusedRowId={traceId || searchParams.get("traceId")}
         hasMore={hasMore}
         isFetching={isFetching}
         isLoading={isLoading || !shouldFetch}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use traceId to highlight the selected trace and display session duration with 2-decimal precision.
> 
> - **Frontend — Sessions Table** (`frontend/components/traces/sessions-table`):
>   - **Selection/Focus**: Update `focusedRowId` in `index.tsx` to use `traceId || searchParams.get("traceId")` for highlighting the selected trace.
>   - **Duration Display**: In `columns.tsx`, round session `duration` to `toFixed(2)` seconds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae82744f434b9edfc070ef1dfac76a6d1d22d255. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjust duration precision and update row focus logic in session table.
> 
>   - **Behavior**:
>     - Changes duration display precision from 3 to 2 decimal places in `columns.tsx`.
>     - Updates `focusedRowId` logic in `index.tsx` to prioritize `traceId` over `sessionId` from search parameters.
>   - **Misc**:
>     - Minor change in `columns.tsx` to improve duration formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for ae82744f434b9edfc070ef1dfac76a6d1d22d255. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->