### PR TITLE
convert image format from url sage base64 to standard

### DIFF
--- a/frontend/components/traces/span-view/gemini-parts.tsx
+++ b/frontend/components/traces/span-view/gemini-parts.tsx
@@ -14,6 +14,9 @@ import {
     ToolResultContentPart,
 } from "./common";
 
+// Convert URL-safe base64 (RFC 4648 §5) to standard base64 for data URIs.
+const toStandardBase64 = (s: string) => s.replace(/-/g, "+").replace(/_/g, "/");
+
 const GeminiPartRenderer = ({
     part,
     presetKey,
@@ -39,7 +42,7 @@ const GeminiPartRenderer = ({
     }
 
     if ("inlineData" in part) {
-        const src = `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`;
+        const src = `data:${part.inlineData.mimeType};base64,${toStandardBase64(part.inlineData.data)}`;
         if (part.inlineData.mimeType.startsWith("image/")) {
             return <ImageContentPart src={src} />;
         }

--- a/frontend/components/traces/span-view/gemini-parts.tsx
+++ b/frontend/components/traces/span-view/gemini-parts.tsx
@@ -6,6 +6,8 @@ import {
     type GeminiPartSchema,
 } from "@/lib/spans/types/gemini";
 
+import { toStandardBase64 } from "@/lib/utils";
+
 import {
     FileContentPart,
     ImageContentPart,
@@ -13,9 +15,6 @@ import {
     ToolCallContentPart,
     ToolResultContentPart,
 } from "./common";
-
-// Convert URL-safe base64 (RFC 4648 §5) to standard base64 for data URIs.
-const toStandardBase64 = (s: string) => s.replace(/-/g, "+").replace(/_/g, "/");
 
 const GeminiPartRenderer = ({
     part,

--- a/frontend/lib/spans/types/gemini.ts
+++ b/frontend/lib/spans/types/gemini.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4";
 
 import { type Message } from "@/lib/playground/types";
 import { isStorageUrl, urlToBase64 } from "@/lib/s3";
+import { toStandardBase64 } from "@/lib/utils";
 
 /** Part Schemas **/
 
@@ -170,9 +171,6 @@ export const parseGeminiOutput = (data: unknown): z.infer<typeof GeminiContentsS
 };
 
 /** Conversion Functions **/
-
-// Convert URL-safe base64 (RFC 4648 §5) to standard base64 for data URIs.
-const toStandardBase64 = (s: string) => s.replace(/-/g, "+").replace(/_/g, "/");
 
 export const convertGeminiToPlaygroundMessages = async (
   messages: z.infer<typeof GeminiContentsSchema>

--- a/frontend/lib/spans/types/gemini.ts
+++ b/frontend/lib/spans/types/gemini.ts
@@ -171,6 +171,9 @@ export const parseGeminiOutput = (data: unknown): z.infer<typeof GeminiContentsS
 
 /** Conversion Functions **/
 
+// Convert URL-safe base64 (RFC 4648 §5) to standard base64 for data URIs.
+const toStandardBase64 = (s: string) => s.replace(/-/g, "+").replace(/_/g, "/");
+
 export const convertGeminiToPlaygroundMessages = async (
   messages: z.infer<typeof GeminiContentsSchema>
 ): Promise<Message[]> =>
@@ -195,7 +198,9 @@ export const convertGeminiToPlaygroundMessages = async (
             }
             content.push({
               type: "image",
-              image: imageData.startsWith("data:") ? imageData : `data:${part.inlineData.mimeType};base64,${imageData}`,
+              image: imageData.startsWith("data:")
+                ? imageData
+                : `data:${part.inlineData.mimeType};base64,${toStandardBase64(imageData)}`,
             });
           } else {
             content.push({

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -294,6 +294,9 @@ export function generateRandomKey(length: number): string {
     .join("");
 }
 
+// Convert URL-safe base64 (RFC 4648 §5) to standard base64 for data URIs.
+export const toStandardBase64 = (s: string) => s.replace(/-/g, "+").replace(/_/g, "/");
+
 export const inferImageType = (base64: string): `image/${string}` | null => {
   if (base64.startsWith("/9j/")) {
     return "image/jpeg";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to how inline Gemini `inlineData` is embedded in data URIs; main risk is if any upstream data unexpectedly relies on URL-safe base64 characters.
> 
> **Overview**
> Fixes Gemini inline data rendering/conversion by converting URL-safe base64 (`-`/`_`) into standard base64 (`+`/`/`) before constructing `data:*;base64,...` URIs.
> 
> Adds a shared `toStandardBase64` helper in `frontend/lib/utils.ts` and uses it in both the trace span Gemini part renderer (`gemini-parts.tsx`) and `convertGeminiToPlaygroundMessages` (`gemini.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5372e9a0f5d8ddcc60209b5107c4455fe416e411. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->