### PR TITLE
exclude deleted items

### DIFF
--- a/frontend/lib/actions/checkout/webhook.ts
+++ b/frontend/lib/actions/checkout/webhook.ts
@@ -112,7 +112,7 @@ export const handleSubscriptionChange = async (event: SubscriptionEvent, cancel:
   const flatItems = subscription.items.data
     .filter((item) => item.price.recurring?.usage_type !== "metered")
     .filter((item) => item.price.lookup_key !== DATAPLANE_ADDON_LOOKUP_KEY)
-    .filter((item) => item.deleted !== undefined);
+    .filter((item) => item.deleted === undefined);
   const tierItems = flatItems.length > 0 ? flatItems : subscription.items.data;
 
   for (const subscriptionItem of tierItems) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to Stripe webhook item filtering; low risk aside from potentially altering tier selection in edge cases where deleted items were previously (incorrectly) included.
> 
> **Overview**
> Prevents `handleSubscriptionChange` from using deleted Stripe subscription items when determining a workspace’s subscription tier by changing the filter to keep only items where `item.deleted === undefined`.
> 
> This avoids tier/product resolution being corrupted by intermediate or removed items during Stripe subscription updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c70652808d612e38641163916b29a39caa504f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->