### PR TITLE
fix: parse system prompt in gemini raw format for rollout sessions

### DIFF
--- a/frontend/lib/actions/spans/system-messages.ts
+++ b/frontend/lib/actions/spans/system-messages.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v4";
 
 import { tryParseJson } from "@/lib/actions/common/utils.ts";
 import { executeQuery } from "@/lib/actions/sql";
+import { extractGeminiSystemMessage, parseGeminiInput } from "@/lib/spans/types/gemini";
 import { LangChainMessagesSchema } from "@/lib/spans/types/langchain";
 import { OpenAIMessagesSchema } from "@/lib/spans/types/openai";
 export const GetSystemMessagesSchema = z.object({
@@ -58,6 +59,13 @@ function parseSystemMessageFromInput(input: string): string | null {
     }
   } catch {
     // Schema validation failed, try next format
+  }
+
+  // Gemini native format (parts-based with role: "system")
+  const geminiContents = parseGeminiInput(parsed);
+  if (geminiContents) {
+    const text = extractGeminiSystemMessage(geminiContents);
+    if (text) return text;
   }
 
   try {

--- a/frontend/lib/actions/spans/system-messages.ts
+++ b/frontend/lib/actions/spans/system-messages.ts
@@ -61,7 +61,7 @@ function parseSystemMessageFromInput(input: string): string | null {
     // Schema validation failed, try next format
   }
 
-  // Gemini native format (parts-based with role: "system")
+  // Gemini
   const geminiContents = parseGeminiInput(parsed);
   if (geminiContents) {
     const text = extractGeminiSystemMessage(geminiContents);

--- a/frontend/lib/spans/types/gemini.ts
+++ b/frontend/lib/spans/types/gemini.ts
@@ -136,6 +136,18 @@ export const GeminiCandidateSchema = z
 
 export const GeminiCandidatesSchema = z.array(GeminiCandidateSchema);
 
+/** Helpers **/
+
+/** Find the system message in a Contents array and return its text. */
+export const extractGeminiSystemMessage = (
+  messages: z.infer<typeof GeminiContentsSchema>
+): string | null => {
+  const system = messages.find((m) => m.role === "system");
+  if (!system) return null;
+  const textPart = system.parts.find((p) => "text" in p);
+  return textPart && "text" in textPart ? textPart.text : null;
+};
+
 /** High-level input / output schemas **/
 
 // Input is always Content(s)

--- a/frontend/lib/spans/types/gemini.ts
+++ b/frontend/lib/spans/types/gemini.ts
@@ -144,8 +144,8 @@ export const extractGeminiSystemMessage = (
 ): string | null => {
   const system = messages.find((m) => m.role === "system");
   if (!system) return null;
-  const textPart = system.parts.find((p) => "text" in p);
-  return textPart && "text" in textPart ? textPart.text : null;
+  const texts = system.parts.filter((p) => "text" in p).map((p) => (p as { text: string }).text);
+  return texts.length > 0 ? texts.join("\n") : null;
 };
 
 /** High-level input / output schemas **/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive parsing logic change limited to system-message extraction; main risk is missing/incorrect system prompt extraction for some Gemini payload shapes.
> 
> **Overview**
> System message extraction for traced spans now also understands **Gemini raw input format**.
> 
> `parseSystemMessageFromInput` in `system-messages.ts` now attempts to parse inputs via `parseGeminiInput` and returns the first system-role text found using the new `extractGeminiSystemMessage` helper added to `gemini.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0d04655c9f5e4635ab2a154f50004f04649f325. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->