### PR TITLE
bump clickhouse and moka to remove dependency on thiserror 1

### DIFF
--- a/app-server/Cargo.lock
+++ b/app-server/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
  "sha3",
  "sodiumoxide",
  "sqlx",
- "thiserror 2.0.17",
+ "thiserror",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
@@ -438,7 +438,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror",
  "time",
 ]
 
@@ -1247,6 +1247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,42 +1398,52 @@ dependencies = [
 
 [[package]]
 name = "clickhouse"
-version = "0.13.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9a81a1dffadd762ee662635ce409232258ce9beebd7cc0fa227df0b5e7efc0"
+checksum = "a4916807143285e80eefcaf741a29a98bbd687e4581352631a74ab223e66558b"
 dependencies = [
+ "bnum",
  "bstr",
  "bytes",
  "cityhash-rs",
- "clickhouse-derive",
- "futures",
+ "clickhouse-macros",
+ "clickhouse-types",
  "futures-channel",
+ "futures-util",
  "http-body-util",
  "hyper 1.7.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "lz4_flex",
- "replace_with",
+ "polonius-the-crab",
  "rustls 0.23.31",
- "sealed",
  "serde",
- "static_assertions",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "url",
  "uuid",
 ]
 
 [[package]]
-name = "clickhouse-derive"
-version = "0.2.0"
+name = "clickhouse-macros"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70f3e2893f7d3e017eeacdc9a708fbc29a10488e3ebca21f9df6a5d2b616dbb"
+checksum = "ff6669899e23cb87b43daf7996f0ea3b9c07d0fb933d745bb7b815b052515ae3"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "clickhouse-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "358fbfd439fb0bed02a3e2ecc5131f6a9d039ba5639aed650cf0e845f6ebfc16"
+dependencies = [
+ "bytes",
+ "thiserror",
 ]
 
 [[package]]
@@ -2138,21 +2154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,7 +2250,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2259,20 +2259,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generator"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows",
 ]
 
 [[package]]
@@ -2412,6 +2398,17 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "higher-kinded-types"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e690f8474c6c5d8ff99656fcbc195a215acc3949481a8b0b3351c838972dc776"
+dependencies = [
+ "macro_rules_attribute",
+ "never-say-never",
+ "paste",
+]
 
 [[package]]
 name = "hkdf"
@@ -3055,19 +3052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,6 +3065,22 @@ name = "lz4_flex"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "matchers"
@@ -3148,23 +3148,22 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.10"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+checksum = "8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "equivalent",
  "event-listener",
  "futures-util",
- "loom",
  "parking_lot",
  "portable-atomic",
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -3190,6 +3189,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
 name = "nom"
@@ -3370,7 +3375,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror",
  "tracing",
 ]
 
@@ -3388,7 +3393,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
  "tracing",
 ]
 
@@ -3429,7 +3434,7 @@ dependencies = [
  "rc2",
  "sha1",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror",
  "x509-parser",
 ]
 
@@ -3478,6 +3483,12 @@ name = "parse-size"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -3649,6 +3660,16 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.0.8",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "polonius-the-crab"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec242d7eccbb2fd8b3b5b6e3cf89f94a91a800f469005b44d154359609f8af72"
+dependencies = [
+ "higher-kinded-types",
+ "never-say-never",
 ]
 
 [[package]]
@@ -3977,12 +3998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "replace_with"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
-
-[[package]]
 name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4260,12 +4275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4290,17 +4299,6 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "sealed"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -4486,7 +4484,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
  "time",
  "url",
  "uuid",
@@ -4768,7 +4766,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4854,7 +4852,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror",
  "tracing",
  "uuid",
  "whoami",
@@ -4895,7 +4893,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror",
  "tracing",
  "uuid",
  "whoami",
@@ -4921,7 +4919,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.17",
+ "thiserror",
  "tracing",
  "url",
  "uuid",
@@ -4932,12 +4930,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -5060,31 +5052,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.17",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -5853,28 +5825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5885,17 +5835,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -5925,16 +5864,6 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link",
-]
 
 [[package]]
 name = "windows-registry"
@@ -6047,15 +5976,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -6232,7 +6152,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror",
  "time",
 ]
 

--- a/app-server/Cargo.toml
+++ b/app-server/Cargo.toml
@@ -17,7 +17,7 @@ backoff = {version = "0.4.0", features = ["tokio"]}
 base64 = "0.22.1"
 bytes = "1.10.1"
 chrono = {version = "0.4.41", features = ["serde"]}
