### PR TITLE
updates to sitemap

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 import { PostHogProvider } from "./providers";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://www.lmnr.ai"),
+  metadataBase: new URL("https://laminar.sh"),
   title: "Laminar",
   keywords: [
     "laminar",
@@ -20,17 +20,27 @@ export const metadata: Metadata = {
     "label",
     "analyze",
     "ai",
+    "ai agent",
     "eval",
     "llm ops",
+    "ai ops",
     "observability",
-    "openai",
+    "tracing",
+    "ai sdk tracing",
+    "ai tracing",
     "llm",
     "llm observability",
+    "ai observability",
+    "agent observability",
+    "ai agent observability",
+    "ai agent tracing",
+    "ai agent evals",
+    "ai agent evaluation",
   ],
   openGraph: {
     type: "website",
     title: "Laminar",
-    description: "The AI engineering platform",
+    description: "Understand why your agent failed. Iterate fast to fix it.",
     siteName: "Laminar",
     images: {
       url: "/opengraph-image.png",
@@ -39,7 +49,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary",
-    description: "The AI engineering platform",
+    description: "Understand why your agent failed. Iterate fast to fix it.",
     title: "Laminar",
     images: {
       url: "/twitter-image.png",

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/api/", "/project/", "/checkout/", "/onboarding"],
     },
-    sitemap: "https://www.lmnr.ai/sitemap.xml",
+    sitemap: "https://laminar.sh/sitemap.xml",
   };
 }

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,16 +1,16 @@
-import { type MetadataRoute } from "next";
+import type { MetadataRoute } from "next";
 
 import { getBlogPosts } from "@/lib/blog/utils";
 
-const BASE_URL = "https://www.lmnr.ai";
+const BASE_URL = "https://laminar.sh";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const blogPosts = getBlogPosts({ sortByDate: false });
 
-  const blogUrls = blogPosts.map((post) => ({
+  const blogUrls: MetadataRoute.Sitemap = blogPosts.map((post) => ({
     url: `${BASE_URL}/blog/${post.slug}`,
     lastModified: new Date(post.data.date),
-    changeFrequency: "monthly" as const,
+    changeFrequency: "monthly",
     priority: 0.7,
   }));
 
@@ -20,6 +20,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
+      images: [`${BASE_URL}/opengraph-image.png`],
     },
     {
       url: `${BASE_URL}/pricing`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> SEO/sitemap metadata-only changes with no runtime business logic or data handling impact; main risk is incorrect URLs affecting search indexing.
> 
> **Overview**
> Switches the canonical site base from `lmnr.ai` to `laminar.sh` across `metadataBase`, `robots.txt` sitemap URL, and the generated sitemap `BASE_URL`.
> 
> Expands page metadata by updating OpenGraph/Twitter descriptions and adding additional AI/agent/tracing-related keywords.
> 
> Tweaks sitemap typing and content by explicitly typing `blogUrls`, removing the `as const` cast on `changeFrequency`, and adding an `images` entry for the homepage sitemap item.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90e2a816fd5758f01df5508ae40f2527e25de350. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->