### PR TITLE
refactor: remove rmcp-actix-web

### DIFF
--- a/app-server/Cargo.lock
+++ b/app-server/Cargo.lock
@@ -261,7 +261,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -400,7 +400,6 @@ dependencies = [
  "regex",
  "reqwest",
  "rmcp",
- "rmcp-actix-web",
  "rustls 0.23.37",
  "schemars",
  "sentry",
@@ -1247,31 +1246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
 
 [[package]]
-name = "bon"
-version = "3.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
-dependencies = [
- "bon-macros",
- "rustversion",
-]
-
-[[package]]
-name = "bon-macros"
-version = "3.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
-dependencies = [
- "darling 0.23.0",
- "ident_case",
- "prettyplease",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,17 +1347,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.0",
-]
 
 [[package]]
 name = "chrono"
@@ -1578,15 +1541,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2407,22 +2361,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "rand_core 0.10.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -2898,12 +2838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,7 +2958,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -3060,12 +2994,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -4089,12 +4017,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4113,17 +4035,6 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -4163,12 +4074,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rayon"
@@ -4393,44 +4298,17 @@ checksum = "ee4950422f87cf98fffc36946ad672c3024750b3c301491599715b7d6497dfbc"
 dependencies = [
  "async-trait",
  "base64",
- "bytes",
  "chrono",
  "futures",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand 0.10.0",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
- "sse-stream",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tokio-util",
- "tower-service",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "rmcp-actix-web"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68bcb7c3448869c5c3ab953d842b4376f432e137618da4b8f875cd119accac3"
-dependencies = [
- "actix-web",
- "async-stream",
- "bon",
- "futures",
- "rmcp",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
  "tracing",
 ]
 
@@ -4977,7 +4855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -4994,7 +4872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -5341,19 +5219,6 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
-]
-
-[[package]]
-name = "sse-stream"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
-dependencies = [
- "bytes",
- "futures-util",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -6088,15 +5953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6159,40 +6015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -6580,88 +6402,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.114",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/app-server/Cargo.toml
+++ b/app-server/Cargo.toml
@@ -38,8 +38,7 @@ rayon = "1.11.0"
 redis = {version = "0.32.7", features = ["tokio-comp"]}
 regex = "1.12.2"
 reqwest = {version = "0.12.22", features = ["json"]}
-rmcp = {version = "1", features = ["server", "transport-streamable-http-server"]}
-rmcp-actix-web = "0.12"
+rmcp = {version = "1", features = ["server"]}
 rustls = {version = "0.23", features = ["ring"]}
 # Sentry SDK must be compatible with the opentelemetry version. For sentry = 0.46.0, opentelemetry = 0.29
 sentry = {version = "0.46.0", features = ["opentelemetry"]}

--- a/app-server/src/api/v1/mcp.rs
+++ b/app-server/src/api/v1/mcp.rs
@@ -1,15 +1,16 @@
 use std::{collections::HashMap, sync::Arc};
 
-use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use actix_web::{HttpMessage, HttpRequest, HttpResponse, web};
+use bytes::Bytes;
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::*,
     schemars,
-    service::RequestContext,
+    service::{RequestContext, serve_directly},
     tool, tool_handler, tool_router,
+    transport::OneshotTransport,
 };
-use rmcp_actix_web::transport::StreamableHttpService;
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -185,42 +186,105 @@ impl ServerHandler for LaminarMcpServer {
     }
 }
 
-// ============ Service builder ============
+// ============ Actix-web handler ============
 
