### PR TITLE
Bug fix in realtime

### DIFF
--- a/app-server/src/traces/consumer.rs
+++ b/app-server/src/traces/consumer.rs
@@ -379,12 +379,12 @@ async fn process_batch(
         return;
     }
 
+    // Send realtime span updates directly to SSE connections after successful ClickHouse writes
+    send_span_updates(&spans, &sse_connections).await;
+
     // Check for spans matching trigger conditions and push to trace summary queue
     check_and_push_trace_summaries(project_id, &spans, db.clone(), cache.clone(), queue.clone())
         .await;
-
-    // Send realtime span updates directly to SSE connections after successful ClickHouse writes
-    send_span_updates(&spans, &sse_connections).await;
 
     // Both `spans` and `span_and_metadata_vec` are consumed when building `stripped_spans`
     let stripped_spans = spans

--- a/frontend/app/api/projects/[projectId]/realtime/route.ts
+++ b/frontend/app/api/projects/[projectId]/realtime/route.ts
@@ -88,6 +88,7 @@ export async function GET(
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
         "Connection": "keep-alive",
+        "X-Accel-Buffering": "no",
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Headers": "Cache-Control",
       },

--- a/frontend/components/traces/traces-table/index.tsx
+++ b/frontend/components/traces/traces-table/index.tsx
@@ -204,6 +204,10 @@ function TracesTableContent() {
             newTraces.splice(FETCH_SIZE);
           }
 
+          if (traceData.startTime) {
+            incrementStat(traceData.startTime, traceData.status === "error");
+          }
+
           return newTraces;
         }
       });
@@ -236,9 +240,6 @@ function TracesTableContent() {
           // Process batched trace updates
           for (const trace of payload.traces) {
             updateRealtimeTrace(trace);
-            if (trace.startTime) {
-              incrementStat(trace.startTime, trace.status === "error");
-            }
           }
         }
       } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prioritizes SSE messages over heartbeats with a 30s interval, adds X-Accel-Buffering headers, improves connection cleanup/logging, reorders span update timing, and streamlines frontend trace stats updates.
> 
> - **Realtime (backend)**:
>   - Set SSE heartbeat to `30s` using `tokio::time` and prioritize messages over heartbeat in `poll_next`.
>   - Add `"X-Accel-Buffering": "no"` header to SSE responses.
>   - Improve `send_to_key` by logging send failures, cleaning closed connections with info logs, and logging when no connections exist.
> - **Traces consumer**:
>   - Send `send_span_updates` immediately after successful ClickHouse writes (before trigger summary checks).
> - **Frontend**:
>   - API SSE route adds `"X-Accel-Buffering": "no"` header.
>   - Traces table updates stats only when inserting new traces; removes duplicate increment during SSE processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c60b5d58ee348c2a3334dc1d9bb6aba4752d5f29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->