### PR TITLE
parse tool calls output for aisdk 5 and 6

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -1285,7 +1285,11 @@ fn parse_ai_sdk_tool_calls(
         .iter()
         .filter_map(|tool_call| {
             tool_call.get("toolName").map(|tool_name| {
-                let args_value = tool_call.get("args").cloned().unwrap_or_default();
+                let args_value = tool_call
+                    .get("args")
+                    .or(tool_call.get("input"))
+                    .cloned()
+                    .unwrap_or_default();
                 let args = if let serde_json::Value::String(s) = &args_value {
                     serde_json::from_str::<IndexMap<String, serde_json::Value>>(s).ok()
                 } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates AI SDK tool call parsing to accept arguments from `args` or `input` keys, ensuring compatibility with SDK v5 and v6.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac546b2101a7c14ea590839630309040fc14a3ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->