### PR TITLE
fix: dashboard time range selection

### DIFF
--- a/frontend/components/ui/date-range-filter/store.tsx
+++ b/frontend/components/ui/date-range-filter/store.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isNil } from "lodash";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { createContext, type PropsWithChildren, useContext, useEffect, useMemo, useRef } from "react";
 import { type DateRange as ReactDateRange } from "react-day-picker";
@@ -87,7 +88,7 @@ const createDateRangeFilterStore = (
         calendarDate: undefined,
       });
 
-      if (mode === "url" && currentSearchParams) {
+      if (mode === "url" && !isNil(currentSearchParams)) {
         const newSearchParams = new URLSearchParams(currentSearchParams);
         newSearchParams.delete("startDate");
         newSearchParams.delete("endDate");
@@ -123,7 +124,7 @@ const createDateRangeFilterStore = (
         endDate: endDateIso,
       });
 
-      if (mode === "url" && currentSearchParams) {
+      if (mode === "url" && !isNil(currentSearchParams)) {
         const newSearchParams = new URLSearchParams(currentSearchParams);
         newSearchParams.delete("pastHours");
         newSearchParams.set("pageNumber", "0");


### PR DESCRIPTION
empty params caused empty string which was falsey. Caused condition to misevaluate as a result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to URL-update conditionals in the date range filter store; minimal behavioral impact beyond fixing the empty-query edge case.
> 
> **Overview**
> Fixes date range selection when the current URL query string is empty by treating `currentSearchParams` as present unless it’s `null`/`undefined`.
> 
> `selectQuickRange` and `applyAbsoluteRange` now use `isNil` checks before mutating/pushing updated `URLSearchParams`, preventing falsey empty-string params from skipping URL updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2aab4a3b3d4975d13b70da39fc676e34550e078. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->