### PR TITLE
fix evals page status column, fix status in views

### DIFF
--- a/frontend/components/evaluation/columns.tsx
+++ b/frontend/components/evaluation/columns.tsx
@@ -286,7 +286,7 @@ export const defaultColumns: ColumnDef<EvaluationDatapointPreviewWithCompared>[]
   {
     cell: (row) => (
       <div className="flex h-full justify-center items-center w-10">
-        {row.getValue() ? (
+        {row.getValue() === "error" ? (
           <X className="self-center text-destructive" size={18} />
         ) : (
           <Check className="text-success" size={18} />

--- a/frontend/lib/clickhouse/migrations/9_success_status.sql
+++ b/frontend/lib/clickhouse/migrations/9_success_status.sql
@@ -1,0 +1,80 @@
+DROP VIEW IF EXISTS raw_traces_v0;
+CREATE VIEW IF NOT EXISTS raw_traces_v0 SQL SECURITY INVOKER AS
+    SELECT
+        MIN(spans.start_time) AS start_time,
+        MAX(spans.end_time) AS end_time,
+        SUM(input_tokens) AS input_tokens,
+        SUM(output_tokens) AS output_tokens,
+        SUM(total_tokens) AS total_tokens,
+        SUM(input_cost) AS input_cost,
+        SUM(output_cost) AS output_cost,
+        SUM(total_cost) AS total_cost,
+        MAX(spans.end_time) - MIN(spans.start_time) AS duration,
+        argMax(trace_metadata, length(trace_metadata)) AS metadata,
+        anyIf(session_id, session_id != '<null>' AND session_id != '') AS session_id,
+        anyIf(user_id, user_id != '<null>' AND user_id != '') AS user_id,
+        CASE WHEN countIf(spans.status = 'error') > 0 THEN 'error' ELSE 'success' END AS status,
+        anyIf(span_id, parent_span_id='00000000-0000-0000-0000-000000000000') AS top_span_id,
+        anyIf(name, parent_span_id='00000000-0000-0000-0000-000000000000') AS top_span_name,
+        anyIf(CASE
+            WHEN span_type = 0 THEN 'DEFAULT'
+            WHEN span_type = 1 THEN 'LLM'
+            WHEN span_type = 3 THEN 'EXECUTOR'
+            WHEN span_type = 4 THEN 'EVALUATOR'
+            WHEN span_type = 5 THEN 'EVALUATION'
+            WHEN span_type = 6 THEN 'TOOL'
+            WHEN span_type = 7 THEN 'HUMAN_EVALUATOR'
+            WHEN span_type = 8 THEN 'EVENT'
+            ELSE 'UNKNOWN'
+         END, parent_span_id='00000000-0000-0000-0000-000000000000') AS top_span_type,
+        CASE WHEN countIf(span_type IN (3, 4, 5)) > 0 THEN 'EVALUATION' ELSE 'DEFAULT' END AS trace_type,
+        arrayDistinct(arrayFlatten(arrayConcat(groupArray(tags_array)))) AS tags,
+        trace_id id,
+        project_id
+    FROM spans
+    WHERE project_id={project_id:UUID} AND spans.start_time>={start_time:DateTime64} AND spans.start_time<={end_time:DateTime64}
+    GROUP BY id, project_id;
+
+DROP VIEW IF EXISTS spans_v0;
+CREATE VIEW IF NOT EXISTS spans_v0 SQL SECURITY INVOKER AS
+    SELECT
+        span_id,
+        name,
+        CASE
+            WHEN span_type = 0 THEN 'DEFAULT'
+            WHEN span_type = 1 THEN 'LLM'
+            WHEN span_type = 3 THEN 'EXECUTOR'
+            WHEN span_type = 4 THEN 'EVALUATOR'
+            WHEN span_type = 5 THEN 'EVALUATION'
+            WHEN span_type = 6 THEN 'TOOL'
+            WHEN span_type = 7 THEN 'HUMAN_EVALUATOR'
+            WHEN span_type = 8 THEN 'EVENT'
+            ELSE 'UNKNOWN'
+        END AS span_type,
+        start_time,
+        end_time,
+        end_time - start_time AS duration,
+        input_cost,
+        output_cost,
+        total_cost,
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        request_model,
+        response_model,
+        model,
+        trace_id,
+        provider,
+        path,
+        input,
+        output,
+        CASE
+          WHEN status = 'error' THEN 'error'
+          WHEN status = 'success' THEN 'success'
+          ELSE 'success'
+        END AS status,
+        parent_span_id,
+        attributes,
+        tags_array as tags
+    FROM spans
+    WHERE project_id={project_id:UUID};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes evaluation UI status icon logic and updates ClickHouse views to compute/normalize success/error status.
> 
> - **Frontend (evaluation)**:
>   - Status column in `frontend/components/evaluation/columns.tsx` now renders `X` only when `status === "error"`; otherwise shows `Check`.
> - **Database (ClickHouse)**:
>   - Add `frontend/lib/clickhouse/migrations/9_success_status.sql` defining views:
>     - `raw_traces_v0`: aggregates spans and sets `status` to `error` if any span errored, else `success`.
>     - `spans_v0`: normalizes span `status` to `error`/`success` (default `success`) and exposes span fields and tags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22d71757e2d3bc7e51906a4e70889282e2a5b6c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes status column display in evaluation page and updates status logic in SQL views.
> 
>   - **Frontend**:
>     - Fixes status column logic in `columns.tsx` to correctly display error status using `X` icon when `row.getValue()` is "error".
>   - **SQL Migrations**:
>     - Adds `9_success_status.sql` to create views `raw_traces_v0` and `spans_v0`.
>     - Updates status logic in both views to set status as 'error' if any span has 'error', otherwise 'success'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 22d71757e2d3bc7e51906a4e70889282e2a5b6c3. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->