### PR TITLE
fix: large fields in evals caused long loading times

### DIFF
--- a/frontend/components/evaluation/columns.tsx
+++ b/frontend/components/evaluation/columns.tsx
@@ -283,7 +283,9 @@ const createColumnSizeConfig = (heatmapEnabled: boolean, isComparison: boolean =
   minSize: heatmapEnabled ? (isComparison ? 140 : 100) : isComparison ? 80 : 60,
 });
 
-export const defaultColumns: ColumnDef<EvaluationDatapointPreviewWithCompared>[] = [
+export const getDefaultColumns = (
+  disableLongTooltips?: boolean
+): ColumnDef<EvaluationDatapointPreviewWithCompared>[] => [
   {
     cell: (row) => (
       <div className="flex h-full justify-center items-center w-10">
@@ -308,13 +310,17 @@ export const defaultColumns: ColumnDef<EvaluationDatapointPreviewWithCompared>[]
   {
     id: "data",
     accessorFn: (row) => row.data,
-    cell: (row) => <JsonTooltip data={row.getValue()} columnSize={row.column.getSize()} />,
+    cell: disableLongTooltips
+      ? (row) => <span className="truncate">{String(row.getValue() ?? "")}</span>
+      : (row) => <JsonTooltip data={row.getValue()} columnSize={row.column.getSize()} />,
     header: "Data",
   },
   {
     id: "target",
     accessorFn: (row) => row.target,
-    cell: (row) => <JsonTooltip data={row.getValue()} columnSize={row.column.getSize()} />,
+    cell: disableLongTooltips
+      ? (row) => <span className="truncate">{String(row.getValue() ?? "")}</span>
+      : (row) => <JsonTooltip data={row.getValue()} columnSize={row.column.getSize()} />,
     header: "Target",
   },
   {

--- a/frontend/components/evaluation/columns.tsx
+++ b/frontend/components/evaluation/columns.tsx
@@ -355,9 +355,7 @@ export const getComplementaryColumns = (
           (row: EvaluationDatapointPreviewWithCompared) => row.executorOutput,
           (output) => (output ? JSON.stringify(output) : "-")
         ),
-    cell: disableLongTooltips
-      ? (row) => <span className="truncate">{String(row.getValue() ?? "")}</span>
-      : undefined,
+    cell: disableLongTooltips ? (row) => <span className="truncate">{String(row.getValue() ?? "")}</span> : undefined,
     header: "Output",
   },
   {

--- a/frontend/components/evaluation/columns.tsx
+++ b/frontend/components/evaluation/columns.tsx
@@ -344,13 +344,20 @@ export const comparedComplementaryColumns: ColumnDef<EvaluationDatapointPreviewW
   },
 ];
 
-export const complementaryColumns: ColumnDef<EvaluationDatapointPreviewWithCompared>[] = [
+export const getComplementaryColumns = (
+  disableLongTooltips?: boolean
+): ColumnDef<EvaluationDatapointPreviewWithCompared>[] => [
   {
     id: "output",
-    accessorFn: flow(
-      (row: EvaluationDatapointPreviewWithCompared) => row.executorOutput,
-      (output) => (output ? JSON.stringify(output) : "-")
-    ),
+    accessorFn: disableLongTooltips
+      ? (row: EvaluationDatapointPreviewWithCompared) => row.executorOutput ?? "-"
+      : flow(
+          (row: EvaluationDatapointPreviewWithCompared) => row.executorOutput,
+          (output) => (output ? JSON.stringify(output) : "-")
+        ),
+    cell: disableLongTooltips
+      ? (row) => <span className="truncate">{String(row.getValue() ?? "")}</span>
+      : undefined,
     header: "Output",
   },
   {

--- a/frontend/components/evaluation/evaluation-datapoints-table.tsx
+++ b/frontend/components/evaluation/evaluation-datapoints-table.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useMemo, useState } from "react";
 
 import {
   comparedComplementaryColumns,
-  complementaryColumns,
+  getComplementaryColumns,
   getComparedScoreColumns,
   getDefaultColumns,
   getScoreColumns,
@@ -124,7 +124,7 @@ const EvaluationDatapointsTableContent = ({
         ...getComparedScoreColumns(scores, heatmapEnabled, scoreRanges),
       ];
     }
-    return [...defaultCols, ...complementaryColumns, ...getScoreColumns(scores, heatmapEnabled, scoreRanges)];
+    return [...defaultCols, ...getComplementaryColumns(isDisableLongTooltips), ...getScoreColumns(scores, heatmapEnabled, scoreRanges)];
   }, [targetId, scores, heatmapEnabled, scoreRanges, isDisableLongTooltips]);
 
   return (

--- a/frontend/components/evaluation/evaluation-datapoints-table.tsx
+++ b/frontend/components/evaluation/evaluation-datapoints-table.tsx
@@ -6,8 +6,8 @@ import React, { useEffect, useMemo, useState } from "react";
 import {
   comparedComplementaryColumns,
   complementaryColumns,
-  defaultColumns,
   getComparedScoreColumns,
+  getDefaultColumns,
   getScoreColumns,
 } from "@/components/evaluation/columns";
 import SearchEvaluationInput from "@/components/evaluation/search-evaluation-input";
@@ -37,6 +37,7 @@ interface EvaluationDatapointsTableProps {
   hasMore: boolean;
   isFetching: boolean;
   fetchNextPage: () => void;
+  isDisableLongTooltips?: boolean;
 }
 
 const filters: ColumnFilter[] = [
@@ -61,6 +62,7 @@ const EvaluationDatapointsTableContent = ({
   hasMore,
   isFetching,
   fetchNextPage,
+  isDisableLongTooltips,
 }: EvaluationDatapointsTableProps) => {
   const searchParams = useSearchParams();
 
@@ -114,15 +116,16 @@ const EvaluationDatapointsTableContent = ({
   }, [data, scores, targetId]);
 
   const columns = useMemo(() => {
+    const defaultCols = getDefaultColumns(isDisableLongTooltips);
     if (targetId) {
       return [
-        ...defaultColumns,
+        ...defaultCols,
         ...comparedComplementaryColumns,
         ...getComparedScoreColumns(scores, heatmapEnabled, scoreRanges),
       ];
     }
-    return [...defaultColumns, ...complementaryColumns, ...getScoreColumns(scores, heatmapEnabled, scoreRanges)];
-  }, [targetId, scores, heatmapEnabled, scoreRanges]);
+    return [...defaultCols, ...complementaryColumns, ...getScoreColumns(scores, heatmapEnabled, scoreRanges)];
+  }, [targetId, scores, heatmapEnabled, scoreRanges, isDisableLongTooltips]);
 
   return (
     <div className="flex overflow-hidden flex-1">

--- a/frontend/components/shared/evaluation/shared-evaluation.tsx
+++ b/frontend/components/shared/evaluation/shared-evaluation.tsx
@@ -236,6 +236,7 @@ function SharedEvaluationContent({ evaluationId, evaluationName }: SharedEvaluat
           hasMore={hasMorePages}
           isFetching={isFetchingPage}
           fetchNextPage={fetchNextPage}
+          isDisableLongTooltips
         />
       </div>
       {traceId && (

--- a/frontend/lib/actions/evaluation/index.ts
+++ b/frontend/lib/actions/evaluation/index.ts
@@ -77,12 +77,12 @@ export const getEvaluationDatapoints = async (
   // Step 1: Get trace IDs from search if provided
   const spanHits: { trace_id: string; span_id: string }[] = search
     ? await searchSpans({
-      projectId,
-      traceId: undefined,
-      searchQuery: search,
-      timeRange: getTimeRangeForEvaluation(evaluation.createdAt),
-      searchType: searchIn as SpanSearchType[],
-    })
+        projectId,
+        traceId: undefined,
+        searchQuery: search,
+        timeRange: getTimeRangeForEvaluation(evaluation.createdAt),
+        searchType: searchIn as SpanSearchType[],
+      })
     : [];
   const searchTraceIds = [...new Set(spanHits.map((span) => span.trace_id))];
 
@@ -139,6 +139,7 @@ export const getEvaluationDatapoints = async (
     filters: datapointFilters,
     limit,
     offset,
+    isTruncateLongColumns: false,
   });
 
   const rawResults = await executeQuery<EvaluationDatapointRow>({
@@ -245,12 +246,12 @@ export const getEvaluationStatistics = async (
   // Step 1: Get trace IDs from search if provided
   const spanHits: { trace_id: string; span_id: string }[] = search
     ? await searchSpans({
-      projectId,
-      traceId: undefined,
-      searchQuery: search,
-      timeRange: getTimeRangeForEvaluation(evaluation.createdAt),
-      searchType: searchIn as SpanSearchType[],
-    })
+        projectId,
+        traceId: undefined,
+        searchQuery: search,
+        timeRange: getTimeRangeForEvaluation(evaluation.createdAt),
+        searchType: searchIn as SpanSearchType[],
+      })
     : [];
   const searchTraceIds = [...new Set(spanHits.map((span) => span.trace_id))];
 

--- a/frontend/lib/actions/evaluation/utils.ts
+++ b/frontend/lib/actions/evaluation/utils.ts
@@ -55,10 +55,10 @@ const evaluationDatapointsColumnFilterConfig: ColumnFilterConfig = {
 const evaluationDatapointsSelectColumns = [
   "id",
   "evaluation_id as evaluationId",
-  "data",
-  "target",
+  "substring(data, 1, 200) as data",
+  "substring(target, 1, 200) as target",
   "metadata",
-  "executor_output as executorOutput",
+  "substring(executor_output, 1, 200) as executorOutput",
   "index",
   "trace_id as traceId",
   "group_id as groupId",

--- a/frontend/lib/actions/evaluation/utils.ts
+++ b/frontend/lib/actions/evaluation/utils.ts
@@ -51,23 +51,6 @@ const evaluationDatapointsColumnFilterConfig: ColumnFilterConfig = {
   ]),
 };
 
-// Evaluation datapoints view column mapping
-const evaluationDatapointsSelectColumns = [
-  "id",
-  "evaluation_id as evaluationId",
-  "substring(data, 1, 200) as data",
-  "substring(target, 1, 200) as target",
-  "metadata",
-  "substring(executor_output, 1, 200) as executorOutput",
-  "index",
-  "trace_id as traceId",
-  "group_id as groupId",
-  "scores",
-  "formatDateTime(created_at, '%Y-%m-%dT%H:%i:%S.%fZ') as createdAt",
-  "dataset_id as datasetId",
-  "dataset_datapoint_id as datasetDatapointId",
-  "formatDateTime(dataset_datapoint_created_at, '%Y-%m-%dT%H:%i:%S.%fZ') as datasetDatapointCreatedAt",
-];
 
 export interface BuildEvaluationDatapointsQueryOptions {
   evaluationId: string;
@@ -75,6 +58,26 @@ export interface BuildEvaluationDatapointsQueryOptions {
   filters: Filter[];
   limit: number;
   offset: number;
+  isTruncateLongColumns?: boolean;
+}
+
+function getEvaluationDatapointsSelectColumns(isTruncateLongColumns?: boolean): string[] {
+  return [
+    "id",
+    "evaluation_id as evaluationId",
+    isTruncateLongColumns ? "substring(data, 1, 200) as data" : "data",
+    isTruncateLongColumns ? "substring(target, 1, 200) as target" : "target",
+    "metadata",
+    isTruncateLongColumns ? "substring(executor_output, 1, 200) as executorOutput" : "executor_output as executorOutput",
+    "index",
+    "trace_id as traceId",
+    "group_id as groupId",
+    "scores",
+    "formatDateTime(created_at, '%Y-%m-%dT%H:%i:%S.%fZ') as createdAt",
+    "dataset_id as datasetId",
+    "dataset_datapoint_id as datasetDatapointId",
+    "formatDateTime(dataset_datapoint_created_at, '%Y-%m-%dT%H:%i:%S.%fZ') as datasetDatapointCreatedAt",
+  ];
 }
 
 export interface BuildEvaluationStatisticsQueryOptions {
@@ -92,7 +95,7 @@ export interface BuildTracesForEvaluationQueryOptions {
 export const buildEvaluationDatapointsQueryWithParams = (
   options: BuildEvaluationDatapointsQueryOptions
 ): QueryResult => {
-  const { evaluationId, traceIds, filters, limit, offset } = options;
+  const { evaluationId, traceIds, filters, limit, offset, isTruncateLongColumns } = options;
 
   const customConditions: Array<{
     condition: string;
@@ -136,7 +139,7 @@ export const buildEvaluationDatapointsQueryWithParams = (
 
   const queryOptions: SelectQueryOptions = {
     select: {
-      columns: evaluationDatapointsSelectColumns,
+      columns: getEvaluationDatapointsSelectColumns(isTruncateLongColumns),
       table: "evaluation_datapoints",
     },
     filters: nonScoreFilters,

--- a/frontend/lib/actions/shared/evaluation/index.ts
+++ b/frontend/lib/actions/shared/evaluation/index.ts
@@ -135,6 +135,7 @@ export async function getSharedEvaluationDatapoints({
     filters: datapointFilters,
     limit,
     offset,
+    isTruncateLongColumns: true,
   });
 
   const rawResults = await executeQuery<EvaluationDatapointRow>({


### PR DESCRIPTION
## Summary
- Evaluation datapoints query was fetching full `data`, `target`, and `executor_output` JSON blobs for every row, causing slow page loads even with only 50 rows per page
- Truncate these fields to 200 characters at the ClickHouse query level since table cells only display previews
- Truncation occurs conditionally just for shared evals and not for regular evals

Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both query generation and table rendering; risk is mainly around inadvertently truncating fields in non-shared views or changing tooltip/display behavior for large JSON values.
> 
> **Overview**
> Improves shared evaluation page performance by **truncating large `data`/`target`/`executor_output` fields to 200 chars at the ClickHouse query level** via a new `isTruncateLongColumns` option on `buildEvaluationDatapointsQueryWithParams` (enabled for shared evals, disabled for normal evals).
> 
> Updates the eval datapoints table to support an `isDisableLongTooltips` mode: column definitions are now generated by `getDefaultColumns`/`getComplementaryColumns` and render truncated plain text instead of `JsonTooltip`/JSON-stringified output when this flag is set (used by `shared-evaluation`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab77b8d194943036788208f79523326822ddc9da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->