### PR TITLE
Fix workspace rename button not working on click

### DIFF
--- a/frontend/components/workspace/workspace-settings.tsx
+++ b/frontend/components/workspace/workspace-settings.tsx
@@ -205,19 +205,19 @@ export default function WorkspaceSettings({ workspace, isOwner }: WorkspaceSetti
                   )}
                 />
               </div>
+              <DialogFooter>
+                <Button
+                  type="submit"
+                  disabled={!renameForm.formState.isValid || renameForm.formState.isSubmitting}
+                  handleEnter={true}
+                >
+                  <Loader2
+                    className={cn("mr-2 h-4 w-4", renameForm.formState.isSubmitting ? "animate-spin" : "hidden")}
+                  />
+                  Rename
+                </Button>
+              </DialogFooter>
             </form>
-            <DialogFooter>
-              <Button
-                type="submit"
-                disabled={!renameForm.formState.isValid || renameForm.formState.isSubmitting}
-                handleEnter={true}
-              >
-                <Loader2
-                  className={cn("mr-2 h-4 w-4", renameForm.formState.isSubmitting ? "animate-spin" : "hidden")}
-                />
-                Rename
-              </Button>
-            </DialogFooter>
           </DialogContent>
         </Dialog>
       </SettingsSection>


### PR DESCRIPTION
## Summary
- Fixed the workspace rename button not responding to clicks in the workspace settings dialog
- The issue was caused by the submit button being placed outside the `<form>` element

## Problem
When users tried to rename a workspace by clicking the "Rename" button in the workspace settings, nothing happened. However, pressing the Enter key after typing the new name worked correctly.

## Root Cause
The `DialogFooter` component containing the submit button was positioned outside the `<form>` element in the JSX structure. This meant the button with `type="submit"` was not associated with the form, so clicking it had no effect. The Enter key worked because the form's `onSubmit` handler was correctly bound to the form element itself.

## Solution
Moved the `DialogFooter` component inside the `<form>` element so that the submit button is properly associated with the form and can trigger form submission when clicked.

## Changes
- **File:** `frontend/components/workspace/workspace-settings.tsx`
- **Change:** Moved `DialogFooter` (lines 208-219) inside the closing `</form>` tag

## Testing
- TypeScript compilation passes without errors
- Pre-commit hooks (Prettier, ESLint, type-check) all pass
- The fix follows standard HTML form structure patterns

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small JSX structure change limited to the rename dialog; no backend/API or data-handling logic changes.
> 
> **Overview**
> Fixes the workspace rename dialog so the **Rename** button click actually submits the form.
> 
> Moves the `DialogFooter` (and its `type="submit"` button) inside the rename `<form>` in `workspace-settings.tsx`, aligning click behavior with the existing Enter-key submission path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26c3f78d378012c5be0d9cd0db997d19ce7b73f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->