### PR TITLE
fix non-ai-sdk tools, allow for tool parameters to be JSON obj

### DIFF
--- a/frontend/components/traces/stats-shields.tsx
+++ b/frontend/components/traces/stats-shields.tsx
@@ -119,7 +119,7 @@ const extractToolsFromAttributes = (attributes: Record<string, any>): Tool[] => 
       const name = attributes[`llm.request.functions.${index}.name`];
       const description = attributes[`llm.request.functions.${index}.description`];
       const rawParameters = attributes[`llm.request.functions.${index}.parameters`];
-      const parameters = (rawParameters && typeof rawParameters == "string")
+      const parameters = typeof rawParameters === "string"
         ? rawParameters
         : JSON.stringify(rawParameters || {});
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Normalize tool parameters to strings and skip empty tool arrays when extracting tools from span attributes.
> 
> - **Frontend** (`frontend/components/traces/stats-shields.tsx`)
>   - **extractToolsFromAttributes**:
>     - Skip empty `ai.prompt.tools` arrays.
>     - Normalize `parameters` to strings for tools:
>       - For `ai.prompt.tools`: pass through strings; `JSON.stringify` objects.
>       - For `llm.request.functions.*.parameters`: pass through strings; `JSON.stringify` objects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4dafe6f5610224126cb5e783871596290d45200. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Normalize tool parameter extraction to return JSON strings and skip empty `ai.prompt.tools` arrays in `stats-shields.tsx`.
> 
>   - **Behavior**:
>     - In `extractToolsFromAttributes`, skip processing when `ai.prompt.tools` is empty.
>     - Ensure `parameters` are JSON strings for `ai.prompt.tools` and `llm.request.functions.*` by stringifying non-string values.
>   - **Misc**:
>     - Minor changes in `frontend/components/traces/stats-shields.tsx` to improve tool parameter handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for b4dafe6f5610224126cb5e783871596290d45200. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->