### PR TITLE
Comparison Blog

### DIFF
--- a/frontend/assets/blog/2026-01-29-laminar-vs-langfuse-vs-langsmith-llm-observability-compared.mdx
+++ b/frontend/assets/blog/2026-01-29-laminar-vs-langfuse-vs-langsmith-llm-observability-compared.mdx
@@ -278,8 +278,6 @@ Langfuse offers cloud plans and a **free self-host open-source option** (MIT lic
 
 ### LangSmith
 
-### LangSmith
-
 LangSmith offers three deployment models:
 
 - **Cloud:** Fully managed by LangChain (data in GCP us-central-1, or EU region)
@@ -319,6 +317,7 @@ You can send traces to LangSmith alongside other OTel-compatible backends, or ex
 - **Real-time trace visibility** during long-running operations
 - **Replay from spans** as a first-class workflow
 - **Browser-agent session replay** tied directly to traces
+- Open-source core with self-hosting options
 - OpenTelemetry ingestion for existing OTel pipelines
 
 ### Langfuse
@@ -346,6 +345,7 @@ You can send traces to LangSmith alongside other OTel-compatible backends, or ex
 - Real-time visibility during long-running operations is a must-have
 - Replay from captured spans is critical to your iteration workflow
 - You're building browser-automation agents and need synchronized session replay
+- You prefer open-source tooling with self-host flexibility
 - Data-volume pricing fits your usage pattern better than trace-based
 
 **Choose Langfuse if:**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Content-only change adding a new MDX blog post; low risk aside from potential rendering issues due to embedded table markup.
> 
> **Overview**
> Adds a new MDX blog post (`2026-01-29-laminar-vs-langfuse-vs-langsmith-llm-observability-compared.mdx`) comparing Laminar, Langfuse, and LangSmith across tracing, agent support, replay/debug workflows, pricing, deployment models, and OpenTelemetry support.
> 
> The post includes structured comparison tables, a “which to choose” decision guide, and outbound CTA links to each product’s pricing page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c50210c7690f1f81c4956edda8e29988d17cdc17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a new blog post comparing Laminar, Langfuse, and LangSmith on various observability aspects with summary tables and CTAs.
> 
>   - **Content**:
>     - Adds new blog post `2026-01-29-laminar-vs-langfuse-vs-langsmith-llm-observability-compared.mdx`.
>     - Compares Laminar, Langfuse, and LangSmith on tracing, agent support, replay/debugging, pricing, deployment, and OpenTelemetry.
>     - Includes summary tables and CTAs for each platform.
>   - **Focus**:
>     - Developer-focused comparison for evaluating observability tools.
>     - Highlights key differentiators and provides guidance on choosing the right platform.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr&utm_source=github&utm_medium=referral)<sup> for c50210c7690f1f81c4956edda8e29988d17cdc17. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->