### PR TITLE
fix realtime, remove trace dep

### DIFF
--- a/frontend/components/traces/trace-view/index.tsx
+++ b/frontend/components/traces/trace-view/index.tsx
@@ -206,10 +206,6 @@ const PureTraceView = ({ traceId, spanId, onClose, propsTrace }: TraceViewProps)
   const fetchSpans = useCallback(
     async (search: string, filters: Filter[]) => {
       try {
-        if (!trace) {
-          return;
-        }
-
         setIsSpansLoading(true);
         setSpansError(undefined);
 
@@ -368,7 +364,6 @@ const PureTraceView = ({ traceId, spanId, onClose, propsTrace }: TraceViewProps)
   }, []);
 
   useEffect(() => {
-    if (!trace) return;
 
     fetchSpans(search, filters);
 
@@ -377,7 +372,7 @@ const PureTraceView = ({ traceId, spanId, onClose, propsTrace }: TraceViewProps)
       setTraceError(undefined);
       setSpansError(undefined);
     };
-  }, [traceId, projectId, filters, trace, setSpans, setTraceError, setSpansError]);
+  }, [traceId, projectId, filters, setSpans, setTraceError, setSpansError]);
 
   useRealtime({
     key: `trace_${traceId}`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `trace` checks and dependency so spans are always fetched and real-time updates work reliably.
> 
> - **Frontend (trace view)**:
>   - `frontend/components/traces/trace-view/index.tsx`:
>     - `fetchSpans`: removed early `trace` guard; spans now fetched regardless of `trace` presence (still applies date filters when `trace` exists).
>     - `useEffect` (spans fetch): removed `if (!trace) return` and dropped `trace` from dependencies; fetch runs based on `traceId`, `projectId`, and `filters` only; keeps cleanup resetting spans/errors.
>     - No UI changes; improves real-time span updates by decoupling from `trace`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 501b614b6897c7341aa8d9b86c60e9a6177a54cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary `trace` checks in `fetchSpans` and `useEffect` in `index.tsx` to simplify logic and improve real-time updates.
> 
>   - **Behavior**:
>     - Removed unnecessary `if (!trace)` checks in `fetchSpans` and `useEffect` in `index.tsx`.
>     - Simplifies logic for fetching spans and handling real-time updates.
>   - **Dependencies**:
>     - Removes dependency on `trace` in `useEffect` dependency array in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 501b614b6897c7341aa8d9b86c60e9a6177a54cb. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->