### PR TITLE
fix: realtime traces constantly scrolling to selected span

### DIFF
--- a/frontend/components/rollout-sessions/rollout-session-view/list/index.tsx
+++ b/frontend/components/rollout-sessions/rollout-session-view/list/index.tsx
@@ -59,7 +59,7 @@ const List = ({ traceId, onSpanSelect }: ListProps) => {
       });
       return () => cancelAnimationFrame(rafId);
     }
-  }, [selectedSpanIndex, virtualizer]);
+  }, [selectedSpanIndex, virtualizer, isSpansLoading]);
 
   const items = virtualizer?.getVirtualItems() || [];
 

--- a/frontend/components/rollout-sessions/rollout-session-view/list/index.tsx
+++ b/frontend/components/rollout-sessions/rollout-session-view/list/index.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { compact, isEmpty, times } from "lodash";
+import { compact, isEmpty, isNil, isNull, times } from "lodash";
 import { useParams } from "next/navigation";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -44,24 +44,22 @@ const List = ({ traceId, onSpanSelect }: ListProps) => {
     overscan: 20,
   });
 
+  const selectedSpanIndex = useMemo(() => {
+    if (isNil(selectedSpan)) return null;
+    const selectedIndex = listSpans.findIndex((span) => span.spanId === selectedSpan.spanId);
+    return selectedIndex;
+  }, [selectedSpan?.spanId, listSpans, isSpansLoading]);
+
+  // Scroll to selected span when selection changes
   useEffect(() => {
-    if (!selectedSpan || isSpansLoading) return;
-
-    const scrollToSelected = () => {
-      const selectedIndex = listSpans.findIndex((span) => span.spanId === selectedSpan.spanId);
-
-      if (selectedIndex !== -1) {
-        virtualizer.scrollToIndex(selectedIndex, {
-          align: "start",
-        });
-      }
-    };
-
-    const rafId = requestAnimationFrame(scrollToSelected);
-
-    return () => cancelAnimationFrame(rafId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (isNull(selectedSpanIndex) || isSpansLoading) return;
+    if (selectedSpanIndex !== -1) {
+      const rafId = requestAnimationFrame(() => {
+        virtualizer.scrollToIndex(selectedSpanIndex, { align: "start" });
+      });
+      return () => cancelAnimationFrame(rafId);
+    }
+  }, [selectedSpanIndex, virtualizer]);
 
   const items = virtualizer?.getVirtualItems() || [];
 

--- a/frontend/components/rollout-sessions/rollout-session-view/list/index.tsx
+++ b/frontend/components/rollout-sessions/rollout-session-view/list/index.tsx
@@ -48,7 +48,7 @@ const List = ({ traceId, onSpanSelect }: ListProps) => {
     if (isNil(selectedSpan)) return null;
     const selectedIndex = listSpans.findIndex((span) => span.spanId === selectedSpan.spanId);
     return selectedIndex;
-  }, [selectedSpan?.spanId, listSpans, isSpansLoading]);
+  }, [selectedSpan?.spanId, listSpans]);
 
   // Scroll to selected span when selection changes
   useEffect(() => {

--- a/frontend/components/rollout-sessions/rollout-session-view/tree/index.tsx
+++ b/frontend/components/rollout-sessions/rollout-session-view/tree/index.tsx
@@ -46,7 +46,7 @@ const Tree = ({ traceId, onSpanSelect }: TreeProps) => {
     if (isNil(selectedSpan)) return null;
     const selectedIndex = treeSpans.findIndex((item) => item.span.spanId === selectedSpan.spanId);
     return selectedIndex;
-  }, [selectedSpan?.spanId, treeSpans, isSpansLoading]);
+  }, [selectedSpan?.spanId, treeSpans]);
 
   // Scroll to selected span when selection changes
   useEffect(() => {

--- a/frontend/components/rollout-sessions/rollout-session-view/tree/index.tsx
+++ b/frontend/components/rollout-sessions/rollout-session-view/tree/index.tsx
@@ -57,7 +57,7 @@ const Tree = ({ traceId, onSpanSelect }: TreeProps) => {
       });
       return () => cancelAnimationFrame(rafId);
     }
-  }, [selectedSpanIndex, virtualizer]);
+  }, [selectedSpanIndex, virtualizer, isSpansLoading]);
 
   const items = virtualizer?.getVirtualItems() || [];
 

--- a/frontend/components/rollout-sessions/rollout-session-view/tree/index.tsx
+++ b/frontend/components/rollout-sessions/rollout-session-view/tree/index.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { compact, isEmpty, times } from "lodash";
+import { compact, isEmpty, isNil, isNull, times } from "lodash";
 import { useParams } from "next/navigation";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 
@@ -42,19 +42,22 @@ const Tree = ({ traceId, onSpanSelect }: TreeProps) => {
     overscan: 20,
   });
 
+  const selectedSpanIndex = useMemo(() => {
+    if (isNil(selectedSpan)) return null;
+    const selectedIndex = treeSpans.findIndex((item) => item.span.spanId === selectedSpan.spanId);
+    return selectedIndex;
+  }, [selectedSpan?.spanId, treeSpans, isSpansLoading]);
+
   // Scroll to selected span when selection changes
   useEffect(() => {
-    if (!selectedSpan || isSpansLoading) return;
-
-    const selectedIndex = treeSpans.findIndex((item) => item.span.spanId === selectedSpan.spanId);
-
-    if (selectedIndex !== -1) {
+    if (isNull(selectedSpanIndex) || isSpansLoading) return;
+    if (selectedSpanIndex !== -1) {
       const rafId = requestAnimationFrame(() => {
-        virtualizer.scrollToIndex(selectedIndex, { align: "start" });
+        virtualizer.scrollToIndex(selectedSpanIndex, { align: "start" });
       });
       return () => cancelAnimationFrame(rafId);
     }
-  }, [selectedSpan?.spanId, treeSpans, virtualizer, isSpansLoading]);
+  }, [selectedSpanIndex, virtualizer]);
 
   const items = virtualizer?.getVirtualItems() || [];
 

