### PR TITLE
update prices to 2025-11

### DIFF
--- a/frontend/lib/db/initial-data.json
+++ b/frontend/lib/db/initial-data.json
@@ -330,6 +330,32 @@
         }
       },
       {
+        "id": "9aeb7bad-bbe3-45c5-930f-64a8c3ab003f",
+        "created_at": "2025-11-20 11:01:35.065708+00",
+        "updated_at": "2025-11-20 11:01:35.065708+00",
+        "provider": "anthropic",
+        "model": "claude-haiku-4-5",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
+        "id": "d807a649-1d37-4c4c-89a9-be15857a9c8c",
+        "created_at": "2025-11-19 11:28:27.84584+00",
+        "updated_at": "2025-11-19 11:28:27.84584+00",
+        "provider": "anthropic",
+        "model": "claude-haiku-4-5-20251001",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
         "id": "e40c2c10-6f84-414e-b15d-3a6bd406aea1",
         "created_at": "2024-10-16 17:36:24.312254+00",
         "updated_at": "2024-10-16 17:36:24.312254+00",
@@ -401,6 +427,32 @@
         "input_cached_price_per_million": 0.6,
         "additional_prices": {
           "input_cache_write_price_per_million": 7.5
+        }
+      },
+      {
+        "id": "c7728d6f-7c9b-4a11-9d56-4ae8e15bc419",
+        "created_at": "2025-11-20 11:01:09.738056+00",
+        "updated_at": "2025-11-20 11:01:09.738056+00",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-5",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "fdaf3547-da44-494d-afb0-28f76313ffe0",
+        "created_at": "2025-10-28 21:30:48.175571+00",
+        "updated_at": "2025-10-28 21:30:48.175571+00",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-5-20250929",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
         }
       },
       {
@@ -819,6 +871,17 @@
         "input_price_per_million": 0.25,
         "output_price_per_million": 2.0,
         "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "4d4acc9e-c6b1-410b-8452-574bbcb07788",
+        "created_at": "2025-10-13 12:41:33.610608+00",
+        "updated_at": "2025-10-13 12:41:33.610608+00",
+        "provider": "azure",
+        "model": "gpt-5-mini-2025-08-07",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -1895,13 +1958,3660 @@
         "additional_prices": {}
       },
       {
-        "id": "66d906bd-2ab1-4089-9c6a-45ce0b1929d6",
-        "created_at": "2025-07-10 12:35:03.028174+00",
-        "updated_at": "2025-07-10 12:35:03.028174+00",
+        "id": "f109e838-5e94-4661-9327-cd5e0d25b665",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "ada-v2",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9c63bd1d-d689-4e83-b31a-9864e6b99802",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-2.0",
+        "input_price_per_million": 8.0,
+        "output_price_per_million": 24.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "c593509a-e918-48c7-acb4-082697d648ed",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-2.1",
+        "input_price_per_million": 8.0,
+        "output_price_per_million": 24.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "d428d03f-4bcc-44a3-9377-24701de14966",
+        "created_at": "2025-11-20 10:59:05.930815+00",
+        "updated_at": "2025-11-20 10:59:05.930815+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-haiku",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "03c174ec-1f28-4f8a-9906-97100f70e16a",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-haiku-20241022",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "d9be3fb2-0f6a-4344-a0aa-039ca8cf1a10",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-haiku-20241022-v1:0",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "9712b62c-a53a-4322-a77f-231632500041",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-haiku-latest",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "ecc10835-b51b-4f5e-aef1-8aea911c6641",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "a2b3cb71-00e7-4a12-97ed-890bbbd22ea2",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-sonnet-20240620",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "8d46b58d-cd23-4131-9007-6194ec5a7c01",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-sonnet-20240620-v1:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "6b95f4e3-3036-4700-bed0-0e23736f9da9",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-sonnet-20241022",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "9674c8f4-293b-4ac5-a40d-d1f20b15e048",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-sonnet-20241022-v2:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "85769a47-c814-4a0d-ad71-b1efe5c2d8b5",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-5-sonnet-latest",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "f150dd52-02f5-453b-93f6-9470bcf51515",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-7-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "250cde9f-9275-4791-80c5-47e78da0f769",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-7-sonnet-20250219",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "8d98e279-acaf-4132-83f8-b580c0cd531a",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-7-sonnet-latest",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "88fcfe67-db3b-4571-837b-e33c5695212f",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-haiku",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "c96be22f-b970-431a-b201-bd3bbc630bbb",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-haiku-20240307",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "a2bada59-4149-4fc3-b0e4-84aa44eead7f",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-haiku-20240307-v1:0",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "7aa37126-b300-42a3-b53b-7629d5897fea",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-opus",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "c7a3e31f-5d4f-4306-b960-e3a46fb91896",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-opus-20240229",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "84875bd6-40b4-4e85-8dff-1495e81c26d1",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-opus-20240229-v1:0",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "691936d8-72c8-432c-8136-bb00cbb12da5",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-opus-latest",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "6544349c-0d57-41d4-97a9-7da21119ec7d",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "fccc6ce3-0295-4fee-aa60-a83bc246e18e",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-sonnet-20240229",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "041f8849-a3d9-4435-bf32-8b8ab51f72e3",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-3-sonnet-20240229-v1:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "95382560-b6e7-4e09-8c00-437f12672b60",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-4-sonnet-20250514",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "58d3357b-98ed-4a98-9672-68681249222b",
+        "created_at": "2025-11-20 11:01:35.065708+00",
+        "updated_at": "2025-11-20 11:01:35.065708+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-haiku-4-5",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
+        "id": "8bd88b94-7ed8-4e32-a852-f4ccfb314d09",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-haiku-4-5-20251001",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
+        "id": "d88d6844-38c6-4ae7-837b-f7650adda79a",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-instant",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "466bc126-2b99-4790-bff4-b412bc902aed",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-instant-1.2",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "824f9f8f-e125-4911-bf03-87c99d367f39",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-opus-4-1-20250805",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "7f0e5e23-37d4-4308-bfe5-77d722c0d65b",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-opus-4-20250514",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "55af8049-238f-4507-8ff0-e342ec28add3",
+        "created_at": "2025-10-28 21:25:43.053123+00",
+        "updated_at": "2025-10-28 21:25:43.053123+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-sonnet-4",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "50557c43-a6b4-4c10-95d9-64ad9dce7894",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-sonnet-4-20250514",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "aed198e1-bfd8-4ef2-b283-dde08b430d19",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-sonnet-4-20250514--long-context",
+        "input_price_per_million": 6.0,
+        "output_price_per_million": 22.5,
+        "input_cached_price_per_million": 0.6,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 7.5
+        }
+      },
+      {
+        "id": "7d0fa090-a4e1-4bfe-a934-877cccfcb502",
+        "created_at": "2025-11-20 11:01:09.738056+00",
+        "updated_at": "2025-11-20 11:01:09.738056+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-sonnet-4-5",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "cad441c1-018e-4426-9da0-3174ad1b0971",
+        "created_at": "2025-11-19 13:09:11.018464+00",
+        "updated_at": "2025-11-19 13:09:11.018464+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-sonnet-4-5-20250929",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "e767cf66-baa7-432d-82cb-6c914c3033fc",
+        "created_at": "2025-10-28 21:20:09.702029+00",
+        "updated_at": "2025-10-28 21:20:09.702029+00",
+        "provider": "gateway",
+        "model": "anthropic/claude-sonnet-4.5",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "1f3c5bdf-3d4c-4e6a-9f3d-ee1620d29da9",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "azure-openai",
+        "input_price_per_million": 0.02,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "2f897fd2-92db-44d2-a367-ee6cbc705b51",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "babbage-002",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9e77bcb5-cd50-452c-b297-b620e60c91fc",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "chatgpt-4o-latest",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "5454dc7e-dd31-4b74-ae10-113c9bead80d",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-2.0",
+        "input_price_per_million": 8.0,
+        "output_price_per_million": 24.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "e608337f-6b77-4a8b-b9b4-85300d36c47d",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-2.1",
+        "input_price_per_million": 8.0,
+        "output_price_per_million": 24.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "cc1489ea-80d3-4d95-8da9-38d63407ce85",
+        "created_at": "2025-11-20 10:59:05.930815+00",
+        "updated_at": "2025-11-20 10:59:05.930815+00",
+        "provider": "gateway",
+        "model": "claude-3-5-haiku",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "6ed7c25a-fc4c-47dc-b405-e9f62fc8361a",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-5-haiku-20241022",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "1e31ff60-cf7f-4fc8-bb9a-936cc5f2a675",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-5-haiku-20241022-v1:0",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "75d28b2b-6595-47bd-ace5-b8c10d083bec",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-5-haiku-latest",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "efcaf46b-bc26-4d4b-8ceb-fd1abc48100f",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-5-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "c2ffa5c2-b77a-4b41-8f9b-17d865f4a1ae",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-5-sonnet-20240620",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "925544d9-2bed-40c1-a262-37e4b58366fa",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-5-sonnet-20240620-v1:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "9491aa2d-3822-45cb-bc46-bdaa57204e8f",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-5-sonnet-20241022",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "b4250af1-42b6-4b2a-a834-e7d640c4d195",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-5-sonnet-20241022-v2:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "2784a956-620c-4121-98ba-3731ab4ffff7",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-5-sonnet-latest",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "6804d310-098c-4657-97fa-1717c49ad551",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-7-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "1020a22d-8495-4600-b94c-dccb73a60caa",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-7-sonnet-20250219",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "315ca21a-32c0-499a-a040-3d42e378296e",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-7-sonnet-latest",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "90538b6d-5fbe-4130-bced-31346a699238",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-haiku",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "db518e8f-8684-42cc-b672-9316b97b7b7b",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-haiku-20240307",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "36f5e9be-ca06-4cab-bb3c-5e26a2da1500",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-haiku-20240307-v1:0",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "1671e8c7-aeee-405e-bcaf-112a1bc31b16",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-opus",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "1feee026-369b-41ed-8cbe-d364e983abcc",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-opus-20240229",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "5a51603a-3e57-4a4a-a24e-9213c8e8dcf8",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-opus-20240229-v1:0",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "21ae9417-6aed-4efe-8a92-eeeba32878a1",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-opus-latest",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "20769b9d-f018-40b4-8be2-5ae02e998a09",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "da229856-ad45-48db-a3bb-21d1b970a318",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-sonnet-20240229",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "22eee3e8-a99a-4d66-9845-5091acb5c24e",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-3-sonnet-20240229-v1:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "45da203d-b098-49ab-ada0-4a02f20781b0",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-4-sonnet-20250514",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "7f929f25-beba-42eb-9b51-4aab7ab50733",
+        "created_at": "2025-11-20 11:01:35.065708+00",
+        "updated_at": "2025-11-20 11:01:35.065708+00",
+        "provider": "gateway",
+        "model": "claude-haiku-4-5",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
+        "id": "d557b96a-fbe0-404f-aa38-9bd6ac52871b",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-haiku-4-5-20251001",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
+        "id": "6ff7548f-7e3c-4d2f-a4cf-915ff2defec1",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-instant",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "ba3c29ad-ff0c-49e8-87e8-d2f891e635e8",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-instant-1.2",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "b448102e-3477-4d99-84cc-c5d7ea7f87a1",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-opus-4-1-20250805",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "646b2d9f-6e73-4109-97c5-11f5ed0fb0b8",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-opus-4-20250514",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "c6afcccd-0f17-4761-9ac4-bb75299ba0f0",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
         "provider": "gateway",
         "model": "claude-sonnet-4-20250514",
         "input_price_per_million": 3.0,
         "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "4aa1f93d-ce9c-4fcd-9482-b369f094d2d6",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-sonnet-4-20250514--long-context",
+        "input_price_per_million": 6.0,
+        "output_price_per_million": 22.5,
+        "input_cached_price_per_million": 0.6,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 7.5
+        }
+      },
+      {
+        "id": "cd94bf0a-c2c5-4315-ac5f-560646a91f45",
+        "created_at": "2025-11-20 11:01:09.738056+00",
+        "updated_at": "2025-11-20 11:01:09.738056+00",
+        "provider": "gateway",
+        "model": "claude-sonnet-4-5",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "98f84df8-4501-4730-8e88-1a714fcb974e",
+        "created_at": "2025-11-19 13:09:17.367028+00",
+        "updated_at": "2025-11-19 13:09:17.367028+00",
+        "provider": "gateway",
+        "model": "claude-sonnet-4-5-20250929",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "f8f20984-a590-40c5-a567-91d4c4c1921a",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "codex-mini",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 6.0,
+        "input_cached_price_per_million": 0.375,
+        "additional_prices": {}
+      },
+      {
+        "id": "bf2d783c-5a15-4599-9c7e-babc499382ea",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "codex-mini-latest",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 6.0,
+        "input_cached_price_per_million": 0.375,
+        "additional_prices": {}
+      },
+      {
+        "id": "bce5804f-3c15-4cae-8f4a-9fd2750d6e91",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "computer-use-preview",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "f0598e1e-128f-498d-bad3-6c53e3b6d3fd",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "davinci-002",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "041c5225-624a-4646-8a31-de9bbebafcc9",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-1.0-pro",
+        "input_price_per_million": 0.5,
+        "output_price_per_million": 1.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "baa64ebc-5c8e-44db-88db-796215c0a390",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-1.5-flash",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "0c1971be-fb93-45fd-b051-30041306767d",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-1.5-flash--long-context",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "d1be394a-b03b-4c5a-b23c-0cf35482ef03",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-1.5-flash-8b",
+        "input_price_per_million": 0.0375,
+        "output_price_per_million": 0.15,
+        "input_cached_price_per_million": 0.01,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 0.25
+        }
+      },
+      {
+        "id": "7b946252-811f-4b31-b3d1-fd75732fde47",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-1.5-flash-8b--long-context",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.02,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 0.25
+        }
+      },
+      {
+        "id": "d19169e9-2891-489a-b67b-28411ca4e842",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-1.5-pro",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.3125,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 4.5
+        }
+      },
+      {
+        "id": "e844c020-ad57-4505-9e9f-e68ff82758a0",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-1.5-pro--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 4.5
+        }
+      },
+      {
+        "id": "7b1e0463-7868-4252-8c48-236da74f57ed",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.0-flash",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "dfc91070-10a5-40c3-a18c-226bc0a2f80a",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.0-flash-exp",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "40d1b1c6-6b79-482a-9a4a-f7b9b7004494",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.0-flash-lite",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "bea9c520-89aa-480d-9e28-9a97ced39e53",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.0-flash-lite-exp",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "799ca02d-baca-4300-a8a6-5d16ed0b18a6",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.0-flash-lite-exp-01-21",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "f08753ae-f12f-4c71-9d02-5cd76428bdb7",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.0-flash-lite-preview-02-05",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "54734c77-fda0-401a-a592-35491f3c8edb",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-flash",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "b313b35a-1379-4a30-87cc-ac0ec970ecfb",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "44adaa2c-b60d-45d2-9bdd-b81121c4327b",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-flash-lite-preview",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "249ecf27-fa7a-4f41-9d79-ec7ba04eba82",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-flash-lite-preview-06-17",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "aa15de8b-0c38-46f1-b1d3-9f4ad76abe54",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-flash-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "5873f0ca-5e7f-4a01-8a3b-46d3cac8c8ea",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-flash-preview-04-17",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "19ccba55-b049-4a03-be2c-3f79ceb8fbd4",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-flash-preview-05-20",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "6c3a6dc5-8d5f-4c33-92ba-f62a5be843de",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-flash-preview-09-2025",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "fa36d4cb-de86-471c-8a0e-fbd438f1d7fa",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "56a2270f-c2fb-46ab-b1e3-78b6aa98d099",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "12bb71bf-3e4c-4677-a533-d44f5f375c96",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-exp-03-25",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "feb6c4c9-2f47-4b5e-ac76-e7a912b28c00",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-exp-03-25--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "d26025b5-6bc5-4016-bbaa-b666b7cae87a",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-preview",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "33a44477-5b65-4a23-9e09-df83a6282de5",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-preview--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "cd9f4b6e-f952-4792-9cd4-e75a471c4ef7",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-preview-03-25",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "166232f5-dbc8-4fd7-8a43-e6d0b4e95695",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-preview-03-25--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "06542785-812d-494e-b7ef-fb4168012cdd",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-preview-05-06",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "bf5a0a76-93a5-4ebc-bd85-e4d3fd56c437",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-preview-05-06--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "60768342-1f49-485c-a6e9-309238ae7939",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-preview-06-05",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "2b2a5e3c-9d72-4c56-b472-132086af9d50",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-2.5-pro-preview-06-05--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "5107bb98-3650-4650-a895-c06196e4d941",
+        "created_at": "2025-11-19 13:08:58.28942+00",
+        "updated_at": "2025-11-19 13:08:58.28942+00",
+        "provider": "gateway",
+        "model": "gemini-3-pro-preview",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": 0.2,
+        "additional_prices": {}
+      },
+      {
+        "id": "9d1811f2-7a45-438a-97ed-58700163d200",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-1.0-pro",
+        "input_price_per_million": 0.5,
+        "output_price_per_million": 1.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "8c009835-cf30-4174-a6af-90cf80dc30a5",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-1.5-flash",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "0bb9353b-cc79-49ad-bec1-00a4ed55f6b0",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-1.5-flash--long-context",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "5c6c5d95-c485-4848-9a23-e11602dfcc03",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-1.5-flash-8b",
+        "input_price_per_million": 0.0375,
+        "output_price_per_million": 0.15,
+        "input_cached_price_per_million": 0.01,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 0.25
+        }
+      },
+      {
+        "id": "a82f0813-e979-4c9e-9913-f15c752113a0",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-1.5-flash-8b--long-context",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.02,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 0.25
+        }
+      },
+      {
+        "id": "ea84d855-c434-4c98-8b4f-347f9156e740",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-1.5-pro",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.3125,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 4.5
+        }
+      },
+      {
+        "id": "0497b710-645d-468f-b8ea-f0bbf37c12fa",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-1.5-pro--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 4.5
+        }
+      },
+      {
+        "id": "18f3a4c5-a2b7-48e3-ae86-3731df6ef1cb",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.0-flash",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "65687ce2-71d1-4927-82b7-b8336ec5a0f5",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.0-flash-exp",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "944cc6c5-babf-48c8-b600-fe21d0ba3638",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.0-flash-lite",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "ed38fb2b-baaf-4c89-9510-e29d860a912c",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.0-flash-lite-exp",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "76c6bd76-d814-4ef6-97e4-280de5310751",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.0-flash-lite-exp-01-21",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "ad7ac8f5-384e-4818-b8fa-4913539d7460",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.0-flash-lite-preview-02-05",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "17f2ee77-2551-4a4b-9cf6-4b2ce94b6c3d",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-flash",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "83ca852d-5ac1-4e47-948a-3837642af343",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "ef5c9fa5-c4d1-40f0-9d52-b8c68295a998",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-flash-lite-preview",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "13b7a82c-37ed-4656-bee3-c65f137f9898",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-flash-lite-preview-06-17",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "8af77d09-29df-4afd-8aec-bd9070a31e62",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-flash-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "162c4363-4d87-4c55-abff-081e3d455cb2",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-flash-preview-04-17",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "b4841ecc-3a79-400b-92c2-d97f598e91f5",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-flash-preview-05-20",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "1fdd33d8-9a04-40f4-89bc-8564010ba0cb",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-flash-preview-09-2025",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "d9e4e864-b799-42ac-adee-ba73032cf590",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "c1643081-b10f-4858-9b99-bcc0460f601c",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "6fafbde2-b573-4417-89b9-b84a2b6115be",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-exp-03-25",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "4577216b-4e08-41c3-8dde-7475512b9654",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-exp-03-25--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "a7092f39-f43d-416f-8534-9184946dcc95",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-preview",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "e43c0904-9501-4196-bbc9-a7161b24e589",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-preview--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "c97a51d1-ff70-440a-bcf7-7081479bac3a",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-preview-03-25",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "1a4098b3-bbbe-459c-82f9-40efb42452d3",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-preview-03-25--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "53583a9b-c50b-4e86-bace-c2203b83a15c",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-preview-05-06",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "6f3d17c7-0613-4a34-9e57-ed9a4a7029f1",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-preview-05-06--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "b2aa1ed6-f10f-4e17-b530-12ecbd8a3d73",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-preview-06-05",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "5d3b9aad-62d8-4528-bcc2-9577b62813b8",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-2.5-pro-preview-06-05--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "efdc7a5e-0abb-4de4-a573-233abd55fef4",
+        "created_at": "2025-11-19 13:08:18.869446+00",
+        "updated_at": "2025-11-19 13:08:18.869446+00",
+        "provider": "gateway",
+        "model": "google/gemini-3-pro-preview",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": 0.2,
+        "additional_prices": {}
+      },
+      {
+        "id": "5a33721d-95c4-4aa9-abd8-1087c08311e6",
+        "created_at": "2025-11-19 13:25:59.742582+00",
+        "updated_at": "2025-11-19 13:25:59.742582+00",
+        "provider": "gateway",
+        "model": "google/gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "e1d4bebf-1ae8-4da0-b022-538d00356879",
+        "created_at": "2025-11-19 13:26:30.582271+00",
+        "updated_at": "2025-11-19 13:26:30.582271+00",
+        "provider": "gateway",
+        "model": "google/gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "869f66da-3879-4d5b-92ff-225fa3ada501",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-3.5-turbo-0125",
+        "input_price_per_million": 0.5,
+        "output_price_per_million": 1.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "79c95121-e2a2-4dcc-8707-6a484531ff95",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-3.5-turbo-0301",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "4cf8aa91-51d1-40e3-b491-5dcf4405a135",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-3.5-turbo-0613",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "4898dee9-feff-47b7-8a16-75a926e7bee7",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-3.5-turbo-1106",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "df47063f-d263-41ca-b073-536529f59225",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-3.5-turbo-16k-0613",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "e20450b4-8230-4b86-9585-7ee1628fa83e",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-3.5-turbo-instruct",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9e4df22f-e383-46a7-b05f-6e9eb3e36e93",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4",
+        "input_price_per_million": 30.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "4dd00a28-eed1-4867-8d45-99c73bc3702f",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4-0125-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "46dd3fdb-ef87-4933-94fc-20eb108fc051",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4-1106-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "afd86f8a-9315-44ba-bab0-3091248e0da1",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4-32k",
+        "input_price_per_million": 60.0,
+        "output_price_per_million": 120.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "b3b1926c-ed06-4e39-8e75-8e9baf4d5db1",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4-turbo",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "a2da9c36-938f-4f4f-8dd6-3bb9747f115c",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4-turbo-2024-04-09",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "c55a7204-f5ea-40a0-8c4f-0308d719962f",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4-vision-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "490fd276-768b-4c3f-870a-adcf22fc197b",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4.1",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "0f17a36a-3b61-4ad1-9084-aa118cdcb5a1",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4.1-2025-04-14",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "a46030c9-5164-4b48-84e1-b4e2c402acc8",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4.1-mini",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.6,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {}
+      },
+      {
+        "id": "83993f08-b2c4-4cd0-86d7-ee9bf8285add",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4.1-mini-2025-04-14",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.6,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {}
+      },
+      {
+        "id": "d99483e8-40ac-4803-9ce2-66d12df8af35",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4.1-nano",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "f81d3be0-d856-4adb-b0a6-d6130c8ed632",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4.1-nano-2025-04-14",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "26f4d8eb-1b8d-4615-95d0-8fc62b23598b",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4.5-preview",
+        "input_price_per_million": 75.0,
+        "output_price_per_million": 150.0,
+        "input_cached_price_per_million": 37.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "2816b7ff-879d-4d3a-9bce-b4ce09aa2f8e",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4.5-preview-2025-02-27",
+        "input_price_per_million": 75.0,
+        "output_price_per_million": 150.0,
+        "input_cached_price_per_million": 37.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "d5574995-7e5b-4517-8b22-0480cbfbdc8d",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "148ef785-f856-446e-bf3e-b197f1d75dc5",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-2024-05-13",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "ea696d92-736f-4073-93f2-0fa20c3a7ef2",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-2024-08-06",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "836cffc3-6a1b-47f9-8f33-cc2dac71eaf9",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-2024-11-20",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "153429dc-6168-420b-b2e0-78312f12e256",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-audio-preview",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "a74d6c93-9ca2-4f16-9cb1-b83b08f9504b",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-audio-preview-2024-10-01",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "3940e346-deb8-461b-a3b3-9e65b21094da",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-audio-preview-2024-12-17",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "7f8e50be-7d9f-445b-ab6e-ef15008056bc",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-mini",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "7fc01f9d-d5ca-49ef-a61c-1edeb5fd209c",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-mini-2024-07-18",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "a2592ef6-cc83-43de-86a7-839fddff9e98",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-mini-audio-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "8048e5f5-9741-4350-b808-10ab2dc12640",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-mini-audio-preview-2024-12-17",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "6be989a8-f2ff-4247-9602-5f509a6ab505",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-mini-realtime-preview",
+        "input_price_per_million": 0.6,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {}
+      },
+      {
+        "id": "bc98d202-ed23-4d25-8ea5-833de11385cb",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-mini-realtime-preview-2024-12-17",
+        "input_price_per_million": 0.6,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {}
+      },
+      {
+        "id": "6b21e454-9945-41f9-bfa7-6a952842e3b1",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-mini-search-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "53c64a58-b524-4595-a86b-b3efc8c881a8",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-mini-search-preview-2025-03-11",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "5ecc9073-af29-43de-875c-30bbe13697cd",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-realtime-preview",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "cf461ff7-e5d3-4a3f-99f2-0e90755c322f",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-realtime-preview-2024-10-01",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "8e5a2ce6-d5e1-4a16-a093-2c1c7d6233a3",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-realtime-preview-2024-12-17",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "58d693c1-76ea-49a1-9b6d-ffb2232d5379",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-search-preview",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "97e1553e-5228-4490-9f13-d04613114e70",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-4o-search-preview-2025-03-11",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "781766bb-981a-4862-9048-fc17cf49d947",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "82407fec-d862-4ff3-aeba-da688b0a84d3",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5-2025-08-07",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "0161343f-a9c4-4774-9754-fd5b995f73a8",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "6899b9da-e6ed-4f0a-9ef1-057ff113c9d4",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5-mini",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "5f8b3739-050c-4097-a125-84b5fb5ec091",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5-mini-2025-08-07",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "b9198bf9-452c-47a8-b1d1-ea84db4d72c7",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5-nano",
+        "input_price_per_million": 0.05,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.005,
+        "additional_prices": {}
+      },
+      {
+        "id": "598d190a-f9a3-4dda-bac0-1a77129ab78e",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5-nano-2025-08-07",
+        "input_price_per_million": 0.05,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.005,
+        "additional_prices": {}
+      },
+      {
+        "id": "cc0e9c01-224f-48f1-aad8-626e9870e222",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5-pro",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 120.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "f644cf0b-bc7d-41dd-9934-a9f6e700e997",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5.1-2025-11-13",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "62f169a6-2022-4880-90f9-f311acf71b48",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5.1-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "fe074919-0d7f-41a6-8b36-7453a5a979db",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "gpt-5.1-codex-mini",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "2a2575b5-64e2-4561-a665-9ca4b92b23fe",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "grok-3-mini",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 0.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "0d86888c-18e1-4469-ab95-6e7d89b5f330",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "meta-llama/llama-4-maverick-17b-128e-instruct",
+        "input_price_per_million": 0.2,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "f2e38672-92f2-4d7b-bb14-93d84622c880",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o1",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "68f20ec8-8206-4355-b92a-e48ff9cc4304",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o1-2024-12-17",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "8aea384a-d3da-4a98-a8e5-115ebfee9d14",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o1-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "1846d256-f5de-4da1-9f64-6e7801153845",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o1-mini-2024-09-12",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "9f918a60-9287-4539-82b7-8f8dd4c79950",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o1-preview",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "4f1e2d82-dc45-4f25-9206-3606eec28f12",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o1-preview-2024-09-12",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "7539cdcf-539d-492a-a8c9-a881784516d4",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o1-pro",
+        "input_price_per_million": 150.0,
+        "output_price_per_million": 600.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "7ca241b5-a760-455b-92e9-3a8090df7546",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o1-pro-2025-03-19",
+        "input_price_per_million": 150.0,
+        "output_price_per_million": 600.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "01a314ec-c507-420a-9abb-23abce7d9f1b",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o3",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "2b236a89-5410-41b3-b661-3bd2e08e200c",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o3-2025-04-16",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "4a0e6400-2799-4dc1-8cd8-c61ca9201483",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o3-deep-research",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 40.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "ea7d315c-7eaa-4621-940a-1a1eda142271",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o3-deep-research-2025-06-26",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 40.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "9a61f251-63e4-4c57-a40e-7c54a85ff546",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o3-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "286e13e8-31a1-4dac-b7f0-2bddf643c339",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o3-mini-2025-01-31",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "45f9ee11-da27-4c45-9ade-40e5d9c78b76",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o3-pro",
+        "input_price_per_million": 20.0,
+        "output_price_per_million": 80.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "ac6edb16-f512-4863-9b83-221cf460291c",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o3-pro-2025-06-10",
+        "input_price_per_million": 20.0,
+        "output_price_per_million": 80.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "d00ddcc7-917a-4b52-8b7c-e52b23fe69cc",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o4-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.275,
+        "additional_prices": {}
+      },
+      {
+        "id": "268f7fbb-8afe-4504-91d4-1d03a25b2b06",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o4-mini-2025-04-16",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.275,
+        "additional_prices": {}
+      },
+      {
+        "id": "d099d839-8a4b-4fbb-8a19-0947cf897ecb",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o4-mini-deep-research",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "e0aef34c-1b63-4baa-9243-961824a858c1",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "o4-mini-deep-research-2025-06-26",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "6580ea91-8d78-4f66-afcc-777c54949ae4",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/ada-v2",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "cff311ee-b80e-4674-acf4-cde8830b2e7a",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/azure-openai",
+        "input_price_per_million": 0.02,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "271e3efb-e6ce-4e33-b20a-0fb4a795a5f4",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/babbage-002",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "42772d2e-1d47-4cf9-8108-e954418b3419",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/chatgpt-4o-latest",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "3ddf883c-cdf4-46a3-b095-4178e827a48d",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/codex-mini",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 6.0,
+        "input_cached_price_per_million": 0.375,
+        "additional_prices": {}
+      },
+      {
+        "id": "2adf82e7-83ca-46fa-a023-032beb2d2373",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/codex-mini-latest",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 6.0,
+        "input_cached_price_per_million": 0.375,
+        "additional_prices": {}
+      },
+      {
+        "id": "4d3b5316-cb51-4546-ac92-aa513ef0e6bb",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/computer-use-preview",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "b0c077c6-93d8-4a8d-9485-a32d275dc7e1",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/davinci-002",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "84cebdb4-23cf-4263-a316-71977e63dc65",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gemini-2.0-flash",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "0ecd7dca-1936-4ff8-aef5-41e16b64d175",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
+        "provider": "gateway",
+        "model": "openai/google/gemini-2.5-flash",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "5aee09ad-37b1-4384-8a2e-43afde731e5e",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-3.5-turbo-0125",
+        "input_price_per_million": 0.5,
+        "output_price_per_million": 1.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "14ae12af-7521-4277-93a9-15af2e8b7f20",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-3.5-turbo-0301",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "414a19ae-4786-4c1e-aa37-c86eac9c67bb",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-3.5-turbo-0613",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "e0fbdba1-120b-4d19-9e33-f0e0de366727",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-3.5-turbo-1106",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "6705ff00-1b1e-4fbe-809a-b42f82f1b428",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-3.5-turbo-16k-0613",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "1f5468a0-4ebf-4ebb-b73d-1955d701aa87",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-3.5-turbo-instruct",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "ad4c6e24-9e17-40b8-a4d0-481e6f8db7cc",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4",
+        "input_price_per_million": 30.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "4b324b84-358e-43ee-b67c-c15ddd58a34f",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4-0125-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "b64305c3-d90e-4eef-b3c2-156187eb8651",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4-1106-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "6ca362c4-b2b2-4f9a-9ac6-8c639877797c",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4-32k",
+        "input_price_per_million": 60.0,
+        "output_price_per_million": 120.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "4a0599ac-42f7-46ab-9b83-5dde517fb03f",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4-turbo",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "d2b42f7a-eb66-4e8c-a051-8161ae51ad3c",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4-turbo-2024-04-09",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "92675735-4293-41c8-8f45-a9c2a8c10eb7",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4-vision-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "7fa16ee1-7705-428a-bd84-c7d1d7ab6e7a",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4.1",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "ca57b083-d6b8-4dc8-95f5-25bf8b4ecc53",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4.1-2025-04-14",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "36c74473-c41f-4b69-8a14-6737233cabfb",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4.1-mini",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.6,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {}
+      },
+      {
+        "id": "86e82b7b-7103-460f-8493-47a1a5b3f00f",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4.1-mini-2025-04-14",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.6,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {}
+      },
+      {
+        "id": "72f241f0-653f-42dd-9d33-9f265afba00a",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4.1-nano",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "02514ed4-f8db-4f6f-bb0d-5d9e4f4ef86d",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4.1-nano-2025-04-14",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "18dc269a-ddbe-4bcc-a859-4bb0c4fbafc4",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4.5-preview",
+        "input_price_per_million": 75.0,
+        "output_price_per_million": 150.0,
+        "input_cached_price_per_million": 37.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "3d6b2df3-4c09-4d63-b3ba-9a44dcfc7cf3",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4.5-preview-2025-02-27",
+        "input_price_per_million": 75.0,
+        "output_price_per_million": 150.0,
+        "input_cached_price_per_million": 37.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "04df50ed-1fcf-4563-9e15-11678f6f9213",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "5c24b0f5-61f7-4b62-b36a-7d096cf8222f",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-2024-05-13",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "5ae6b039-a68d-4c98-a438-fd5bbb92f701",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-2024-08-06",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "89fcd837-058f-45d1-8308-389263b1005f",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-2024-11-20",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "4b81ca8d-aab2-4a38-b6f8-9132a59e9a8c",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-audio-preview",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "720df683-00a8-4461-a01b-45313b651857",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-audio-preview-2024-10-01",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "05ceaba1-15c7-4795-b72e-6e007ec11cc4",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-audio-preview-2024-12-17",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9e797ea4-ac35-4508-9fcc-f5f702d89b1a",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-mini",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "f11a99f1-263e-4522-a01e-c990b2cff8b6",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-mini-2024-07-18",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "a03896ed-5678-405f-b128-7845549fd19a",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-mini-audio-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "5da23a60-a9b1-4f35-bcf4-747392944ded",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-mini-audio-preview-2024-12-17",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "59f34561-891b-41bf-a8f8-fcdd4dc71a2a",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-mini-realtime-preview",
+        "input_price_per_million": 0.6,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {}
+      },
+      {
+        "id": "3c78c412-aaa3-406e-b2ce-21c5f2e1d1da",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-mini-realtime-preview-2024-12-17",
+        "input_price_per_million": 0.6,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {}
+      },
+      {
+        "id": "6ccef63c-fc3c-4c38-9267-fa76b2f1d2bc",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-mini-search-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "acf88ffa-8ebe-423d-ba9e-2948ad5b88b0",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-mini-search-preview-2025-03-11",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "d7205143-f213-4175-bf7c-89262771a206",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-realtime-preview",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "380aae77-677f-4551-9e11-fdc0d6cdb33e",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-realtime-preview-2024-10-01",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "6a84b7dc-cb6e-4b1d-9199-08d1d62df077",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-realtime-preview-2024-12-17",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "a815f7e5-0e99-4ff1-90c7-3d6585370ceb",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-search-preview",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "2944d2ab-4d6d-4043-9845-d10c5a400875",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-4o-search-preview-2025-03-11",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "4f02b0a7-6c2c-46ec-96b1-62baa07eb066",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "9f7dac91-d7ca-47d6-a2d3-9c4ee9e81e16",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5-2025-08-07",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "7d8b00bd-359e-4d83-8810-a562ecc0f115",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "b72690ce-4395-4c56-8ab0-dbd5c4805164",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5-mini",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "efb4e07c-c841-49c5-b10f-5cb154e9cb91",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5-mini-2025-08-07",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "2e72de23-e49d-4800-9fc1-aa87f74f4e80",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5-nano",
+        "input_price_per_million": 0.05,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.005,
+        "additional_prices": {}
+      },
+      {
+        "id": "7def8326-3282-4910-b410-ec6bdbdb7f2e",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5-nano-2025-08-07",
+        "input_price_per_million": 0.05,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.005,
+        "additional_prices": {}
+      },
+      {
+        "id": "a89882b7-c54b-48bb-a97f-58f1268165e4",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5-pro",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 120.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "2dca916c-1b02-4a18-beb2-4a0ed16ffd7d",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5.1-2025-11-13",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "d90f46d4-5d08-4d39-90fd-d8ec793f969e",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5.1-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "1636e63f-46ad-4668-a0fd-2da02bf2b514",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/gpt-5.1-codex-mini",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "9fee8874-b4c3-4dff-83be-33877a7ba3c7",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/grok-3-mini",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 0.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "7dded7f4-185e-458e-b4d1-5532e6f6ad35",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/meta-llama/llama-4-maverick-17b-128e-instruct",
+        "input_price_per_million": 0.2,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "76feec3f-dcdb-4a0d-be01-906e95711297",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o1",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "a15f15e8-a16d-4b17-94c8-be119ebaf551",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o1-2024-12-17",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "ee1b8713-6ed5-4bf4-97bf-46ae57670dc8",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o1-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "e954f936-374f-44f1-a909-cba03ff87714",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o1-mini-2024-09-12",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "9ccae223-2a52-453b-9c0e-b5b7c2af1524",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o1-preview",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "b700bc41-368a-45a7-89bf-8ac8eaf9bd83",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o1-preview-2024-09-12",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "8dabdb45-182e-408a-8a5d-f7660e5b6726",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o1-pro",
+        "input_price_per_million": 150.0,
+        "output_price_per_million": 600.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9898408b-72ba-41e8-ab78-4bc7e74831a8",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o1-pro-2025-03-19",
+        "input_price_per_million": 150.0,
+        "output_price_per_million": 600.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "eca69906-fb01-444f-a796-ea933d66dd5b",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o3",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "4e964b62-d504-4a46-b3ae-9a2d6dda7e8a",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o3-2025-04-16",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "b45234cf-8f49-4a27-a563-3821c544da59",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o3-deep-research",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 40.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "e9bb0c6a-8dee-4c8b-b343-3a524abef351",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o3-deep-research-2025-06-26",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 40.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "6eea6665-c722-4e13-b504-76e6d86b8304",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o3-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "e20a3ec8-6749-45f9-8d8c-170630383f14",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o3-mini-2025-01-31",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "1e7ad330-9bb3-4545-a025-bd039e55a30f",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o3-pro",
+        "input_price_per_million": 20.0,
+        "output_price_per_million": 80.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "e7702804-74d6-4540-8a8d-f46717389830",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o3-pro-2025-06-10",
+        "input_price_per_million": 20.0,
+        "output_price_per_million": 80.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "e69a701b-e38e-48a8-ac01-0cb490731c3d",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o4-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.275,
+        "additional_prices": {}
+      },
+      {
+        "id": "943cda0f-0d86-46be-b12c-904f9684307f",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o4-mini-2025-04-16",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.275,
+        "additional_prices": {}
+      },
+      {
+        "id": "cc5c569e-84b2-43f3-8aa9-0b5bb8c3180a",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o4-mini-deep-research",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "7f60cb86-4e7e-4a57-9b41-9b43f24a5de4",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/o4-mini-deep-research-2025-06-26",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "24f8e671-60c1-4613-9bf3-81d1f6b8e44b",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/text-embedding-3-large",
+        "input_price_per_million": 0.13,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "deba78ae-934b-4dcb-a4a6-b4f1e67bf847",
+        "created_at": "2025-11-19 13:09:02.60446+00",
+        "updated_at": "2025-11-19 13:09:02.60446+00",
+        "provider": "gateway",
+        "model": "openai/text-embedding-3-small",
+        "input_price_per_million": 0.02,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "227e2ee7-0393-40fa-8bb3-4efc7f3921f1",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "text-embedding-3-large",
+        "input_price_per_million": 0.13,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "8e5cb3a5-78eb-4ad6-b1f7-f1a888ec56a6",
+        "created_at": "2025-11-19 13:09:06.318131+00",
+        "updated_at": "2025-11-19 13:09:06.318131+00",
+        "provider": "gateway",
+        "model": "text-embedding-3-small",
+        "input_price_per_million": 0.02,
+        "output_price_per_million": 0.0,
         "input_cached_price_per_million": null,
         "additional_prices": {}
       },