-clickhouse = {version = "0.13.3", features = ["rustls-tls", "uuid"]}
+clickhouse = {version = "0.14.1", features = ["rustls-tls", "uuid"]}
 dashmap = "6.1.0"
 deadpool = "0.12.2"
 dotenv = "0.15"
@@ -28,7 +28,7 @@ indexmap = {version = "2.11.4", features = ["serde"]}
 itertools = "0.14.0"
 lapin = "3.7"
 log = "0.4.28"
-moka = {version = "0.12.10", features = ["sync", "future"]}
+moka = {version = "0.12.11", features = ["sync", "future"]}
 num_cpus = "1.16.0"
 opentelemetry = {version = "0.29.1", features = ["trace"]}
 opentelemetry_sdk = {version = "0.29.0", features = ["trace"]}

--- a/app-server/src/ch/browser_events.rs
+++ b/app-server/src/ch/browser_events.rs
@@ -28,7 +28,8 @@ pub async fn insert_browser_events(
     event_batch: &EventBatch,
 ) -> Result<usize, clickhouse::error::Error> {
     let mut insert = clickhouse
-        .insert("browser_session_events")
+        .insert::<BrowserEventCHRow>("browser_session_events")
+        .await
         .map_err(|e| {
             // From external POV this should be a permanent error,
             // but looking at the code it seems like `insert` always returns `Ok`,

--- a/app-server/src/ch/datapoints.rs
+++ b/app-server/src/ch/datapoints.rs
@@ -76,7 +76,7 @@ pub async fn insert_datapoints(
         return Ok(());
     }
 
-    let ch_insert = clickhouse.insert("dataset_datapoints");
+    let ch_insert = clickhouse.insert::<CHDatapoint>("dataset_datapoints").await;
     match ch_insert {
         Ok(mut ch_insert) => {
             for datapoint in datapoints {

--- a/app-server/src/ch/evaluation_datapoint_outputs.rs
+++ b/app-server/src/ch/evaluation_datapoint_outputs.rs
@@ -66,7 +66,9 @@ pub async fn insert_evaluation_datapoint_outputs(
         return Ok(());
     }
 
-    let ch_insert = clickhouse.insert("evaluation_datapoint_executor_outputs");
+    let ch_insert = clickhouse
+        .insert::<CHEvaluationDatapointOutput>("evaluation_datapoint_executor_outputs")
+        .await;
     match ch_insert {
         Ok(mut ch_insert) => {
             for datapoint in evaluation_datapoint_outputs {

--- a/app-server/src/ch/evaluation_datapoints.rs
+++ b/app-server/src/ch/evaluation_datapoints.rs
@@ -133,7 +133,9 @@ pub async fn insert_evaluation_datapoints(
     .await?;
 
     // For new datapoints, we need to insert them
-    let ch_insert = clickhouse.insert("evaluation_datapoints");
+    let ch_insert = clickhouse
+        .insert::<CHEvaluationDatapoint>("evaluation_datapoints")
+        .await;
     match ch_insert {
         Ok(mut ch_insert) => {
             for result in new_datapoints {

--- a/app-server/src/ch/evaluation_scores.rs
+++ b/app-server/src/ch/evaluation_scores.rs
@@ -83,7 +83,9 @@ pub async fn insert_evaluation_scores(
         return Ok(());
     }
 
-    let ch_insert = clickhouse.insert("evaluation_scores");
+    let ch_insert = clickhouse
+        .insert::<EvaluationScore>("evaluation_scores")
+        .await;
     match ch_insert {
         Ok(mut ch_insert) => {
             for evaluation_score in evaluation_scores {

--- a/app-server/src/ch/evaluator_scores.rs
+++ b/app-server/src/ch/evaluator_scores.rs
@@ -57,7 +57,9 @@ pub async fn insert_evaluator_score_ch(
     evaluator_id: Option<Uuid>,
     score: f64,
 ) -> Result<()> {
-    let ch_insert = clickhouse.insert("evaluator_scores");
+    let ch_insert = clickhouse
+        .insert::<CHEvaluatorScore>("evaluator_scores")
+        .await;
     match ch_insert {
         Ok(mut ch_insert) => {
             ch_insert

--- a/app-server/src/ch/events.rs
+++ b/app-server/src/ch/events.rs
@@ -62,7 +62,7 @@ pub async fn insert_events(clickhouse: clickhouse::Client, events: Vec<CHEvent>)
         return Ok(0);
     }
 
-    let ch_insert = clickhouse.insert("events");
+    let ch_insert = clickhouse.insert::<CHEvent>("events").await;
     match ch_insert {
         Ok(mut ch_insert) => {
             let mut total_size_bytes = 0;

--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -182,7 +182,7 @@ pub async fn insert_spans_batch(clickhouse: clickhouse::Client, spans: &[CHSpan]
         return Ok(());
     }
 
-    let ch_insert = clickhouse.insert("spans");
+    let ch_insert = clickhouse.insert::<CHSpan>("spans").await;
     match ch_insert {
         Ok(mut ch_insert) => {
             // Write all spans to the batch

--- a/app-server/src/ch/tags.rs
+++ b/app-server/src/ch/tags.rs
@@ -56,7 +56,7 @@ pub async fn insert_tag(
 ) -> Result<Uuid> {
     let id = Uuid::new_v4();
     let tag = CHTag::new(project_id, id, name, source, span_id);
-    let ch_insert = client.insert("tags");
+    let ch_insert = client.insert::<CHTag>("tags").await;
     match ch_insert {
         Ok(mut ch_insert) => {
             ch_insert.write(&tag).await?;
@@ -83,7 +83,7 @@ pub async fn insert_tags_batch(client: clickhouse::Client, tags: &[SpanTag]) -> 
         return Ok(());
     }
 
-    let ch_insert = client.insert("tags");
+    let ch_insert = client.insert::<CHTag>("tags").await;
     match ch_insert {
         Ok(mut ch_insert) => {
             ch_insert = ch_insert.with_option("wait_for_async_insert", "0");

--- a/app-server/src/ch/traces.rs
+++ b/app-server/src/ch/traces.rs
@@ -238,7 +238,7 @@ pub async fn upsert_traces_batch(
         return Ok(());
     }
 
-    let mut insert = client.insert("traces_replacing")?;
+    let mut insert = client.insert::<CHTrace>("traces_replacing").await?;
 
     for trace in traces {
         insert.write(trace).await?;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade ClickHouse and Moka dependencies and migrate all ClickHouse insertions to the new typed, async insert API across CH modules.
> 
> - **Dependencies**:
>   - Update `clickhouse` to `0.14.1` and `moka` to `0.12.11` in `app-server/Cargo.toml`.
>   - Unify `thiserror` dependency (remove explicit v1 pin); refresh `Cargo.lock` with new transitive crates (e.g., `clickhouse-macros`, `clickhouse-types`) and removals tied to the upgrade.
> - **ClickHouse insertion API migration**:
>   - Replace `insert("table")` with typed `insert::<Type>("table").await` and adjust call sites in:
>     - `app-server/src/ch/browser_events.rs`
>     - `app-server/src/ch/datapoints.rs`
>     - `app-server/src/ch/evaluation_datapoint_outputs.rs`
>     - `app-server/src/ch/evaluation_datapoints.rs`
>     - `app-server/src/ch/evaluation_scores.rs`
>     - `app-server/src/ch/evaluator_scores.rs`
>     - `app-server/src/ch/events.rs`
>     - `app-server/src/ch/spans.rs`
>     - `app-server/src/ch/tags.rs`
>     - `app-server/src/ch/traces.rs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb5cef2ec0c6b14bcd28c7a8761d11f9ab3260c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update dependencies and modify Clickhouse insertions to use new API in multiple files.
> 
>   - **Dependencies**:
>     - Update `clickhouse` to `0.14.1` and `moka` to `0.12.11` in `Cargo.toml`.
>     - Remove specific version dependency on `thiserror 1.0.69` in `Cargo.lock`.
>   - **Clickhouse Insertions**:
>     - Update `insert` calls to specify type and use `.await` in `browser_events.rs`, `datapoints.rs`, `evaluation_datapoint_outputs.rs`.
>     - Similar updates in `evaluation_datapoints.rs`, `evaluation_scores.rs`, `evaluator_scores.rs`.
>     - Apply changes to `events.rs`, `spans.rs`, `tags.rs`, `traces.rs` for consistency with new `clickhouse` API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for fb5cef2ec0c6b14bcd28c7a8761d11f9ab3260c1. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->