--- a/frontend/components/traces/trace-view/list/index.tsx
+++ b/frontend/components/traces/trace-view/list/index.tsx
@@ -50,7 +50,7 @@ const List = ({ traceId, onSpanSelect, isShared = false }: ListProps) => {
     if (isNil(selectedSpan)) return null;
     const selectedIndex = listSpans.findIndex((span) => span.spanId === selectedSpan.spanId);
     return selectedIndex;
-  }, [selectedSpan?.spanId, listSpans, isSpansLoading]);
+  }, [selectedSpan?.spanId, listSpans]);
 
   // Scroll to selected span when selection changes
   useEffect(() => {

--- a/frontend/components/traces/trace-view/list/index.tsx
+++ b/frontend/components/traces/trace-view/list/index.tsx
@@ -61,7 +61,7 @@ const List = ({ traceId, onSpanSelect, isShared = false }: ListProps) => {
       });
       return () => cancelAnimationFrame(rafId);
     }
-  }, [selectedSpanIndex, virtualizer]);
+  }, [selectedSpanIndex, virtualizer, isSpansLoading]);
 
   const items = virtualizer?.getVirtualItems() || [];
 

--- a/frontend/components/traces/trace-view/tree/index.tsx
+++ b/frontend/components/traces/trace-view/tree/index.tsx
@@ -57,7 +57,7 @@ const Tree = ({ traceId, onSpanSelect, isShared = false }: TreeProps) => {
       });
       return () => cancelAnimationFrame(rafId);
     }
-  }, [selectedSpanIndex, virtualizer]);
+  }, [selectedSpanIndex, virtualizer, isSpansLoading]);
 
   const items = virtualizer?.getVirtualItems() || [];
 

--- a/frontend/components/traces/trace-view/tree/index.tsx
+++ b/frontend/components/traces/trace-view/tree/index.tsx
@@ -46,7 +46,7 @@ const Tree = ({ traceId, onSpanSelect, isShared = false }: TreeProps) => {
     if (isNil(selectedSpan)) return null;
     const selectedIndex = treeSpans.findIndex((item) => item.span.spanId === selectedSpan.spanId);
     return selectedIndex;
-  }, [selectedSpan?.spanId, treeSpans, isSpansLoading]);
+  }, [selectedSpan?.spanId, treeSpans]);
 
   // Scroll to selected span when selection changes
   useEffect(() => {

--- a/frontend/components/traces/trace-view/tree/index.tsx
+++ b/frontend/components/traces/trace-view/tree/index.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { compact, isEmpty, times } from "lodash";
+import { compact, isEmpty, isNil, isNull, times } from "lodash";
 import { useParams } from "next/navigation";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 
@@ -42,19 +42,22 @@ const Tree = ({ traceId, onSpanSelect, isShared = false }: TreeProps) => {
     overscan: 20,
   });
 
+  const selectedSpanIndex = useMemo(() => {
+    if (isNil(selectedSpan)) return null;
+    const selectedIndex = treeSpans.findIndex((item) => item.span.spanId === selectedSpan.spanId);
+    return selectedIndex;
+  }, [selectedSpan?.spanId, treeSpans, isSpansLoading]);
+
   // Scroll to selected span when selection changes
   useEffect(() => {
-    if (!selectedSpan || isSpansLoading) return;
-
-    const selectedIndex = treeSpans.findIndex((item) => item.span.spanId === selectedSpan.spanId);
-
-    if (selectedIndex !== -1) {
+    if (isNull(selectedSpanIndex) || isSpansLoading) return;
+    if (selectedSpanIndex !== -1) {
       const rafId = requestAnimationFrame(() => {
-        virtualizer.scrollToIndex(selectedIndex, { align: "start" });
+        virtualizer.scrollToIndex(selectedSpanIndex, { align: "start" });
       });
       return () => cancelAnimationFrame(rafId);
     }
-  }, [selectedSpan?.spanId, treeSpans, virtualizer, isSpansLoading]);
+  }, [selectedSpanIndex, virtualizer]);
 
   const items = virtualizer?.getVirtualItems() || [];
 


### PR DESCRIPTION
This was caused by a useEffect scrolling to the selected span for condensed timeline span click feature. 

The fix was to trigger this behavior only on selectedSpanIndex change instead of listening to both selected span and all spans. 

Listening to all spans caused scroll to behavior anytime a new span arrived.

I split the `scrollTo` `useEffect` into a `useMemo` and a `useEffect`. The array of all spans dependency was moved from the `useEffect` to the `useMemo` to avoid retriggering the `useEffect` whenever a new span arrives.

The same fix was applied four times on (Tree, Reader) x (Rollout, Trace view)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI behavior change affecting only auto-scroll behavior in four virtualized components; main risk is missing an intended scroll in edge cases when selection or span ordering changes.
> 
> **Overview**
> Stops the trace and rollout session *List* and *Tree* views from constantly jumping back to the selected span during realtime updates.
> 
> This refactors the scroll-to-selected logic to compute `selectedSpanIndex` in a `useMemo` and run the `scrollToIndex` effect only when that index changes (and is valid), rather than re-triggering on incoming span array changes; null/undefined handling was tightened via `isNil`/`isNull`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 172170ece348944e993cb252de14608549a1007b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->