@@ -2086,12 +5796,12 @@
       {
         "id": "49450685-4a99-4f97-b0c9-3b7d9ea285d6",
         "created_at": "2025-06-26 22:33:06.632881+00",
-        "updated_at": "2025-06-26 22:33:06.632881+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
         "provider": "gemini",
         "model": "gemini-2.5-flash",
         "input_price_per_million": 0.3,
         "output_price_per_million": 2.5,
-        "input_cached_price_per_million": 0.075,
+        "input_cached_price_per_million": 0.03,
         "additional_prices": {}
       },
       {
@@ -2165,6 +5875,17 @@
         "additional_prices": {
           "output_thinking_price_per_million": 3.5
         }
+      },
+      {
+        "id": "357694b3-eba8-46ac-819b-d6bedeffd546",
+        "created_at": "2025-10-07 22:13:26.441693+00",
+        "updated_at": "2025-10-07 22:13:26.441693+00",
+        "provider": "gemini",
+        "model": "gemini-2.5-flash-preview-09-2025",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
       },
       {
         "id": "5a291382-25a8-4696-bd7e-d5fde02d32dc",
@@ -2296,6 +6017,39 @@
         "input_price_per_million": 2.5,
         "output_price_per_million": 15.0,
         "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "f0fb3f3d-0770-46f2-8f36-ecb1bb39e6d6",
+        "created_at": "2025-11-18 17:11:09.195236+00",
+        "updated_at": "2025-11-18 17:11:09.195236+00",
+        "provider": "gemini",
+        "model": "gemini-3-pro-preview",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": 0.2,
+        "additional_prices": {}
+      },
+      {
+        "id": "26609b8c-b9e8-48f6-8bb7-81be42b076c5",
+        "created_at": "2025-11-19 13:18:41.965082+00",
+        "updated_at": "2025-11-19 13:18:41.965082+00",
+        "provider": "gemini",
+        "model": "gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "78a95232-ca13-424b-90ba-6cb68c86ff20",
+        "created_at": "2025-11-19 13:21:35.315315+00",
+        "updated_at": "2025-11-19 13:21:35.315315+00",
+        "provider": "gemini",
+        "model": "gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -2468,12 +6222,23 @@
       {
         "id": "7e05841f-3ea7-476c-96eb-b78f2f657dc7",
         "created_at": "2025-06-29 13:30:48.991054+00",
-        "updated_at": "2025-06-29 13:30:48.991054+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
         "provider": "gemini",
         "model": "models/gemini-2.5-flash",
         "input_price_per_million": 0.3,
         "output_price_per_million": 2.5,
-        "input_cached_price_per_million": 0.075,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "aed32588-8f3a-4bb8-aaed-a07430436aa8",
+        "created_at": "2025-11-20 10:49:35.558827+00",
+        "updated_at": "2025-11-20 10:49:35.558827+00",
+        "provider": "gemini",
+        "model": "models/gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -2659,6 +6424,28 @@
         "additional_prices": {}
       },
       {
+        "id": "80b2c5a1-acc6-47e2-ba86-ae2a267e5323",
+        "created_at": "2025-11-19 13:19:04.394124+00",
+        "updated_at": "2025-11-19 13:19:04.394124+00",
+        "provider": "gemini",
+        "model": "models/gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "50212963-8abe-4583-ba77-2253a342c05e",
+        "created_at": "2025-11-19 13:21:43.884686+00",
+        "updated_at": "2025-11-19 13:21:43.884686+00",
+        "provider": "gemini",
+        "model": "models/gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
         "id": "d7f85885-05ee-4209-9894-eb4b66a50d65",
         "created_at": "2025-03-26 12:35:02.937791+00",
         "updated_at": "2025-03-26 12:35:02.937791+00",
@@ -2828,12 +6615,23 @@
       {
         "id": "d5a4d63a-7fbb-4754-af9a-878c6a4226da",
         "created_at": "2025-06-29 13:34:53.814843+00",
-        "updated_at": "2025-06-29 13:34:53.814843+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
         "provider": "google",
         "model": "gemini-2.5-flash",
         "input_price_per_million": 0.3,
         "output_price_per_million": 2.5,
-        "input_cached_price_per_million": 0.075,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "bedefadd-7be8-4a70-98be-dc9c409b84ab",
+        "created_at": "2025-11-20 10:49:48.696447+00",
+        "updated_at": "2025-11-20 10:49:48.696447+00",
+        "provider": "google",
+        "model": "gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -3019,6 +6817,39 @@
         "additional_prices": {}
       },
       {
+        "id": "2494c609-8e19-46a0-9305-fdba2e153deb",
+        "created_at": "2025-11-20 22:52:38.615373+00",
+        "updated_at": "2025-11-20 22:52:38.615373+00",
+        "provider": "google",
+        "model": "gemini-3-pro-preview",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": 0.2,
+        "additional_prices": {}
+      },
+      {
+        "id": "7024574c-5e0c-42ee-be51-41ddf2af38f1",
+        "created_at": "2025-11-20 10:58:22.427114+00",
+        "updated_at": "2025-11-20 10:58:22.427114+00",
+        "provider": "google",
+        "model": "gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "bb484c63-a24d-4b7e-a773-bfb5905e9628",
+        "created_at": "2025-11-19 13:21:47.462061+00",
+        "updated_at": "2025-11-19 13:21:47.462061+00",
+        "provider": "google",
+        "model": "gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
         "id": "212e3dd9-4dde-467e-9fba-a54e09738c88",
         "created_at": "2025-03-26 12:35:02.937791+00",
         "updated_at": "2025-03-26 12:35:02.937791+00",
@@ -3188,12 +7019,23 @@
       {
         "id": "ceac8aa8-e0e0-43bb-8d2a-70bef04b5afe",
         "created_at": "2025-06-29 13:34:56.440453+00",
-        "updated_at": "2025-06-29 13:34:56.440453+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
         "provider": "google",
         "model": "models/gemini-2.5-flash",
         "input_price_per_million": 0.3,
         "output_price_per_million": 2.5,
-        "input_cached_price_per_million": 0.075,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "50da1fa9-cd30-4e51-8735-df19a1171b2a",
+        "created_at": "2025-11-20 10:49:50.651553+00",
+        "updated_at": "2025-11-20 10:49:50.651553+00",
+        "provider": "google",
+        "model": "models/gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -3379,6 +7221,28 @@
         "additional_prices": {}
       },
       {
+        "id": "9c823974-ae58-485c-97af-7ed5c9c6e289",
+        "created_at": "2025-11-19 13:19:37.749894+00",
+        "updated_at": "2025-11-19 13:19:37.749894+00",
+        "provider": "google",
+        "model": "models/gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "3e2790b5-6c71-4361-8b7f-1a86ca6936c6",
+        "created_at": "2025-11-19 13:21:51.176323+00",
+        "updated_at": "2025-11-19 13:21:51.176323+00",
+        "provider": "google",
+        "model": "models/gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
         "id": "7b30ace1-0d9a-47b1-a19c-c3f32afc520d",
         "created_at": "2024-12-25 15:19:23.65862+00",
         "updated_at": "2024-12-25 15:19:23.65862+00",
@@ -3548,12 +7412,23 @@
       {
         "id": "bebfa3ab-4294-408f-9f9c-940342407e45",
         "created_at": "2025-06-29 13:36:07.866305+00",
-        "updated_at": "2025-06-29 13:36:07.866305+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
         "provider": "google_genai",
         "model": "gemini-2.5-flash",
         "input_price_per_million": 0.3,
         "output_price_per_million": 2.5,
-        "input_cached_price_per_million": 0.075,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "6d8bbe59-5444-42e0-b88e-a4731d3f4713",
+        "created_at": "2025-11-20 10:49:56.393841+00",
+        "updated_at": "2025-11-20 10:49:56.393841+00",
+        "provider": "google_genai",
+        "model": "gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -3739,6 +7614,39 @@
         "additional_prices": {}
       },
       {
+        "id": "c92e3907-7600-407f-aa69-ea708dbb116b",
+        "created_at": "2025-11-20 22:52:41.528829+00",
+        "updated_at": "2025-11-20 22:52:41.528829+00",
+        "provider": "google_genai",
+        "model": "gemini-3-pro-preview",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": 0.2,
+        "additional_prices": {}
+      },
+      {
+        "id": "d7c7b6cf-7080-4bc2-8064-8aab6a86da52",
+        "created_at": "2025-11-19 13:21:04.506656+00",
+        "updated_at": "2025-11-19 13:21:04.506656+00",
+        "provider": "google_genai",
+        "model": "gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "f0d0b496-131c-4d3c-a1fb-c800d8a49e28",
+        "created_at": "2025-11-19 13:21:59.865247+00",
+        "updated_at": "2025-11-19 13:21:59.865247+00",
+        "provider": "google_genai",
+        "model": "gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
         "id": "48f962c4-8d37-4bf6-a569-09c13ef2b324",
         "created_at": "2024-12-25 15:19:23.65862+00",
         "updated_at": "2024-12-25 15:19:23.65862+00",
@@ -3908,12 +7816,23 @@
       {
         "id": "ca301aba-b747-48dc-9bb6-0412813d1a65",
         "created_at": "2025-06-29 13:36:12.341891+00",
-        "updated_at": "2025-06-29 13:36:12.341891+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
         "provider": "google_genai",
         "model": "models/gemini-2.5-flash",
         "input_price_per_million": 0.3,
         "output_price_per_million": 2.5,
-        "input_cached_price_per_million": 0.075,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "92a1d1d8-2774-4e66-945e-d9f2b8f4e514",
+        "created_at": "2025-11-20 10:49:58.605076+00",
+        "updated_at": "2025-11-20 10:49:58.605076+00",
+        "provider": "google_genai",
+        "model": "models/gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -4096,6 +8015,28 @@
         "input_price_per_million": 2.5,
         "output_price_per_million": 15.0,
         "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "ddfb320b-22e7-4b43-a8b1-820fd1de323e",
+        "created_at": "2025-11-19 13:21:00.564125+00",
+        "updated_at": "2025-11-19 13:21:00.564125+00",
+        "provider": "google_genai",
+        "model": "models/gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "7acfa2fa-6f5b-4476-9a74-f39a33176d7e",
+        "created_at": "2025-11-19 13:21:56.742855+00",
+        "updated_at": "2025-11-19 13:21:56.742855+00",
+        "provider": "google_genai",
+        "model": "models/gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -4341,6 +8282,17 @@
         "additional_prices": {}
       },
       {
+        "id": "af3e10fe-b71d-4dc1-8262-62ac1767a86a",
+        "created_at": "2025-10-28 21:34:19.577977+00",
+        "updated_at": "2025-10-28 21:34:19.577977+00",
+        "provider": "groq",
+        "model": "moonshotai/kimi-k2-instruct-0905",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 3.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
         "id": "304c5213-43ae-4272-864a-dd595b7c2251",
         "created_at": "2025-09-10 13:25:23.335147+00",
         "updated_at": "2025-09-10 13:25:23.335147+00",
@@ -4382,6 +8334,17 @@
         "input_price_per_million": 0.29,
         "output_price_per_million": 0.59,
         "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "84132fff-476f-419b-8ab9-87431905dd3b",
+        "created_at": "2025-11-18 17:10:25.967666+00",
+        "updated_at": "2025-11-18 17:10:25.967666+00",
+        "provider": "litellm_proxy",
+        "model": "vertex_ai/gemini-3-pro-preview",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": 0.2,
         "additional_prices": {}
       },
       {
@@ -4778,6 +8741,17 @@
         "input_price_per_million": 0.1,
         "output_price_per_million": 0.4,
         "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "d6108f9c-4cc4-40ce-9e00-bc969c25f1c7",
+        "created_at": "2025-10-28 21:33:11.7143+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
+        "provider": "openai",
+        "model": "google/gemini-2.5-flash",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.03,
         "additional_prices": {}
       },
       {
@@ -5266,6 +9240,17 @@
         "additional_prices": {}
       },
       {
+        "id": "839ed15f-d6db-4423-b1f7-c7ffa4a8bca1",
+        "created_at": "2025-11-19 11:25:23.185102+00",
+        "updated_at": "2025-11-19 11:25:23.185102+00",
+        "provider": "openai",
+        "model": "gpt-5-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
         "id": "d25e4057-a7c1-43fb-a3c0-8c821d8f3f06",
         "created_at": "2025-08-07 20:22:34.873438+00",
         "updated_at": "2025-08-07 20:22:34.873438+00",
@@ -5307,6 +9292,61 @@
         "input_price_per_million": 0.05,
         "output_price_per_million": 0.4,
         "input_cached_price_per_million": 0.005,
+        "additional_prices": {}
+      },
+      {
+        "id": "4b0b4849-4fb1-499f-85db-4025fb811385",
+        "created_at": "2025-11-19 11:25:56.618706+00",
+        "updated_at": "2025-11-19 11:25:56.618706+00",
+        "provider": "openai",
+        "model": "gpt-5-pro",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 120.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "20347243-5a00-4e5a-87bd-384702644c60",
+        "created_at": "2025-11-19 14:48:35.54662+00",
+        "updated_at": "2025-11-19 14:48:35.54662+00",
+        "provider": "openai",
+        "model": "gpt-5.1",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "cff12bc0-b9dd-4af2-9c43-30935883861a",
+        "created_at": "2025-11-19 11:33:34.144516+00",
+        "updated_at": "2025-11-19 11:33:34.144516+00",
+        "provider": "openai",
+        "model": "gpt-5.1-2025-11-13",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "d5de3a31-d5cb-4073-be16-041349236a0c",
+        "created_at": "2025-11-19 11:24:54.644567+00",
+        "updated_at": "2025-11-19 11:24:54.644567+00",
+        "provider": "openai",
+        "model": "gpt-5.1-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "e1c5e7b4-659c-4655-bfdf-8fe63067d746",
+        "created_at": "2025-11-19 12:49:20.185982+00",
+        "updated_at": "2025-11-19 12:49:20.185982+00",
+        "provider": "openai",
+        "model": "gpt-5.1-codex-mini",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -5574,6 +9614,419 @@
         "additional_prices": {}
       },
       {
+        "id": "0c40f97b-0429-419d-bda3-460cfc89f8c2",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "ada-v2",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "224686c9-4e3d-4d47-807a-3aae1f957423",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-2.0",
+        "input_price_per_million": 8.0,
+        "output_price_per_million": 24.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "5c951995-bfc6-49f1-a995-cd53e5e54ab4",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-2.1",
+        "input_price_per_million": 8.0,
+        "output_price_per_million": 24.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "72d0f084-1285-4fe1-8b55-998c51b99d48",
+        "created_at": "2025-11-20 10:56:36.372575+00",
+        "updated_at": "2025-11-20 10:56:36.372575+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-haiku",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "c7df946c-fa69-4b54-9da2-78f6e62d67aa",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-haiku-20241022",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "d100d157-8148-4ccf-a1d5-b0bfba8a3bf0",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-haiku-20241022-v1:0",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "9ba89f4f-5ab1-4fa9-8bf2-4061647f9f32",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-haiku-latest",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "53571e18-85f1-41d5-a12b-230cee17f0c9",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "9efb3d1e-3d7a-421e-872d-634561c98c0a",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-sonnet-20240620",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "de9cdc7b-19d2-4435-afcf-eccacadaf1de",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-sonnet-20240620-v1:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "c0caf42d-081c-48fb-a932-597ed7c5fb8d",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-sonnet-20241022",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "21ee00d9-5393-450f-84d1-7b1f8924e30b",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-sonnet-20241022-v2:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "d91334f2-d19d-4a98-8295-c9d7ed6f8f7a",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-5-sonnet-latest",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "1df00c98-2f39-4295-bc20-f3da5899aeea",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-7-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "e346bd46-481d-4099-a615-dad59830f62f",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-7-sonnet-20250219",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "4364d57f-a5d9-4cc3-a212-cf548deabe7b",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-7-sonnet-latest",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "e5a1c185-db14-421e-acbb-6eefb2284af6",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-haiku",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "3968b9ca-1212-4d6b-ab15-14a4f325bd51",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-haiku-20240307",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "4df4b5d2-fa08-449e-aa5a-343e0207c55b",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-haiku-20240307-v1:0",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "9a7eeccc-4fd2-425b-92a3-38e712fadce6",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-opus",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "496ce84a-5d75-431c-a59f-068254a0050c",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-opus-20240229",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "4c2faf6a-4ce3-45d6-87c0-47ba7e26469f",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-opus-20240229-v1:0",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "52ad436c-9e92-411d-a869-a9d051d30c8a",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-opus-latest",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "3f22b422-41fc-4107-bcf3-2b449d935805",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "56ebf8d5-d5c7-46bc-a75a-9128c2d940bf",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-sonnet-20240229",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "26a19d93-d69e-47c8-b1e1-cbc8dda6a3f6",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-sonnet-20240229-v1:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "40a78608-60e9-479e-ab1f-46e92c64b0db",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-4-sonnet-20250514",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "cdb0e1ad-8e86-41a0-8a85-d6161a6606de",
+        "created_at": "2025-11-20 11:01:35.065708+00",
+        "updated_at": "2025-11-20 11:01:35.065708+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-haiku-4-5",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
+        "id": "e4cefe6c-192c-4b0f-8857-85a03b97cc23",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-haiku-4-5-20251001",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
+        "id": "96f0dfa1-9308-4f35-b4a6-fb2edb8cfba7",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-instant",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "070529ac-8da0-4ed6-8e6f-8526ff7bc10d",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-instant-1.2",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9f2412d4-7d2e-4b7b-b274-5d231f5d64e5",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-opus-4-1-20250805",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "9e8ba6c7-a151-417c-8879-2c1e45fd6e7c",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-opus-4-20250514",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
         "id": "930ecd83-27c5-48f1-8d8b-44f652c9dcb7",
         "created_at": "2025-07-10 12:29:02.981896+00",
         "updated_at": "2025-07-10 12:29:02.981896+00",
@@ -5585,25 +10038,3457 @@
         "additional_prices": {}
       },
       {
-        "id": "54adf84b-0692-454f-ba0d-18bd00cde0f4",
-        "created_at": "2025-07-16 10:09:55.950523+00",
-        "updated_at": "2025-07-16 10:09:55.950523+00",
+        "id": "fe5a827e-26e2-4a48-85e5-d30b10d7b217",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-sonnet-4-20250514",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "f00cd789-fa2c-4c18-85b0-2df0929321a7",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-sonnet-4-20250514--long-context",
+        "input_price_per_million": 6.0,
+        "output_price_per_million": 22.5,
+        "input_cached_price_per_million": 0.6,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 7.5
+        }
+      },
+      {
+        "id": "ea31f3f1-0508-4fbf-a47b-e15a2cebb07a",
+        "created_at": "2025-11-20 11:01:09.738056+00",
+        "updated_at": "2025-11-20 11:01:09.738056+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-sonnet-4-5",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "e89a194d-b1c0-429f-bd04-feb4a63d509d",
+        "created_at": "2025-11-19 13:00:10.069231+00",
+        "updated_at": "2025-11-19 13:00:10.069231+00",
+        "provider": "openrouter",
+        "model": "anthropic/claude-sonnet-4-5-20250929",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "4fb8f8dd-a465-4885-b1de-70332a9325d6",
+        "created_at": "2025-11-19 11:31:18.718225+00",
+        "updated_at": "2025-11-19 11:31:18.718225+00",
+        "provider": "openrouter",
+        "model": "antrhopic/claude-sonnet-4.5",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "99bc8c5e-8e4d-4edf-b997-45859289339b",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "azure-openai",
+        "input_price_per_million": 0.02,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "e578ec02-f84c-46a0-924b-a3476cd7aaf0",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "babbage-002",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "c00a56fd-37a9-46c2-9cb0-62ecaff4ad90",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "chatgpt-4o-latest",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "0c0c4f79-d959-4ecc-b624-8dd043b9d009",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-2.0",
+        "input_price_per_million": 8.0,
+        "output_price_per_million": 24.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "56a6798f-9d9f-4156-b6ac-35a8485241da",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-2.1",
+        "input_price_per_million": 8.0,
+        "output_price_per_million": 24.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "74ff38d1-0db3-42ec-a14b-5c198dc2a06d",
+        "created_at": "2025-11-20 10:56:36.372575+00",
+        "updated_at": "2025-11-20 10:56:36.372575+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-haiku",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "6160d584-6cc2-455b-b6da-2d9ae2bed237",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-haiku-20241022",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "c9b9e488-065e-4cb8-9c1a-027fb5e71708",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-haiku-20241022-v1:0",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "0e6c23a7-e2f9-4224-a664-6e4a629800a4",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-haiku-latest",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": 0.08,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1
+        }
+      },
+      {
+        "id": "1bf26f05-9bbf-4220-826d-8a9a22bf9b9d",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "47626645-da88-4ef7-b82f-feac1ec5f3d6",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-sonnet-20240620",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "74669d5d-6990-4d94-bd74-c7690e31ff14",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-sonnet-20240620-v1:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "f162ddd6-8c64-4d5b-810b-b061db883cd9",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-sonnet-20241022",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "04325051-fe35-4ed1-8def-96af3e8296e3",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-sonnet-20241022-v2:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "ca34a1f0-f4a8-41d4-aad7-89b277767720",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-5-sonnet-latest",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "19345595-d9fa-4f69-a083-1a01d96a2258",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-7-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "743ece9b-ace3-4e99-a743-8945e89c481d",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-7-sonnet-20250219",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "950fd4e9-f3fe-4152-b4bd-69461e862717",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-7-sonnet-latest",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "3f18e4e5-b26b-4702-b719-d90760c187e3",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-haiku",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "29297b02-656e-4232-8e01-81976ff2f6c9",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-haiku-20240307",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "ad68e9c0-48cb-4302-8178-e51564825edc",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-haiku-20240307-v1:0",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 1.25,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "59d5a9f7-8f54-401c-9c38-9123c22f462f",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-opus",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "aee45515-9406-427f-8785-ca22b99552d4",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-opus-20240229",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "5b3d619d-6db3-4967-9304-e55f5cfba897",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-opus-20240229-v1:0",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "4049f5e1-e7e7-47ef-950c-4437f2339418",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-opus-latest",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "e850575e-8f44-43d8-9088-78a0dcb7b321",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-sonnet",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "6c1ea1dc-3d1b-4b92-b8ce-0ed1014319db",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-sonnet-20240229",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "17e573f1-f96e-4a9b-bea3-d8d1c4398675",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-3-sonnet-20240229-v1:0",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "7b81e2e4-4ac8-4e3e-a67d-e886656f3b3d",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-4-sonnet-20250514",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "cc014f0b-da6d-48c9-96c1-22b8d3391dfe",
+        "created_at": "2025-11-20 11:01:35.065708+00",
+        "updated_at": "2025-11-20 11:01:35.065708+00",
+        "provider": "openrouter",
+        "model": "claude-haiku-4-5",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
+        "id": "03411d78-d89c-4b0c-9c84-65189ea241ef",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-haiku-4-5-20251001",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 1.25
+        }
+      },
+      {
+        "id": "608d0b75-2b3d-44a8-b07d-80c462583f14",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-instant",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "028465bc-b23c-411e-adaf-245a74d2210c",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-instant-1.2",
+        "input_price_per_million": 0.8,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "54ec3b8e-264e-48c6-80f7-0cede084b3fe",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-opus-4-1-20250805",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "a90da685-0e08-4390-8345-ea1dc59f3229",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-opus-4-20250514",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 75.0,
+        "input_cached_price_per_million": 1.5,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 18.75
+        }
+      },
+      {
+        "id": "32e2fc0a-783b-4f63-8fc3-f29388dc932a",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-sonnet-4",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "3d628432-821a-49c6-b087-f2e5af68d287",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-sonnet-4-20250514",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "6a4487df-4d5e-48a2-acda-9f41ef40c91c",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-sonnet-4-20250514--long-context",
+        "input_price_per_million": 6.0,
+        "output_price_per_million": 22.5,
+        "input_cached_price_per_million": 0.6,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 7.5
+        }
+      },
+      {
+        "id": "fb9d82c0-86d5-4b4b-bff8-6a7f21f27f2b",
+        "created_at": "2025-11-20 11:01:09.738056+00",
+        "updated_at": "2025-11-20 11:01:09.738056+00",
+        "provider": "openrouter",
+        "model": "claude-sonnet-4-5",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "e36cc699-9dea-4505-9dff-0affc6433abf",
+        "created_at": "2025-11-19 14:51:55.986177+00",
+        "updated_at": "2025-11-19 14:51:55.986177+00",
+        "provider": "openrouter",
+        "model": "claude-sonnet-4-5-20250929",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 3.75
+        }
+      },
+      {
+        "id": "908a01cc-3382-4937-afb0-6d72159ac9a1",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "codex-mini",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 6.0,
+        "input_cached_price_per_million": 0.375,
+        "additional_prices": {}
+      },
+      {
+        "id": "caea3d90-e7fd-4328-b8ea-30f94eeabd47",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "codex-mini-latest",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 6.0,
+        "input_cached_price_per_million": 0.375,
+        "additional_prices": {}
+      },
+      {
+        "id": "7b9ea651-89e6-4951-ad0b-8e3d76055250",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "computer-use-preview",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "01f8c0bf-87e9-4f23-8ea7-eec16112b4d0",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "davinci-002",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9a8c01fc-3b16-4e12-959d-97f047aa2535",
+        "created_at": "2025-11-20 11:03:44.022874+00",
+        "updated_at": "2025-11-20 11:03:44.022874+00",
+        "provider": "openrouter",
+        "model": "deepseek-v3.2-exp",
+        "input_price_per_million": 0.28,
+        "output_price_per_million": 0.42,
+        "input_cached_price_per_million": 0.028,
+        "additional_prices": {}
+      },
+      {
+        "id": "ad390d39-c9bb-44f3-b50c-09a40b329239",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-1.0-pro",
+        "input_price_per_million": 0.5,
+        "output_price_per_million": 1.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "326c6d45-5981-46f4-afca-473da52bf816",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-1.5-flash",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "ad297560-f7a9-4f43-88ed-48b177688b32",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-1.5-flash--long-context",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "d1e5b19b-34f0-49f7-b056-b0e4ac3b13f2",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-1.5-flash-8b",
+        "input_price_per_million": 0.0375,
+        "output_price_per_million": 0.15,
+        "input_cached_price_per_million": 0.01,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 0.25
+        }
+      },
+      {
+        "id": "8d3efb8c-ff3a-4b2d-966c-764601a45719",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-1.5-flash-8b--long-context",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.02,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 0.25
+        }
+      },
+      {
+        "id": "25d43677-77b4-460e-b949-eeaa9cc5c821",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-1.5-pro",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.3125,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 4.5
+        }
+      },
+      {
+        "id": "2e46cd3a-2752-458a-90e2-422254901094",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-1.5-pro--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 4.5
+        }
+      },
+      {
+        "id": "241120b7-ccf0-4b19-b067-c7da311f2931",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.0-flash",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "e7d3e67f-3e19-45d2-aa4e-44e611e8e5d3",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gemini-2.0-flash",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "c656c3be-26a5-41f0-8fc3-2f31cb767049",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.0-flash-exp",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "069501e9-e9fe-42ae-a89b-8e260053a342",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.0-flash-lite",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "b79c3f07-e6b3-4bfe-9a9c-a3b160953490",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.0-flash-lite-exp",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "5a0cc727-704e-4cf5-ae29-ee581591bd79",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.0-flash-lite-exp-01-21",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "7e3e2b20-54ec-4f1f-9f0f-352e8add2163",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.0-flash-lite-preview-02-05",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "3bfb8361-d97b-49d3-bb8d-e55b357717f4",
+        "created_at": "2025-10-19 17:56:49.988251+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-flash",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {
+          "input_cache_write_price_per_million": 0.3
+        }
+      },
+      {
+        "id": "cd6be76a-2a03-4b8b-88fd-370d236ee589",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-flash",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "9e3e837b-fc95-4a79-8dd5-1d808b62bb1e",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "f2857b75-524b-49a9-8b7b-47709661b7ab",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-flash-lite-preview",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "0002a8a1-4cb8-4838-84f8-31eec844c9b6",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-flash-lite-preview-06-17",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "8c8c8648-8489-4ed4-95d9-88e8f7f5a272",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-flash-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "3c684faf-115a-4173-b823-bd6985d19b7d",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-flash-preview-04-17",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "4695ce40-21d1-4fc2-849b-bc6052fa4f0a",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-flash-preview-05-20",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "04ed1cc8-33ec-4e21-8a81-8943915e6cc9",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-flash-preview-09-2025",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "878f39b7-07f7-465f-8a3c-53645a07c1fd",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "1a3ed3fa-c3f2-4290-9585-111f3102c980",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "a5a8646c-57ee-43d0-bd67-b5454e3ae250",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-exp-03-25",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "cdbda1cd-13a0-4053-b685-422127da1d06",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-exp-03-25--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "900ee1fc-f483-4695-b049-6979a651dad1",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-preview",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "c3b35af1-e0ee-4c73-9b26-ca3dd67120f7",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-preview--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "92f56e0d-2c32-4eae-b292-69a95ea0c152",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-preview-03-25",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "cf63215e-b4b4-4855-ab34-bfcfe8b6c4eb",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-preview-03-25--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "571bcb75-54fb-40ba-8c2a-e851a5a62d8a",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-preview-05-06",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "8d5ced14-7ec4-4ab7-84d4-c8a880097bfe",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-preview-05-06--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "5ac0f5e9-00c4-45ab-bae8-7ac75d3acf94",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-preview-06-05",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "42bf57cb-4863-41b6-89e0-c8814022e585",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-2.5-pro-preview-06-05--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "854b3f5b-0e7f-4559-954a-3612dd3aea41",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-3-pro-preview",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": 0.2,
+        "additional_prices": {}
+      },
+      {
+        "id": "2212ce5d-867e-4b93-a289-b83c6d545f7d",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "6f3cd36e-678c-4d75-b0bf-d75e9e5ef902",
+        "created_at": "2025-11-19 14:58:40.495923+00",
+        "updated_at": "2025-11-19 14:58:40.495923+00",
+        "provider": "openrouter",
+        "model": "gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "11be997c-f9b7-4f06-93f1-e6d9b20f447a",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-1.0-pro",
+        "input_price_per_million": 0.5,
+        "output_price_per_million": 1.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "639621b8-a92c-4eaa-a347-35b237d40fbc",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-1.5-flash",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "81aeecbf-dd15-4f87-922c-e2e991268f09",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-1.5-flash--long-context",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "4112ee40-dcd1-4993-aa4f-0ef587d2de6b",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-1.5-flash-8b",
+        "input_price_per_million": 0.0375,
+        "output_price_per_million": 0.15,
+        "input_cached_price_per_million": 0.01,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 0.25
+        }
+      },
+      {
+        "id": "a9ff2787-b040-4e93-8ce1-6753e5b3d6cd",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-1.5-flash-8b--long-context",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.02,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 0.25
+        }
+      },
+      {
+        "id": "535e84d4-8f33-49c5-88ff-379009157dc7",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-1.5-pro",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 5.0,
+        "input_cached_price_per_million": 0.3125,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 4.5
+        }
+      },
+      {
+        "id": "052472a7-bf68-4a30-a6f3-ac8b21d6be73",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-1.5-pro--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 4.5
+        }
+      },
+      {
+        "id": "503ded7e-8aa0-461e-b208-10062e1f421c",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.0-flash",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "034c6834-18d4-471e-8353-9b40d161d0b6",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.0-flash-exp",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "de99ede7-9286-4e08-8c65-98f19a9a254f",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.0-flash-lite",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "002113d4-3284-4257-bff1-7c292a2afc8a",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.0-flash-lite-exp",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "4170e07d-e88c-417f-aee0-557ce1be52d9",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.0-flash-lite-exp-01-21",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "7367f896-bfa5-49e6-821a-13ada10c75a4",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.0-flash-lite-preview-02-05",
+        "input_price_per_million": 0.075,
+        "output_price_per_million": 0.3,
+        "input_cached_price_per_million": 0.01875,
+        "additional_prices": {
+          "input_caching_storage_price_per_million_per_hour": 1
+        }
+      },
+      {
+        "id": "1e44f036-c9f8-4dd8-a60b-6d589802c6ae",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
         "provider": "openrouter",
         "model": "google/gemini-2.5-flash",
         "input_price_per_million": 0.3,
         "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "37fc65ac-9f7f-490b-a4bd-4c564aec4be1",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "90af041c-bca1-4645-8b28-a0e51addb16f",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-flash-lite-preview",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "5e46d8cc-20be-42f7-a46d-d9c2cffcf83c",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-flash-lite-preview-06-17",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "4ee40d2f-7121-4c38-ad99-3f0e004f0a9c",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-flash-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "03ddb9dc-0f08-4407-b774-48c3cca0cbca",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-flash-preview-04-17",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "2dbf6c38-7972-456c-8d17-b92ad3b45b53",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-flash-preview-05-20",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.0375,
+        "additional_prices": {
+          "output_thinking_price_per_million": 3.5
+        }
+      },
+      {
+        "id": "cbc884b9-6a65-4bc2-82b4-6636f43566ef",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-flash-preview-09-2025",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "de8ce759-dbeb-4270-b4ad-b9aec2bcae42",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "054bdfd6-7318-47e3-98dd-505459daa219",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "4a81a869-2ad1-4b3b-8df0-315a7d649d69",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-exp-03-25",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
         "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "1af5e784-d323-4003-814f-68ff29373fb0",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-exp-03-25--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "6a8ad888-b7b8-4b3e-ac15-15843c12d757",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-preview",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "04638773-03f5-47e9-ac85-f6f2df843415",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-preview--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "045728b3-ce89-4600-9d6c-58d1a4b1673b",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-preview-03-25",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "3171e18f-e4d3-42b4-a099-760fcd511d78",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-preview-03-25--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "96bcde98-4290-4a7e-b941-90768b06f8fe",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-preview-05-06",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "4e825e1d-f0c2-4298-861f-8e7b031ec289",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-preview-05-06--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "0ed5e5a9-6a9f-4e7b-9942-f3000014bdf2",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-preview-06-05",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "bab21f8f-749b-428a-bf2c-5df2027b5a63",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-2.5-pro-preview-06-05--long-context",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.625,
+        "additional_prices": {}
+      },
+      {
+        "id": "12442edc-9142-4970-9848-6c921fdbff30",
+        "created_at": "2025-11-19 13:02:28.65694+00",
+        "updated_at": "2025-11-19 13:02:28.65694+00",
+        "provider": "openrouter",
+        "model": "google/gemini-3-pro-preview",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": 0.2,
+        "additional_prices": {}
+      },
+      {
+        "id": "e751a60d-7b85-4f2e-8f07-b3abb3b5e22a",
+        "created_at": "2025-11-19 13:26:16.516999+00",
+        "updated_at": "2025-11-19 13:26:16.516999+00",
+        "provider": "openrouter",
+        "model": "google/gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "8c069d54-5826-4836-a9df-9e1ab097afbb",
+        "created_at": "2025-11-19 13:26:34.01299+00",
+        "updated_at": "2025-11-19 13:26:34.01299+00",
+        "provider": "openrouter",
+        "model": "google/gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "94a021ad-f256-484e-b911-b5f99e1889e1",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-3.5-turbo-0125",
+        "input_price_per_million": 0.5,
+        "output_price_per_million": 1.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "21988304-c654-49f7-86f4-0e3530a73bbc",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-3.5-turbo-0301",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "ee94e58a-8f74-4573-89af-1f19d35d92ad",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-3.5-turbo-0613",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "be8be5c1-77a6-4ab7-aa4c-23428c0f0e61",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-3.5-turbo-1106",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "fc08b473-c275-4446-9c7f-bebbf671456f",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-3.5-turbo-16k-0613",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "0f32ffa9-0cbb-4cba-9c4e-b9abdc2c2def",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-3.5-turbo-instruct",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "02c2ec2d-a562-4c79-83b0-44aacd645f3d",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4",
+        "input_price_per_million": 30.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "b52752dd-b5d6-46b1-98eb-c6046cd2eec6",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4-0125-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "e6bcfb88-bc8d-4e98-9c1d-66d24d1d7862",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4-1106-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "772b66f4-5a37-4f90-95d2-b37c5d21dae2",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4-32k",
+        "input_price_per_million": 60.0,
+        "output_price_per_million": 120.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "34d75f17-7996-4c8b-8261-f301a6873379",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4-turbo",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "adf93d57-98e2-4ceb-b245-ee3cf7791c56",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4-turbo-2024-04-09",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "5e0b4268-dcef-448f-a97f-09eb0f4b658e",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4-vision-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "058d15c4-c578-4674-98ef-0dd228635c7d",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4.1",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "d05b76f8-ac46-4061-9bd8-90505c58e1fa",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4.1-2025-04-14",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "e938347a-3e82-4b14-be19-4391f3a1f4cd",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4.1-mini",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.6,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {}
+      },
+      {
+        "id": "095483dd-e60c-44aa-aafb-e5cb6d33d013",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4.1-mini-2025-04-14",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.6,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {}
+      },
+      {
+        "id": "8865aa4a-36bb-400b-9eba-0b03f325158e",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4.1-nano",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "087939b4-c780-4855-a8ce-477afc986e7c",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4.1-nano-2025-04-14",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "968dfffb-92f5-4b31-9d04-191f3050051e",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4.5-preview",
+        "input_price_per_million": 75.0,
+        "output_price_per_million": 150.0,
+        "input_cached_price_per_million": 37.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "4653e04f-233a-408c-be15-3f3d1920b01b",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4.5-preview-2025-02-27",
+        "input_price_per_million": 75.0,
+        "output_price_per_million": 150.0,
+        "input_cached_price_per_million": 37.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "1ea9806c-0ed1-490d-99e1-cb64597381c1",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "e49beb19-753e-48ab-abd9-9c6c574cc70f",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-2024-05-13",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "8d88b64d-b694-4a9e-9062-2f9da0f2c333",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-2024-08-06",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "22c52cf9-1c19-4323-b02e-dbfadfc4be7b",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-2024-11-20",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "14912c68-6d85-47ac-8c05-4bfda5851ad6",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-audio-preview",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "03512d87-b5e9-485a-a5cc-78d930983a4a",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-audio-preview-2024-10-01",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "809be276-1a14-4911-9076-b6ed281aa605",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-audio-preview-2024-12-17",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "570d9866-c726-4030-9f73-9934dbb6fd63",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-mini",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "d8f6216e-9f06-4192-bee4-eae1e7d0862c",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-mini-2024-07-18",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "5103dcf3-bb4b-4f9d-845d-273255679fe5",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-mini-audio-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "bd4064a0-f38c-4dbe-a39a-abab6a446300",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-mini-audio-preview-2024-12-17",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "c27e1bfc-b447-457b-9e74-b4f1a62942e2",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-mini-realtime-preview",
+        "input_price_per_million": 0.6,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {}
+      },
+      {
+        "id": "d54cec7a-5a69-4fec-aa24-48d4b7586d16",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-mini-realtime-preview-2024-12-17",
+        "input_price_per_million": 0.6,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {}
+      },
+      {
+        "id": "0e2beb23-933e-4dfa-ad9d-bb16cdfb1895",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-mini-search-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "0d7457bb-dd85-4a2a-9efe-f826beb2a518",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-mini-search-preview-2025-03-11",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "cb9b4a38-d65d-4964-8884-1657d0c66324",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-realtime-preview",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "6a473471-338b-4e07-8abf-468287c18b0c",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-realtime-preview-2024-10-01",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "f2f70fba-88c6-4fb4-af4f-c75cc70d47bc",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-realtime-preview-2024-12-17",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "633567da-ce65-4d8e-a715-5da941f140da",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-search-preview",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "7c35be51-c204-4669-8715-ea8279d988ea",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-4o-search-preview-2025-03-11",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "3a9e0c77-3335-4f4b-8674-c3f80efc5232",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "ead5ce3b-db41-4ed6-8a09-e3925cacc430",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5-2025-08-07",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "bd68a3ea-d0e9-435d-a64b-740ef0730228",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "e0be05ad-6231-424a-80fc-7ecfb5de3b23",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5-mini",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "6345fc26-1e91-4f1c-b958-99a886ec0020",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5-mini-2025-08-07",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "397c9081-f46f-4bca-81eb-ab68990d6964",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5-nano",
+        "input_price_per_million": 0.05,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.005,
+        "additional_prices": {}
+      },
+      {
+        "id": "b6429364-4627-47e1-b31c-8819d02f652d",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5-nano-2025-08-07",
+        "input_price_per_million": 0.05,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.005,
+        "additional_prices": {}
+      },
+      {
+        "id": "aec47f70-6581-4cd8-9d4d-f9167869357c",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5-pro",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 120.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "7e117ada-16bb-4ea6-a798-3825a786c372",
+        "created_at": "2025-11-19 14:49:00.35879+00",
+        "updated_at": "2025-11-19 14:49:00.35879+00",
+        "provider": "openrouter",
+        "model": "gpt-5.1",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "3fe19b19-ef0b-4f59-9eb9-6b989c07a819",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5.1-2025-11-13",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "3d702c8f-ec88-4ce7-828c-e3759de606a9",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5.1-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "42361701-1362-47dc-b27c-94ed8ad0345c",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "gpt-5.1-codex-mini",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "b20cce00-3153-48b1-836b-462337ff6471",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "grok-3-mini",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 0.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "167c24ca-0141-48b2-ab09-2291fd9d3530",
+        "created_at": "2025-11-19 14:32:06.616322+00",
+        "updated_at": "2025-11-19 14:32:06.616322+00",
+        "provider": "openrouter",
+        "model": "grok-4-fast",
+        "input_price_per_million": 0.2,
+        "output_price_per_million": 0.5,
+        "input_cached_price_per_million": 0.05,
+        "additional_prices": {}
+      },
+      {
+        "id": "c08a0a0e-2ace-4128-b02d-919b5e2ce8d0",
+        "created_at": "2025-11-19 14:32:32.951122+00",
+        "updated_at": "2025-11-19 14:32:32.951122+00",
+        "provider": "openrouter",
+        "model": "grok-4-fast--long-context",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.0,
+        "input_cached_price_per_million": 0.05,
+        "additional_prices": {}
+      },
+      {
+        "id": "3b387fb6-b439-4f1c-9d26-7eb9fbc4efb2",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "meta-llama/llama-4-maverick-17b-128e-instruct",
+        "input_price_per_million": 0.2,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "d467d88b-0d06-4a95-a6c8-08a7362b1c2c",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o1",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "e09272c0-c7d0-4bc6-82ad-2c5745b16779",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o1-2024-12-17",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "814c8ee5-184f-431e-a3f4-46001280a774",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o1-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "4bf6b9f5-4003-46bd-9925-08aef7bbcefa",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o1-mini-2024-09-12",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "4e6fec74-d2a3-47a4-8f9e-e7a5e0093418",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o1-preview",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "91653dea-9171-4ce3-afab-e24cebdaf8b2",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o1-preview-2024-09-12",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "3ec23b46-e119-4ce6-9865-81084a6d4466",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o1-pro",
+        "input_price_per_million": 150.0,
+        "output_price_per_million": 600.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "212b186f-1570-4ac5-8ba1-2556f51d2047",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o1-pro-2025-03-19",
+        "input_price_per_million": 150.0,
+        "output_price_per_million": 600.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "e8302b47-2f6a-4ca4-a8c4-960b7b67b03b",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o3",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "effc9378-7d30-493b-bba6-165fecdf2a8c",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o3-2025-04-16",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "de2d6308-1ee7-4c13-aba9-aee94d607bb9",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o3-deep-research",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 40.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "a3127735-1703-478c-9fd2-83003694ebd5",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o3-deep-research-2025-06-26",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 40.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "6a8f5c0e-833f-41e4-b2b1-40931bd3e9f8",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o3-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "b7162459-9703-4acd-b704-4813c332d9f3",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o3-mini-2025-01-31",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "2e0c287f-129a-40f9-9f3a-0ec4c1044581",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o3-pro",
+        "input_price_per_million": 20.0,
+        "output_price_per_million": 80.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "8de5ebb8-de20-436f-819b-22602c32a823",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o3-pro-2025-06-10",
+        "input_price_per_million": 20.0,
+        "output_price_per_million": 80.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "0cf607ae-2c3d-4afd-a525-1dff3afea2af",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o4-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.275,
+        "additional_prices": {}
+      },
+      {
+        "id": "823feb64-ba0c-4aac-b0eb-1e16893d1790",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o4-mini-2025-04-16",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.275,
+        "additional_prices": {}
+      },
+      {
+        "id": "92fbc062-5fdb-4b2e-a1ab-9d06a66f88fb",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o4-mini-deep-research",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "5c7e4c01-fd59-4f73-b39d-aaf66331bb6b",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "o4-mini-deep-research-2025-06-26",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "7876068b-8b0d-4a74-82d0-c0a0d2b5963b",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/ada-v2",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "18794f43-846d-4dd0-8c57-e72edb9b38dc",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/azure-openai",
+        "input_price_per_million": 0.02,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "4e2bcafd-4e36-49ed-92be-0f5412156562",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/babbage-002",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "3782b26b-21ff-4eb8-88a7-59b5edc295cf",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/chatgpt-4o-latest",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "5efe04f4-efe7-4b1f-a562-e146250eee4b",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/codex-mini",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 6.0,
+        "input_cached_price_per_million": 0.375,
+        "additional_prices": {}
+      },
+      {
+        "id": "280fa0f7-84db-4eff-a0bd-239db38d8496",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/codex-mini-latest",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 6.0,
+        "input_cached_price_per_million": 0.375,
+        "additional_prices": {}
+      },
+      {
+        "id": "13cb0255-4442-454e-8f14-7febd3cc80ac",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/computer-use-preview",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 12.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "2a84dd60-b745-48cd-9b4a-4a5149159cef",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/davinci-002",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "8e3fb857-6e41-4404-a1d9-389874367a9f",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gemini-2.0-flash",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "eaf76a4b-22dd-451e-bafa-99f6f370cf64",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
+        "provider": "openrouter",
+        "model": "openai/google/gemini-2.5-flash",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "473b8eaf-8fce-493a-8dbd-0fef479cbccf",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-3.5-turbo-0125",
+        "input_price_per_million": 0.5,
+        "output_price_per_million": 1.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "f4762cde-a7c4-47db-92e9-3b5f0d662b71",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-3.5-turbo-0301",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "098d5031-1c2b-423a-aa2c-d17c7557f0ed",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-3.5-turbo-0613",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "a14e6b22-a243-4e2e-9ae3-4a83c372cda1",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-3.5-turbo-1106",
+        "input_price_per_million": 1.0,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "3f4d1dce-6449-40ac-866d-3eccde641d6a",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-3.5-turbo-16k-0613",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 4.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "ed85e176-3abd-4560-8406-3185e5412aa9",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-3.5-turbo-instruct",
+        "input_price_per_million": 1.5,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "a69d2a62-4def-4dcc-9918-812c40375669",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4",
+        "input_price_per_million": 30.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "2382aacb-46bf-4f61-9221-a4e817b92e9c",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4-0125-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "ca74bd89-29fc-4b3d-9458-fff6d34b7a0b",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4-1106-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "a5d7206d-2f80-4c87-af58-caa19f6ee064",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4-32k",
+        "input_price_per_million": 60.0,
+        "output_price_per_million": 120.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "df8adca8-1406-4b3e-9216-edbace6c4fe8",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4-turbo",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "81fe7231-7eb0-4b57-add0-8706375c69f1",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4-turbo-2024-04-09",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "56fa6bad-8b68-4aa0-bb80-1ee2402a832a",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4-vision-preview",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "20a854b8-64b2-44af-80fc-20850cba6ef4",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4.1",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "82a11bfd-1e41-41e0-b398-dc990689c0de",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4.1-2025-04-14",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "4d44cc88-1998-43c3-a7e6-7d41a15a8ac7",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4.1-mini",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.6,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {}
+      },
+      {
+        "id": "36e4ceba-e6f1-414d-a6e4-bf519fb3ea7b",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4.1-mini-2025-04-14",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.6,
+        "input_cached_price_per_million": 0.1,
+        "additional_prices": {}
+      },
+      {
+        "id": "0e7cda51-9865-4b6c-8ef8-041f8da0795c",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4.1-nano",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "2066d476-dbea-4c04-b0ff-8e87a87f166e",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4.1-nano-2025-04-14",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "24f9978f-8de6-4a14-9d23-c96ce1a0f18b",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4.5-preview",
+        "input_price_per_million": 75.0,
+        "output_price_per_million": 150.0,
+        "input_cached_price_per_million": 37.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "10186c2e-bac2-4ef6-b5a2-a0b7d8f8a9cb",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4.5-preview-2025-02-27",
+        "input_price_per_million": 75.0,
+        "output_price_per_million": 150.0,
+        "input_cached_price_per_million": 37.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "ccd2a2f6-de48-44fc-a84c-b8027289574b",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "b43852d8-915b-4a39-b378-d39e7dd5fb59",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-2024-05-13",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "1f1abadd-05bf-4120-85b9-44273ae6c8c8",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-2024-08-06",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "4e804e4a-65c5-44d7-b99d-e451781cd449",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-2024-11-20",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 1.25,
+        "additional_prices": {}
+      },
+      {
+        "id": "0bb9231e-5c30-4ad4-8aec-bdfcd12f8960",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-audio-preview",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "dde04e07-8076-45f7-a7c2-62ae44417599",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-audio-preview-2024-10-01",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "6f086899-d926-4d6c-bd58-a2ce647c18d0",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-audio-preview-2024-12-17",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "b9f612c9-1425-4ae4-a88f-38914755ebe8",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "e7995b3d-d582-4ce6-98de-8c6ec5a7a751",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini-2024-07-18",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "8d28643e-ea74-4af3-8b1d-c66c0362eec1",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini-audio-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9b5c3b46-0902-4369-a7fb-7e1ea14d65a6",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini-audio-preview-2024-12-17",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9eb39e04-0b42-4038-9f8b-03315d285698",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini-realtime-preview",
+        "input_price_per_million": 0.6,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {}
+      },
+      {
+        "id": "a1568ed9-2909-4f02-ba8c-e6d744ac5f4b",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini-realtime-preview-2024-12-17",
+        "input_price_per_million": 0.6,
+        "output_price_per_million": 2.4,
+        "input_cached_price_per_million": 0.3,
+        "additional_prices": {}
+      },
+      {
+        "id": "5e107c8d-53fe-4840-accb-50bfaaee477f",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini-search-preview",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "46d1bbc2-14c5-4db8-b6ca-e397e4947a5a",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini-search-preview-2025-03-11",
+        "input_price_per_million": 0.15,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "518dde30-efac-4fbf-ba0f-85d57f8823d6",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-realtime-preview",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "964b23bc-6d27-4be3-9222-5f7bd1b61e90",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-realtime-preview-2024-10-01",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {
+          "audio_input_price_per_million": 100,
+          "audio_output_price_per_million": 200
+        }
+      },
+      {
+        "id": "1989967c-dd0d-4edc-ad4b-7091baca3254",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-realtime-preview-2024-12-17",
+        "input_price_per_million": 5.0,
+        "output_price_per_million": 20.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "b1a0c0c8-1527-4b69-af57-d6479a3bf65f",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-search-preview",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "d8390cd9-e9cd-4077-8b6d-28c6db934031",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-search-preview-2025-03-11",
+        "input_price_per_million": 2.5,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "f3d8535b-46c1-4f29-afe9-792d84582323",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "ad991eab-cc1c-450c-9026-786c145a8b92",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5-2025-08-07",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "eb0bbf0a-1468-4243-802c-74cf78058445",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "0959c902-6c2c-4511-a7b6-b2666505aed4",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5-mini",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "91e97982-a92a-4632-bf00-31aa0e5d578e",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5-mini-2025-08-07",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "e6fbef12-2653-4d8a-92ce-cc5a17c05c77",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5-nano",
+        "input_price_per_million": 0.05,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.005,
+        "additional_prices": {}
+      },
+      {
+        "id": "3a693f7c-78dc-4916-8fcd-b68797887039",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5-nano-2025-08-07",
+        "input_price_per_million": 0.05,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.005,
+        "additional_prices": {}
+      },
+      {
+        "id": "1d9ddff7-d048-413f-9bbf-22bfa4bc0272",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5-pro",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 120.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "36d24b0b-def1-4110-9d63-e451da545e0a",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5.1-2025-11-13",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "cc5c146b-510e-4ece-924a-b7acc18bbfd8",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5.1-codex",
+        "input_price_per_million": 1.25,
+        "output_price_per_million": 10.0,
+        "input_cached_price_per_million": 0.125,
+        "additional_prices": {}
+      },
+      {
+        "id": "46e0e198-05b1-4e8a-b47d-a6481bd3cf61",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/gpt-5.1-codex-mini",
+        "input_price_per_million": 0.25,
+        "output_price_per_million": 2.0,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "cddc0330-946d-4ab4-a9cf-0db5c2bf1ff3",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/grok-3-mini",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 0.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "f41f0e75-d927-4ba2-8998-196578e52f46",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/meta-llama/llama-4-maverick-17b-128e-instruct",
+        "input_price_per_million": 0.2,
+        "output_price_per_million": 0.6,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "9e96fe1f-6a6b-4b12-a126-d52e8780a64f",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o1",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "f992afaa-a490-4af2-b368-7acc5718ff78",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o1-2024-12-17",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "94559b53-834d-41de-aed9-96a18b590d4c",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o1-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "09a0892e-f181-4e30-acd2-04d0ec89807f",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o1-mini-2024-09-12",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "9caaf6d9-dc87-42e7-8244-3124db6e2b8a",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o1-preview",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "50f5f1ae-fab2-4d82-aa19-add565f49f37",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o1-preview-2024-09-12",
+        "input_price_per_million": 15.0,
+        "output_price_per_million": 60.0,
+        "input_cached_price_per_million": 7.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "b675dcac-a94a-4c81-9d57-83d9bf9ea933",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o1-pro",
+        "input_price_per_million": 150.0,
+        "output_price_per_million": 600.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "ec2d3283-d877-4c8c-bc26-b0feee5d2e39",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o1-pro-2025-03-19",
+        "input_price_per_million": 150.0,
+        "output_price_per_million": 600.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "14354a57-b6df-452b-9dc9-ef55e36ee945",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o3",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "66ae2d06-3293-499e-b17b-3dcdd65767fe",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o3-2025-04-16",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "fdc92c1d-6b1f-420b-8415-d2cc0f8b4a63",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o3-deep-research",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 40.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "e566f4aa-010d-4a4b-9084-37b2abf4aea5",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o3-deep-research-2025-06-26",
+        "input_price_per_million": 10.0,
+        "output_price_per_million": 40.0,
+        "input_cached_price_per_million": 2.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "761c554d-333f-49c0-b251-a2cdbd0a8c39",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o3-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "5c31eeeb-6c9f-45c9-b245-1f234bbf16ef",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o3-mini-2025-01-31",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.55,
+        "additional_prices": {}
+      },
+      {
+        "id": "efa3b0ad-6377-4ae6-8e15-42344de842c6",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o3-pro",
+        "input_price_per_million": 20.0,
+        "output_price_per_million": 80.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "0b786561-a399-4bc0-a049-75a966078cf9",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o3-pro-2025-06-10",
+        "input_price_per_million": 20.0,
+        "output_price_per_million": 80.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "b0194e04-0c2e-474d-9e15-9c16cd981712",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o4-mini",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.275,
+        "additional_prices": {}
+      },
+      {
+        "id": "7cc3e4b2-9c2d-46b9-a66a-b98ad9c9726d",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o4-mini-2025-04-16",
+        "input_price_per_million": 1.1,
+        "output_price_per_million": 4.4,
+        "input_cached_price_per_million": 0.275,
+        "additional_prices": {}
+      },
+      {
+        "id": "928ebf97-2a49-4629-9067-db56229e22b0",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o4-mini-deep-research",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "5d1961c1-5776-4c78-930b-3aac71cd63ca",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/o4-mini-deep-research-2025-06-26",
+        "input_price_per_million": 2.0,
+        "output_price_per_million": 8.0,
+        "input_cached_price_per_million": 0.5,
+        "additional_prices": {}
+      },
+      {
+        "id": "f1f7c698-a1ee-4e0d-ad69-30a05c2607b4",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/text-embedding-3-large",
+        "input_price_per_million": 0.13,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "1534e23c-e847-4e1e-a0d7-12cf231ff38c",
+        "created_at": "2025-11-19 12:59:30.52772+00",
+        "updated_at": "2025-11-19 12:59:30.52772+00",
+        "provider": "openrouter",
+        "model": "openai/text-embedding-3-small",
+        "input_price_per_million": 0.02,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "d1ea06ec-ee8d-4bc8-b451-fe4ec7df0c47",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "text-embedding-3-large",
+        "input_price_per_million": 0.13,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "7837edf7-0a33-45c0-8c72-9a09b49fd8e3",
+        "created_at": "2025-11-19 14:51:23.821473+00",
+        "updated_at": "2025-11-19 14:51:23.821473+00",
+        "provider": "openrouter",
+        "model": "text-embedding-3-small",
+        "input_price_per_million": 0.02,
+        "output_price_per_million": 0.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "c3671ed7-5702-4a20-8da4-d972c8c2e5ab",
+        "created_at": "2025-11-20 14:57:33.138177+00",
+        "updated_at": "2025-11-20 14:57:33.138177+00",
+        "provider": "openrouter",
+        "model": "x-ai/grok-3",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "f9033b97-f4b5-44e9-91a5-d4a68070b2e9",
+        "created_at": "2025-11-20 14:57:06.614462+00",
+        "updated_at": "2025-11-20 14:57:06.614462+00",
+        "provider": "openrouter",
+        "model": "x-ai/grok-3-mini",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 0.5,
+        "input_cached_price_per_million": null,
+        "additional_prices": {}
+      },
+      {
+        "id": "7ec6f45e-3f34-4625-b2c4-07949ec5a8a8",
+        "created_at": "2025-11-20 14:56:05.728746+00",
+        "updated_at": "2025-11-20 14:56:05.728746+00",
+        "provider": "openrouter",
+        "model": "x-ai/grok-4",
+        "input_price_per_million": 3.0,
+        "output_price_per_million": 15.0,
+        "input_cached_price_per_million": 0.75,
+        "additional_prices": {}
+      },
+      {
+        "id": "2c8806dd-7db5-4d31-b7d9-ad8cf41f0142",
+        "created_at": "2025-11-20 14:56:25.640102+00",
+        "updated_at": "2025-11-20 14:56:25.640102+00",
+        "provider": "openrouter",
+        "model": "x-ai/grok-4--long-context",
+        "input_price_per_million": 6.0,
+        "output_price_per_million": 30.0,
+        "input_cached_price_per_million": 0.75,
+        "additional_prices": {}
+      },
+      {
+        "id": "216e8fe7-16fb-4c38-89ac-163b84c77e36",
+        "created_at": "2025-11-19 13:34:36.584268+00",
+        "updated_at": "2025-11-19 13:34:36.584268+00",
+        "provider": "openrouter",
+        "model": "x-ai/grok-4-fast",
+        "input_price_per_million": 0.2,
+        "output_price_per_million": 0.5,
+        "input_cached_price_per_million": 0.05,
+        "additional_prices": {}
+      },
+      {
+        "id": "49e6a268-9cbb-4a02-b2e9-1445c992b003",
+        "created_at": "2025-11-19 13:35:04.996844+00",
+        "updated_at": "2025-11-19 13:35:04.996844+00",
+        "provider": "openrouter",
+        "model": "x-ai/grok-4-fast--long-context",
+        "input_price_per_million": 0.4,
+        "output_price_per_million": 1.0,
+        "input_cached_price_per_million": 0.05,
+        "additional_prices": {}
+      },
+      {
+        "id": "964c44e1-63f4-43d0-b8c9-47f84d6dbb95",
+        "created_at": "2025-11-20 14:53:20.047085+00",
+        "updated_at": "2025-11-20 14:53:20.047085+00",
+        "provider": "openrouter",
+        "model": "x-ai/grok-4.1-fast",
+        "input_price_per_million": 0.2,
+        "output_price_per_million": 0.5,
+        "input_cached_price_per_million": 0.05,
+        "additional_prices": {}
+      },
+      {
+        "id": "9a4f9f11-0af8-45a1-af47-c76a9b586ce1",
+        "created_at": "2025-11-20 14:55:26.575653+00",
+        "updated_at": "2025-11-20 14:55:26.575653+00",
+        "provider": "openrouter",
+        "model": "x-ai/grok-code-fast-1",
+        "input_price_per_million": 0.2,
+        "output_price_per_million": 1.5,
+        "input_cached_price_per_million": 0.02,
         "additional_prices": {}
       },
       {
         "id": "e78c2ed5-a867-480c-8223-911808bd5d3b",
         "created_at": "2025-07-28 22:08:58.641153+00",
-        "updated_at": "2025-07-28 22:08:58.641153+00",
+        "updated_at": "2025-11-19 14:57:28.10403+00",
         "provider": "vertex_ai",
         "model": "gemini-2.5-flash",
         "input_price_per_million": 0.5,
         "output_price_per_million": 2.0,
-        "input_cached_price_per_million": null,
+        "input_cached_price_per_million": 0.03,
+        "additional_prices": {}
+      },
+      {
+        "id": "205d7780-d837-4605-92f0-c1987cca19a2",
+        "created_at": "2025-09-19 10:55:59.228802+00",
+        "updated_at": "2025-09-19 10:55:59.228802+00",
+        "provider": "vertex_ai",
+        "model": "gemini-2.5-flash-lite",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "ed16279e-5d3f-49b7-841a-f8a7e7465dca",
+        "created_at": "2025-10-13 12:39:16.024877+00",
+        "updated_at": "2025-10-13 12:39:16.024877+00",
+        "provider": "vertex_ai",
+        "model": "gemini-2.5-flash-lite-preview-09-2025",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       },
       {
@@ -5615,6 +13500,50 @@
         "input_price_per_million": 1.25,
         "output_price_per_million": 10.0,
         "input_cached_price_per_million": 0.31,
+        "additional_prices": {}
+      },
+      {
+        "id": "59458d14-f1ab-4a43-bd09-c1183881d816",
+        "created_at": "2025-11-19 13:20:40.718622+00",
+        "updated_at": "2025-11-19 13:20:40.718622+00",
+        "provider": "vertex_ai",
+        "model": "gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "4df08eab-7794-4882-99fe-e20c3e7637cc",
+        "created_at": "2025-11-19 13:22:04.710121+00",
+        "updated_at": "2025-11-19 13:22:04.710121+00",
+        "provider": "vertex_ai",
+        "model": "gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
+        "additional_prices": {}
+      },
+      {
+        "id": "d8afed1b-167f-44fa-9c93-b4a1742e7010",
+        "created_at": "2025-11-19 13:20:43.31383+00",
+        "updated_at": "2025-11-19 13:20:43.31383+00",
+        "provider": "vertex_ai",
+        "model": "models/gemini-flash-latest",
+        "input_price_per_million": 0.3,
+        "output_price_per_million": 2.5,
+        "input_cached_price_per_million": 0.075,
+        "additional_prices": {}
+      },
+      {
+        "id": "c5b78b51-68ce-487d-9030-16a36f73d97e",
+        "created_at": "2025-11-19 13:22:11.611324+00",
+        "updated_at": "2025-11-19 13:22:11.611324+00",
+        "provider": "vertex_ai",
+        "model": "models/gemini-flash-lite-latest",
+        "input_price_per_million": 0.1,
+        "output_price_per_million": 0.4,
+        "input_cached_price_per_million": 0.025,
         "additional_prices": {}
       }
     ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Massive refresh of `frontend/lib/db/initial-data.json` adding 2025-11 models and updated pricing across Anthropic, OpenAI, Google/Gemini, X‑AI Grok, and more, with extensive Gateway/OpenRouter mappings and cache pricing fields.
