### PR TITLE
hotfix: do not paginate evaluation datapoints within one evaluation

### DIFF
--- a/frontend/lib/actions/evaluation/index.ts
+++ b/frontend/lib/actions/evaluation/index.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { compact, groupBy } from "lodash";
 import { z } from "zod/v4";
 
-import { PaginationFiltersSchema } from "@/lib/actions/common/types";
+import { FiltersSchema } from "@/lib/actions/common/types";
 import {
   buildEvaluationDatapointsQueryWithParams,
   buildTracesForEvaluationQueryWithParams,
@@ -29,7 +29,7 @@ import {
 
 export const EVALUATION_TRACE_VIEW_WIDTH = "evaluation-trace-view-width";
 
-export const GetEvaluationDatapointsSchema = PaginationFiltersSchema.extend({
+export const GetEvaluationDatapointsSchema = FiltersSchema.extend({
   evaluationId: z.string(),
   projectId: z.string(),
   search: z.string().nullable().optional(),
@@ -48,8 +48,6 @@ export const getEvaluationDatapoints = async (
   const {
     projectId,
     evaluationId,
-    pageNumber,
-    pageSize,
     search,
     searchIn,
     filter: inputFilters,
@@ -65,9 +63,6 @@ export const getEvaluationDatapoints = async (
   }
 
   const allFilters: FilterDef[] = compact(inputFilters);
-
-  const limit = pageSize;
-  const offset = Math.max(0, pageNumber * pageSize);
 
   // Separate filters into trace and datapoint filters
   const { traceFilters, datapointFilters } = separateFilters(allFilters);
@@ -129,8 +124,6 @@ export const getEvaluationDatapoints = async (
     evaluationId,
     traceIds: filteredTraceIds,
     filters: datapointFilters,
-    limit,
-    offset,
   });
 
   const rawResults = await executeQuery<EvaluationDatapointRow>({ query: mainQuery, parameters: mainParams, projectId });

--- a/frontend/lib/actions/evaluation/utils.ts
+++ b/frontend/lib/actions/evaluation/utils.ts
@@ -70,8 +70,6 @@ export interface BuildEvaluationDatapointsQueryOptions {
   evaluationId: string;
   traceIds: string[];
   filters: FilterDef[];
-  limit: number;
-  offset: number;
 }
 
 export interface BuildTracesForEvaluationQueryOptions {
@@ -84,7 +82,7 @@ export interface BuildTracesForEvaluationQueryOptions {
 export const buildEvaluationDatapointsQueryWithParams = (
   options: BuildEvaluationDatapointsQueryOptions
 ): QueryResult => {
-  const { evaluationId, traceIds, filters, limit, offset } = options;
+  const { evaluationId, traceIds, filters } = options;
 
   const customConditions: Array<{
     condition: string;
@@ -145,10 +143,6 @@ export const buildEvaluationDatapointsQueryWithParams = (
         direction: "ASC",
       },
     ],
-    pagination: {
-      limit,
-      offset,
-    },
   };
 
   return buildSelectQuery(queryOptions);


### PR DESCRIPTION
Proper fix must be done in order not to pull all data in one query. But current UI is broken and only shows the first page, so we need to unblock first

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops paginating evaluation datapoints and adds dataset fields to results, updating schemas and queries accordingly.
> 
> - **Evaluation datapoints**:
>   - Remove pagination: drop `pageNumber/pageSize`, `limit/offset`, and pagination in `buildEvaluationDatapointsQueryWithParams`.
>   - Switch request schema from `PaginationFiltersSchema` to `FiltersSchema`.
>   - Expand selected/returned fields to include `datasetId`, `datasetDatapointId`, `datasetDatapointCreatedAt`.
> - **Queries**:
>   - Update `evaluation_datapoints` select columns with dataset fields.
>   - Remove pagination options from query builder types and calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72860554afc546cd07b558e91bb5afa91acd39dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->