### PR TITLE
rollout api for retrieving mock span

### DIFF
--- a/app-server/src/api/v1/mod.rs
+++ b/app-server/src/api/v1/mod.rs
@@ -4,6 +4,7 @@ pub mod evals;
 pub mod evaluators;
 pub mod metrics;
 pub mod payloads;
+pub mod rollouts;
 pub mod sql;
 pub mod tag;
 pub mod traces;

--- a/app-server/src/api/v1/rollouts.rs
+++ b/app-server/src/api/v1/rollouts.rs
@@ -2,7 +2,6 @@ use actix_web::{HttpResponse, post, web};
 use clickhouse::Row;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use sqlx::types::Json;
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -14,7 +13,7 @@ use crate::{
 #[derive(Deserialize)]
 pub struct RolloutRequest {
     pub path: String,
-    pub index: i32,
+    pub index: usize,
 }
 
 fn deserialize_json_string<'de, D>(deserializer: D) -> Result<Value, D::Error>
@@ -37,7 +36,7 @@ pub struct RolloutSpan {
 #[derive(Serialize)]
 pub struct RolloutResponse {
     pub span: RolloutSpan,
-    pub path_to_count: Json<HashMap<String, i32>>,
+    pub path_to_count: HashMap<String, u32>,
 }
 
 #[post("rollouts/{session_id}")]
@@ -55,13 +54,15 @@ pub async fn get_rollout(
     // Fetch rollout playground
     let rollout_playground = match get_rollout_playground(&db.pool, &session_id, &project_id).await
     {
-        Ok(rollout_playground) => rollout_playground,
-        Err(e) => {
-            if let Some(sqlx::Error::RowNotFound) = e.downcast_ref::<sqlx::Error>() {
+        Ok(rollout_playgroundopt) => match rollout_playgroundopt {
+            Some(rollout_playground) => rollout_playground,
+            None => {
                 return Err(crate::routes::error::Error::NotFound(
                     "No rollout playground was found for given id".to_string(),
                 ));
             }
+        },
+        Err(e) => {
             return Err(e.into());
         }
     };
@@ -76,7 +77,7 @@ pub async fn get_rollout(
         }
     };
 
-    if body.index > max_mock_index {
+    if body.index > max_mock_index as usize {
         return Err(crate::routes::error::Error::NotFound(
             "Given index is larger than maximum mock index".to_string(),
         ));
@@ -97,16 +98,15 @@ pub async fn get_rollout(
         .await?;
 
     // Return the span at the given index
-    let index = body.index as usize;
-    if spans.len() <= index {
+    if spans.len() <= body.index {
         return Err(crate::routes::error::Error::NotFound(
             "Index not found in rollout playground".to_string(),
         ));
     }
 
     let response = RolloutResponse {
-        span: spans[index].clone(),
-        path_to_count: rollout_playground.path_to_count,
+        span: spans[body.index].clone(),
+        path_to_count: rollout_playground.path_to_count.0,
     };
 
     Ok(HttpResponse::Ok().json(response))

--- a/app-server/src/api/v1/rollouts.rs
+++ b/app-server/src/api/v1/rollouts.rs
@@ -1,0 +1,113 @@
+use actix_web::{HttpResponse, post, web};
+use clickhouse::Row;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+use sqlx::types::Json;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::{
+    db::{DB, project_api_keys::ProjectApiKey, rollout_playgrounds::get_rollout_playground},
+    routes::types::ResponseResult,
+};
+
+#[derive(Deserialize)]
+pub struct RolloutRequest {
+    pub path: String,
+    pub index: i32,
+}
+
+fn deserialize_json_string<'de, D>(deserializer: D) -> Result<Value, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    serde_json::from_str(&s).map_err(serde::de::Error::custom)
+}
+
+#[derive(Row, Serialize, Deserialize, Clone)]
+pub struct RolloutSpan {
+    pub input: String,
+    pub output: String,
+    pub name: String,
+    #[serde(deserialize_with = "deserialize_json_string")]
+    pub attributes: Value,
+}
+
+#[derive(Serialize)]
+pub struct RolloutResponse {
+    pub span: RolloutSpan,
+    pub path_to_count: Json<HashMap<String, i32>>,
+}
+
+#[post("rollouts/{session_id}")]
+pub async fn get_rollout(
+    path: web::Path<String>,
+    body: web::Json<RolloutRequest>,
+    project_api_key: ProjectApiKey,
+    db: web::Data<DB>,
+    clickhouse: web::Data<clickhouse::Client>,
+) -> ResponseResult {
+    let db = db.into_inner();
+    let session_id = Uuid::parse_str(&path.into_inner()).unwrap();
+    let project_id = project_api_key.project_id;
+
+    // Fetch rollout playground
+    let rollout_playground = match get_rollout_playground(&db.pool, &session_id, &project_id).await
+    {
+        Ok(rollout_playground) => rollout_playground,
+        Err(e) => {
+            if let Some(sqlx::Error::RowNotFound) = e.downcast_ref::<sqlx::Error>() {
+                return Err(crate::routes::error::Error::NotFound(
+                    "No rollout playground was found for given id".to_string(),
+                ));
+            }
+            return Err(e.into());
+        }
+    };
+
+    // Find the maximum mock index for the given path
+    let max_mock_index = match rollout_playground.path_to_count.get(&body.path) {
+        Some(path_count) => *path_count,
+        None => {
+            return Err(crate::routes::error::Error::NotFound(
+                "Path not found in rollout playground".to_string(),
+            ));
+        }
+    };
+
+    if body.index > max_mock_index {
+        return Err(crate::routes::error::Error::NotFound(
+            "Given index is larger than maximum mock index".to_string(),
+        ));
+    }
+
+    // Find all spans with given trace_id and path
+    let spans = clickhouse
+        .query(
+            "SELECT input, output, name, attributes
+            FROM spans 
+            WHERE project_id = ? AND trace_id = ? AND path = ?
+            ORDER BY start_time ASC",
+        )
+        .bind(project_id)
+        .bind(rollout_playground.trace_id)
+        .bind(&body.path)
+        .fetch_all::<RolloutSpan>()
+        .await?;
+
+    // Return the span at the given index
+    let index = body.index as usize;
+    if spans.len() <= index {
+        return Err(crate::routes::error::Error::NotFound(
+            "Index not found in rollout playground".to_string(),
+        ));
+    }
+
+    let response = RolloutResponse {
+        span: spans[index].clone(),
+        path_to_count: rollout_playground.path_to_count,
+    };
+
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -63,7 +63,7 @@ impl Into<u8> for TraceType {
     }
 }
 
-#[derive(Row, Serialize, Deserialize, Debug)]
+#[derive(Row, Serialize, Deserialize, Debug, Clone)]
 pub struct CHSpan {
     #[serde(with = "clickhouse::serde::uuid")]
     pub span_id: Uuid,

--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -63,7 +63,7 @@ impl Into<u8> for TraceType {
     }
 }
 
-#[derive(Row, Serialize, Deserialize, Debug, Clone)]
+#[derive(Row, Serialize, Deserialize, Debug)]
 pub struct CHSpan {
     #[serde(with = "clickhouse::serde::uuid")]
     pub span_id: Uuid,

--- a/app-server/src/db/mod.rs
+++ b/app-server/src/db/mod.rs
@@ -12,6 +12,7 @@ pub mod events;
 pub mod prices;
 pub mod project_api_keys;
 pub mod projects;
+pub mod rollout_playgrounds;
 pub mod semantic_event_definitions;
 pub mod semantic_event_trigger_spans;
 pub mod slack_channel_to_events;

--- a/app-server/src/db/rollout_playgrounds.rs
+++ b/app-server/src/db/rollout_playgrounds.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, PgPool, types::Json};
+use uuid::Uuid;
+
+use std::collections::HashMap;
+
+#[derive(Deserialize, Serialize, FromRow, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutPlayground {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub trace_id: Uuid,
+    pub path_to_count: Json<HashMap<String, i32>>,
+    pub cursor_timestamp: DateTime<Utc>,
+}
+
+pub async fn get_rollout_playground(
+    pool: &PgPool,
+    session_id: &Uuid,
+    project_id: &Uuid,
+) -> Result<RolloutPlayground> {
+    let result = sqlx::query_as::<_, RolloutPlayground>(
+        "
+        SELECT
+            rollout_playgrounds.id,
+            rollout_playgrounds.project_id,
+            rollout_playgrounds.trace_id,
+            rollout_playgrounds.path_to_count,
+            rollout_playgrounds.cursor_timestamp
+        FROM
+            rollout_playgrounds
+        WHERE
+            rollout_playgrounds.id = $1
+            and rollout_playgrounds.project_id = $2",
+    )
+    .bind(session_id)
+    .bind(project_id)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(result)
+}

--- a/app-server/src/db/rollout_playgrounds.rs
+++ b/app-server/src/db/rollout_playgrounds.rs
@@ -12,7 +12,7 @@ pub struct RolloutPlayground {
     pub id: Uuid,
     pub project_id: Uuid,
     pub trace_id: Uuid,
-    pub path_to_count: Json<HashMap<String, i32>>,
+    pub path_to_count: Json<HashMap<String, u32>>,
     pub cursor_timestamp: DateTime<Utc>,
 }
 
@@ -20,10 +20,9 @@ pub async fn get_rollout_playground(
     pool: &PgPool,
     session_id: &Uuid,
     project_id: &Uuid,
-) -> Result<RolloutPlayground> {
+) -> Result<Option<RolloutPlayground>> {
     let result = sqlx::query_as::<_, RolloutPlayground>(
-        "
-        SELECT
+        "SELECT
             rollout_playgrounds.id,
             rollout_playgrounds.project_id,
             rollout_playgrounds.trace_id,
@@ -37,7 +36,7 @@ pub async fn get_rollout_playground(
     )
     .bind(session_id)
     .bind(project_id)
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await?;
 
     Ok(result)

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1030,7 +1030,8 @@ fn main() -> anyhow::Result<()> {
                                     .service(api::v1::evals::update_eval_datapoint)
                                     .service(api::v1::evaluators::create_evaluator_score)
                                     .service(api::v1::sql::execute_sql_query)
-                                    .service(api::v1::payloads::get_payload),
+                                    .service(api::v1::payloads::get_payload)
+                                    .service(api::v1::rollouts::get_rollout),
                             )
                             .service(
                                 // auth on path projects/{project_id} is handled by middleware on Next.js

--- a/app-server/src/routes/error.rs
+++ b/app-server/src/routes/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     MultipartError(#[from] actix_multipart::MultipartError),
     #[error("{0}")]
     SqlQueryError(#[from] SqlQueryError),
+    #[error("{0}")]
+    NotFound(String),
 }
 
 impl ResponseError for Error {
@@ -23,6 +25,7 @@ impl ResponseError for Error {
                 SqlQueryError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 SqlQueryError::BadResponseError(_) => StatusCode::BAD_REQUEST,
             },
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds POST /v1/rollouts/{session_id} to fetch a specific span by path and index, backed by new rollout_playgrounds DB access and 404 NotFound handling.
> 
> - **API**:
>   - New endpoint `POST /v1/rollouts/{session_id}` implemented in `api/v1/rollouts.rs::get_rollout` to return a span at a given `path` and `index`.
>     - Queries ClickHouse for `spans` by `project_id`, `trace_id`, and `path`; returns the indexed `RolloutSpan` and `path_to_count`.
>     - Registers route in `main.rs` and module in `api/v1/mod.rs`.
> - **Database**:
>   - Add `db/rollout_playgrounds.rs` with `RolloutPlayground` and `get_rollout_playground(session_id, project_id)`; module wired in `db/mod.rs`.
> - **Error Handling**:
>   - Add `Error::NotFound` returning HTTP 404 in `routes/error.rs` for missing session/path/index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a077a20312a57b19323fe42690566243b3087321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `POST /v1/rollouts/{session_id}` endpoint to fetch spans by path/index, with new database query and 404 error handling.
> 
>   - **API**:
>     - Adds `POST /v1/rollouts/{session_id}` in `rollouts.rs` to fetch a span by `path`/`index`.
>     - Registers endpoint in `mod.rs` and `main.rs`.
>   - **DB**:
>     - Introduces `rollout_playgrounds.rs` with `RolloutPlayground` model and `get_rollout_playground()` function.
>     - Exports new module in `mod.rs`.
>   - **Error Handling**:
>     - Adds `Error::NotFound` in `error.rs` for 404 responses.
>   - **Misc**:
>     - Derives `Clone` for `CHSpan` in `spans.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for a077a20312a57b19323fe42690566243b3087321. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->