### PR TITLE
Blog hotfix

### DIFF
--- a/frontend/assets/blog/2026-02-13-laminar-vs-langfuse-why-we-prefer-laminar.mdx
+++ b/frontend/assets/blog/2026-02-13-laminar-vs-langfuse-why-we-prefer-laminar.mdx
@@ -96,7 +96,7 @@ That means you can:
 - Backfill months of traces to validate a hypothesis
 - Turn production trace history into labeled datasets without writing scripts
 
-Langfuse is strong on prompt management, but Signals are built for **agent debugging at scale**: they sit directly on top of traces and make the system queryable in human terms.
+Langfuse is strong on prompt management, but it does **not** have a true equivalent to Signals. Its closest alternatives live in evals and scoring workflows, which are powerful but not trace-native in the same way. Signals are built for **agent debugging at scale**: they sit directly on top of traces and make the system queryable in human terms.
 
 ## UX: Trace-First vs Prompt-First
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Introduces new data-plane networking and auth (encrypted config, Ed25519-signed tokens) plus significant refactors to trace/eval ingestion paths, which could impact data integrity and ingestion reliability if misconfigured or buggy.
> 
> **Overview**
> Adds a new `/v1/mcp` streamable HTTP service (via `rmcp`) that exposes tools to run scoped SELECT-only SQL against trace data and fetch an LLM-optimized trace context, wiring project auth into MCP request context.
> 
> Introduces a *hybrid “data plane” ingestion mode*: workspace deployment config is fetched/cached from Postgres, secrets/URLs are encrypted with XChaCha20-Poly1305, and a short-lived Ed25519-signed bearer token is generated/cached for remote ingest; ClickHouse writes are routed either directly (cloud) or via remote `v1/ingest`, with new batch workers/queues for data-plane span processing.
> 
> Refactors span and evaluation pipelines: spans now carry structured `events` and `size_bytes` through to ClickHouse rows, trace processing/push APIs are updated accordingly, and evaluation datapoint writes are consolidated into upsert/merge logic (including optional `trace_id` updates and shared-trace bookkeeping) while removing legacy evaluator scoring endpoints/modules and ClickHouse score tables. Also tightens RabbitMQ consumer memory behavior by adding configurable `basic_qos` prefetch, updates `sql::execute_sql_query` call sites to pass `db/http_client/cache`, and changes tagging to only append tags (no per-tag insert/IDs in response).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c49aa270562b6c73c044484d923c43f5df5766f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->