### PR TITLE
improve metadata merging on DB insert

### DIFF
--- a/app-server/src/db/trace.rs
+++ b/app-server/src/db/trace.rs
@@ -162,7 +162,8 @@ pub async fn upsert_trace_statistics_batch(
                 top_span_name = COALESCE(EXCLUDED.top_span_name, traces.top_span_name),
                 top_span_type = COALESCE(EXCLUDED.top_span_type, traces.top_span_type),
                 session_id = COALESCE(EXCLUDED.session_id, traces.session_id),
-                metadata = COALESCE(EXCLUDED.metadata, traces.metadata),
+                -- `||` operator shallowly merges the metadata; coalesce prevents None from overwriting the existing metadata
+                metadata = COALESCE(traces.metadata || EXCLUDED.metadata, EXCLUDED.metadata, traces.metadata),
                 user_id = COALESCE(EXCLUDED.user_id, traces.user_id),
                 input_token_count = traces.input_token_count + EXCLUDED.input_token_count,
                 output_token_count = traces.output_token_count + EXCLUDED.output_token_count,


### PR DESCRIPTION
This is still not perfect (if users overwrite the same key, behaviour depends on the spans incoming order, and so is undefined), but already much better than overwriting with latest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves trace upsert behavior to preserve and merge existing metadata.
> 
> - In `app-server/src/db/trace.rs`, `ON CONFLICT` update now sets `metadata = COALESCE(traces.metadata || EXCLUDED.metadata, EXCLUDED.metadata, traces.metadata)`, using Postgres `||` to shallow-merge JSON and `COALESCE` to avoid `NULL` overwrites
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 138cc8dfa3a86fc98f3028f1220dec0125384bba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves metadata merging in `upsert_trace_statistics_batch` in `trace.rs` using shallow merge and `COALESCE`, though key overwrite conflicts remain order-dependent.
> 
>   - **Behavior**:
>     - Improves metadata merging in `upsert_trace_statistics_batch` in `trace.rs` using `||` operator for shallow merge and `COALESCE` to prevent `None` overwrites.
>     - Conflict resolution for key overwrites remains order-dependent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 138cc8dfa3a86fc98f3028f1220dec0125384bba. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->