### PR TITLE
remove tag class id (was always nil)

### DIFF
--- a/app-server/src/ch/tags.rs
+++ b/app-server/src/ch/tags.rs
@@ -22,26 +22,22 @@ impl Into<u8> for TagSource {
 }
 
 #[derive(Row, Serialize, Deserialize)]
-pub struct CHTag {
+struct CHTag {
     #[serde(with = "clickhouse::serde::uuid")]
-    pub project_id: Uuid,
+    project_id: Uuid,
+    created_at: i64, // unix timestamp in nanoseconds
     #[serde(with = "clickhouse::serde::uuid")]
-    pub class_id: Uuid,
-    pub created_at: i64, // unix timestamp in nanoseconds
+    id: Uuid,
+    name: String,
+    source: u8,
     #[serde(with = "clickhouse::serde::uuid")]
-    pub id: Uuid,
-    pub name: String,
-    pub source: u8,
-    #[serde(with = "clickhouse::serde::uuid")]
-    pub span_id: Uuid,
+    span_id: Uuid,
 }
 
 impl CHTag {
     pub fn new(project_id: Uuid, id: Uuid, name: String, source: TagSource, span_id: Uuid) -> Self {
         Self {
             project_id,
-            // TODO: Remove this once we drop the class_id column
-            class_id: Uuid::nil(),
             created_at: chrono_to_nanoseconds(Utc::now()),
             id,
             name,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the unused `class_id` from `CHTag`, makes the struct and its fields private, and updates constructor accordingly.
> 
> - **Tags (ClickHouse)**:
>   - Remove unused `class_id` from `CHTag` and its initialization in `new`.
>   - Make `CHTag` non-public and its fields private.
>   - Keep serialization order and insertion logic unchanged in `insert_tag` and `insert_tags_batch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f559e1a25249049f0764fc4241fae84b131680c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->