### PR TITLE
fix data count

### DIFF
--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -167,7 +167,7 @@ impl CHSpan {
             input: span_input_string,
             output: span_output_string,
             status: span.status.clone().unwrap_or(String::from("")),
-            size_bytes: span.estimate_size_bytes() as u64,
+            size_bytes: span.size_bytes as u64,
             attributes: span.attributes.to_string(),
             trace_metadata,
             trace_type: span.attributes.trace_type().unwrap_or_default().into(),

--- a/app-server/src/db/spans.rs
+++ b/app-server/src/db/spans.rs
@@ -88,6 +88,8 @@ pub struct Span {
     pub tags: Option<Value>,
     pub input_url: Option<String>,
     pub output_url: Option<String>,
+    #[serde(default)]
+    pub size_bytes: usize,
 }
 
 impl Span {
@@ -182,6 +184,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         let span_attributes = span.attributes.to_value();
@@ -404,6 +407,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         let span_attributes = span.attributes.to_value();
@@ -659,6 +663,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         let span_attributes = span.attributes.to_value();

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -94,6 +94,7 @@ pub async fn create_span(
         tags: None,
         input_url: None,
         output_url: None,
+        size_bytes: 0,
     };
 
     let rabbitmq_span_message = RabbitMqSpanMessage { span };

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -216,6 +216,7 @@ pub async fn emit_internal_span(queue: Arc<MessageQueue>, span: InternalSpan) ->
         tags: None,
         input_url: None,
         output_url: None,
+        size_bytes: 0,
     };
 
     if let Some(error) = span.error {

--- a/app-server/src/traces/consumer.rs
+++ b/app-server/src/traces/consumer.rs
@@ -178,6 +178,7 @@ async fn process_span_messages(
         .into_par_iter()
         .map(|message| {
             let mut span = message.span;
+            span.estimate_size_bytes();
             span.parse_and_enrich_attributes();
             span
         })
@@ -334,7 +335,7 @@ async fn process_span_messages(
     if is_feature_enabled(Feature::UsageLimit) {
         let mut bytes_per_project: HashMap<Uuid, usize> = HashMap::new();
         for span in &spans {
-            *bytes_per_project.entry(span.project_id).or_default() += span.estimate_size_bytes();
+            *bytes_per_project.entry(span.project_id).or_default() += span.size_bytes;
         }
 
         for (project_id, bytes) in bytes_per_project {

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -898,9 +898,8 @@ impl Span {
         Ok(())
     }
 
-    pub fn estimate_size_bytes(&self) -> usize {
-        // events size is estimated separately, so ignored here
-
+    /// This function MUST to be called right after we deserialize or create a span object.
+    pub fn estimate_size_bytes(&mut self) {
         // 16 bytes for span_id,
         // 16 bytes for trace_id,
         // 16 bytes for parent_span_id,
@@ -908,7 +907,8 @@ impl Span {
         // 8 bytes for end_time,
 
         // everything else is in attributes
-        return 16
+        // because right after creation attributes contain all span data
+        let size_bytes = 16
             + 16
             + 16
             + 8
@@ -925,6 +925,7 @@ impl Span {
                 .iter()
                 .map(|event| event.estimate_size_bytes())
                 .sum::<usize>();
+        self.size_bytes = size_bytes;
     }
 
     /// Check if the span is the wrapper of a tool call made by AI SDK on behalf
@@ -1454,6 +1455,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         // Verify initial state
@@ -1779,6 +1781,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         // Verify initial state
@@ -2124,6 +2127,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         // Create child span (ai.generateText.doGenerate) - has LLM span type
@@ -2270,6 +2274,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         // Verify initial span relationships and structure
@@ -2742,6 +2747,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         // Create child span (ai.generateText.doGenerate) - has LLM span type
@@ -2895,6 +2901,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         // Verify initial span relationships and structure
@@ -3155,6 +3162,7 @@ mod tests {
             tags: None,
             input_url: None,
             output_url: None,
+            size_bytes: 0,
         };
 
         // Verify initial state


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect how ingested byte counts are computed and stored, which can impact billing/usage limits and analytics if `estimate_size_bytes` is missed or computed at the wrong lifecycle point.
> 
> **Overview**
> Spans now persist a `size_bytes` field (`db::spans::Span`) and `estimate_size_bytes` was changed from a pure getter to a mutating method that populates this field immediately after span creation/deserialization.
> 
> ClickHouse serialization (`CHSpan`) and workspace usage-limit byte accounting in the spans consumer were updated to use `span.size_bytes` (computed once up front) rather than recomputing size later, and all span construction call sites/tests initialize `size_bytes` to `0` for backwards compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bb6785e4888c846e38f5cd8704a5e742a5f105b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->