### PR TITLE
async stream for real time

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -41,7 +41,7 @@ use traces::{
 
 use cache::{Cache, in_memory::InMemoryCache, redis::RedisCache};
 use evaluators::{EVALUATORS_EXCHANGE, EVALUATORS_QUEUE, process_evaluators};
-use realtime::{SseConnectionMap, cleanup_closed_connections};
+use realtime::SseConnectionMap;
 use sodiumoxide;
 use std::{
     borrow::Cow,
@@ -437,8 +437,6 @@ fn main() -> anyhow::Result<()> {
 
     // ==== 3.5 SSE connections map ====
     let sse_connections: SseConnectionMap = Arc::new(dashmap::DashMap::new());
-
-    runtime_handle.spawn(cleanup_closed_connections(sse_connections.clone()));
 
     // ==== Slack client ====
     let slack_client = Arc::new(reqwest::Client::new());

--- a/app-server/src/realtime/mod.rs
+++ b/app-server/src/realtime/mod.rs
@@ -1,13 +1,9 @@
 use actix_web::{HttpResponse, Result as ActixResult, web::Bytes};
+use async_stream::stream;
 use dashmap::DashMap;
 use futures_util::stream::Stream;
 use serde::{Deserialize, Serialize};
-use std::{
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-    time::Duration,
-};
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -35,103 +31,17 @@ pub struct SseMessage {
     pub data: serde_json::Value,
 }
 
-pub struct SseStream {
-    receiver: SseReceiver,
-    heartbeat_interval: tokio::time::Interval,
-    project_id: Uuid,
-    connection_id: Uuid,
-    subscription_key: SubscriptionKey,
-    connections: SseConnectionMap,
-}
-
-impl SseStream {
-    pub fn new(
-        receiver: SseReceiver,
-        project_id: Uuid,
-        connection_id: Uuid,
-        subscription_key: SubscriptionKey,
-        connections: SseConnectionMap,
-    ) -> Self {
-        // Set heartbeat to 30 seconds - well within AWS ALB's 60s default idle timeout
-        let mut heartbeat_interval = tokio::time::interval(Duration::from_secs(30));
-        heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-        Self {
-            receiver,
-            heartbeat_interval,
-            project_id,
-            connection_id,
-            subscription_key,
-            connections,
-        }
-    }
-}
-
-impl Stream for SseStream {
-    type Item = Result<Bytes, actix_web::Error>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // ALWAYS check for messages first - they take priority over heartbeat
-        // This ensures span updates are never delayed by heartbeat timing
-        match self.receiver.poll_recv(cx) {
-            Poll::Ready(Some(message)) => {
-                let json_data = serde_json::to_string(&message.data).unwrap_or_default();
-                let sse_data = format!("event: {}\ndata: {}\n\n", message.event_type, json_data);
-                Poll::Ready(Some(Ok(Bytes::from(sse_data))))
-            }
-            Poll::Ready(None) => {
-                log::info!("SSE receiver closed for project: {}", self.project_id);
-                Poll::Ready(None)
-            }
-            Poll::Pending => {
-                // No messages available, check if heartbeat is due
-                // This keeps ALB connection alive during idle periods
-                if self.heartbeat_interval.poll_tick(cx).is_ready() {
-                    let heartbeat = Bytes::from(": heartbeat\n\n");
-                    return Poll::Ready(Some(Ok(heartbeat)));
-                }
-
-                // No messages and heartbeat not ready - stay pending
-                Poll::Pending
-            }
-        }
-    }
-}
-
-impl Drop for SseStream {
-    fn drop(&mut self) {
-        log::info!(
-            "SSE stream dropped for project: {} key: {} (connection: {})",
-            self.project_id,
-            self.subscription_key,
-            self.connection_id
-        );
-
-        // Remove this specific connection from the connections map
-        let key = (self.project_id, self.subscription_key.clone());
-
-        if let Some(mut connections) = self.connections.get_mut(&key) {
-            connections.retain(|conn| conn.id != self.connection_id);
-
-            let remaining = connections.len();
-
-            if remaining == 0 {
-                drop(connections);
-                self.connections.remove(&key);
-                log::info!(
-                    "Removed empty SSE connection entry for project {} key {}",
-                    self.project_id,
-                    self.subscription_key
-                );
-            } else {
-                log::info!(
-                    "Removed connection {} for project {} key {}, {} connections remaining",
-                    self.connection_id,
-                    self.project_id,
-                    self.subscription_key,
-                    remaining
-                );
-            }
+/// Create SSE response stream - simply forwards messages from the receiver
+/// Stream ends when the browser closes the connection (HTTP connection drops)
+fn create_sse_stream(
+    mut receiver: SseReceiver,
+) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
+    stream! {
+        // Simply forward messages as they arrive
+        while let Some(message) = receiver.recv().await {
+            let json_data = serde_json::to_string(&message.data).unwrap_or_default();
+            let sse_data = format!("event: {}\ndata: {}\n\n", message.event_type, json_data);
+            yield Ok(Bytes::from(sse_data));
         }
     }
 }
@@ -148,13 +58,13 @@ pub fn create_sse_response(
     // Add connection to the global map
     let connection = SseConnection {
         id: connection_id,
-        sender,
+        sender: sender.clone(),
     };
 
     let key = (project_id, subscription_key.clone());
 
     connections
-        .entry(key)
+        .entry(key.clone())
         .or_insert_with(Vec::new)
         .push(connection);
 
@@ -165,13 +75,61 @@ pub fn create_sse_response(
         connection_id,
     );
 
-    let stream = SseStream::new(
-        receiver,
-        project_id,
-        connection_id,
-        subscription_key,
-        connections.clone(),
-    );
+    // Spawn per-connection heartbeat task
+    // This task will detect when the browser closes the connection and clean up
+    let connections_clone = connections.clone();
+    let subscription_key_clone = subscription_key.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
+
+            let heartbeat = SseMessage {
+                event_type: "heartbeat".to_string(),
+                data: serde_json::json!({}),
+            };
+
+            // Try to send heartbeat - if it fails, connection is dead
+            if sender.send(heartbeat).is_err() {
+                log::info!(
+                    "Heartbeat failed for connection {} (browser closed), cleaning up",
+                    connection_id
+                );
+
+                // Remove this connection from the map
+                let key = (project_id, subscription_key_clone.clone());
+                if let Some(mut conns) = connections_clone.get_mut(&key) {
+                    conns.retain(|conn| conn.id != connection_id);
+                    let remaining = conns.len();
+
+                    if remaining == 0 {
+                        drop(conns);
+                        connections_clone.remove(&key);
+                        log::info!(
+                            "Removed empty SSE connection entry for project {} key {}",
+                            project_id,
+                            subscription_key_clone
+                        );
+                    } else {
+                        log::info!(
+                            "Removed connection {} for project {} key {}, {} remaining",
+                            connection_id,
+                            project_id,
+                            subscription_key_clone,
+                            remaining
+                        );
+                    }
+                }
+
+                // Exit the heartbeat task
+                break;
+            }
+        }
+    });
+
+    let stream = create_sse_stream(receiver);
 
     Ok(HttpResponse::Ok()
         .insert_header(("Content-Type", "text/event-stream"))
@@ -199,8 +157,8 @@ pub fn send_to_key(
         conns.retain(|conn| match conn.sender.send(message.clone()) {
             Ok(_) => true,
             Err(e) => {
-                log::warn!(
-                    "Failed to send SSE message to connection {}: {:?}",
+                log::info!(
+                    "Removing dead SSE connection {} (send failed: {:?})",
                     conn.id,
                     e
                 );
@@ -235,54 +193,5 @@ pub fn send_to_key(
             subscription_key,
             message.event_type
         );
-    }
-}
-
-/// Periodically clean up closed SSE connections
-pub async fn cleanup_closed_connections(connections: SseConnectionMap) {
-    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60 * 60)); // Clean up every hour
-
-    loop {
-        interval.tick().await;
-
-        // First collect all keys
-        let all_keys: Vec<_> = connections
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect();
-
-        let mut keys_to_remove = Vec::new();
-
-        // Check each connection
-        for key in all_keys {
-            if let Some(mut conns) = connections.get_mut(&key) {
-                let (project_id, subscription_key) = &key;
-                let initial_count = conns.len();
-
-                // Test each connection by checking if sender is closed
-                conns.retain(|conn| !conn.sender.is_closed());
-
-                let final_count = conns.len();
-                let cleaned = initial_count - final_count;
-
-                if cleaned > 0 {
-                    log::info!(
-                        "Periodic cleanup: removed {} closed connections for project {} key {}",
-                        cleaned,
-                        project_id,
-                        subscription_key
-                    );
-                }
-
-                if conns.is_empty() {
-                    keys_to_remove.push(key.clone());
-                }
-            }
-        }
-
-        // Remove empty entries
-        for key in keys_to_remove {
-            connections.remove(&key);
-        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch SSE to an async stream that forwards messages and add per-connection heartbeats for cleanup; remove periodic cleanup and its spawn.
> 
> - **Realtime**:
>   - Replace `SseStream` with `async_stream`-based `create_sse_stream` that directly forwards `SseMessage`s.
>   - Add per-connection heartbeat task (5s) that detects closed browser connections and cleans up `SseConnectionMap` entries.
>   - Remove hourly `cleanup_closed_connections` task and related code.
>   - Tweak logging during send failures to actively remove dead connections and report cleaned counts.
> - **Server (main.rs)**:
>   - Stop importing/starting `cleanup_closed_connections`; keep only `SseConnectionMap` initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d05d573e11d83750c212f0403a461923331eb2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor SSE handling by replacing `SseStream` with `async_stream` and improving connection management in `mod.rs`.
> 
>   - **Behavior**:
>     - Replaces `SseStream` struct with `create_sse_stream()` function using `async_stream` in `mod.rs`.
>     - Removes `cleanup_closed_connections()` task from `main.rs`.
>     - Heartbeat management moved to per-connection task in `create_sse_response()`.
>   - **Functions**:
>     - `create_sse_stream()` now handles message forwarding using `async_stream`.
>     - `create_sse_response()` spawns a heartbeat task to manage connection cleanup.
>   - **Misc**:
>     - Removes `cleanup_closed_connections()` from `main.rs` and `mod.rs`.
>     - Logging improvements for connection management in `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 3d05d573e11d83750c212f0403a461923331eb2f. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->