### PR TITLE
fix: unconstrained height on shared eval page

### DIFF
--- a/frontend/components/shared/evaluation/shared-evaluation.tsx
+++ b/frontend/components/shared/evaluation/shared-evaluation.tsx
@@ -176,7 +176,7 @@ function SharedEvaluationContent({ evaluationId, evaluationName }: SharedEvaluat
   }, []);
 
   return (
-    <div className="flex flex-col h-full w-full overflow-hidden relative">
+    <div className="flex flex-col h-screen w-full overflow-hidden relative">
       <div className="flex flex-none items-center border-b px-6 py-3.5 gap-2">
         <Link className="mr-2" href="/projects">
           <Image alt="Laminar logo" src={fullLogo} width={100} height={20} />


### PR DESCRIPTION
## Summary
- Shared eval page used `h-full` which resolved to unbounded height since the parent layout chain (root layout) uses `min-h-screen` + `grow` without a fixed height constraint
- This caused the `InfiniteDataTable` scroll container to never become scrollable, so the `IntersectionObserver` kept firing `fetchNextPage` endlessly, loading all pages serially
- For large evaluations this overwhelmed the backend causing 500 errors and preventing costs from displaying
- Changed to `h-screen` (100vh) to directly constrain viewport height, matching how the regular eval page works via `fixed inset-0` in the project layout

Generated with [Claude Code](https://claude.com/claude-code)