### PR TITLE
insert items to labeling queue endpoint

### DIFF
--- a/app-server/src/api/v1/labeling_queues.rs
+++ b/app-server/src/api/v1/labeling_queues.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+use actix_web::{HttpResponse, post, web};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    db::{self, DB, project_api_keys::ProjectApiKey},
+    routes::types::ResponseResult,
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelingQueueItemPayload {
+    pub data: serde_json::Value,
+    pub target: serde_json::Value,
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LabelingQueueItemSource {
+    Span,
+    Datapoint,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelingQueueItemMetadata {
+    pub source: LabelingQueueItemSource,
+    #[serde(default)]
+    pub dataset_id: Option<String>,
+    #[serde(default)]
+    pub trace_id: Option<String>,
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelingQueueItemRequest {
+    pub payload: LabelingQueueItemPayload,
+    pub metadata: LabelingQueueItemMetadata,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateLabelingQueueItemsRequest {
+    pub items: Vec<LabelingQueueItemRequest>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelingQueueItemResponse {
+    pub id: Uuid,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+// /v1/labeling_queues/{queue_id}/items
+#[post("/{queue_id}/items")]
+pub async fn create_labeling_queues_items(
+    path: web::Path<Uuid>,
+    body: web::Json<CreateLabelingQueueItemsRequest>,
+    db: web::Data<DB>,
+    project_api_key: ProjectApiKey,
+) -> ResponseResult {
+    let queue_id = path.into_inner();
+    let request = body.into_inner();
+    let db = db.into_inner();
+    let project_id = project_api_key.project_id;
+
+    // Verify queue exists and belongs to the project
+    if !db::labeling_queues::queue_exists(&db.pool, queue_id, project_id).await? {
+        return Ok(HttpResponse::NotFound().json(serde_json::json!({
+            "error": "Queue not found"
+        })));
+    }
+
+    if request.items.is_empty() {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "No items provided"
+        })));
+    }
+
+    // Convert request items to (metadata, payload) tuples for DB insertion
+    let items: Vec<(serde_json::Value, serde_json::Value)> = request
+        .items
+        .into_iter()
+        .map(|item| {
+            let metadata = serde_json::to_value(&item.metadata).unwrap_or_default();
+            let payload = serde_json::to_value(&item.payload).unwrap_or_default();
+            (metadata, payload)
+        })
+        .collect();
+
+    let created_items =
+        db::labeling_queues::insert_labeling_queue_items(&db.pool, queue_id, items).await?;
+
+    let response: Vec<LabelingQueueItemResponse> = created_items
+        .into_iter()
+        .map(|item| LabelingQueueItemResponse {
+            id: item.id,
+            created_at: item.created_at,
+        })
+        .collect();
+
+    Ok(HttpResponse::Created().json(response))
+}

--- a/app-server/src/api/v1/labeling_queues.rs
+++ b/app-server/src/api/v1/labeling_queues.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    db::{self, DB, project_api_keys::ProjectApiKey},
+    db::{self, DB, labeling_queues::NewLabelingQueueItem, project_api_keys::ProjectApiKey},
     routes::types::ResponseResult,
 };
 
@@ -60,19 +60,18 @@ pub async fn create_labeling_queues_items(
         })));
     }
 
-    // Convert request items to (metadata, payload) tuples for DB insertion
+    // Convert request items to LabelingQueueItemData for DB insertion
     // Queue item metadata is empty for API-ingested items (no source)
-    let items: Vec<(serde_json::Value, serde_json::Value)> = request
+    let items: Vec<NewLabelingQueueItem> = request
         .items
         .into_iter()
