### PR TITLE
update signal_runs ordering_key

### DIFF
--- a/frontend/lib/clickhouse/migrations/17_signal_runs_fix.sql
+++ b/frontend/lib/clickhouse/migrations/17_signal_runs_fix.sql
@@ -1,0 +1,24 @@
+-- recreate signal_runs table without the updated_at column in ordering key
+
+DROP TABLE IF EXISTS signal_runs;
+
+CREATE TABLE IF NOT EXISTS signal_runs
+(
+    project_id UUID,
+    signal_id UUID,
+    job_id UUID,
+    trigger_id UUID,
+    run_id UUID,
+    trace_id UUID,
+    status UInt8,
+    event_id UUID,
+    error_message String,
+    updated_at DateTime64(9, 'UTC'),
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (project_id, signal_id, run_id)
+SETTINGS index_granularity = 8192;
+
+ALTER TABLE signal_runs ADD INDEX IF NOT EXISTS signal_runs_job_id_bf_idx job_id TYPE bloom_filter;
+ALTER TABLE signal_runs ADD INDEX IF NOT EXISTS signal_runs_trigger_id_bf_idx trigger_id TYPE bloom_filter;
+ALTER TABLE signal_runs ADD INDEX IF NOT EXISTS signal_runs_trace_id_bf_idx trace_id TYPE bloom_filter;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Drops and recreates a production table, which can cause data loss or downtime if migration ordering/backup is incorrect. Changing the `ORDER BY` key can also affect query performance and merge behavior.
> 
> **Overview**
> Replaces the `signal_runs` ClickHouse schema by dropping and recreating the table so the `ORDER BY` key changes from `(project_id, signal_id, updated_at, run_id)` to `(project_id, signal_id, run_id)` while still using `ReplacingMergeTree(updated_at)`.
> 
> Reapplies the existing bloom filter secondary indexes on `job_id`, `trigger_id`, and `trace_id` after the table recreation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52bd17546d8d0af68e83540763380ea6262e3625. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->