### PR TITLE
fix: remove min width inflation in condensed timeline

### DIFF
--- a/frontend/components/traces/trace-view/trace-view-store-utils.ts
+++ b/frontend/components/traces/trace-view/trace-view-store-utils.ts
@@ -360,7 +360,7 @@ export const transformSpansToCondensedTimeline = (spans: TraceViewSpan[]): Conde
     spansWithPosition.push({
       span,
       left,
-      width: Math.max(width, 0.5), // Minimum width for visibility
+      width,
       originalDepth: depthMap.get(span.spanId) ?? 0,
       startMs: spanStartMs,
       endMs: spanEndMs,


### PR DESCRIPTION
## Summary
- Removed the `Math.max(width, 0.5)` minimum width clamp in the condensed timeline data transformation layer
- This 0.5% floor inflated short spans (~748ms) to visually represent ~4.5s on long traces (~15min), causing sequential spans to falsely appear as overlapping
- The CSS `max(width%, 4px)` minimum in the renderer already ensures span visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to UI layout math; risk is limited to potentially making extremely short spans harder to see if downstream rendering doesn’t enforce its own minimum width.
> 
> **Overview**
> Fixes condensed trace timeline layout by removing the `Math.max(width, 0.5)` minimum-width clamp when computing span widths in `transformSpansToCondensedTimeline`.
> 
> This prevents short spans from being artificially widened (and thus appearing to overlap), relying on the renderer’s own minimum pixel width for visibility instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d93e9a256cc6c96bef79e8d78731d037aa0ea38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->