> 
> - **Data seed update (`frontend/lib/db/initial-data.json`)**:
>   - **Anthropic**: Add/normalize Claude families including `claude-sonnet-4(-5)`, `claude-haiku-4-5` (and dated/long‑context variants) across `anthropic`, `gateway`, and `openrouter`; include cache write pricing.
>   - **OpenAI**: Bulk additions via `gateway` and `openrouter` for `gpt-4.x`, `gpt-4o*` (audio/realtime/search), `gpt-5*` (mini/nano/pro/codex), `o1/o3/o4` (and dated/deep‑research variants), `text-embedding-3-*`, legacy (`ada/babbage/davinci`) and tooling models; populate pricing and cached prices.
>   - **Google/Gemini**: Large catalog expansion across `gemini`, `google`, `google_genai`, `vertex_ai`, `gateway`, and `openrouter` for `gemini-1.x/2.x/2.5/3-pro` (flash/lite/pro, long‑context, previews); adjust many `input_cached_price_per_million` and add “output_thinking”/cache fields where applicable.
>   - **X‑AI Grok**: Add `grok-3`, `grok-3-mini`, `grok-4` (incl. long‑context/fast variants) with pricing.
>   - **Other providers**: Introduce/expand `deepseek-*`, `meta-llama/*`, `mistral/*`, `groq/*`, `moonshotai/*`, `qwen/*` entries via `gateway`/`openrouter` with prices.
>   - **Pricing/metadata tweaks**: Standardize cache pricing keys (`input_cache_write_price_per_million`), set/adjust `input_cached_price_per_million` for numerous models, and update IDs/timestamps for the 2025‑11 catalog snapshot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ce072f63b4d54dbc6d90deaaa2ca77e8f689c04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->