### PR TITLE
live browser view for agent rollout

### DIFF
--- a/frontend/components/rollout-sessions/rollout-session-view/rollout-session-content.tsx
+++ b/frontend/components/rollout-sessions/rollout-session-view/rollout-session-content.tsx
@@ -331,6 +331,13 @@ export default function RolloutSessionContent({ sessionId, spanId }: RolloutSess
           setIsSessionDeleted(true);
         }
       },
+      trace_update: (event: MessageEvent) => {
+        const payload = JSON.parse(event.data);
+        if (payload.trace) {
+          console.log("trace_update", payload.trace);
+          setTrace(payload.trace);
+        }
+      },
     }),
     [setSpans, setTrace, setBrowserSession, setHasBrowserSession, setSessionStatus, setIsSessionDeleted]
   );
@@ -541,7 +548,7 @@ export default function RolloutSessionContent({ sessionId, spanId }: RolloutSess
         ) : (
           <ResizablePanelGroup id="rollout-session-view-panels" direction="vertical">
             <ResizablePanel className="flex flex-col flex-1 h-full overflow-hidden relative">
-              {tab === "metadata" && trace && <Metadata trace={trace} />}
+              {tab === "metadata" && trace && <Metadata metadata={trace.metadata} />}
               {tab === "timeline" && <Timeline />}
               {tab === "reader" && (
                 <div className="flex flex-1 h-full overflow-hidden relative">
@@ -573,6 +580,7 @@ export default function RolloutSessionContent({ sessionId, spanId }: RolloutSess
                       hasBrowserSession={hasBrowserSession}
                       traceId={trace?.id}
                       llmSpanIds={llmSpanIds}
+                      browserLiveViewUrl={JSON.parse(trace?.metadata || "{}").browser_live_view_url}
                     />
                   )}
                 </ResizablePanel>

--- a/frontend/components/traces/trace-view/index.tsx
+++ b/frontend/components/traces/trace-view/index.tsx
@@ -478,7 +478,7 @@ const PureTraceView = ({ traceId, spanId, onClose, propsTrace }: TraceViewProps)
           ) : (
             <ResizablePanelGroup id="trace-view-panels" direction="vertical">
               <ResizablePanel className="flex flex-col flex-1 h-full overflow-hidden relative">
-                {tab === "metadata" && trace && <Metadata trace={trace} />}
+                {tab === "metadata" && trace && <Metadata metadata={trace.metadata} />}
                 {tab === "chat" && trace && (
                   <Chat
                     trace={trace}

--- a/frontend/components/traces/trace-view/metadata.tsx
+++ b/frontend/components/traces/trace-view/metadata.tsx
@@ -1,14 +1,13 @@
 import React from "react";
 
-import { type TraceViewTrace } from "@/components/traces/trace-view/trace-view-store";
 import ContentRenderer from "@/components/ui/content-renderer/index";
 
 interface MetadataProps {
-  trace: TraceViewTrace;
+  metadata: string;
 }
 
-const Metadata = ({ trace }: MetadataProps) => {
-  const metadataValue = trace.metadata || "{}";
+const Metadata = ({ metadata }: MetadataProps) => {
+  const metadataValue = metadata || "{}";
 
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -25,7 +25,7 @@ const nextConfig: NextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://esm.sh https://p.laminar.sh https://us.i.posthog.com https://www.gstatic.com http://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https: data:; font-src 'self' https: data:; img-src 'self' data: https: blob:; connect-src 'self' https: wss: ws: https://p.laminar.sh https://us.i.posthog.com https://github.com https://api.github.com; frame-src 'self' https://unpkg.com; media-src 'self' https://image.mux.com blob:; object-src 'none'; base-uri 'self'; form-action 'self' https://github.com; frame-ancestors 'none';",
+              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://esm.sh https://p.laminar.sh https://us.i.posthog.com https://www.gstatic.com http://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https: data:; font-src 'self' https: data:; img-src 'self' data: https: blob:; connect-src 'self' https: wss: ws: https://p.laminar.sh https://us.i.posthog.com https://github.com https://api.github.com; frame-src 'self' https: http: https://unpkg.com; media-src 'self' https://image.mux.com blob:; object-src 'none'; base-uri 'self'; form-action 'self' https://github.com; frame-ancestors 'none';",
           },
           {
             key: "X-Content-Type-Options",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces live browser viewing and tighter realtime updates for rollouts, plus metadata payload normalization.
> 
> - Backend (Rust):
>   - Change `RealtimeTrace.metadata` from `Option<Value>` to `String` and serialize via `to_string()`.
>   - Add `has_browser_session` to `RealtimeTrace`.
>   - In `send_trace_updates`, also emit `trace_update` to per-session channels `rollout_session_<session_id>` when `metadata['rollout.session_id']` is present.
> - Frontend (Next.js/React):
>   - `Metadata` component now accepts `metadata: string`; update callers in `trace-view` and rollout session view accordingly.
>   - Rollout session SSE handlers now process `trace_update` and update local `trace`.
>   - `SessionPlayer` supports a new "Live View" tab (iframe) via `browserLiveViewUrl` parsed from `trace.metadata`; tab selection logic updated.
>   - Pass `browserLiveViewUrl` to `SessionPlayer` in rollout session view.
>   - Relax CSP `frame-src` to allow `https:` and `http:` for embedding external live views.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dccc26b4bab467aa5e138c14b77f228c24de3941. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add live browser view for agent rollouts, updating backend and frontend components to handle and display browser sessions in real-time.
> 
>   - **Backend**:
>     - `realtime.rs`: Add `has_browser_session` to `RealtimeTrace` and send trace updates to `rollout_session_<session_id>` if `rollout.session_id` is present in metadata.
>     - Change `metadata` from `Option<Value>` to `String` in `RealtimeTrace`.
>   - **Frontend**:
>     - `rollout-session-content.tsx`: Add `trace_update` event handler to update trace state.
>     - `session-player.tsx`: Add `live-view` tab for `browserLiveViewUrl` and handle tab switching.
>     - `metadata.tsx`: Update `Metadata` component to accept `metadata` as `string`.
>   - **Config**:
>     - `next.config.ts`: Update `Content-Security-Policy` to allow `http` and `https` in `frame-src`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for dccc26b4bab467aa5e138c14b77f228c24de3941. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->