### PR TITLE
fix: improve blog post mobile layout and typography (LAM-1160)

### DIFF
--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -1,4 +1,6 @@
+import { ChevronLeft } from "lucide-react";
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 
@@ -42,10 +44,19 @@ export default async function BlogPostPage(props0: { params: Promise<{ slug: str
     const { data, content } = getBlogPost(params.slug);
 
     return (
-      <div className="mt-8 md:mt-16 lg:mt-32 flex justify-center flex-col items-center pb-16 px-4">
-        <BlogMeta data={data} />
-        <article className="flex flex-col z-30 md:w-[700px] lg:max-w-3xl w-full px-8 md:px-0">
-          <div className="pt-4 text-lg">
+      <div className="mt-8 md:mt-14 lg:mt-20 flex justify-center flex-col items-center pb-16 px-4">
+        <div className="w-full md:w-[700px] lg:max-w-3xl">
+          <Link
+            href="/blog"
+            className="text-sm text-secondary-foreground hover:text-primary flex items-center gap-0.5 w-fit"
+          >
+            <ChevronLeft size={16} />
+            Blog
+          </Link>
+        </div>
+        <BlogMeta data={data} className="mt-4" />
+        <article className="flex flex-col z-30 md:w-[700px] lg:max-w-3xl w-full md:px-0 sm:mt-8">
+          <div className="pt-4 text-base">
             <MDXRemote
               source={content}
               components={{

--- a/frontend/app/blog/layout.tsx
+++ b/frontend/app/blog/layout.tsx
@@ -9,8 +9,12 @@ export default async function BlogLayout({ children }: PropsWithChildren) {
   const session = await getServerSession(authOptions);
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <LandingHeader hasSession={session !== null && session !== undefined} isIncludePadding />
+    <div className="min-h-screen flex flex-col bg-landing-surface-800">
+      <LandingHeader
+        hasSession={session !== null && session !== undefined}
+        isIncludePadding
+        className="sm:border-none border-b border-b-landing-surface-500"
+      />
       <main className="flex-1">{children}</main>
       {/* Spacer */}
       <div className="w-full h-[160px]" />

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -41,7 +41,7 @@ export default async function BlogsPage() {
               />
             )}
             <CardHeader>
-              <CardTitle className="font-title text-2xl text-white">{post.data.title}</CardTitle>
+              <CardTitle className="font-space-grotesk text-2xl text-white">{post.data.title}</CardTitle>
             </CardHeader>
             <CardContent className="flex grow"></CardContent>
             <CardFooter className="flex align-bottom">

--- a/frontend/components/blog/blog-meta.tsx
+++ b/frontend/components/blog/blog-meta.tsx
@@ -2,27 +2,29 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { type BlogMetadata } from "@/lib/blog/types";
-import { formatUTCDate } from "@/lib/utils";
-
-import { Label } from "../ui/label";
+import { cn, formatUTCDate } from "@/lib/utils";
 
 interface BlogMetaProps {
   data: BlogMetadata;
+  className?: string;
 }
 
-export default function BlogMeta({ data }: BlogMetaProps) {
+export default function BlogMeta({ data, className }: BlogMetaProps) {
   return (
-    <div className="flex flex-col gap-8 items-center">
-      <div className="flex flex-col w-full md:w-[700px] lg:max-w-3xl gap-4 mb-16">
-        <h1 className="text-5xl font-bold font-title">{data.title}</h1>
-        <p className="text-secondary-foreground text-sm"> {formatUTCDate(data.date)} </p>
-        {data.author.url ? (
-          <Label className="text-secondary-foreground hover:text-primary">
-            <Link href={data.author.url}>{data.author.name}</Link>
-          </Label>
-        ) : (
-          <Label className="text-secondary-foreground">{data.author.name}</Label>
-        )}
+    <div className={cn("flex flex-col gap-8 items-center", className)}>
+      <div className="flex flex-col w-full md:w-[700px] lg:max-w-3xl space-y-4">
+        <h1 className="text-3xl sm:text-5xl leading-tight font-medium font-space-grotesk">{data.title}</h1>
+        <div className="flex space-x-3 text-sm text-secondary-foreground">
+          <p>{formatUTCDate(data.date)}</p>
+          <p>·</p>
+          {data.author.url ? (
+            <Link href={data.author.url} className="hover:text-primary">
+              {data.author.name}
+            </Link>
+          ) : (
+            <p>{data.author.name}</p>
+          )}
+        </div>
       </div>
       {data.image && (
         <div className="w-full flex rounded overflow-hidden">

--- a/frontend/components/blog/md-heading.tsx
+++ b/frontend/components/blog/md-heading.tsx
@@ -1,4 +1,3 @@
-
 import Link from "next/link";
 
 import { headingToUrl } from "@/lib/blog/utils";
@@ -10,33 +9,48 @@ interface MDHeadingProps {
 }
 
 export default function MDHeading({ props, level }: MDHeadingProps) {
-  return <div className="flex space-x-2 group">
-    <HeadingContent props={props} level={level} />
-    <Link
-      href={`#${headingToUrl(props.children as string)}`}
-      className={cn("cursor-pointer group-hover:block group-hover:underline hidden text-secondary-foreground", levelToClassName(level))}
-    >
-      #
-    </Link>
-  </div>;
+  return (
+    <div className="flex space-x-2 group">
+      <HeadingContent props={props} level={level} />
+      <Link
+        href={`#${headingToUrl(props.children as string)}`}
+        className={cn(
+          "cursor-pointer group-hover:block group-hover:underline hidden text-secondary-foreground",
+          levelToClassName(level)
+        )}
+      >
+        #
+      </Link>
+    </div>
+  );
 }
 
-function HeadingContent({ props, level }: { props: any, level: number }) {
+function HeadingContent({ props, level }: { props: any; level: number }) {
   switch (level) {
-    case 0: return <h1 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
-    case 1: return <h2 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
-    case 2: return <h3 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
-    case 3: return <h4 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
-    default: return <h1 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
+    case 0:
+      return <h1 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
+    case 1:
+      return <h2 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
+    case 2:
+      return <h3 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
+    case 3:
+      return <h4 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
+    default:
+      return <h1 {...props} id={headingToUrl(props.children as string)} className={levelToClassName(level)} />;
   }
 }
 
 function levelToClassName(level: number) {
   switch (level) {
-    case 0: return "text-3xl font-bold font-title";
-    case 1: return "text-2xl pt-4 font-bold font-title mt-8";
-    case 2: return "text-xl pt-4 font-bold font-title mt-8";
-    case 3: return "text-lg pt-4 font-bold font-title mt-8";
-    default: return "text-3xl font-bold font-title";
+    case 0:
+      return "text-3xl font-medium font-space-grotesk";
+    case 1:
+      return "text-2xl pt-4 font-medium font-space-grotesk mt-8";
+    case 2:
+      return "text-xl pt-4 font-medium font-space-grotesk mt-8";
+    case 3:
+      return "text-lg pt-4 font-medium font-space-grotesk mt-8";
+    default:
+      return "text-3xl font-medium font-space-grotesk";
   }
 }


### PR DESCRIPTION
## Summary
- Fix excessive horizontal padding on mobile blog body text (was 48px, now 16px)
- Switch blog titles and headings to Space Grotesk font for consistency with landing pages
- Add back-to-blog chevron navigation link at top of posts
- Combine date and author into a single inline meta row with dot separator
- Make title size responsive (text-3xl on mobile, text-5xl on desktop) with proper line height

Generated with [Claude Code](https://claude.com/claude-code)

<img width="1836" height="988" alt="Screenshot 2026-02-06 at 1 04 56 PM" src="https://github.com/user-attachments/assets/dbf425c0-5316-42ec-9a96-fda8555332e8" />

<img width="1841" height="992" alt="Screenshot 2026-02-06 at 1 04 49 PM" src="https://github.com/user-attachments/assets/4ce8a1da-21af-4255-bcaa-7f592fe61112" />

<img width="789" height="885" alt="Screenshot 2026-02-06 at 1 04 30 PM" src="https://github.com/user-attachments/assets/0bf99e06-dec8-4bd4-92a3-4cd8594fa693" />

<img width="627" height="875" alt="Screenshot 2026-02-06 at 1 04 24 PM" src="https://github.com/user-attachments/assets/410d6b86-2840-4762-8771-8145b202e2c8" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily Tailwind/CSS and minor component API changes limited to blog UI; low chance of functional impact beyond visual regressions.
> 
> **Overview**
> Improves blog post page UX by adding a **back-to-blog** chevron link, tightening vertical spacing, and reducing mobile body padding/typography for better readability.
> 
> Updates blog typography to use `font-space-grotesk` for titles/headings, makes post titles responsive, and consolidates metadata into a single inline date/author row (with optional author link) via an updated `BlogMeta` API (`className` support).
> 
> Applies landing-surface background and header border styling to the blog layout, and updates blog index card titles to match the new font.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 177bb4b360207aa7529d13279a0d7ba8a88f57aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->