### PR TITLE
add FK on shared evals project_id

### DIFF
--- a/frontend/lib/db/migrations/0068_goofy_omega_flight.sql
+++ b/frontend/lib/db/migrations/0068_goofy_omega_flight.sql
@@ -4,3 +4,5 @@ CREATE TABLE "shared_evals" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"project_id" uuid DEFAULT gen_random_uuid() NOT NULL
 );
+--> statement-breakpoint
+ALTER TABLE "shared_evals" ADD CONSTRAINT "shared_evals_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint


### PR DESCRIPTION
The relations file already has that constraint, and both the prod and local DBs work as expected, just updating the migration with an accidentally deleted key

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small schema migration that only adds a referential integrity constraint; risk is limited to potential cleanup/behavior changes on project deletion due to cascading deletes.
> 
> **Overview**
> Adds a DB constraint tying `shared_evals.project_id` to `projects.id` via a new foreign key.
> 
> The FK is configured with **`ON DELETE CASCADE`** to automatically remove `shared_evals` rows when their parent project is deleted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce9479e0ced95e8bd5312a4d16d2d0df5751df1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->