### PR TITLE
feat(mcp): full text search in spans

### DIFF
--- a/app-server/src/api/v1/mcp.rs
+++ b/app-server/src/api/v1/mcp.rs
@@ -20,6 +20,7 @@ use crate::{
     llm::LlmClient,
     mq::MessageQueue,
     query_engine::QueryEngine,
+    quickwit::client::QuickwitClient,
     sql::{self, ClickhouseReadonlyClient, SqlQuerySource},
 };
 
@@ -49,13 +50,27 @@ pub struct GetTraceContextParams {
     pub trace_id: Uuid,
 }
 
+const MCP_SEARCH_MAX_HITS: usize = 200;
+const MCP_SEARCH_DEFAULT_HITS: usize = 50;
+
+/// Parameters for the span search tool.
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchSpansParams {
+    /// Full-text query matched against span inputs, outputs, and attributes.
+    pub query: String,
+    /// Maximum number of results to return (default: 50, max: 200).
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
 // ============ MCP Server ============
 
 #[derive(Clone)]
 pub struct LaminarMcpServer {
-    #[cfg_attr(not(feature = "signals"), allow(dead_code))]
     clickhouse: clickhouse::Client,
     clickhouse_ro: Option<Arc<ClickhouseReadonlyClient>>,
+    quickwit: Option<QuickwitClient>,
     query_engine: Arc<QueryEngine>,
     http_client: Arc<reqwest::Client>,
     db: Arc<DB>,
@@ -71,6 +86,7 @@ impl LaminarMcpServer {
     pub fn new(
         clickhouse: clickhouse::Client,
         clickhouse_ro: Option<Arc<ClickhouseReadonlyClient>>,
+        quickwit: Option<QuickwitClient>,
         query_engine: Arc<QueryEngine>,
         http_client: Arc<reqwest::Client>,
         db: Arc<DB>,
@@ -81,6 +97,7 @@ impl LaminarMcpServer {
         Self {
             clickhouse,
             clickhouse_ro,
+            quickwit,
             query_engine,
             http_client,
             db,
@@ -189,6 +206,57 @@ impl LaminarMcpServer {
             ))])),
         }
     }
+
+    /// Full-text search across span inputs, outputs, and attributes.
+    /// Returns matching spans as a JSON array of `{ traceId, spanId }`.
+    #[tool(name = "search_spans")]
+    async fn search_spans(
+        &self,
+        context: RequestContext<RoleServer>,
+        Parameters(params): Parameters<SearchSpansParams>,
+    ) -> Result<CallToolResult, McpError> {
+        if params.query.trim().is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text("[]")]));
+        }
+
+        let project_id = context
+            .extensions
+            .get::<ProjectId>()
+            .ok_or_else(|| McpError::internal_error("Missing project context", None))?
+            .0;
+
+        let quickwit = self.quickwit.as_ref().ok_or_else(|| {
+            McpError::internal_error(
+                "Full-text search is not available (Quickwit not configured)",
+                None,
+            )
+        })?;
+
+        let limit = params
+            .limit
+            .filter(|l| *l > 0)
+            .unwrap_or(MCP_SEARCH_DEFAULT_HITS)
+            .min(MCP_SEARCH_MAX_HITS);
+
+        let hits = crate::search::search_spans(
+            quickwit,
+            &self.clickhouse,
+            project_id,
+            params.query.trim(),
+            None,
+            limit,
+            0,
+            None,
+            None,
+            false,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("Search failed: {}", e), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&hits).unwrap_or_default(),
+        )]))
+    }
 }
 
 #[cfg(feature = "signals")]
@@ -268,6 +336,7 @@ impl McpState {
     pub fn new(
         clickhouse: clickhouse::Client,
         clickhouse_ro: Option<Arc<ClickhouseReadonlyClient>>,
+        quickwit: Option<QuickwitClient>,
         query_engine: Arc<QueryEngine>,
         http_client: Arc<reqwest::Client>,
         db: Arc<DB>,
@@ -279,6 +348,7 @@ impl McpState {
             server: LaminarMcpServer::new(
                 clickhouse,
                 clickhouse_ro,
+                quickwit,
                 query_engine,
                 http_client,
                 db,

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1703,6 +1703,7 @@ fn main() -> anyhow::Result<()> {
                     let mcp_state = web::Data::new(api::v1::mcp::McpState::new(
                         clickhouse_for_http.clone(),
                         clickhouse_readonly_client.clone(),
+                        quickwit_client.clone(),
                         query_engine.clone(),
                         Arc::new(http_client_for_http.clone()),
                         db_for_http.clone(),


### PR DESCRIPTION
## Summary
- Add `search_spans` MCP tool for full-text search across span inputs, outputs, and attributes
- Refactored span search query logic to be reusable between API routes and MCP tools

## Test plan
- [ ] Verify MCP `search_spans` tool returns matching spans
- [ ] Verify existing span search API route still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New MCP entry point queries indexed span content (inputs/outputs/attributes) via Quickwit; misconfiguration or load could affect search infrastructure, but behavior mirrors the existing HTTP span search route.
> 
> **Overview**
> Exposes **full-text span search** on the MCP surface via a new **`search_spans`** tool. Callers pass a query and optional `limit` (default 50, cap 200); results are a JSON array of `{ traceId, spanId }`. Empty queries return `[]`. Search runs through the shared **`crate::search::search_spans`** path (Quickwit + ClickHouse), scoped by the authenticated project from MCP extensions.
> 
> **`LaminarMcpServer`** and **`McpState`** now hold an optional **`QuickwitClient`**. If Quickwit is not configured, the tool fails with a clear internal error instead of silently succeeding. **`main.rs`** passes the same **`quickwit_client`** used elsewhere into **`McpState::new`** when the HTTP/MCP server starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ebfecd711a81d224743b9c29232a58cab2c489c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->