### PR TITLE
fix shared trace events query

### DIFF
--- a/frontend/lib/actions/shared/spans/index.ts
+++ b/frontend/lib/actions/shared/spans/index.ts
@@ -63,10 +63,10 @@ export const getSharedSpans = async (input: z.infer<typeof GetSharedTraceSchema>
     query: `
       SELECT id, formatDateTime(timestamp , '%Y-%m-%dT%H:%i:%S.%fZ') as timestamp, span_id spanId, name, attributes
       FROM events
-      WHERE span_id IN {spanIds: Array(UUID)}
+      WHERE trace_id = {traceId: UUID}
     `,
     parameters: {
-      spanIds: spans.map((span) => span.spanId),
+      traceId,
     },
     projectId: sharedTrace.projectId,
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fetch shared trace events by trace_id rather than a span_id list in `getSharedSpans`.
> 
> - **Shared spans data fetching (`frontend/lib/actions/shared/spans/index.ts`)**:
>   - Change events query to `WHERE trace_id = {traceId: UUID}` and pass `traceId` parameter.
>   - Remove dependency on `spanIds` list for events retrieval.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab73a198d62f649d19319702d03b5491b7141235. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `getSharedSpans` query to filter events by `trace_id` instead of `span_id`.
> 
>   - **Behavior**:
>     - Fixes query in `getSharedSpans` to filter events by `trace_id` instead of `span_id`.
>     - Ensures all events related to a trace are retrieved, not just specific spans.
>   - **Query**:
>     - Updates SQL query in `getSharedSpans` to use `trace_id` for filtering in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for ab73a198d62f649d19319702d03b5491b7141235. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->