### PR TITLE
fix build

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1352,6 +1352,9 @@ fn main() -> anyhow::Result<()> {
                         clickhouse_for_http.clone(),
                         clickhouse_readonly_client.clone(),
                         query_engine.clone(),
+                        Arc::new(http_client_for_http.clone()),
+                        db_for_http.clone(),
+                        cache_for_http.clone(),
                     );
 
                     log::info!("Spinning up full HTTP server");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-plumbing change to MCP service construction; no behavior changes beyond unblocking compilation and ensuring the SQL tool has required runtime handles.
> 
> **Overview**
> Fixes MCP SQL tool wiring by threading shared dependencies (`reqwest::Client`, `DB`, `Cache`) into `LaminarMcpServer` and `build_mcp_service`.
> 
> `query_laminar_sql` now forwards these handles into `sql::execute_sql_query`, and `main.rs` updates MCP service initialization accordingly so the MCP endpoint builds and can route/execute SQL consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eab4eb45acc9d79e814b66eb915134a12dd344aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->