### PR TITLE
start passing new format input, output, tool defs

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -594,6 +594,38 @@ impl Span {
                 }
                 convert_ai_sdk_tool_calls(&mut self.attributes.raw_attributes);
             }
+
+            // New format `gen_ai.input.messages` and `gen_ai.output.messages` overrides the old format `gen_ai.prompt/completion`
+            if let Some(input) = self
+                .attributes
+                .raw_attributes
+                .remove("gen_ai.input.messages")
+            {
+                if let Value::String(s) = input {
+                    if let Ok(parsed) = serde_json::from_str::<Value>(&s) {
+                        self.input = Some(parsed);
+                    } else {
+                        self.input = Some(serde_json::Value::String(s));
+                    }
+                } else {
+                    self.input = Some(input);
+                }
+            }
+            if let Some(output) = self
+                .attributes
+                .raw_attributes
+                .remove("gen_ai.output.messages")
+            {
+                if let Value::String(s) = output {
+                    if let Ok(parsed) = serde_json::from_str::<Value>(&s) {
+                        self.output = Some(parsed);
+                    } else {
+                        self.output = Some(serde_json::Value::String(s));
+                    }
+                } else {
+                    self.output = Some(output);
+                }
+            }
         }
 
         // try parsing LiteLLM inner span for well-known providers

--- a/frontend/components/traces/stats-shields.tsx
+++ b/frontend/components/traces/stats-shields.tsx
@@ -106,6 +106,25 @@ const extractToolsFromAttributes = (attributes: Record<string, any>): Tool[] => 
     }
   }
 
+  const genAiToolDefinitions = get(attributes, "gen_ai.tool.definitions");
+  // TODO: add strong typing here, make it flexible for non-OpenAI tool typing, potentially
+  // moving the schema parsing to provider-specific types, i.e. @/lib/spans/types
+  if (genAiToolDefinitions) {
+    try {
+      const parsed = JSON.parse(genAiToolDefinitions)
+      return parsed.map((tool: any) => {
+        const func = tool.function ?? tool;
+        return {
+          name: func.name,
+          description: func.description,
+          parameters: typeof func.parameters === "string" ? func.parameters : JSON.stringify(func.parameters || {}),
+        }
+      });
+    } catch (e) {
+      console.error("Failed to parse gen_ai.tool.definitions:", e);
+    }
+  }
+
   const functionIndices = uniq(
     Object.keys(attributes)
       .map((key) => key.match(/^llm\.request\.functions\.(\d+)\.name$/)?.[1])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces support for new GenAI message and tool formats across backend and UI.
> 
> - **Backend (spans.rs):** Parse `gen_ai.input.messages` and `gen_ai.output.messages` (stringified or object) and let them override legacy `gen_ai.prompt/*` and `gen_ai.completion/*` parsing.
> - **Playground:** Add parser for `gen_ai.tool.definitions` and prefer tools from `ai.prompt.tools` → `gen_ai.tool.definitions` → legacy `llm.request.functions` when building config.
> - **Trace stats UI:** Show tools defined via `gen_ai.tool.definitions` alongside existing sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 136763aa50ea4ab777c612ee39c6246e34a0a7c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR updates the handling of new AI tool input/output formats and enhances tool parsing logic in both backend and frontend components.
> 
>   - **Behavior**:
>     - `Span::parse_and_enrich_attributes` in `spans.rs` now supports `gen_ai.input.messages` and `gen_ai.output.messages`, overriding old formats.
>     - `parseAiSdkToolsFromSpan` and `parseGenAiToolsDefinitionsFromSpan` in `utils.tsx` handle AI SDK and GenAI tool definitions.
>     - `extractToolsFromAttributes` in `stats-shields.tsx` parses `gen_ai.tool.definitions` and `ai.prompt.tools`.
>   - **Frontend**:
>     - `getPlaygroundConfig` in `utils.tsx` updated to parse tools using new functions.
>     - `ToolsList` and `StructuredOutputSchema` in `stats-shields.tsx` display parsed tools and schemas.
>   - **Misc**:
>     - Error handling added for JSON parsing failures in `utils.tsx` and `stats-shields.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for 136763aa50ea4ab777c612ee39c6246e34a0a7c8. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->