### PR TITLE
fix: sync session needle to trace time and fix playback speed

### DIFF
--- a/frontend/components/rollout-sessions/rollout-session-view/condensed-timeline/index.tsx
+++ b/frontend/components/rollout-sessions/rollout-session-view/condensed-timeline/index.tsx
@@ -37,6 +37,7 @@ function CondensedTimeline() {
     condensedTimelineZoom,
     setCondensedTimelineZoom,
     sessionTime,
+    sessionStartTime,
     browserSession,
   } = useRolloutSessionStoreContext((state) => ({
     getCondensedTimelineData: state.getCondensedTimelineData,
@@ -50,11 +51,13 @@ function CondensedTimeline() {
     condensedTimelineZoom: state.condensedTimelineZoom,
     setCondensedTimelineZoom: state.setCondensedTimelineZoom,
     sessionTime: state.sessionTime,
+    sessionStartTime: state.sessionStartTime,
     browserSession: state.browserSession,
   }));
 
   const {
     spans: condensedSpans,
+    startTime: spanTimelineStartMs,
     totalDurationMs,
     totalRows,
   } = useMemo(() => getCondensedTimelineData(), [getCondensedTimelineData, storeSpans]);
@@ -136,7 +139,7 @@ function CondensedTimeline() {
           {browserSession && sessionTime !== undefined && totalDurationMs > 0 && (
             <div
               className="absolute inset-y-0 pointer-events-none z-[33]"
-              style={{ left: `${((sessionTime * 1000) / totalDurationMs) * 100}%` }}
+              style={{ left: `${((sessionTime * 1000 + (sessionStartTime ?? spanTimelineStartMs) - spanTimelineStartMs) / totalDurationMs) * 100}%` }}
             >
               <div className="absolute top-0 h-6 flex items-center -translate-x-1/2 z-[34]">
                 <div className="size-5 bg-landing-text-500 text-primary-foreground rounded-full flex items-center justify-center">

--- a/frontend/components/rollout-sessions/rollout-session-view/rollout-session-store.tsx
+++ b/frontend/components/rollout-sessions/rollout-session-view/rollout-session-store.tsx
@@ -57,6 +57,7 @@ interface RolloutSessionStoreState {
   browserSession: boolean;
   langGraph: boolean;
   sessionTime?: number;
+  sessionStartTime?: number;
   tab: "tree" | "reader";
   sidebarWidth: number;
   hasBrowserSession: boolean;
@@ -95,6 +96,7 @@ interface RolloutSessionStoreActions {
   setBrowserSession: (browserSession: boolean) => void;
   setLangGraph: (langGraph: boolean) => void;
   setSessionTime: (time?: number) => void;
+  setSessionStartTime: (time?: number) => void;
   setTab: (tab: RolloutSessionStoreState["tab"]) => void;
   setSidebarWidth: (width: number) => void;
   setHasBrowserSession: (hasBrowserSession: boolean) => void;
@@ -317,6 +319,7 @@ const createRolloutSessionStore = ({
           }
         },
         setSessionTime: (sessionTime) => set({ sessionTime }),
+        setSessionStartTime: (sessionStartTime) => set({ sessionStartTime }),
         setIsTraceLoading: (isTraceLoading) => set({ isTraceLoading }),
         setIsSpansLoading: (isSpansLoading) => set({ isSpansLoading }),
         setLangGraph: (langGraph: boolean) => set({ langGraph }),

--- a/frontend/components/traces/session-player.tsx
+++ b/frontend/components/traces/session-player.tsx
@@ -36,9 +36,10 @@ const speedOptions = [1, 2, 4, 8, 16];
 
 const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }: SessionPlayerProps) => {
   const { projectId } = useParams();
-  const { setSessionTime, sessionTime } = useTraceViewStoreContext((state) => ({
+  const { setSessionTime, sessionTime, setSessionStartTime } = useTraceViewStoreContext((state) => ({
     setSessionTime: state.setSessionTime,
     sessionTime: state.sessionTime,
+    setSessionStartTime: state.setSessionStartTime,
   }));
 
   const playerContainerRef = useRef<HTMLDivElement>(null);
@@ -132,6 +133,7 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
         setEvents(result.events);
         setUrlChanges(result.urlChanges);
         setDuration(result.duration);
+        setSessionStartTime(result.startTime);
         if (result.urlChanges.length > 0) {
           setCurrentUrl(result.urlChanges[0].url);
         }
@@ -149,8 +151,9 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
 
   useEffect(() => {
     if (playerRef.current && sessionTime !== undefined) {
+      // Skip goto if this update came from the player itself (avoid feedback loop)
+      if (Math.abs(sessionTime - lastPlayerTime.current) < 0.05) return;
       playerRef.current.goto(sessionTime * 1000);
-      lastPlayerTime.current = sessionTime;
     }
   }, [sessionTime]);
 
@@ -183,6 +186,7 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
 
       playerRef.current.addEventListener("ui-update-current-time", (event: any) => {
         const timeInSeconds = event.payload / 1000;
+        lastPlayerTime.current = timeInSeconds;
         setSessionTime(timeInSeconds);
         updateCurrentUrl(eventStartTime + event.payload);
       });

--- a/frontend/components/traces/trace-view/condensed-timeline/index.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/index.tsx
@@ -32,6 +32,7 @@ function CondensedTimeline() {
     condensedTimelineZoom,
     setCondensedTimelineZoom,
     sessionTime,
+    sessionStartTime,
     browserSession,
   } = useTraceViewStoreContext((state) => ({
     getCondensedTimelineData: state.getCondensedTimelineData,
@@ -45,11 +46,13 @@ function CondensedTimeline() {
     condensedTimelineZoom: state.condensedTimelineZoom,
     setCondensedTimelineZoom: state.setCondensedTimelineZoom,
     sessionTime: state.sessionTime,
+    sessionStartTime: state.sessionStartTime,
     browserSession: state.browserSession,
   }));
 
   const {
     spans: condensedSpans,
+    startTime: spanTimelineStartMs,
     totalDurationMs,
     totalRows,
   } = useMemo(() => getCondensedTimelineData(), [getCondensedTimelineData, storeSpans]);
@@ -131,7 +134,7 @@ function CondensedTimeline() {
           {browserSession && sessionTime !== undefined && totalDurationMs > 0 && (
             <div
               className="absolute inset-y-0 pointer-events-none z-[33]"
-              style={{ left: `${((sessionTime * 1000) / totalDurationMs) * 100}%` }}
+              style={{ left: `${((sessionTime * 1000 + (sessionStartTime ?? spanTimelineStartMs) - spanTimelineStartMs) / totalDurationMs) * 100}%` }}
             >
               <div className="absolute top-0 h-6 flex items-center -translate-x-1/2 z-[34]">
                 <div className="size-5 bg-landing-text-500 text-primary-foreground rounded-full flex items-center justify-center">

--- a/frontend/components/traces/trace-view/trace-view-store.tsx
+++ b/frontend/components/traces/trace-view/trace-view-store.tsx
@@ -99,6 +99,7 @@ interface TraceViewStoreState {
   browserSession: boolean;
   langGraph: boolean;
   sessionTime?: number;
+  sessionStartTime?: number;
   tab: "tree" | "reader";
   treeWidth: number;
   hasBrowserSession: boolean;
@@ -124,6 +125,7 @@ interface TraceViewStoreActions {
   setBrowserSession: (browserSession: boolean) => void;
   setLangGraph: (langGraph: boolean) => void;
   setSessionTime: (time?: number) => void;
+  setSessionStartTime: (time?: number) => void;
   setTab: (tab: TraceViewStoreState["tab"]) => void;
   setTreeWidth: (width: number) => void;
   setHasBrowserSession: (hasBrowserSession: boolean) => void;
@@ -281,6 +283,7 @@ const createTraceViewStore = (initialTrace?: TraceViewTrace, storeKey?: string) 
           }
         },
         setSessionTime: (sessionTime) => set({ sessionTime }),
+        setSessionStartTime: (sessionStartTime) => set({ sessionStartTime }),
         setIsTraceLoading: (isTraceLoading) => set({ isTraceLoading }),
         setIsSpansLoading: (isSpansLoading) => set({ isSpansLoading }),
         setLangGraph: (langGraph: boolean) => set({ langGraph }),


### PR DESCRIPTION
## Summary
- The condensed timeline needle was mispositioned because it assumed rrweb session time 0 equals trace start — now accounts for the offset between recording start and earliest span start
- Fixed a feedback loop where the rrweb player's own `ui-update-current-time` events triggered `goto()` calls back to the same position, causing extremely slow playback
- Applied both fixes identically to trace view and rollout session view components

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/state synchronization changes only; main risk is minor regressions in timeline needle positioning or session seeking behavior due to new time-offset calculations.
> 
> **Overview**
> Fixes browser-session playback synchronization in both trace view and rollout session view.
> 
> The condensed timeline “session needle” is now positioned using the rrweb recording `startTime` offset relative to the earliest span start, rather than assuming 0s aligns with trace start. The rrweb session player now avoids a `goto()` feedback loop by tracking the last player-emitted time and ignoring near-identical store updates, preventing slow playback; `sessionStartTime` is stored in the relevant zustand stores and populated from the events API response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 890ff1a43684ca6aad82fa48747b1f5d1765c1d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->