### PR TITLE
update license label on landing from MIT to Apache

### DIFF
--- a/frontend/components/landing/second-half/index.tsx
+++ b/frontend/components/landing/second-half/index.tsx
@@ -58,7 +58,7 @@ const SecondHalf = ({ className }: Props) => {
                   "md:py-[18px]"
                 )}
               >
-                <p className={cn(bodySQL, "basis-0 grow min-h-px min-w-px")}>Fully open-source, MIT licensed</p>
+                <p className={cn(bodySQL, "basis-0 grow min-h-px min-w-px")}>Fully open-source, Apache 2.0 licensed</p>
               </div>
               <div
                 className={cn(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Text-only change on the landing page; no logic, API, or data handling changes.
> 
> **Overview**
> Updates the landing page `SecondHalf` “Self-host anywhere” section to display **Apache 2.0** instead of **MIT** in the open-source license label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf85ca6abaad169d7d26d99994c57369530b4dce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update license label from MIT to Apache 2.0 in `SecondHalf` component.
> 
>   - **Behavior**:
>     - Update license label from "MIT licensed" to "Apache 2.0 licensed" in `SecondHalf` component in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for cf85ca6abaad169d7d26d99994c57369530b4dce. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->