### PR TITLE
fix span icon color for realtime by sending stringified top span type

### DIFF
--- a/app-server/src/db/spans.rs
+++ b/app-server/src/db/spans.rs
@@ -23,6 +23,21 @@ pub enum SpanType {
     TOOL,
 }
 
+impl std::fmt::Display for SpanType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpanType::DEFAULT => write!(f, "DEFAULT"),
+            SpanType::LLM => write!(f, "LLM"),
+            SpanType::PIPELINE => write!(f, "PIPELINE"),
+            SpanType::EXECUTOR => write!(f, "EXECUTOR"),
+            SpanType::EVALUATOR => write!(f, "EVALUATOR"),
+            SpanType::HUMAN_EVALUATOR => write!(f, "HUMAN_EVALUATOR"),
+            SpanType::EVALUATION => write!(f, "EVALUATION"),
+            SpanType::TOOL => write!(f, "TOOL"),
+        }
+    }
+}
+
 impl FromStr for SpanType {
     type Err = anyhow::Error;
 

--- a/app-server/src/traces/realtime.rs
+++ b/app-server/src/traces/realtime.rs
@@ -28,7 +28,7 @@ struct RealtimeTrace {
     top_span_id: Option<Uuid>,
     trace_type: String,
     top_span_name: Option<String>,
-    top_span_type: Option<i16>,
+    top_span_type: Option<String>,
     status: Option<String>,
     user_id: Option<String>,
     tags: Vec<String>,
@@ -136,7 +136,9 @@ impl RealtimeTrace {
             top_span_id: trace.top_span_id(),
             trace_type: trace.trace_type().to_string(),
             top_span_name: trace.top_span_name(),
-            top_span_type: trace.top_span_type(),
+            top_span_type: trace
+                .top_span_type()
+                .map(|t| SpanType::from(t as u8).to_string()),
             status: trace.status(),
             user_id: trace.user_id(),
             tags: trace.tags().clone(),

--- a/frontend/components/traces/span-type-icon.tsx
+++ b/frontend/components/traces/span-type-icon.tsx
@@ -73,7 +73,9 @@ export default function SpanTypeIcon({
     <div
       className={cn("flex items-center justify-center z-10 rounded", className)}
       style={{
-        backgroundColor: status === "error" ? "rgba(204, 51, 51, 1)" : SPAN_TYPE_TO_COLOR[spanType], // Red background for errors
+        backgroundColor: (status === "error")
+          ? "rgba(204, 51, 51, 1)" // Red background for errors
+          : (SPAN_TYPE_TO_COLOR?.[spanType] || SPAN_TYPE_TO_COLOR[SpanType.DEFAULT]),
         minWidth: containerWidth,
         minHeight: containerHeight,
         width: containerWidth,


### PR DESCRIPTION
Do both:
- stringify top span type on realtime trace
- default to the default color if span type colour cannot be inferred

Tested that 1 fixed it not 2 by also sending a trace with top level LLM span

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Send `top_span_type` as a string in realtime traces and fallback to default color on the span icon when type color is missing.
> 
> - **Backend (Realtime/DB)**:
>   - `RealtimeTrace.top_span_type` changed from `Option<i16>` to `Option<String>`; now serialized via `SpanType::from(...).to_string()`.
>   - Add `Display` impl for `SpanType` to support stringification.
> - **Frontend (UI)**:
>   - `SpanTypeIcon` background color now safely resolves via `SPAN_TYPE_TO_COLOR?.[spanType]` with fallback to `SpanType.DEFAULT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d258e5e7a3a28bec2217d182073b22c12bb78d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix span icon color in real-time traces by stringifying `top_span_type` and defaulting to a color if not inferred.
> 
>   - **Behavior**:
>     - Stringify `top_span_type` in `RealtimeTrace` in `realtime.rs` to ensure correct icon color.
>     - Default to `SpanType.DEFAULT` color in `span-type-icon.tsx` if `spanType` color is not found.
>   - **Implementation**:
>     - Implement `Display` trait for `SpanType` in `spans.rs` to support string conversion.
>     - Modify `top_span_type` from `Option<i16>` to `Option<String>` in `RealtimeTrace` in `realtime.rs`.
>     - Update `backgroundColor` logic in `SpanTypeIcon` in `span-type-icon.tsx` to handle missing colors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 7d258e5e7a3a28bec2217d182073b22c12bb78d2. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->