### PR TITLE
Update datapoint accept trace

### DIFF
--- a/app-server/src/api/v1/evals.rs
+++ b/app-server/src/api/v1/evals.rs
@@ -89,6 +89,7 @@ pub async fn save_eval_datapoints(
 pub struct UpdateEvalDatapointRequest {
     pub executor_output: Option<Value>,
     pub scores: HashMap<String, Option<f64>>,
+    #[serde(default)]
     pub trace_id: Option<Uuid>,
 }
 

--- a/app-server/src/api/v1/evals.rs
+++ b/app-server/src/api/v1/evals.rs
@@ -89,6 +89,7 @@ pub async fn save_eval_datapoints(
 pub struct UpdateEvalDatapointRequest {
     pub executor_output: Option<Value>,
     pub scores: HashMap<String, Option<f64>>,
+    pub trace_id: Option<Uuid>,
 }
 
 #[post("/evals/{eval_id}/datapoints/{datapoint_id}")]
@@ -117,6 +118,7 @@ pub async fn update_eval_datapoint(
         &group_id,
         req.executor_output,
         req.scores,
+        req.trace_id,
     )
     .await?;
 

--- a/app-server/src/db/trace.rs
+++ b/app-server/src/db/trace.rs
@@ -357,3 +357,21 @@ pub async fn insert_shared_traces(
 
     Ok(())
 }
+
+pub async fn delete_shared_traces(
+    pool: &PgPool,
+    project_id: Uuid,
+    trace_ids: &[Uuid],
+) -> Result<()> {
+    if trace_ids.is_empty() {
+        return Ok(());
+    }
+
+    sqlx::query("DELETE FROM shared_traces WHERE project_id = $1 AND id = ANY($2)")
+        .bind(project_id)
+        .bind(trace_ids)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}

--- a/app-server/src/evaluations/mod.rs
+++ b/app-server/src/evaluations/mod.rs
@@ -116,7 +116,8 @@ pub async fn insert_evaluation_datapoints(
                 }
 
                 if update.executor_output.is_none() {
-                    update.executor_output = Some(parse_json_value_from_string(&existing.executor_output));
+                    update.executor_output =
+                        Some(parse_json_value_from_string(&existing.executor_output));
                 }
 
                 if update.trace_id.is_nil() {
@@ -190,6 +191,7 @@ pub async fn update_evaluation_datapoint(
     group_id: &String,
     executor_output: Option<Value>,
     scores: HashMap<String, Option<f64>>,
+    trace_id: Option<Uuid>,
 ) -> Result<()> {
     // Get the existing datapoint
     let existing_map = get_existing_datapoints(
@@ -235,7 +237,7 @@ pub async fn update_evaluation_datapoint(
         metadata,
         executor_output: executor_output
             .or_else(|| Some(parse_json_value_from_string(&existing.executor_output))),
-        trace_id: existing.trace_id,
+        trace_id: trace_id.unwrap_or(existing.trace_id),
         index: existing.index as i32,
         scores: merged_scores,
         dataset_link,

--- a/app-server/src/evaluations/mod.rs
+++ b/app-server/src/evaluations/mod.rs
@@ -207,7 +207,13 @@ pub async fn update_evaluation_datapoint(
         .ok_or(anyhow::anyhow!("Evaluation datapoint not found"))?;
 
     if is_shared_evaluation(pool, project_id, evaluation_id).await? {
-        insert_shared_traces(pool, project_id, &[existing.trace_id]).await?;
+        let mut trace_ids = vec![existing.trace_id];
+        if let Some(new_trace_id) = trace_id {
+            if new_trace_id != existing.trace_id {
+                trace_ids.push(new_trace_id);
+            }
+        }
+        insert_shared_traces(pool, project_id, &trace_ids).await?;
     }
 
     let mut merged_scores: HashMap<String, Option<f64>> =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches evaluation datapoint update logic and shared-trace persistence; incorrect handling could leave `shared_traces` out of sync or remove the wrong shared trace.
> 
> **Overview**
> Allows `POST /evals/{eval_id}/datapoints/{datapoint_id}` to optionally accept and persist a new `traceId` when updating an evaluation datapoint.
> 
> For shared evaluations, updating a datapoint’s trace now also updates the `shared_traces` mapping by deleting the old trace association and inserting the new one, and adds `delete_shared_traces` to support this cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b45bcdc1702d644735d0dcb78f2fa00edf72acb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->