### PR TITLE
Dev

### DIFF
--- a/app-server/src/api/v1/mod.rs
+++ b/app-server/src/api/v1/mod.rs
@@ -7,6 +7,7 @@ pub mod mcp;
 pub mod metrics;
 pub mod payloads;
 pub mod rollouts;
+pub mod spans;
 pub mod sql;
 pub mod tag;
 pub mod traces;

--- a/app-server/src/api/v1/spans.rs
+++ b/app-server/src/api/v1/spans.rs
@@ -1,0 +1,119 @@
+use std::{collections::HashMap, sync::Arc};
+
+use actix_web::{HttpResponse, post, web};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    api::v1::traces::RabbitMqSpanMessage,
+    cache::Cache,
+    db::{DB, project_api_keys::ProjectApiKey, spans::{Span, SpanType}},
+    features::{Feature, is_feature_enabled},
+    mq::MessageQueue,
+    routes::types::ResponseResult,
+    traces::{producer::publish_span_messages, spans::SpanAttributes},
+    utils::limits::get_workspace_bytes_limit_exceeded,
+};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSpanRequest {
+    pub name: String,
+    pub span_type: Option<SpanType>,
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub input: Option<serde_json::Value>,
+    pub output: Option<serde_json::Value>,
+    pub attributes: Option<HashMap<String, serde_json::Value>>,
+    pub trace_id: Uuid,
+    pub span_id: Uuid,
+    pub parent_span_id: Option<Uuid>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSpanResponse {
+    pub span_id: Uuid,
+    pub trace_id: Uuid,
+}
+
+// /v1/spans
+#[post("")]
+pub async fn create_spans(
+    request: web::Json<Vec<CreateSpanRequest>>,
+    project_api_key: ProjectApiKey,
+    spans_message_queue: web::Data<Arc<MessageQueue>>,
+    db: web::Data<DB>,
+    cache: web::Data<Cache>,
+    clickhouse: web::Data<clickhouse::Client>,
+) -> ResponseResult {
+    let project_id = project_api_key.project_id;
+    let db = db.into_inner();
+    let cache = cache.into_inner();
+
+    if is_feature_enabled(Feature::UsageLimit) {
+        let bytes_limit_exceeded = get_workspace_bytes_limit_exceeded(
+            db.clone(),
+            clickhouse.into_inner().as_ref().clone(),
+            cache.clone(),
+            project_id,
+        )
+        .await
+        .map_err(|e| {
+            log::error!("Failed to get workspace limits: {:?}", e);
+        });
+
+        if bytes_limit_exceeded.is_ok_and(|exceeded| exceeded) {
+            return Ok(HttpResponse::Forbidden().json("Workspace data limit exceeded"));
+        }
+    }
+
+    let requests = request.into_inner();
+
+    let mut responses = Vec::with_capacity(requests.len());
+    let mut messages = Vec::with_capacity(requests.len());
+
+    for req in requests {
+        let span = Span {
+            span_id: req.span_id,
+            trace_id: req.trace_id,
+            project_id,
+            parent_span_id: req.parent_span_id,
+            name: req.name,
+            attributes: SpanAttributes::new(req.attributes.unwrap_or_default()),
+            input: req.input,
+            output: req.output,
+            span_type: req.span_type.unwrap_or(SpanType::Default),
+            start_time: req.start_time,
+            end_time: req.end_time,
+            status: None,
+            events: vec![],
+            tags: None,
+            input_url: None,
+            output_url: None,
+            size_bytes: 0,
+        };
+
+        responses.push(CreateSpanResponse {
+            span_id: req.span_id,
+            trace_id: req.trace_id,
+        });
+        messages.push(RabbitMqSpanMessage { span });
+    }
+
+    publish_span_messages(
+        messages,
+        project_id,
+        spans_message_queue.as_ref().clone(),
+        db,
+        cache,
+    )
+    .await
+    .map_err(|e| {
+        log::error!("Failed to publish spans to queue: {:?}", e);
+        anyhow::anyhow!("Failed to publish spans")
+    })?;
+
+    Ok(HttpResponse::Ok().json(responses))
+}

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1403,6 +1403,11 @@ fn main() -> anyhow::Result<()> {
                                     .service(api::v1::traces::process_traces),
                             )
                             .service(
+                                web::scope("/v1/spans")
+                                    .wrap(project_ingestion_auth.clone())
+                                    .service(api::v1::spans::create_spans),
+                            )
+                            .service(
                                 web::scope("/v1/logs")
                                     .wrap(project_ingestion_auth.clone())
                                     .service(api::v1::logs::process_logs),

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -71,6 +71,9 @@ pub async fn process_span_messages(
     if is_feature_enabled(Feature::Storage) && config.is_none() {
         let storage_futures = spans
             .iter_mut()
+            // only upload non-llm spans to avoid parsing issues with
+            // llm-span-specific features, such as debugger
+            .filter(|span| !span.is_llm_span())
             .map(|span| {
                 let project_id: Uuid = span.project_id;
                 let queue_clone = queue.clone();

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -947,13 +947,16 @@ impl Span {
     }
 
     pub fn is_llm_span(&self) -> bool {
-        self.span_type == SpanType::LLM
-            || (self.span_type == SpanType::Cached
-                && self
-                    .attributes
-                    .raw_attributes
-                    .get("lmnr.span.original_type")
-                    == Some(&Value::String("LLM".to_string())))
+        let is_cached_llm_span = self.attributes.span_type() == SpanType::Cached
+            && self
+                .attributes
+                .raw_attributes
+                .get("lmnr.span.original_type")
+                == Some(&Value::String("LLM".to_string()));
+        !self.is_ai_sdk_tool_call_span()
+            && (self.attributes.span_type() == SpanType::LLM
+                || is_cached_llm_span
+                || self.span_type == SpanType::LLM)
     }
 }
 

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -908,8 +908,10 @@ impl Span {
         // 8 bytes for start_time,
         // 8 bytes for end_time,
 
-        // everything else is in attributes
-        // because right after creation attributes contain all span data
+        // For OTel spans, input/output start inside raw_attributes and are
+        // parsed out later, so raw_attributes alone captures the payload.
+        // For /v1/spans, input/output are set directly on the Span and must
+        // be counted separately.
         let size_bytes = 16
             + 16
             + 16
@@ -922,6 +924,14 @@ impl Span {
                 .iter()
                 .map(|(k, v)| k.len() + estimate_json_size(v))
                 .sum::<usize>()
+            + self
+                .input
+                .as_ref()
+                .map_or(0, |v| estimate_json_size(v))
+            + self
+                .output
+                .as_ref()
+                .map_or(0, |v| estimate_json_size(v))
             + self
                 .events
                 .iter()

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-content.tsx
@@ -300,6 +300,24 @@ export default function DebuggerSessionContent({ sessionId, spanId }: DebuggerSe
           setSessionStatus(payload.status);
         }
       },
+      trace_update: (event: MessageEvent) => {
+        const payload = JSON.parse(event.data);
+        if (payload.traces && Array.isArray(payload.traces)) {
+          for (const t of payload.traces) {
+            if (t.hasBrowserSession && !hasBrowserSession) {
+              setHasBrowserSession(true);
+              setBrowserSession(true);
+            }
+            if (t.metadata) {
+              setTrace((prev) => {
+                if (!prev || prev.metadata) return prev;
+                const metadata = typeof t.metadata === "string" ? t.metadata : JSON.stringify(t.metadata);
+                return { ...prev, metadata };
+              });
+            }
+          }
+        }
+      },
       session_deleted: (event: MessageEvent) => {
         const payload = JSON.parse(event.data);
         if (payload.session_id) {
@@ -493,7 +511,7 @@ export default function DebuggerSessionContent({ sessionId, spanId }: DebuggerSe
             </ResizablePanel>
             {browserSession && (
               <>
-                <ResizableHandle className="z-50" withHandle />
+                <ResizableHandle className="hover:bg-blue-400 z-10 transition-colors hover:scale-200" withHandle />
                 <ResizablePanel>
                   {!isLoading && trace?.id && (
                     <SessionPlayer

--- a/frontend/components/debugger-sessions/debugger-session-view/sidebar/traces-tab.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/sidebar/traces-tab.tsx
@@ -87,13 +87,13 @@ const TracesContent = () => {
   );
 
   return (
-    <div className="flex flex-col gap-3 px-4 py-2">
+    <div className="flex flex-col flex-1 gap-3 px-4 py-2 overflow-hidden">
       <span className="text-secondary-foreground text-xs px-1">
         Select a trace to rerun in debugger. Trace structure must match the agent you are running locally.
       </span>
 
       <InfiniteDataTable<TraceRow>
-        className="w-full"
+        className="w-full flex-1"
         columns={sidebarTraceColumns}
         data={traces}
         getRowId={(t) => t.id}

--- a/frontend/components/onboarding/api-key-generator.tsx
+++ b/frontend/components/onboarding/api-key-generator.tsx
@@ -13,9 +13,16 @@ import { cn } from "@/lib/utils.ts";
 interface ApiKeyGeneratorProps {
   context: "traces" | "evaluations";
   title?: string;
+  titleClassName?: string;
+  subtitle?: string;
 }
 
-export default function ApiKeyGenerator({ context, title = "Get your API Key" }: ApiKeyGeneratorProps) {
+export default function ApiKeyGenerator({
+  context,
+  title = "Get your API Key",
+  titleClassName,
+  subtitle,
+}: ApiKeyGeneratorProps) {
   const { projectId } = useParams();
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -55,8 +62,11 @@ export default function ApiKeyGenerator({ context, title = "Get your API Key" }:
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-3">
-        <h2 className="text-lg font-medium">{title}</h2>
+      <div className="flex flex-row justify-between items-center">
+        <div className="flex flex-col gap-1">
+          <h2 className={cn("text-lg font-medium", titleClassName)}>{title}</h2>
+          {subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
+        </div>
         {!generatedKey && (
           <Button onClick={handleGenerateKey} disabled={isLoading}>
             <Loader2 className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={14} />

--- a/frontend/components/traces/placeholder/automatic-tab.tsx
+++ b/frontend/components/traces/placeholder/automatic-tab.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Terminal } from "lucide-react";
+
+import { CopyButton } from "@/components/ui/copy-button";
+
+import ApiKeyGenerator from "../../onboarding/api-key-generator";
+import { PromptCard } from "./prompt-card";
+import { LAMINAR_INSTALL_FROM_SCRATCH, LAMINAR_MIGRATION_PROMPT } from "./prompts";
+
+const SKILLS_COMMANDS = [
+  {
+    label: "Quick demo trace",
+    command: "npx skills add lmnr-ai/laminar-skills --skill laminar-quickstart-trace",
+  },
+  {
+    label: "Instrument a real codebase",
+    command: "npx skills add lmnr-ai/laminar-skills --skill laminar-instrument-codebase",
+  },
+  {
+    label: "Migrate from another tool",
+    command: "npx skills add lmnr-ai/laminar-skills --skill laminar-migrate-observability",
+  },
+];
+
+const PROMPT_CARDS = [
+  {
+    title: "Install and instrument from scratch",
+    subtitle: "Best for new projects or repos without existing observability.",
+    prompt: LAMINAR_INSTALL_FROM_SCRATCH,
+  },
+  {
+    title: "Migrate from another observability platform",
+    subtitle: "Best if you already use Langfuse, LangSmith, Helicone, or custom OpenTelemetry.",
+    prompt: LAMINAR_MIGRATION_PROMPT,
+  },
+];
+
+export function AutomaticTab() {
+  return (
+    <div className="flex flex-col gap-8">
+      <ApiKeyGenerator
+        context="traces"
+        title="1. Paste an API key into your .env"
+        titleClassName="text-base"
+        subtitle=""
+      />
+
+      <div className="flex flex-col gap-2">
+        <h3 className="text-base font-medium">2. Paste and run a prompt</h3>
+        <div className="flex flex-col gap-2">
+          {PROMPT_CARDS.map((card) => (
+            <PromptCard key={card.title} {...card} />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h3 className="text-base font-medium">3. Or install and run a skill</h3>
+        <div className="flex flex-col gap-2">
+          {SKILLS_COMMANDS.map((item) => (
+            <div key={item.command} className="rounded-lg border bg-background p-4">
+              <span className="text-sm font-medium text-primary">{item.label}</span>
+              <div className="mt-2 flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2">
+                <Terminal className="w-3.5 h-3.5 text-primary/70 shrink-0" />
+                <code className="text-sm font-mono flex-1 min-w-0 truncate">{item.command}</code>
+                <CopyButton
+                  text={item.command}
+                  variant="ghost"
+                  size="icon"
+                  className="shrink-0 text-muted-foreground"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/traces/placeholder/index.tsx
+++ b/frontend/components/traces/placeholder/index.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { ArrowUpRight, Radio } from "lucide-react";
+import { ArrowUpRight, Sparkles, Terminal } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 
+import { CopyButton } from "@/components/ui/copy-button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useRealtime } from "@/lib/hooks/use-realtime";
 
 import FrameworksGrid from "../../integrations/frameworks-grid";
-import ApiKeyGenerator from "../../onboarding/api-key-generator.tsx";
+import ApiKeyGenerator from "../../onboarding/api-key-generator";
 import Header from "../../ui/header";
+import { LAMINAR_BASIC_INSTALL_PROMPT, LAMINAR_INSTRUMENTATION_PROMPT, LAMINAR_MIGRATION_PROMPT } from "./prompts";
 
 const InstallTabsSection = dynamic(() => import("./tabs-section.tsx").then((mod) => mod.InstallTabsSection), {
   ssr: false,
@@ -22,6 +25,137 @@ const InitializationTabsSection = dynamic(
     ssr: false,
   }
 );
+
+const SKILLS_COMMANDS = [
+  {
+    label: "Quick demo trace",
+    command: "npx skills add lmnr-ai/laminar-skills --skill laminar-quickstart-trace",
+  },
+  {
+    label: "Instrument a real codebase",
+    command: "npx skills add lmnr-ai/laminar-skills --skill laminar-instrument-codebase",
+  },
+  {
+    label: "Migrate from another tool",
+    command: "npx skills add lmnr-ai/laminar-skills --skill laminar-migrate-observability",
+  },
+];
+
+const PROMPT_CARDS = [
+  {
+    title: "Incorporate Laminar into an existing product",
+    subtitle: "Best if you already have an LLM/agent pipeline and want high-quality traces.",
+    prompt: LAMINAR_INSTRUMENTATION_PROMPT,
+  },
+  {
+    title: "Basic install + auto-instrumentation",
+    subtitle: "Best if you just want traces to show up quickly with minimal code changes.",
+    prompt: LAMINAR_BASIC_INSTALL_PROMPT,
+  },
+  {
+    title: "Migrate from another observability platform",
+    subtitle: "Best if you already use Langfuse, LangSmith, Helicone, or custom OpenTelemetry.",
+    prompt: LAMINAR_MIGRATION_PROMPT,
+  },
+];
+
+function PromptCard({ title, subtitle, prompt }: { title: string; subtitle: string; prompt: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="flex flex-col">
+      <div className="group rounded-lg border bg-background p-4 transition-colors hover:bg-muted/30">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-1 min-w-0">
+            <span className="text-sm font-medium">{title}</span>
+            <span className="text-xs text-muted-foreground">{subtitle}</span>
+          </div>
+          <CopyButton text={prompt} variant="ghost" size="icon" className="shrink-0 text-muted-foreground" />
+        </div>
+      </div>
+      {expanded && (
+        <div className="max-h-64 overflow-auto rounded-b-md border border-t-0 bg-background p-3">
+          <pre className="text-xs text-muted-foreground whitespace-pre-wrap break-words font-mono">{prompt}</pre>
+        </div>
+      )}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="self-start text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer mt-1 px-1"
+      >
+        {expanded ? "Hide prompt" : "View prompt"}
+      </button>
+    </div>
+  );
+}
+
+function AutomaticTab() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h3 className="text-sm font-medium">Skills</h3>
+        <p className="text-xs text-muted-foreground">Run a command in your terminal to get started instantly.</p>
+        <div className="flex flex-col gap-2">
+          {SKILLS_COMMANDS.map((item) => (
+            <div key={item.command} className="rounded-lg border bg-background p-4">
+              <span className="text-sm font-medium text-primary">{item.label}</span>
+              <div className="mt-2 flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2">
+                <Terminal className="w-3.5 h-3.5 text-primary/70 shrink-0" />
+                <code className="text-sm font-mono flex-1 min-w-0 truncate">{item.command}</code>
+                <CopyButton
+                  text={item.command}
+                  variant="ghost"
+                  size="icon"
+                  className="shrink-0 text-muted-foreground"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h3 className="text-sm font-medium">Prompts</h3>
+        <p className="text-xs text-muted-foreground">Copy and paste into your coding agent.</p>
+        <div className="flex flex-col gap-2">
+          {PROMPT_CARDS.map((card) => (
+            <PromptCard key={card.title} {...card} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ManualTab() {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-3">
+        <h3 className="text-sm font-medium">Install Laminar SDK</h3>
+        <InstallTabsSection />
+      </div>
+
+      <ApiKeyGenerator context="traces" />
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-sm font-medium">Integrations</h3>
+          <p className="text-xs text-muted-foreground">
+            Learn how to integrate Laminar with your favorite frameworks and SDKs.
+          </p>
+        </div>
+        <FrameworksGrid gridClassName="grid grid-cols-7 gap-4" />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-sm font-medium">Initialize Laminar</h3>
+          <p className="text-xs text-muted-foreground">Add 2 lines of code at the top of your project.</p>
+        </div>
+        <InitializationTabsSection />
+      </div>
+    </div>
+  );
+}
 
 export default function TracesPagePlaceholder() {
   const router = useRouter();
@@ -59,43 +193,42 @@ export default function TracesPagePlaceholder() {
       <Header path={"traces"} />
       <ScrollArea>
         <div className="flex flex-col mx-auto p-6 max-w-3xl gap-8 pb-16">
-          <div className="flex flex-col gap-2">
-            <h1 className="text-2xl font-semibold">Get started with Tracing</h1>
-            <p className="text-muted-foreground">
-              You don{"'"}t have any traces yet. Follow these steps to start sending traces.
-            </p>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <h1 className="text-2xl font-semibold">Get started with Tracing</h1>
+              <p className="text-sm text-muted-foreground">
+                You don{"'"}t have any traces yet. Choose how you{"'"}d like to set up.
+              </p>
+            </div>
             {isConnected && (
-              <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 rounded-lg border border-border/50">
-                <Radio className="w-4 h-4 text-primary animate-pulse" />
-                <span className="text-sm text-muted-foreground">Waiting for incoming traces...</span>
+              <div className="flex items-center gap-3 rounded-lg border border-primary/20 bg-primary/5 px-4 py-3">
+                <span className="relative flex h-2.5 w-2.5 shrink-0">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-60" />
+                  <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-primary" />
+                </span>
+                <span className="text-sm">Listening for incoming traces&hellip;</span>
               </div>
             )}
           </div>
 
-          <div className="flex flex-col gap-3">
-            <h2 className="text-lg font-medium">Install Laminar SDK</h2>
-            <InstallTabsSection />
-          </div>
-
-          <ApiKeyGenerator context="traces" />
-
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-1">
-              <h2 className="text-lg font-medium">Integrations</h2>
-              <p className="text-sm text-muted-foreground">
-                Learn how to integrate Laminar with your favorite frameworks and SDKs.
-              </p>
-            </div>
-            <FrameworksGrid gridClassName="grid grid-cols-7 gap-4" />
-          </div>
-
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-1">
-              <h2 className="text-lg font-medium">Initialize Laminar</h2>
-              <p className="text-sm text-muted-foreground">Add 2 lines of code at the top of your project.</p>
-            </div>
-            <InitializationTabsSection />
-          </div>
+          <Tabs defaultValue="manual" className="gap-4">
+            <TabsList className="border-none">
+              <TabsTrigger value="automatic" className="gap-1.5">
+                <Sparkles className="w-3.5 h-3.5" />
+                Set up with AI
+              </TabsTrigger>
+              <TabsTrigger value="manual" className="gap-1.5">
+                <Terminal className="w-3.5 h-3.5" />
+                Manual
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="automatic">
+              <AutomaticTab />
+            </TabsContent>
+            <TabsContent value="manual">
+              <ManualTab />
+            </TabsContent>
+          </Tabs>
 
           <div className="flex items-center gap-6 text-sm">
             <a

--- a/frontend/components/traces/placeholder/index.tsx
+++ b/frontend/components/traces/placeholder/index.tsx
@@ -1,161 +1,16 @@
 "use client";
 
 import { ArrowUpRight, Sparkles, Terminal } from "lucide-react";
-import dynamic from "next/dynamic";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 
-import { CopyButton } from "@/components/ui/copy-button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useRealtime } from "@/lib/hooks/use-realtime";
 
-import FrameworksGrid from "../../integrations/frameworks-grid";
-import ApiKeyGenerator from "../../onboarding/api-key-generator";
 import Header from "../../ui/header";
-import { LAMINAR_BASIC_INSTALL_PROMPT, LAMINAR_INSTRUMENTATION_PROMPT, LAMINAR_MIGRATION_PROMPT } from "./prompts";
-
-const InstallTabsSection = dynamic(() => import("./tabs-section.tsx").then((mod) => mod.InstallTabsSection), {
-  ssr: false,
-});
-
-const InitializationTabsSection = dynamic(
-  () => import("./tabs-section.tsx").then((mod) => mod.InitializationTabsSection),
-  {
-    ssr: false,
-  }
-);
-
-const SKILLS_COMMANDS = [
-  {
-    label: "Quick demo trace",
-    command: "npx skills add lmnr-ai/laminar-skills --skill laminar-quickstart-trace",
-  },
-  {
-    label: "Instrument a real codebase",
-    command: "npx skills add lmnr-ai/laminar-skills --skill laminar-instrument-codebase",
-  },
-  {
-    label: "Migrate from another tool",
-    command: "npx skills add lmnr-ai/laminar-skills --skill laminar-migrate-observability",
-  },
-];
-
-const PROMPT_CARDS = [
-  {
-    title: "Incorporate Laminar into an existing product",
-    subtitle: "Best if you already have an LLM/agent pipeline and want high-quality traces.",
-    prompt: LAMINAR_INSTRUMENTATION_PROMPT,
-  },
-  {
-    title: "Basic install + auto-instrumentation",
-    subtitle: "Best if you just want traces to show up quickly with minimal code changes.",
-    prompt: LAMINAR_BASIC_INSTALL_PROMPT,
-  },
-  {
-    title: "Migrate from another observability platform",
-    subtitle: "Best if you already use Langfuse, LangSmith, Helicone, or custom OpenTelemetry.",
-    prompt: LAMINAR_MIGRATION_PROMPT,
-  },
-];
-
-function PromptCard({ title, subtitle, prompt }: { title: string; subtitle: string; prompt: string }) {
-  const [expanded, setExpanded] = useState(false);
-
-  return (
-    <div className="flex flex-col">
-      <div className="group rounded-lg border bg-background p-4 transition-colors hover:bg-muted/30">
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex flex-col gap-1 min-w-0">
-            <span className="text-sm font-medium">{title}</span>
-            <span className="text-xs text-muted-foreground">{subtitle}</span>
-          </div>
-          <CopyButton text={prompt} variant="ghost" size="icon" className="shrink-0 text-muted-foreground" />
-        </div>
-      </div>
-      {expanded && (
-        <div className="max-h-64 overflow-auto rounded-b-md border border-t-0 bg-background p-3">
-          <pre className="text-xs text-muted-foreground whitespace-pre-wrap break-words font-mono">{prompt}</pre>
-        </div>
-      )}
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="self-start text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer mt-1 px-1"
-      >
-        {expanded ? "Hide prompt" : "View prompt"}
-      </button>
-    </div>
-  );
-}
-
-function AutomaticTab() {
-  return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-2">
-        <h3 className="text-sm font-medium">Skills</h3>
-        <p className="text-xs text-muted-foreground">Run a command in your terminal to get started instantly.</p>
-        <div className="flex flex-col gap-2">
-          {SKILLS_COMMANDS.map((item) => (
-            <div key={item.command} className="rounded-lg border bg-background p-4">
-              <span className="text-sm font-medium text-primary">{item.label}</span>
-              <div className="mt-2 flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2">
-                <Terminal className="w-3.5 h-3.5 text-primary/70 shrink-0" />
-                <code className="text-sm font-mono flex-1 min-w-0 truncate">{item.command}</code>
-                <CopyButton
-                  text={item.command}
-                  variant="ghost"
-                  size="icon"
-                  className="shrink-0 text-muted-foreground"
-                />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <h3 className="text-sm font-medium">Prompts</h3>
-        <p className="text-xs text-muted-foreground">Copy and paste into your coding agent.</p>
-        <div className="flex flex-col gap-2">
-          {PROMPT_CARDS.map((card) => (
-            <PromptCard key={card.title} {...card} />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ManualTab() {
-  return (
-    <div className="flex flex-col gap-8">
-      <div className="flex flex-col gap-3">
-        <h3 className="text-sm font-medium">Install Laminar SDK</h3>
-        <InstallTabsSection />
-      </div>
-
-      <ApiKeyGenerator context="traces" />
-
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-1">
-          <h3 className="text-sm font-medium">Integrations</h3>
-          <p className="text-xs text-muted-foreground">
-            Learn how to integrate Laminar with your favorite frameworks and SDKs.
-          </p>
-        </div>
-        <FrameworksGrid gridClassName="grid grid-cols-7 gap-4" />
-      </div>
-
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-1">
-          <h3 className="text-sm font-medium">Initialize Laminar</h3>
-          <p className="text-xs text-muted-foreground">Add 2 lines of code at the top of your project.</p>
-        </div>
-        <InitializationTabsSection />
-      </div>
-    </div>
-  );
-}
+import { AutomaticTab } from "./automatic-tab";
+import { ManualTab } from "./manual-tab";
 
 export default function TracesPagePlaceholder() {
   const router = useRouter();
@@ -211,7 +66,7 @@ export default function TracesPagePlaceholder() {
             )}
           </div>
 
-          <Tabs defaultValue="manual" className="gap-4">
+          <Tabs defaultValue="manual" className="gap-7">
             <TabsList className="border-none">
               <TabsTrigger value="automatic" className="gap-1.5">
                 <Sparkles className="w-3.5 h-3.5" />

--- a/frontend/components/traces/placeholder/manual-tab.tsx
+++ b/frontend/components/traces/placeholder/manual-tab.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import FrameworksGrid from "../../integrations/frameworks-grid";
+import ApiKeyGenerator from "../../onboarding/api-key-generator";
+
+const InstallTabsSection = dynamic(() => import("./tabs-section.tsx").then((mod) => mod.InstallTabsSection), {
+  ssr: false,
+});
+
+const InitializationTabsSection = dynamic(
+  () => import("./tabs-section.tsx").then((mod) => mod.InitializationTabsSection),
+  {
+    ssr: false,
+  }
+);
+
+export function ManualTab() {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-3">
+        <h3 className="text-base font-medium">Install Laminar SDK</h3>
+        <InstallTabsSection />
+      </div>
+
+      <ApiKeyGenerator context="traces" titleClassName="text-base" />
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-base font-medium">Integrations</h3>
+          <p className="text-xs text-muted-foreground">
+            Learn how to integrate Laminar with your favorite frameworks and SDKs.
+          </p>
+        </div>
+        <FrameworksGrid gridClassName="grid grid-cols-7 gap-4" />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-base font-medium">Initialize Laminar</h3>
+          <p className="text-xs text-muted-foreground">Add 2 lines of code at the top of your project.</p>
+        </div>
+        <InitializationTabsSection />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/traces/placeholder/prompt-card.tsx
+++ b/frontend/components/traces/placeholder/prompt-card.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+
+export function PromptCard({ title, subtitle, prompt }: { title: string; subtitle?: string; prompt: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="flex flex-col">
+      <div className="group rounded-lg border bg-background p-4 transition-colors hover:bg-muted/30">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-1 min-w-0">
+            <span className="text-sm font-medium">{title}</span>
+            {subtitle && <span className="text-xs text-muted-foreground">{subtitle}</span>}
+          </div>
+          <div className="flex items-center shrink-0">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setExpanded(!expanded)}
+              className="text-muted-foreground"
+            >
+              {expanded ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </Button>
+            <CopyButton text={prompt} variant="ghost" size="icon" className="text-muted-foreground" />
+          </div>
+        </div>
+      </div>
+      {expanded && (
+        <div className="max-h-64 overflow-auto rounded-b-md border border-t-0 bg-background p-3">
+          <pre className="text-xs text-muted-foreground whitespace-pre-wrap break-words font-mono">{prompt}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/traces/placeholder/prompts.ts
+++ b/frontend/components/traces/placeholder/prompts.ts
@@ -1,0 +1,210 @@
+export const LAMINAR_INSTRUMENTATION_PROMPT = `
+You are a senior observability engineer for LLM/agent systems, specializing in Laminar (traces, spans, datasets, evaluations). Your job: propose and (if asked) implement best-practice Laminar instrumentation for my system so production runs become high-quality, analyzable traces.
+
+## Ground rules
+- Do not guess Laminar APIs. If you are unsure, ask a question or tell me what you need to confirm.
+- Keep changes minimal and aligned with the existing repo style (avoid refactors unless necessary).
+- Prefer stable, low-cardinality names and tags. Put high-cardinality values (request IDs, user IDs, document IDs) into metadata/attributes, not span names or tags.
+- Reader Mode is intentionally high-signal: it focuses on LLM and TOOL spans. Ensure the key work in the system is represented with LLM/TOOL spans (or clearly parented under them) so traces are easy to scan.
+
+## How Laminar thinks (mental model)
+- One trace = one request/turn/job/pipeline run (a single unit of work you want to analyze end-to-end).
+- A trace is a tree of spans (units of work). Spans can be typed (LLM, TOOL, DEFAULT, EXECUTOR, etc.) to drive UI behavior and analysis.
+- Auto-instrumentation can capture common LLM and tool libraries, but we still need first-party spans around our orchestration/business logic so traces are understandable.
+- Great traces have:
+  - A single clear root span per trace boundary
+  - A small number of meaningful child spans for major steps (routing, retrieval, tool execution, post-processing, evaluation)
+  - Consistent naming (stable across runs)
+  - Context for filtering/analysis: userId, sessionId, metadata, tags
+  - Privacy controls: sensitive inputs/outputs are not recorded
+
+## Inputs I will provide (ask for anything missing)
+- Language/runtime: TypeScript/Node or Python (or both)
+- Framework/entrypoints: HTTP server, workers, cron, CLI, streaming, serverless, data pipeline scheduler, etc.
+- LLM provider(s) and how calls are made (OpenAI SDK, Anthropic SDK, LangChain/LlamaIndex, custom HTTP, etc.)
+- A short architecture sketch: main flows, queue boundaries, background jobs, tool interfaces
+- Data sensitivity: what MUST NOT be recorded (PII, secrets, prompts, attachments, customer data, etc.)
+- The repo/code for key files (or a focused excerpt) and constraints (minimal diffs, no new deps, etc.)
+
+## Installation and setup expectations (for coding agents like Claude/Codex)
+- First, determine the repo's package manager and use it (don't invent a new one):
+  - TypeScript: if pnpm-lock.yaml -> use 'pnpm add @lmnr-ai/lmnr@latest'; if yarn.lock -> 'yarn add @lmnr-ai/lmnr@latest'; if package-lock.json -> 'npm add @lmnr-ai/lmnr@latest'; if bun.lockb -> 'bun add @lmnr-ai/lmnr@latest'.
+  - Python: if pyproject.toml uses Poetry -> 'poetry add lmnr'; if uv.lock -> 'uv add lmnr'; if requirements.txt -> add 'lmnr' then install; otherwise ask what dependency manager is used.
+- If Python auto-instrumentation is missing provider spans, install the relevant extras for that provider (example: 'pip install -U lmnr[vertexai]'). If you are unsure which extras to use, ask or consult the Laminar integrations docs.
+- If this is a monorepo, install Laminar in the package(s) that actually run the traced code (server, worker, eval runner), not just the repo root.
+- Do not hardcode or commit secrets. Add the env var name (LMNR_PROJECT_API_KEY) to existing .env.example/README and tell me how to set it in my deployment platform.
+- If self-hosted, ensure the Laminar base URL is configured (LMNR_BASE_URL env var or baseUrl/base_url option).
+- If you can run commands, install dependencies and run the smallest relevant verification (typecheck/tests) to confirm imports and initialization work. If you cannot run commands, output the exact commands I should run.
+
+## Your tasks
+1) Clarify (only if needed)
+Ask up to 8 targeted questions. If enough info is provided, do not ask questions and proceed.
+
+2) Ensure initialization and auto-instrumentation are correct
+- Identify where Laminar.initialize must run (earliest safe startup point) so auto-instrumented spans appear.
+- TypeScript: decide between initialize({ instrumentModules: ... }) vs initialize() + patch({ ... }) depending on framework/module loading.
+- Python: choose instruments/disabled_instruments as needed.
+- If self-hosted: ensure base_url + ports are configured correctly.
+- Next.js (if applicable):
+  - Add serverExternalPackages: ['@lmnr-ai/lmnr'] to next.config.ts.
+  - Initialize in instrumentation.ts via register() when NEXT_RUNTIME is nodejs.
+  - Because instrumentation.ts imports are isolated, patch LLM SDKs in the module where you construct clients using Laminar.patch({ ... }).
+  - If using Vercel AI SDK, pass Laminar tracer into experimental_telemetry (use getTracer()) so model/tool spans attach to the right trace.
+- If the project already has OpenTelemetry:
+  - Either keep Laminar SDK as the primary tracer, or explicitly configure the OTLP exporter to send to Laminar (OTLP/gRPC recommended).
+  - Ensure the Authorization is sent correctly (Node gRPC uses metadata; Python header key must be 'authorization' lowercase).
+- If you see lots of noisy HTTP/fs/dns spans, check for other OpenTelemetry auto-instrumentation being initialized before Laminar and remove/disable it (Laminar should remain high-signal by default).
+
+3) Design the tracing structure (high-level blueprint)
+For each major flow, define:
+- Trace boundary (what counts as one trace)
+- Root span name (stable and descriptive)
+- Child spans (major steps)
+- Which spans should be typed as LLM vs TOOL vs DEFAULT/EXECUTOR
+- What context to attach early (user/session/metadata) so it inherits
+- Tagging strategy (low-cardinality taxonomy)
+- Optional: where to emit custom events for key state changes
+
+4) Apply Laminar best practices (implementation rules)
+- Prefer observe() (TypeScript) / @observe() (Python) for functions and handlers.
+- Use manual spans for blocks or advanced control:
+  - TypeScript: Laminar.startActiveSpan(...) for an active parent; Laminar.startSpan(...) for detached spans; activate detached spans with Laminar.withSpan(span, fn).
+  - Python: with Laminar.start_as_current_span(...) for active spans; use start_span() + use_span() when you must pass span objects.
+- Always end spans (try/finally or context managers). Never leak spans.
+- Set trace context near the start of the trace so everything downstream inherits:
+  - userId via Laminar.setTraceUserId(...) / Laminar.set_trace_user_id(...)
+  - sessionId via Laminar.setTraceSessionId(...) / Laminar.set_trace_session_id(...) (reuse across turns/workflows)
+  - metadata via Laminar.setTraceMetadata(...) / Laminar.set_trace_metadata(...) (JSON-serializable; avoid PII; stable keys)
+- Tags:
+  - At span creation time: observe({ tags: [...] }) or startSpan({ tags: [...] })
+  - From inside a span context: TypeScript uses Laminar.setSpanTags([...]); Python can use Laminar.add_span_tags([...])
+  - Post-hoc user feedback: capture traceId inside a span context, then later call LaminarClient.tags.tag(traceId, ...) to tag the root span
+- Span naming and cardinality:
+  - Do not put dynamic IDs in span names.
+  - Keep tag values low-cardinality (feature flags, dataset names, environment, outcome labels).
+  - Use metadata for richer context and identifiers.
+- Privacy:
+  - If sensitive: disable capture via ignoreInput/ignoreOutput (TypeScript) or ignore_input/ignore_output (Python), or use input/output formatters to redact.
+  - Never put secrets/PII into span names, tags, or metadata.
+- Cross-service and async boundaries:
+  - Propagate context via Laminar.serializeLaminarSpanContext() (TypeScript) / Laminar.serialize_span_context() (Python).
+  - Downstream continues the trace using parentSpanContext / parent_span_context when starting a span.
+  - If context is missing/invalid, start a new trace (do not break the app).
+- Short-lived processes:
+  - Do not flush in hot paths.
+  - Flush at the end (Laminar.flush(); in Python serverless use Laminar.force_flush() when needed).
+  - For Node.js one-off scripts, also call Laminar.shutdown() at the end when appropriate.
+- Custom LLM providers or custom tools:
+  - Create spans with spanType LLM/TOOL so Reader Mode and UI render correctly.
+  - For custom LLM spans, set the model/provider usage attributes required for cost tracking (or set explicit cost if pricing cannot be inferred).
+
+5) Produce an implementation plan and concrete changes
+Deliverables:
+- Instrumentation blueprint (flow -> spans -> context)
+- List of files/locations to change
+- Code snippets or a patch-style diff (depending on what I ask for)
+- A naming, metadata, and tagging convention proposal (with examples)
+- Verification checklist: how to validate traces in the UI (root span exists, children nested, Reader Mode is readable, filters work, tags show)
+- Optional: 3 to 5 useful SQL queries using Laminar SQL tables (spans, traces, events, tags, dataset_datapoints, dataset_datapoint_versions, evaluation_datapoints)
+- Optional (if I ask for evals): add or migrate evaluations using Laminar evaluate(), and provide runnable commands (lmnr eval / npx lmnr eval) that work with the repo's tooling.
+
+## Output format
+- Start with clarifying questions (if any), then the blueprint, then implementation steps, then code/pseudo-code, then verification and SQL.
+- Keep changes minimal and aligned with the existing code style.
+- If you are unsure about a UI label/flow, describe it generically rather than guessing.
+
+Now, here is my project context + code:
+[PASTE HERE]
+`.trimStart();
+
+export const LAMINAR_BASIC_INSTALL_PROMPT = `
+You are a coding agent (Claude Code / Codex). Your job is to add a minimal, correct Laminar setup to my repo so that LLM calls (and tool calls, if applicable) show up as spans in Laminar with as little manual instrumentation as possible.
+
+## Constraints
+- Use the repo's existing package manager (don't invent a new one).
+- Keep diffs minimal; avoid refactors.
+- Do not hardcode or commit secrets.
+- Prefer auto-instrumentation; only add observe() / @observe() when needed to group multiple calls under one trace or add essential structure.
+
+## What I will provide
+- Language/runtime: TypeScript/Node or Python
+- The AI SDK/framework(s) used for model calls (OpenAI SDK, Anthropic SDK, Vercel AI SDK, LangChain/LlamaIndex, etc.)
+- The app entrypoint(s) (server, worker, CLI, serverless function) where initialization should happen
+
+## Your tasks
+1) Confirm prerequisites (ask only if unclear)
+- Identify the package manager and the AI SDK(s) used.
+- Identify where LLM calls happen and what a "single run" means (one request, one job, one CLI invocation).
+
+2) Install Laminar correctly
+- TypeScript: install @lmnr-ai/lmnr using pnpm/yarn/npm/bun based on lockfiles.
+- Python: add lmnr using the project's dependency manager; if auto-instrumentation is missing provider spans, install the relevant lmnr extras for that provider (see Laminar integrations docs; example: lmnr[vertexai]).
+
+3) Configure API key safely
+- Ensure LMNR_PROJECT_API_KEY is read from env.
+- Update existing .env.example / README with LMNR_PROJECT_API_KEY (do not add real values).
+- If self-hosted, set LMNR_BASE_URL (or pass baseUrl/base_url to Laminar.initialize) and verify the URL/ports.
+
+4) Initialize Laminar once at the right spot
+- Ensure Laminar.initialize happens early enough that auto-instrumentation can patch the AI SDK.
+- TypeScript: use initialize({ projectApiKey: process.env.LMNR_PROJECT_API_KEY, instrumentModules: { ... } }) when possible.
+- If imports happen before initialization (or in Next.js where instrumentation.ts is isolated), patch in the module that constructs the clients using Laminar.patch({ ... }).
+- If using Vercel AI SDK, pass Laminar tracer into experimental_telemetry (use getTracer()) so spans attach to the correct trace.
+
+5) Verify end-to-end
+- Run the smallest command to trigger a single LLM call.
+- Confirm: a trace appears in the Laminar UI, and you can see at least one LLM span (and tool spans if you're using tools).
+
+## Deliverables
+- A patch-style diff (or concrete file edits) showing exactly what changed.
+- Exact commands to run locally to verify.
+- A short checklist of what I should see in the Laminar UI.
+
+Now, here is my repo context + code:
+[PASTE HERE]
+`.trimStart();
+
+export const LAMINAR_MIGRATION_PROMPT = `
+You are a coding agent (Claude Code / Codex). Your job is to migrate my existing observability/tracing setup to Laminar with minimal diffs, preserving semantics and making traces easy to analyze in Laminar.
+
+## What I will provide
+- The current observability tool (Langfuse, LangSmith, Helicone, custom OpenTelemetry, etc.)
+- Language/runtime and framework/entrypoints
+- The repo/code where current tracing is implemented (middleware, decorators, wrappers)
+- Any requirements we rely on today: user/session tracking, tags/labels, metadata, evaluation runs, redaction rules
+
+## Migration goals
+- Keep the same trace boundaries (what counts as one trace/run) unless there's a clear improvement.
+- Preserve span naming semantics (stable names; no high-cardinality IDs in span names).
+- Ensure Laminar captures LLM spans (and tool spans) reliably via initialization/patching.
+- Map context correctly:
+  - User/session: Laminar.setTraceUserId / set_trace_user_id and Laminar.setTraceSessionId / set_trace_session_id (or observe() options where appropriate)
+  - Metadata: Laminar trace metadata (setTraceMetadata / set_trace_metadata), set early so it applies to the whole trace
+  - Tags: Laminar span tags (tags option at creation, or setSpanTags / add_span_tags inside span context)
+- Avoid double-instrumentation (don't run two tracer SDKs that both instrument the same calls).
+- Maintain privacy constraints (use ignoreInput/ignoreOutput or redaction formatters; never put PII in names/tags/metadata).
+
+## Your tasks
+1) Identify the current tool and mapping
+- Identify the constructs in the current tool (trace/span/observation, tags, metadata, sessions).
+- Propose a mapping to Laminar concepts and APIs.
+
+2) Implement the migration
+- Remove/disable the old SDK where possible.
+- Install Laminar with the repo's package manager and add LMNR_PROJECT_API_KEY env wiring.
+- If self-hosted, set LMNR_BASE_URL (or pass baseUrl/base_url to Laminar.initialize and LaminarClient).
+- Add Laminar.initialize at the right entrypoint(s) so auto-instrumentation works.
+- Replace tracing wrappers/decorators with Laminar observe() / @observe() or manual spans as needed.
+- If the repo already uses OpenTelemetry exporters, configure OTLP export to Laminar (OTLP/gRPC recommended) and ensure Authorization is set correctly.
+
+3) Verify
+- Provide exact commands to run and what to check in the UI (trace structure, LLM spans, tags/metadata present, no noisy spans explosion).
+
+## Deliverables
+- A patch-style diff (or concrete file edits), plus a short explanation of each change.
+- A verification checklist.
+- If I ask: include guidance for migrating evaluations to Laminar evaluate() and running them via lmnr eval / npx lmnr eval.
+
+Now, here is my repo context + code:
+[PASTE HERE]
+`.trimStart();

--- a/frontend/components/traces/placeholder/prompts.ts
+++ b/frontend/components/traces/placeholder/prompts.ts
@@ -1,168 +1,220 @@
-export const LAMINAR_INSTRUMENTATION_PROMPT = `
-You are a senior observability engineer for LLM/agent systems, specializing in Laminar (traces, spans, datasets, evaluations). Your job: propose and (if asked) implement best-practice Laminar instrumentation for my system so production runs become high-quality, analyzable traces.
+export const LAMINAR_INSTALL_FROM_SCRATCH = `
+Instrument this codebase with Laminar tracing. Docs: https://docs.laminar.sh
 
-## Ground rules
-- Do not guess Laminar APIs. If you are unsure, ask a question or tell me what you need to confirm.
-- Keep changes minimal and aligned with the existing repo style (avoid refactors unless necessary).
-- Prefer stable, low-cardinality names and tags. Put high-cardinality values (request IDs, user IDs, document IDs) into metadata/attributes, not span names or tags.
-- Reader Mode is intentionally high-signal: it focuses on LLM and TOOL spans. Ensure the key work in the system is represented with LLM/TOOL spans (or clearly parented under them) so traces are easy to scan.
+## Goal
 
-## How Laminar thinks (mental model)
-- One trace = one request/turn/job/pipeline run (a single unit of work you want to analyze end-to-end).
-- A trace is a tree of spans (units of work). Spans can be typed (LLM, TOOL, DEFAULT, EXECUTOR, etc.) to drive UI behavior and analysis.
-- Auto-instrumentation can capture common LLM and tool libraries, but we still need first-party spans around our orchestration/business logic so traces are understandable.
-- Great traces have:
-  - A single clear root span per trace boundary
-  - A small number of meaningful child spans for major steps (routing, retrieval, tool execution, post-processing, evaluation)
-  - Consistent naming (stable across runs)
-  - Context for filtering/analysis: userId, sessionId, metadata, tags
-  - Privacy controls: sensitive inputs/outputs are not recorded
+One trace per agent run. Every request/turn produces a single span tree showing the full execution — your logic, every LLM call, tool use, retrieval, and sub-agent work — not scattered isolated spans.
 
-## Inputs I will provide (ask for anything missing)
-- Language/runtime: TypeScript/Node or Python (or both)
-- Framework/entrypoints: HTTP server, workers, cron, CLI, streaming, serverless, data pipeline scheduler, etc.
-- LLM provider(s) and how calls are made (OpenAI SDK, Anthropic SDK, LangChain/LlamaIndex, custom HTTP, etc.)
-- A short architecture sketch: main flows, queue boundaries, background jobs, tool interfaces
-- Data sensitivity: what MUST NOT be recorded (PII, secrets, prompts, attachments, customer data, etc.)
-- The repo/code for key files (or a focused excerpt) and constraints (minimal diffs, no new deps, etc.)
+\`\`\`
+@observe handle_turn          → root (your entry point)
+├── @observe route_request    → your logic
+│   ├── @observe search       → your tool
+│   │   ├── embedding call    → auto-instrumented
+│   │   └── rerank call       → auto-instrumented
+│   └── LLM call              → auto-instrumented
+└── @observe format_response  → your logic
+\`\`\`
 
-## Installation and setup expectations (for coding agents like Claude/Codex)
-- First, determine the repo's package manager and use it (don't invent a new one):
-  - TypeScript: if pnpm-lock.yaml -> use 'pnpm add @lmnr-ai/lmnr@latest'; if yarn.lock -> 'yarn add @lmnr-ai/lmnr@latest'; if package-lock.json -> 'npm add @lmnr-ai/lmnr@latest'; if bun.lockb -> 'bun add @lmnr-ai/lmnr@latest'.
-  - Python: if pyproject.toml uses Poetry -> 'poetry add lmnr'; if uv.lock -> 'uv add lmnr'; if requirements.txt -> add 'lmnr' then install; otherwise ask what dependency manager is used.
-- If Python auto-instrumentation is missing provider spans, install the relevant extras for that provider (example: 'pip install -U lmnr[vertexai]'). If you are unsure which extras to use, ask or consult the Laminar integrations docs.
-- If this is a monorepo, install Laminar in the package(s) that actually run the traced code (server, worker, eval runner), not just the repo root.
-- Do not hardcode or commit secrets. Add the env var name (LMNR_PROJECT_API_KEY) to existing .env.example/README and tell me how to set it in my deployment platform.
-- If self-hosted, ensure the Laminar base URL is configured (LMNR_BASE_URL env var or baseUrl/base_url option).
-- If you can run commands, install dependencies and run the smallest relevant verification (typecheck/tests) to confirm imports and initialization work. If you cannot run commands, output the exact commands I should run.
+- **Root span**: \`@observe\`/\`observe()\` on the entry point of each agent run.
+- **Leaves**: LLM calls and framework ops are auto-instrumented as child spans.
+- **Branches**: \`@observe\`/\`observe()\` on your own functions (routing, tools, pipelines) to give the tree structure.
+- **Context**: user ID, session ID, metadata — set once at the root, inherited by all children.
 
-## Your tasks
-1) Clarify (only if needed)
-Ask up to 8 targeted questions. If enough info is provided, do not ask questions and proceed.
+## 1 — Install
 
-2) Ensure initialization and auto-instrumentation are correct
-- Identify where Laminar.initialize must run (earliest safe startup point) so auto-instrumented spans appear.
-- TypeScript: decide between initialize({ instrumentModules: ... }) vs initialize() + patch({ ... }) depending on framework/module loading.
-- Python: choose instruments/disabled_instruments as needed.
-- If self-hosted: ensure base_url + ports are configured correctly.
-- Next.js (if applicable):
-  - Add serverExternalPackages: ['@lmnr-ai/lmnr'] to next.config.ts.
-  - Initialize in instrumentation.ts via register() when NEXT_RUNTIME is nodejs.
-  - Because instrumentation.ts imports are isolated, patch LLM SDKs in the module where you construct clients using Laminar.patch({ ... }).
-  - If using Vercel AI SDK, pass Laminar tracer into experimental_telemetry (use getTracer()) so model/tool spans attach to the right trace.
-- If the project already has OpenTelemetry:
-  - Either keep Laminar SDK as the primary tracer, or explicitly configure the OTLP exporter to send to Laminar (OTLP/gRPC recommended).
-  - Ensure the Authorization is sent correctly (Node gRPC uses metadata; Python header key must be 'authorization' lowercase).
-- If you see lots of noisy HTTP/fs/dns spans, check for other OpenTelemetry auto-instrumentation being initialized before Laminar and remove/disable it (Laminar should remain high-signal by default).
+Detect the language and package manager. Install using the project's conventions.
 
-3) Design the tracing structure (high-level blueprint)
-For each major flow, define:
-- Trace boundary (what counts as one trace)
-- Root span name (stable and descriptive)
-- Child spans (major steps)
-- Which spans should be typed as LLM vs TOOL vs DEFAULT/EXECUTOR
-- What context to attach early (user/session/metadata) so it inherits
-- Tagging strategy (low-cardinality taxonomy)
-- Optional: where to emit custom events for key state changes
+- Python: \`lmnr\` (use \`[all]\` extra for broad support, or specific extras like \`[openai]\`, \`[anthropic]\`)
+- TypeScript: \`@lmnr-ai/lmnr\`
 
-4) Apply Laminar best practices (implementation rules)
-- Prefer observe() (TypeScript) / @observe() (Python) for functions and handlers.
-- Use manual spans for blocks or advanced control:
-  - TypeScript: Laminar.startActiveSpan(...) for an active parent; Laminar.startSpan(...) for detached spans; activate detached spans with Laminar.withSpan(span, fn).
-  - Python: with Laminar.start_as_current_span(...) for active spans; use start_span() + use_span() when you must pass span objects.
-- Always end spans (try/finally or context managers). Never leak spans.
-- Set trace context near the start of the trace so everything downstream inherits:
-  - userId via Laminar.setTraceUserId(...) / Laminar.set_trace_user_id(...)
-  - sessionId via Laminar.setTraceSessionId(...) / Laminar.set_trace_session_id(...) (reuse across turns/workflows)
-  - metadata via Laminar.setTraceMetadata(...) / Laminar.set_trace_metadata(...) (JSON-serializable; avoid PII; stable keys)
-- Tags:
-  - At span creation time: observe({ tags: [...] }) or startSpan({ tags: [...] })
-  - From inside a span context: TypeScript uses Laminar.setSpanTags([...]); Python can use Laminar.add_span_tags([...])
-  - Post-hoc user feedback: capture traceId inside a span context, then later call LaminarClient.tags.tag(traceId, ...) to tag the root span
-- Span naming and cardinality:
-  - Do not put dynamic IDs in span names.
-  - Keep tag values low-cardinality (feature flags, dataset names, environment, outcome labels).
-  - Use metadata for richer context and identifiers.
-- Privacy:
-  - If sensitive: disable capture via ignoreInput/ignoreOutput (TypeScript) or ignore_input/ignore_output (Python), or use input/output formatters to redact.
-  - Never put secrets/PII into span names, tags, or metadata.
-- Cross-service and async boundaries:
-  - Propagate context via Laminar.serializeLaminarSpanContext() (TypeScript) / Laminar.serialize_span_context() (Python).
-  - Downstream continues the trace using parentSpanContext / parent_span_context when starting a span.
-  - If context is missing/invalid, start a new trace (do not break the app).
-- Short-lived processes:
-  - Do not flush in hot paths.
-  - Flush at the end (Laminar.flush(); in Python serverless use Laminar.force_flush() when needed).
-  - For Node.js one-off scripts, also call Laminar.shutdown() at the end when appropriate.
-- Custom LLM providers or custom tools:
-  - Create spans with spanType LLM/TOOL so Reader Mode and UI render correctly.
-  - For custom LLM spans, set the model/provider usage attributes required for cost tracking (or set explicit cost if pricing cannot be inferred).
+Ask the user to provide their Laminar project API key and add it as \`LMNR_PROJECT_API_KEY\` to the project's environment configuration. Do not commit it to version control.
 
-5) Produce an implementation plan and concrete changes
-Deliverables:
-- Instrumentation blueprint (flow -> spans -> context)
-- List of files/locations to change
-- Code snippets or a patch-style diff (depending on what I ask for)
-- A naming, metadata, and tagging convention proposal (with examples)
-- Verification checklist: how to validate traces in the UI (root span exists, children nested, Reader Mode is readable, filters work, tags show)
-- Optional: 3 to 5 useful SQL queries using Laminar SQL tables (spans, traces, events, tags, dataset_datapoints, dataset_datapoint_versions, evaluation_datapoints)
-- Optional (if I ask for evals): add or migrate evaluations using Laminar evaluate(), and provide runnable commands (lmnr eval / npx lmnr eval) that work with the repo's tooling.
+## 2 — Initialize
 
-## Output format
-- Start with clarifying questions (if any), then the blueprint, then implementation steps, then code/pseudo-code, then verification and SQL.
-- Keep changes minimal and aligned with the existing code style.
-- If you are unsure about a UI label/flow, describe it generically rather than guessing.
+Call once, at the entry point, **before** creating any LLM clients.
 
-Now, here is my project context + code:
-[PASTE HERE]
-`.trimStart();
+**Python** (auto-detects installed libraries):
 
-export const LAMINAR_BASIC_INSTALL_PROMPT = `
-You are a coding agent (Claude Code / Codex). Your job is to add a minimal, correct Laminar setup to my repo so that LLM calls (and tool calls, if applicable) show up as spans in Laminar with as little manual instrumentation as possible.
+\`\`\`python
+from lmnr import Laminar
+Laminar.initialize()
+\`\`\`
 
-## Constraints
-- Use the repo's existing package manager (don't invent a new one).
-- Keep diffs minimal; avoid refactors.
-- Do not hardcode or commit secrets.
-- Prefer auto-instrumentation; only add observe() / @observe() when needed to group multiple calls under one trace or add essential structure.
+**TypeScript** (must pass modules explicitly):
 
-## What I will provide
-- Language/runtime: TypeScript/Node or Python
-- The AI SDK/framework(s) used for model calls (OpenAI SDK, Anthropic SDK, Vercel AI SDK, LangChain/LlamaIndex, etc.)
-- The app entrypoint(s) (server, worker, CLI, serverless function) where initialization should happen
+\`\`\`typescript
+import { Laminar } from '@lmnr-ai/lmnr';
+import OpenAI from 'openai';
+import Anthropic from '@anthropic-ai/sdk';
 
-## Your tasks
-1) Confirm prerequisites (ask only if unclear)
-- Identify the package manager and the AI SDK(s) used.
-- Identify where LLM calls happen and what a "single run" means (one request, one job, one CLI invocation).
+Laminar.initialize({
+  projectApiKey: process.env.LMNR_PROJECT_API_KEY,
+  instrumentModules: {
+    OpenAI: OpenAI,
+    anthropic: Anthropic,
+    // stagehand: Stagehand, puppeteer: puppeteer,
+    // playwright: { chromium }, kernel: Kernel,
+  },
+});
+\`\`\`
 
-2) Install Laminar correctly
-- TypeScript: install @lmnr-ai/lmnr using pnpm/yarn/npm/bun based on lockfiles.
-- Python: add lmnr using the project's dependency manager; if auto-instrumentation is missing provider spans, install the relevant lmnr extras for that provider (see Laminar integrations docs; example: lmnr[vertexai]).
+**Next.js** — requires three pieces:
 
-3) Configure API key safely
-- Ensure LMNR_PROJECT_API_KEY is read from env.
-- Update existing .env.example / README with LMNR_PROJECT_API_KEY (do not add real values).
-- If self-hosted, set LMNR_BASE_URL (or pass baseUrl/base_url to Laminar.initialize) and verify the URL/ports.
+1. \`instrumentation.ts\` at project root:
+\`\`\`typescript
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { Laminar } = await import('@lmnr-ai/lmnr');
+    Laminar.initialize({ projectApiKey: process.env.LMNR_PROJECT_API_KEY });
+  }
+}
+\`\`\`
 
-4) Initialize Laminar once at the right spot
-- Ensure Laminar.initialize happens early enough that auto-instrumentation can patch the AI SDK.
-- TypeScript: use initialize({ projectApiKey: process.env.LMNR_PROJECT_API_KEY, instrumentModules: { ... } }) when possible.
-- If imports happen before initialization (or in Next.js where instrumentation.ts is isolated), patch in the module that constructs the clients using Laminar.patch({ ... }).
-- If using Vercel AI SDK, pass Laminar tracer into experimental_telemetry (use getTracer()) so spans attach to the correct trace.
+2. \`next.config.ts\` — add \`serverExternalPackages: ['@lmnr-ai/lmnr']\`. For Next.js < 15, also add \`experimental: { instrumentationHook: true }\`.
 
-5) Verify end-to-end
-- Run the smallest command to trigger a single LLM call.
-- Confirm: a trace appears in the Laminar UI, and you can see at least one LLM span (and tool spans if you're using tools).
+3. Patch LLM SDKs where you create clients (instrumentation.ts imports are isolated):
+\`\`\`typescript
+import { Laminar } from '@lmnr-ai/lmnr';
+import OpenAI from 'openai';
+Laminar.patch({ OpenAI: OpenAI });
+export const openai = new OpenAI();
+\`\`\`
 
-## Deliverables
-- A patch-style diff (or concrete file edits) showing exactly what changed.
-- Exact commands to run locally to verify.
-- A short checklist of what I should see in the Laminar UI.
+**Vercel AI SDK** — pass the Laminar tracer to every \`generateText\`/\`streamText\` call:
 
-Now, here is my repo context + code:
-[PASTE HERE]
-`.trimStart();
+\`\`\`typescript
+import { getTracer } from '@lmnr-ai/lmnr';
+const { text } = await generateText({
+  model: openai('gpt-4.1-nano'),
+  prompt: '...',
+  experimental_telemetry: { isEnabled: true, tracer: getTracer() },
+});
+\`\`\`
+
+Use \`observe()\` to group multiple AI SDK calls under one trace in a route handler.
+
+## 3 — Auto-instrumented integrations (do NOT manually trace these)
+
+These are traced automatically after initialization. Do not wrap their calls with \`@observe\`.
+
+| Integration | Lang | Notes |
+|---|---|---|
+| **OpenAI** | TS+Py | TS: \`instrumentModules: { OpenAI }\`. Py: auto. |
+| **Anthropic** | TS+Py | TS: \`instrumentModules: { anthropic }\` (lowercase key). Py: auto. |
+| **Google Gemini** | Py | Auto. |
+| **Cohere** | Py | Auto. Chat, Embed, Rerank. |
+| **LiteLLM** | Py | Auto. Remove deprecated \`LaminarLiteLLMCallback\`. |
+| **OpenRouter** | TS+Py | Use OpenAI SDK with \`baseURL: 'https://openrouter.ai/api/v1'\`. |
+| **LangChain/LangGraph** | Py | Auto. Chains, agents, tools, graph nodes. |
+| **Vercel AI SDK** | TS | Pass \`getTracer()\` via \`experimental_telemetry\` (see above). |
+| **Pydantic AI** | Py | Configure OTLP exporter → \`https://api.lmnr.ai:8443/v1/traces\`, then \`Agent.instrument_all()\`. |
+| **Claude Agent SDK** | TS+Py | TS: \`Laminar.wrapClaudeAgentQuery(origQuery)\`. Py: auto. |
+| **OpenHands SDK** | Py | Fully automatic when \`LMNR_PROJECT_API_KEY\` is set. |
+| **Browser Use** | Py | Auto. Agent steps + browser session recordings. |
+| **Stagehand** | TS | \`instrumentModules: { stagehand: Stagehand }\`. Session recordings + LLM cost. |
+| **Puppeteer** | TS | \`instrumentModules: { puppeteer }\`. Session recordings. |
+| **Playwright** | TS+Py | TS: \`instrumentModules: { playwright: { chromium } }\`. Py: auto. |
+| **Skyvern** | Py | Auto. LLM calls, browser recordings, workflow steps. |
+| **Kernel** | TS+Py | TS: \`instrumentModules: { kernel: Kernel }\`. Py: auto. |
+
+## 4 — Observe your own code (most important step)
+
+Without this, auto-instrumented LLM calls have no parent and each becomes its own trace.
+
+**Python:**
+\`\`\`python
+from lmnr import observe
+
+@observe()
+def handle_turn(user_input: str) -> str:
+    return format_response(route_request(user_input))
+
+@observe()
+def route_request(user_input: str):
+    if needs_search(user_input):
+        return search(user_input)
+    return chat(user_input)
+
+@observe()
+def search(query: str):
+    docs = retrieve(query)
+    response = client.chat.completions.create(...)  # auto-instrumented leaf
+    return response.choices[0].message.content
+\`\`\`
+
+**TypeScript:**
+\`\`\`typescript
+import { observe } from '@lmnr-ai/lmnr';
+
+const handleTurn = (input: string) =>
+  observe({ name: 'handleTurn' }, async () => {
+    return formatResponse(await routeRequest(input));
+  });
+\`\`\`
+
+**Wrap**: entry points, orchestration/routing, tool implementations, RAG pipelines, sub-agent calls.
+**Don't wrap**: LLM SDK calls (auto-instrumented), framework internals (auto-instrumented), trivial utils.
+**Sensitive data**: use \`@observe(ignore_input=True, ignore_output=True)\` / \`observe({ ignoreInput: true, ignoreOutput: true })\`.
+
+## 5 — Trace context
+
+Set inside the root observed function. Applies to the entire trace.
+
+**Python:**
+\`\`\`python
+from lmnr import Laminar, observe
+
+@observe()
+def handle_request(user_id: str, conversation_id: str, user_input: str):
+    Laminar.set_trace_user_id(user_id)
+    Laminar.set_trace_session_id(conversation_id)  # groups turns into a conversation
+    Laminar.set_trace_metadata({"environment": os.getenv("ENVIRONMENT", "development")})
+    return run_agent(user_input)
+\`\`\`
+
+**TypeScript:**
+\`\`\`typescript
+const handleRequest = (userId: string, convId: string, input: string) =>
+  observe({ name: 'handleRequest', userId, sessionId: convId }, async () => {
+    Laminar.setTraceMetadata({ environment: process.env.NODE_ENV });
+    return runAgent(input);
+  });
+\`\`\`
+
+**Tags** — categorical labels on individual spans: \`@observe(tags=["beta"])\` / \`observe({ tags: ['beta'] })\`. Dynamically: \`Laminar.add_span_tags([...])\` (Py) / \`Laminar.setSpanTags([...])\` (TS).
+
+## 6 — Cross-service traces (if applicable)
+
+If a run spans multiple services, serialize span context upstream and deserialize downstream to keep one trace.
+
+**Py:** \`Laminar.serialize_span_context()\` → pass via header → \`Laminar.deserialize_span_context(ctx)\` → \`Laminar.start_as_current_span(parent_span_context=parent)\`.
+**TS:** \`Laminar.serializeLaminarSpanContext()\` → pass via header → \`Laminar.startSpan({ parentSpanContext })\`.
+
+Skip if the agent runs in one process.
+
+## 7 — Flush (serverless/CLI only)
+
+Long-running servers don't need this. For short-lived processes, flush before exit:
+
+- **Py:** \`Laminar.force_flush()\` (serverless) / \`Laminar.flush()\` (CLI) / \`Laminar.shutdown()\` (final)
+- **TS:** \`await Laminar.flush()\` / \`await Laminar.shutdown()\`
+
+## 8 — Verify
+
+Trigger a request and confirm the trace shows: a single root span, intermediate spans for your logic, leaf spans for LLM calls, all in one tree, with user/session/metadata attached.
+
+If LLM calls appear as separate top-level traces, you're missing an \`@observe\` on the calling function.
+
+## Rules
+
+- Initialize once, before any LLM clients.
+- TS must pass modules to \`instrumentModules\`. Python auto-detects.
+- Don't double-instrument auto-traced libraries.
+- \`@observe\`/\`observe()\` only on your own code.
+- **Every agent run must have a root span.** Without it, nothing nests.
+- Set context inside the root span.
+- Next.js: \`instrumentation.ts\` + \`Laminar.patch()\` + \`getTracer()\` for AI SDK.
+- Serverless/CLI: flush before exit.`.trimStart();
 
 export const LAMINAR_MIGRATION_PROMPT = `
 You are a coding agent (Claude Code / Codex). Your job is to migrate my existing observability/tracing setup to Laminar with minimal diffs, preserving semantics and making traces easy to analyze in Laminar.

--- a/frontend/components/ui/date-range-filter/index.tsx
+++ b/frontend/components/ui/date-range-filter/index.tsx
@@ -11,21 +11,36 @@ import { Calendar, type CalendarProps } from "@/components/ui/calendar.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Label } from "@/components/ui/label.tsx";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover.tsx";
+import { Skeleton } from "@/components/ui/skeleton.tsx";
 import { cn } from "@/lib/utils.ts";
 
 import { DateRangeFilterProvider, useDateRangeFilterContext } from "./store";
 import { getTimeDifference, QUICK_RANGES } from "./utils.ts";
 
-const DateRangeButton = ({ displayRange }: { displayRange: { from: Date; to: Date } }) => (
-  <div className="flex items-center space-x-2">
-    <Badge className="text-xs bg-accent hover:bg-secondary py-px px-2 mr-2">
-      {getTimeDifference(displayRange.from, displayRange.to)}
-    </Badge>
-    <span className="text-muted-foreground">
-      {formatDate(displayRange.from, "MMM d, h:mm a")} - {formatDate(displayRange.to, "MMM d, h:mm a")}
-    </span>
-  </div>
-);
+const DateRangeButton = ({ displayRange }: { displayRange: { from: Date; to: Date } }) => {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <div className="flex items-center space-x-2">
+        <Skeleton className="h-4 w-8 rounded-full" />
+        <Skeleton className="h-4 w-48" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Badge className="text-xs bg-accent hover:bg-secondary py-px px-2 mr-2">
+        {getTimeDifference(displayRange.from, displayRange.to)}
+      </Badge>
+      <span className="text-muted-foreground">
+        {formatDate(displayRange.from, "MMM d, h:mm a")} - {formatDate(displayRange.to, "MMM d, h:mm a")}
+      </span>
+    </div>
+  );
+};
 
 const QuickRangesList = ({
   pastHours,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new ingestion API and refactors span publishing/processing paths, which could affect trace ingestion reliability and usage-limit enforcement if edge cases are missed. Frontend changes are mostly UI/event-handling updates with low blast radius.
> 
> **Overview**
> Adds a new authenticated ingestion endpoint `POST /v1/spans` that accepts pre-built spans, enforces workspace usage limits, and publishes them to the existing spans queue.
> 
> Refactors trace span publishing by extracting `publish_span_messages` (now reused by both OTLP trace ingestion and the new `/v1/spans` API), adjusts span size estimation to include direct `input`/`output`, and skips payload uploads for LLM spans to avoid debugger-related parsing issues.
> 
> Improves realtime debugger updates by broadcasting `trace_update` events keyed by `rollout.session_id` and handling those events in the debugger UI to auto-enable browser session playback and backfill trace metadata.
> 
> Updates the empty-traces onboarding placeholder with new Manual vs “Set up with AI” tabs (prompt cards + skill commands), extends `ApiKeyGenerator` with optional subtitle/styling, and adds minor UI polish (date-range filter skeleton to avoid hydration mismatch, layout tweaks, resizer handle styling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79bd0b16496e726ac43f975ad49a629e8e053b43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->