### PR TITLE
always wait for async insert except events and tags

### DIFF
--- a/app-server/src/ch/events.rs
+++ b/app-server/src/ch/events.rs
@@ -64,6 +64,7 @@ pub async fn insert_events(clickhouse: clickhouse::Client, events: Vec<CHEvent>)
     match ch_insert {
         Ok(mut ch_insert) => {
             let mut total_size_bytes = 0;
+            ch_insert = ch_insert.with_option("wait_for_async_insert", "0");
             for event in events {
                 ch_insert.write(&event).await?;
                 total_size_bytes += event.size_bytes as usize;

--- a/app-server/src/ch/tags.rs
+++ b/app-server/src/ch/tags.rs
@@ -90,6 +90,7 @@ pub async fn insert_tags_batch(client: clickhouse::Client, tags: &[SpanTag]) -> 
     let ch_insert = client.insert("tags");
     match ch_insert {
         Ok(mut ch_insert) => {
+            ch_insert = ch_insert.with_option("wait_for_async_insert", "0");
             for span_tag in tags {
                 let id = Uuid::new_v4();
                 let tag = CHTag::new(

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -471,7 +471,7 @@ fn main() -> anyhow::Result<()> {
         .with_user(clickhouse_user)
         .with_database("default")
         .with_option("async_insert", "1")
-        .with_option("wait_for_async_insert", "0");
+        .with_option("wait_for_async_insert", "1");
 
     let clickhouse = match clickhouse_password {
         Ok(password) => clickhouse_client.with_password(password),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable ClickHouse async insert waiting globally, but skip waiting for `events` and batch `tags` inserts.
> 
> - **ClickHouse configuration**:
>   - Set global client option `wait_for_async_insert` to `"1"` in `app-server/src/main.rs`.
> - **Insert behavior overrides**:
>   - `app-server/src/ch/events.rs`: For `insert_events`, set `wait_for_async_insert` to `"0"` when inserting into `events`.
>   - `app-server/src/ch/tags.rs`: For `insert_tags_batch`, set `wait_for_async_insert` to `"0"` when inserting into `tags`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb291d47bd325d6cb04dcc223f694a11bcec239f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `wait_for_async_insert` to `0` for events and tags inserts, and `1` in main ClickHouse client configuration.
> 
>   - **Behavior**:
>     - Set `wait_for_async_insert` to `0` in `insert_events()` in `events.rs` and `insert_tags_batch()` in `tags.rs`.
>     - Set `wait_for_async_insert` to `1` in ClickHouse client configuration in `main.rs`.
>   - **Files Affected**:
>     - `events.rs`: Modifies `insert_events()` to not wait for async insert.
>     - `tags.rs`: Modifies `insert_tags_batch()` to not wait for async insert.
>     - `main.rs`: Changes ClickHouse client setup to wait for async insert.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for bb291d47bd325d6cb04dcc223f694a11bcec239f. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->