-        .map(|item| {
-            let queue_item_metadata = serde_json::json!({});
-            let payload = serde_json::json!({
+        .map(|item| NewLabelingQueueItem {
+            metadata: serde_json::json!({}),
+            payload: serde_json::json!({
                 "data": item.data,
                 "target": item.target,
                 "metadata": item.metadata,
-            });
-            (queue_item_metadata, payload)
+            }),
         })
         .collect();
 

--- a/app-server/src/api/v1/labeling_queues.rs
+++ b/app-server/src/api/v1/labeling_queues.rs
@@ -87,11 +87,11 @@ pub async fn create_labeling_queues_items(
         .items
         .into_iter()
         .map(|item| {
-            let metadata = serde_json::to_value(&item.metadata).unwrap_or_default();
-            let payload = serde_json::to_value(&item.payload).unwrap_or_default();
-            (metadata, payload)
+            let metadata = serde_json::to_value(&item.metadata)?;
+            let payload = serde_json::to_value(&item.payload)?;
+            Ok((metadata, payload))
         })
-        .collect();
+        .collect::<Result<Vec<_>, serde_json::Error>>()?;
 
     let created_items =
         db::labeling_queues::insert_labeling_queue_items(&db.pool, queue_id, items).await?;

--- a/app-server/src/api/v1/labeling_queues.rs
+++ b/app-server/src/api/v1/labeling_queues.rs
@@ -66,6 +66,7 @@ pub async fn create_labeling_queues_items(
         .items
         .into_iter()
         .map(|item| NewLabelingQueueItem {
+            id: Uuid::now_v7(),
             metadata: serde_json::json!({}),
             payload: serde_json::json!({
                 "data": item.data,

--- a/app-server/src/api/v1/mod.rs
+++ b/app-server/src/api/v1/mod.rs
@@ -2,6 +2,7 @@ pub mod browser_sessions;
 pub mod datasets;
 pub mod evals;
 pub mod evaluators;
+pub mod labeling_queues;
 pub mod metrics;
 pub mod payloads;
 pub mod rollouts;

--- a/app-server/src/db/labeling_queues.rs
+++ b/app-server/src/db/labeling_queues.rs
@@ -14,6 +14,13 @@ pub struct LabelingQueueItem {
     pub payload: serde_json::Value,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewLabelingQueueItem {
+    pub metadata: serde_json::Value,
+    pub payload: serde_json::Value,
+}
+
 /// Check if a labeling queue exists and belongs to the given project.
 pub async fn queue_exists(pool: &PgPool, queue_id: Uuid, project_id: Uuid) -> Result<bool> {
     let exists = sqlx::query_scalar::<_, bool>(
@@ -32,30 +39,25 @@ pub async fn queue_exists(pool: &PgPool, queue_id: Uuid, project_id: Uuid) -> Re
 pub async fn insert_labeling_queue_items(
     pool: &PgPool,
     queue_id: Uuid,
-    items: Vec<(serde_json::Value, serde_json::Value)>, // (metadata, payload)
+    items: Vec<NewLabelingQueueItem>,
 ) -> Result<Vec<LabelingQueueItem>> {
     if items.is_empty() {
         return Ok(vec![]);
     }
 
-    let mut queue_ids: Vec<Uuid> = Vec::with_capacity(items.len());
-    let mut metadatas: Vec<serde_json::Value> = Vec::with_capacity(items.len());
-    let mut payloads: Vec<serde_json::Value> = Vec::with_capacity(items.len());
-
-    for (metadata, payload) in items {
-        queue_ids.push(queue_id);
-        metadatas.push(metadata);
-        payloads.push(payload);
-    }
+    let (metadatas, payloads): (Vec<serde_json::Value>, Vec<serde_json::Value>) = items
+        .into_iter()
+        .map(|item| (item.metadata, item.payload))
+        .unzip();
 
     let created_items = sqlx::query_as::<_, LabelingQueueItem>(
         r#"
         INSERT INTO labeling_queue_items (queue_id, metadata, payload)
-        SELECT * FROM UNNEST($1::uuid[], $2::jsonb[], $3::jsonb[])
+        SELECT $1, metadata, payload FROM UNNEST($2::jsonb[], $3::jsonb[]) AS t(metadata, payload)
         RETURNING id, created_at, queue_id, metadata, payload
         "#,
     )
-    .bind(&queue_ids)
+    .bind(&queue_id)
     .bind(&metadatas)
     .bind(&payloads)
     .fetch_all(pool)

--- a/app-server/src/db/labeling_queues.rs
+++ b/app-server/src/db/labeling_queues.rs
@@ -1,0 +1,65 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, PgPool};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelingQueueItem {
+    pub id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub queue_id: Uuid,
+    pub metadata: serde_json::Value,
+    pub payload: serde_json::Value,
+}
+
+/// Check if a labeling queue exists and belongs to the given project.
+pub async fn queue_exists(pool: &PgPool, queue_id: Uuid, project_id: Uuid) -> Result<bool> {
+    let exists = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM labeling_queues WHERE id = $1 AND project_id = $2)",
+    )
+    .bind(queue_id)
+    .bind(project_id)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(exists)
+}
+
+/// Insert multiple labeling queue items into the database.
+/// Returns the created items with their generated IDs and timestamps.
+pub async fn insert_labeling_queue_items(
+    pool: &PgPool,
+    queue_id: Uuid,
+    items: Vec<(serde_json::Value, serde_json::Value)>, // (metadata, payload)
+) -> Result<Vec<LabelingQueueItem>> {
+    if items.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut queue_ids: Vec<Uuid> = Vec::with_capacity(items.len());
+    let mut metadatas: Vec<serde_json::Value> = Vec::with_capacity(items.len());
+    let mut payloads: Vec<serde_json::Value> = Vec::with_capacity(items.len());
+
+    for (metadata, payload) in items {
+        queue_ids.push(queue_id);
+        metadatas.push(metadata);
+        payloads.push(payload);
+    }
+
+    let created_items = sqlx::query_as::<_, LabelingQueueItem>(
+        r#"
+        INSERT INTO labeling_queue_items (queue_id, metadata, payload)
+        SELECT * FROM UNNEST($1::uuid[], $2::jsonb[], $3::jsonb[])
+        RETURNING id, created_at, queue_id, metadata, payload
+        "#,
+    )
+    .bind(&queue_ids)
+    .bind(&metadatas)
+    .bind(&payloads)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(created_items)
+}

--- a/app-server/src/db/mod.rs
+++ b/app-server/src/db/mod.rs
@@ -9,6 +9,7 @@ pub mod evaluators;
 pub mod event_cluster_configs;
 pub mod event_definitions;
 pub mod events;
+pub mod labeling_queues;
 pub mod prices;
 pub mod project_api_keys;
 pub mod projects;

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1013,6 +1013,13 @@ fn main() -> anyhow::Result<()> {
                                     .wrap(project_ingestion_auth.clone())
                                     .service(api::v1::metrics::process_metrics),
                             )
+                            .service(
+                                web::scope("/v1/labeling_queues")
+                                    .wrap(project_ingestion_auth.clone())
+                                    .service(
+                                        api::v1::labeling_queues::create_labeling_queues_items,
+                                    ),
+                            )
                             // Default endpoints block ingest-only keys
                             .service(
                                 web::scope("/v1/tag")

--- a/frontend/app/api/projects/[projectId]/queues/[queueId]/move/route.ts
+++ b/frontend/app/api/projects/[projectId]/queues/[queueId]/move/route.ts
@@ -10,11 +10,12 @@ export async function POST(req: Request, props: { params: Promise<{ projectId: s
       return Response.json({ error: "Invalid request body" }, { status: 400 });
     }
 
-    const { refDate, direction } = parsedBody.data;
+    const { refDate, refId, direction } = parsedBody.data;
 
     const result = await moveQueueItem({
       queueId: params.queueId,
       refDate,
+      refId,
       direction,
     });
 

--- a/frontend/components/queue/queue.tsx
+++ b/frontend/components/queue/queue.tsx
@@ -74,23 +74,35 @@ function QueueInner() {
     };
   }, [currentItem, isLoading, dataset, isValid]);
 
-  const sourceLink = useMemo(() => {
-    if (!currentItem) return `/project/${projectId}/labeling-queues/${storeQueue?.id}`;
+  const sourceInfo = useMemo(() => {
+    if (!currentItem) return null;
 
-    if (get(currentItem.metadata, "source") === "datapoint") {
-      return `/project/${projectId}/datasets/${get(currentItem.metadata, "datasetId")}?datapointId=${get(currentItem.metadata, "id")}`;
+    const source = get(currentItem.metadata, "source");
+
+    if (source === "datapoint") {
+      return {
+        label: "datapoint",
+        link: `/project/${projectId}/datasets/${get(currentItem.metadata, "datasetId")}?datapointId=${get(currentItem.metadata, "id")}`,
+      };
     }
 
-    if (get(currentItem.metadata, "source") === "span") {
-      return `/project/${projectId}/traces?traceId=${get(currentItem.metadata, "traceId")}&spanId=${get(currentItem.metadata, "id")}`;
+    if (source === "span") {
+      return {
+        label: "span",
+        link: `/project/${projectId}/traces?traceId=${get(currentItem.metadata, "traceId")}&spanId=${get(currentItem.metadata, "id")}`,
+      };
     }
 
-    if (get(currentItem.metadata, "source") === "sql") {
-      return `/project/${projectId}/sql/${get(currentItem.metadata, "id")}`;
+    if (source === "sql") {
+      return {
+        label: "sql",
+        link: `/project/${projectId}/sql/${get(currentItem.metadata, "id")}`,
+      };
     }
 
-    return `/project/${projectId}/labeling-queues/${storeQueue?.id}`;
-  }, [currentItem, projectId, storeQueue?.id]);
+    // No source - manually created
+    return null;
+  }, [currentItem, projectId]);
 
   const onChange = useCallback(
     (v: string) => {
@@ -263,11 +275,17 @@ function QueueInner() {
             <>
               <span className="mb-1">Payload</span>
               <div className="flex text-xs gap-1 text-nowrap truncate">
-                <span className="text-secondary-foreground">Created from</span>
-                <Link className="flex text-xs items-center text-primary" href={sourceLink}>
-                  {get(currentItem?.metadata, "source", "-")}
-                  <ArrowUpRight className="w-3 h-3" />
-                </Link>
+                {sourceInfo ? (
+                  <>
+                    <span className="text-secondary-foreground">Created from</span>
+                    <Link className="flex text-xs items-center text-primary" href={sourceInfo.link}>
+                      {sourceInfo.label}
+                      <ArrowUpRight className="w-3 h-3" />
+                    </Link>
+                  </>
+                ) : (
+                  <span className="text-secondary-foreground">Created manually</span>
+                )}
               </div>
               <div className="flex flex-1 overflow-hidden mt-2">
                 <ResizableWrapper height={height} onHeightChange={setHeight}>

--- a/frontend/components/queue/queue.tsx
+++ b/frontend/components/queue/queue.tsx
@@ -120,6 +120,7 @@ function QueueInner() {
   const move = useCallback(
     async (
       refDate: string,
+      refId: string,
       direction: "next" | "prev" = "next",
       load: "skip" | "move" | "first-load" | false = "move"
     ) => {
@@ -127,7 +128,7 @@ function QueueInner() {
         setIsLoading(load);
         const response = await fetch(`/api/projects/${projectId}/queues/${storeQueue?.id}/move`, {
           method: "POST",
-          body: JSON.stringify({ refDate, direction }),
+          body: JSON.stringify({ refDate, refId, direction }),
         });
         if (!response.ok) {
           toast({ variant: "destructive", title: "Error", description: "Failed to move queue. Please try again." });
@@ -185,7 +186,7 @@ function QueueInner() {
         }
 
         if (currentItem) {
-          await move(currentItem.createdAt);
+          await move(currentItem.createdAt, currentItem.id, "next");
         }
       } catch (e) {
         toast({
@@ -201,7 +202,8 @@ function QueueInner() {
   );
 
   useEffect(() => {
-    move(new Date(0).toISOString(), "next", "first-load");
+    // Use epoch date and empty UUID to get the first item
+    move(new Date(0).toISOString(), "00000000-0000-0000-0000-000000000000", "next", "first-load");
   }, []);
 
   useHotkeys(
@@ -210,7 +212,7 @@ function QueueInner() {
       (event: KeyboardEvent) => {
         event.preventDefault();
         if (currentItem && !states.next) {
-          move(currentItem.createdAt, "next");
+          move(currentItem.createdAt, currentItem.id, "next");
         }
       },
       [currentItem, move, states.next]
@@ -224,7 +226,7 @@ function QueueInner() {
       (event: KeyboardEvent) => {
         event.preventDefault();
         if (currentItem && !states.prev) {
-          move(currentItem.createdAt, "prev");
+          move(currentItem.createdAt, currentItem.id, "prev");
         }
       },
       [currentItem, move, states.prev]
@@ -319,7 +321,7 @@ function QueueInner() {
                 <div className="flex items-center text-center text-xs opacity-75">⌘ + ›</div>
               </Button>
               <Button
-                onClick={() => currentItem && move(currentItem.createdAt, "prev")}
+                onClick={() => currentItem && move(currentItem.createdAt, currentItem.id, "prev")}
                 disabled={states.prev}
                 variant="outline"
               >
@@ -327,7 +329,7 @@ function QueueInner() {
                 <div className="text-center text-xs opacity-75">⌘ + ↓</div>
               </Button>
               <Button
-                onClick={() => currentItem && move(currentItem.createdAt, "next")}
+                onClick={() => currentItem && move(currentItem.createdAt, currentItem.id, "next")}
                 disabled={states.next}
                 variant="outline"
               >

--- a/frontend/components/traces/add-to-labeling-queue-popover.tsx
+++ b/frontend/components/traces/add-to-labeling-queue-popover.tsx
@@ -127,7 +127,7 @@ export default function AddToLabelingQueuePopover({
     } finally {
       setIsLoading(false);
     }
-  }, [data, datapointIds, datasetId, spanId, projectId, selectedQueue, toast, isDatapointMode, isSpanMode]);
+  }, [data, datapointIds, datasetId, spanId, traceId, projectId, selectedQueue, toast, isDatapointMode, isSpanMode]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/frontend/components/traces/add-to-labeling-queue-popover.tsx
+++ b/frontend/components/traces/add-to-labeling-queue-popover.tsx
@@ -25,6 +25,7 @@ interface AddToLabelingQueuePopoverProps {
   datapointIds?: string[];
   datasetId?: string;
   spanId?: string;
+  traceId?: string;
   buttonVariant?: "default" | "secondary" | "outline" | "ghost" | "link" | "destructive";
   buttonSize?: "default" | "sm" | "lg" | "icon";
 }
@@ -34,6 +35,7 @@ export default function AddToLabelingQueuePopover({
   datapointIds,
   datasetId,
   spanId,
+  traceId,
   buttonVariant = "secondary",
   buttonSize = "sm",
   children,
@@ -69,6 +71,7 @@ export default function AddToLabelingQueuePopover({
               metadata: {
                 source: "span",
                 id: spanId,
+                traceId,
               },
             }),
           });

--- a/frontend/components/traces/span-controls.tsx
+++ b/frontend/components/traces/span-controls.tsx
@@ -104,7 +104,7 @@ export function SpanControls({ children, span, events }: PropsWithChildren<SpanC
             <div className="flex gap-2 flex-wrap items-center">
               <TagsTrigger />
               <RegisterEvaluatorPopover spanPath={get(span.attributes, "lmnr.span.path", [])} />
-              <AddToLabelingQueuePopover spanId={span.spanId} />
+              <AddToLabelingQueuePopover spanId={span.spanId} traceId={span.traceId} />
               <ExportSpansPopover span={span} />
             </div>
             <TagsList />

--- a/frontend/lib/actions/queue/index.ts
+++ b/frontend/lib/actions/queue/index.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { z } from "zod/v4";
 
 import { createDatapoints } from "@/lib/clickhouse/datapoints";

--- a/frontend/lib/actions/queue/index.ts
+++ b/frontend/lib/actions/queue/index.ts
@@ -25,10 +25,10 @@ export const PushQueueItemSchema = z.object({
         metadata: z.record(z.string(), z.any()),
       }),
       metadata: z.object({
-        source: z.enum(["span", "datapoint"]),
+        source: z.enum(["span", "datapoint"]).optional(),
         datasetId: z.string().optional(),
         traceId: z.string().optional(),
-        id: z.string(),
+        id: z.string().optional(),
       }),
     })
   ),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces bulk ingestion for labeling queues and makes queue navigation deterministic across API, DB, and UI.
> 
> - **API/DB**: Adds `POST /v1/labeling_queues/{queue_id}/items` to insert multiple items; validates project ownership via `queue_exists`; batch inserts with `insert_labeling_queue_items`; wires route under `/v1/labeling_queues`.
> - **Queue navigation**: Updates move logic to order by `(created_at, id)` and requires `refId`; first-load uses epoch and empty UUID.
> - **UI/Flows**: `queue.tsx` displays source link when available or "Created manually"; navigation/actions send `refId`; `AddToLabelingQueuePopover`/`span-controls` pass optional `traceId`; makes push item metadata fields optional in schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7b8929297e81b1995e11bdc8b376fe2e87ea418. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds batch insertion endpoint for labeling queues, updates database logic, and modifies frontend for enhanced queue navigation and source context display.
> 
>   - **API/Server**:
>     - Adds `POST /v1/labeling_queues/{queue_id}/items` in `labeling_queues.rs` to insert multiple items into a labeling queue.
>     - Validates queue ownership and returns created `id` and `createdAt`.
>     - Registers route in `main.rs` under `/v1/labeling_queues` with ingestion auth.
>   - **Database**:
>     - New `labeling_queues.rs` module with `queue_exists` and `insert_labeling_queue_items()` for batch insertion using `UNNEST`.
>     - Updates `mod.rs` to include `labeling_queues` module.
>   - **Frontend**:
>     - Updates `queue.tsx` to use compound ordering `(createdAt, id)` for queue navigation.
>     - Modifies `move` API route and hotkeys to include `refId`.
>     - Displays source link or "Created manually" in `queue.tsx`.
>     - Updates `AddToLabelingQueuePopover` and `SpanControls` to pass `traceId`.
>     - Makes `metadata.source` and `id` optional in schemas in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for f7b8929297e81b1995e11bdc8b376fe2e87ea418. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->