-pub fn build_mcp_service(
-    clickhouse: clickhouse::Client,
-    clickhouse_ro: Option<Arc<ClickhouseReadonlyClient>>,
-    query_engine: Arc<QueryEngine>,
-    http_client: Arc<reqwest::Client>,
-    db: Arc<DB>,
-    cache: Arc<Cache>,
-) -> StreamableHttpService<LaminarMcpServer, LocalSessionManager> {
-    StreamableHttpService::builder()
-        .service_factory({
-            let clickhouse = clickhouse.clone();
-            let clickhouse_ro = clickhouse_ro.clone();
-            let query_engine = query_engine.clone();
-            let http_client = http_client.clone();
-            let db = db.clone();
-            let cache = cache.clone();
-            Arc::new(move || {
-                Ok(LaminarMcpServer::new(
-                    clickhouse.clone(),
-                    clickhouse_ro.clone(),
-                    query_engine.clone(),
-                    http_client.clone(),
-                    db.clone(),
-                    cache.clone(),
-                ))
-            })
-        })
-        .session_manager(Arc::new(LocalSessionManager::default()))
-        .stateful_mode(false)
-        .on_request_fn(|http_req, mcp_ext| {
-            use actix_web::HttpMessage;
-            if let Some(api_key) = http_req.extensions().get::<ProjectApiKey>() {
-                mcp_ext.insert(ProjectId(api_key.project_id));
+/// Shared state for the MCP endpoint, passed via actix-web `Data`.
+pub struct McpState {
+    server: LaminarMcpServer,
+}
+
+impl McpState {
+    pub fn new(
+        clickhouse: clickhouse::Client,
+        clickhouse_ro: Option<Arc<ClickhouseReadonlyClient>>,
+        query_engine: Arc<QueryEngine>,
+        http_client: Arc<reqwest::Client>,
+        db: Arc<DB>,
+        cache: Arc<Cache>,
+    ) -> Self {
+        Self {
+            server: LaminarMcpServer::new(
+                clickhouse,
+                clickhouse_ro,
+                query_engine,
+                http_client,
+                db,
+                cache,
+            ),
+        }
+    }
+}
+
+/// POST /v1/mcp — Stateless Streamable HTTP MCP endpoint.
+///
+/// Follows the MCP Streamable HTTP spec:
+/// - Requests → routed through rmcp's ServerHandler, response as JSON
+/// - Notifications → 202 Accepted (no body)
+#[actix_web::post("")]
+pub async fn mcp_handler(
+    req: HttpRequest,
+    body: web::Bytes,
+    state: web::Data<McpState>,
+) -> HttpResponse {
+    // Parse JSON-RPC message
+    let message: ClientJsonRpcMessage = match serde_json::from_slice(&body) {
+        Ok(msg) => msg,
+        Err(e) => {
+            return HttpResponse::BadRequest()
+                .content_type("application/json")
+                .body(format!("{{\"error\": \"Invalid JSON-RPC: {e}\"}}"));
+        }
+    };
+
+    match message {
+        // Notifications (e.g. notifications/initialized) → 202 Accepted
+        ClientJsonRpcMessage::Notification(_) => HttpResponse::Accepted().finish(),
+
+        // Responses/Errors from client → 202 Accepted
+        ClientJsonRpcMessage::Response(_) | ClientJsonRpcMessage::Error(_) => {
+            HttpResponse::Accepted().finish()
+        }
+
+        // Requests (initialize, tools/list, tools/call, etc.) → process via rmcp
+        ClientJsonRpcMessage::Request(mut request) => {
+            // Inject project_id from auth middleware into rmcp extensions
+            if let Some(api_key) = req.extensions().get::<ProjectApiKey>() {
+                request
+                    .request
+                    .extensions_mut()
+                    .insert(ProjectId(api_key.project_id));
             }
-        })
-        .build()
+
+            // Use rmcp's OneshotTransport + serve_directly (same pattern as the
+            // official tower handler) to route through our ServerHandler.
+            let (transport, mut receiver) =
+                OneshotTransport::<RoleServer>::new(ClientJsonRpcMessage::Request(request));
+            let service_handle = serve_directly(state.server.clone(), transport, None);
+
+            tokio::spawn(async move {
+                let _ = service_handle.waiting().await;
+            });
+
+            // Collect the response from the channel
+            match receiver.recv().await {
+                Some(response) => {
+                    let body = serde_json::to_vec(&response).unwrap_or_else(|_| b"{}".to_vec());
+                    HttpResponse::Ok()
+                        .content_type("application/json")
+                        .body(Bytes::from(body))
+                }
+                None => HttpResponse::InternalServerError()
+                    .content_type("application/json")
+                    .body("{\"error\": \"No response from handler\"}"),
+            }
+        }
+    }
+}
+
+/// Catch-all for non-POST methods (GET, DELETE, etc.) → 405 Method Not Allowed.
+/// MCP Streamable HTTP spec requires 405 (not 404) when a method is unsupported.
+pub async fn method_not_allowed() -> HttpResponse {
+    HttpResponse::MethodNotAllowed()
+        .insert_header(("Allow", "POST"))
+        .finish()
 }

--- a/app-server/src/api/v1/mcp.rs
+++ b/app-server/src/api/v1/mcp.rs
@@ -230,9 +230,10 @@ pub async fn mcp_handler(
     let message: ClientJsonRpcMessage = match serde_json::from_slice(&body) {
         Ok(msg) => msg,
         Err(e) => {
+            let error_body = serde_json::json!({ "error": format!("Invalid JSON-RPC: {e}") });
             return HttpResponse::BadRequest()
                 .content_type("application/json")
-                .body(format!("{{\"error\": \"Invalid JSON-RPC: {e}\"}}"));
+                .body(error_body.to_string());
         }
     };
 

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1294,15 +1294,14 @@ fn main() -> anyhow::Result<()> {
                     // == Name generator ==
                     let name_generator = Arc::new(NameGenerator::new());
 
-                    // == MCP service (must be created outside HttpServer::new to share session state) ==
-                    let mcp_service = api::v1::mcp::build_mcp_service(
+                    let mcp_state = web::Data::new(api::v1::mcp::McpState::new(
                         clickhouse_for_http.clone(),
                         clickhouse_readonly_client.clone(),
                         query_engine.clone(),
                         Arc::new(http_client_for_http.clone()),
                         db_for_http.clone(),
                         cache_for_http.clone(),
-                    );
+                    ));
 
                     log::info!("Spinning up full HTTP server");
                     HttpServer::new(move || {
@@ -1378,7 +1377,9 @@ fn main() -> anyhow::Result<()> {
                             .service(
                                 web::scope("/v1/mcp")
                                     .wrap(project_auth.clone())
-                                    .service(mcp_service.clone().scope()),
+                                    .app_data(mcp_state.clone())
+                                    .service(api::v1::mcp::mcp_handler)
+                                    .default_service(web::route().to(api::v1::mcp::method_not_allowed)),
                             )
                             .service(
                                 web::scope("/v1")


### PR DESCRIPTION
    refactor: remove rmcp-actix-web
    And replace with a manually implemented actix web handler.

    Checked responses against expected respones in the MCP spec.
    https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `/v1/mcp` HTTP handling path and response semantics (202/405/JSON parsing) by replacing a library-provided service with custom request routing, which could affect MCP client compatibility if edge cases differ from the spec.
> 
> **Overview**
> Replaces the `rmcp-actix-web` integration with a manually implemented actix-web MCP endpoint for `/v1/mcp`, routing JSON-RPC requests through `rmcp` via `OneshotTransport`/`serve_directly` and injecting `ProjectId` from auth middleware.
> 
> Updates HTTP behavior to match the Streamable HTTP MCP spec (e.g., `202 Accepted` for notifications/client responses and `405 Method Not Allowed` for non-POST methods), and refactors server startup to register the new handler/state instead of cloning a service builder.
> 
> Removes `rmcp-actix-web` (and related transitive deps/features) from `Cargo.toml`/`Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d536d0618bab732c6d2d56ddd6a5fd506d4cc79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->