### PR TITLE
Capitalize sidebar menu labels

### DIFF
--- a/frontend/components/project/utils.ts
+++ b/frontend/components/project/utils.ts
@@ -14,57 +14,57 @@ import {
 
 export const getSidebarMenus = (projectId: string) => [
   {
-    name: "dashboards",
+    name: "Dashboards",
     href: `/project/${projectId}/dashboard`,
     icon: LayoutGrid,
   },
   {
-    name: "traces",
+    name: "Traces",
     href: `/project/${projectId}/traces`,
     icon: Rows4,
   },
   {
-    name: "signals",
+    name: "Signals",
     href: `/project/${projectId}/signals`,
     icon: Radio,
   },
   {
-    name: "evaluations",
+    name: "Evaluations",
     href: `/project/${projectId}/evaluations`,
     icon: FlaskConical,
   },
   {
-    name: "evaluators",
+    name: "Evaluators",
     href: `/project/${projectId}/evaluators`,
     icon: SquareFunction,
   },
   {
-    name: "datasets",
+    name: "Datasets",
     href: `/project/${projectId}/datasets`,
     icon: Database,
   },
   {
-    name: "labeling",
+    name: "Labeling",
     href: `/project/${projectId}/labeling-queues`,
     icon: Pen,
   },
   {
-    name: "sql editor",
+    name: "SQL Editor",
     href: `/project/${projectId}/sql`,
     icon: SquareTerminal,
   },
   {
-    name: "playgrounds",
+    name: "Playgrounds",
     href: `/project/${projectId}/playgrounds`,
     icon: PlayCircle,
   },
   {
-    name: "rollout sessions",
+    name: "Rollout Sessions",
     href: `/project/${projectId}/rollout-sessions`,
     icon: GitFork,
   },
   {
-    name: "settings",
+    name: "Settings",
     href: `/project/${projectId}/settings`,
     icon: Settings,
   },


### PR DESCRIPTION
## Summary
- Updated all sidebar menu labels to start with capital letters for better consistency and professional appearance

## Changes
Updated menu labels in `frontend/components/project/utils.ts`:
- dashboards → Dashboards
- traces → Traces
- signals → Signals
- evaluations → Evaluations
- evaluators → Evaluators
- datasets → Datasets
- labeling → Labeling
- sql editor → SQL Editor
- playgrounds → Playgrounds
- rollout sessions → Rollout Sessions
- settings → Settings

## Test plan
- [x] TypeScript compilation passes
- [x] Pre-commit hooks pass (prettier, eslint)
- [ ] Verify menu labels display correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational string changes to sidebar labels; no behavior, routing, or data-handling logic is modified.
> 
> **Overview**
> Updates `getSidebarMenus` in `frontend/components/project/utils.ts` to **capitalize all sidebar menu `name` labels** (including `SQL Editor`), improving consistency of the project sidebar UI without changing routes or icons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93b94d7d8801c5bc8817508a62c23c27710484b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->