### PR TITLE
refactor batch and rt processing, fix requires next step did not respect realtime flag on message

### DIFF
--- a/app-server/src/signals/mod.rs
+++ b/app-server/src/signals/mod.rs
@@ -12,6 +12,7 @@ pub mod prompts;
 pub mod provider;
 pub mod queue;
 pub mod realtime_api;
+pub mod response_processor;
 pub mod spans;
 pub mod submissions_consumer;
 pub mod tools;

--- a/app-server/src/signals/pendings_consumer.rs
+++ b/app-server/src/signals/pendings_consumer.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use crate::{
     cache::Cache,
     ch::{
-        signal_run_messages::delete_signal_run_messages,
+        signal_run_messages::{delete_signal_run_messages, insert_signal_run_messages},
         signal_runs::{CHSignalRun, insert_signal_runs},
     },
     db::DB,
@@ -328,6 +328,11 @@ pub async fn process_succeeded_batch(
     )
     .await?;
 
+    // Insert new conversation messages BEFORE routing any runs to queues.
+    // A consumer could pick up the run before finalize_runs persists them, causing
+    // process_run to read stale message history (e.g. missing retry guidance).
+    insert_signal_run_messages(clickhouse.clone(), &processed.new_messages).await?;
+
     // Route pending runs to the signals queue (batch pipeline next step)
     for run_id in &processed.pending_run_ids {
         let msg = processed.run_to_message.get(run_id).unwrap();
@@ -358,7 +363,6 @@ pub async fn process_succeeded_batch(
     finalize_runs(
         &processed.succeeded_runs,
         &permanently_failed_runs,
-        processed.new_messages,
         clickhouse.clone(),
         db.clone(),
         cache.clone(),

--- a/app-server/src/signals/pendings_consumer.rs
+++ b/app-server/src/signals/pendings_consumer.rs
@@ -320,7 +320,7 @@ pub async fn process_succeeded_batch(
     let mut processed = process_provider_responses(
         &message.messages,
         &response.responses,
-        &message.batch_id,
+        Some(message.batch_id.clone()),
         clickhouse.clone(),
         queue.clone(),
         config.clone(),

--- a/app-server/src/signals/pendings_consumer.rs
+++ b/app-server/src/signals/pendings_consumer.rs
@@ -1,78 +1,27 @@
 use async_trait::async_trait;
-use serde::Serialize;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
 use crate::{
     cache::Cache,
-    ch::signal_run_messages::insert_signal_run_messages,
-    db::spans::SpanType,
-    features::{Feature, is_feature_enabled},
-    utils::limits::update_workspace_signal_runs_used,
-};
-use crate::{
-    ch::signal_events::{CHSignalEvent, insert_signal_events},
-    ch::signal_run_messages::{CHSignalRunMessage, delete_signal_run_messages},
-    ch::signal_runs::{CHSignalRun, insert_signal_runs},
+    ch::{
+        signal_run_messages::delete_signal_run_messages,
+        signal_runs::{CHSignalRun, insert_signal_runs},
+    },
     db::DB,
     mq::MessageQueue,
     signals::SignalRun,
     signals::{
-        SignalWorkerConfig, llm_model, llm_provider,
-        postprocess::process_event_notifications_and_clustering,
-        prompts::MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE,
-        provider::{
-            LanguageModelClient, ProviderClient,
-            models::{
-                ProviderBatchOutput, ProviderContent as Content,
-                ProviderFinishReason as FinishReason, ProviderFunctionCall as FunctionCall,
-                ProviderFunctionResponse as FunctionResponse, ProviderInlineResponse,
-                ProviderPart as Part,
-            },
-        },
+        SignalWorkerConfig,
+        provider::{LanguageModelClient, ProviderClient, models::ProviderBatchOutput},
         push_to_signals_queue,
         queue::{SignalJobPendingBatchMessage, SignalMessage, push_to_waiting_queue},
-        spans::{get_trace_span_ids_and_end_time, span_short_id},
-        tools::get_full_spans,
-        utils::{
-            InternalSpan, emit_internal_span, nanoseconds_to_datetime, replace_span_tags_with_links,
-        },
+        response_processor::{FailureMetadata, finalize_runs, process_provider_responses},
     },
     worker::{HandlerError, MessageHandler},
 };
 
 const DEFAULT_RETRY_COUNT: u32 = 4;
-
-pub struct FailureMetadata {
-    pub finish_reason: Option<FinishReason>,
-    pub is_processing_error: bool,
-}
-
-#[derive(Debug, Serialize)]
-enum NextStepReason {
-    ToolResult(serde_json::Value),
-    MalformedFunctionCallRetry,
-}
-
-#[derive(Debug, Serialize)]
-enum StepResult {
-    CompletedNoEvent,
-    CompletedWithEvent {
-        attributes: serde_json::Value,
-        summary: String,
-    },
-    RequiresNextStep {
-        reason: NextStepReason,
-    },
-    Failed {
-        error: String,
-        finish_reason: Option<FinishReason>,
-        is_processing_error: bool,
-    },
-}
 
 pub struct SignalJobPendingBatchHandler {
     pub db: Arc<DB>,
@@ -215,7 +164,6 @@ pub async fn retry_or_fail_runs(
         let metadata = failure_metadata.get(&run.run_id);
 
         let retryable = if let Some(meta) = metadata {
-            // Processing errors are always retryable regardless of finish reason
             if meta.is_processing_error {
                 true
             } else {
@@ -369,701 +317,60 @@ pub async fn process_succeeded_batch(
         message.batch_id
     )))?;
 
-    let inlined_responses = &response.responses;
-    let mut new_messages = Vec::new();
+    let mut processed = process_provider_responses(
+        &message.messages,
+        &response.responses,
+        &message.batch_id,
+        clickhouse.clone(),
+        queue.clone(),
+        config.clone(),
+        db.clone(),
+    )
+    .await?;
 
-    let mut run_to_message: HashMap<Uuid, SignalMessage> = HashMap::new();
-    for msg in message.messages.iter() {
-        run_to_message.insert(msg.run_id, msg.clone());
-    }
+    // Route pending runs to the signals queue (batch pipeline next step)
+    for run_id in &processed.pending_run_ids {
+        let msg = processed.run_to_message.get(run_id).unwrap();
+        let mut next_step_msg = msg.clone();
+        next_step_msg.step += 1;
 
-    let mut succeeded_runs: Vec<SignalRun> = Vec::new();
-    let mut failed_runs: Vec<SignalRun> = Vec::new();
-    let mut pending_run_ids: HashSet<Uuid> = HashSet::new();
-    let mut failure_metadata: HashMap<Uuid, FailureMetadata> = HashMap::new();
-
-    for inline_response in inlined_responses.iter() {
-        let run_id = inline_response
-            .metadata
-            .as_ref()
-            .and_then(|m| m.get("run_id"))
-            .and_then(|v| v.as_str())
-            .and_then(|s| uuid::Uuid::parse_str(s).ok());
-        let trace_id = inline_response
-            .metadata
-            .as_ref()
-            .and_then(|m| m.get("trace_id"))
-            .and_then(|v| v.as_str())
-            .and_then(|s| uuid::Uuid::parse_str(s).ok());
-
-        let run_id = match run_id {
-            Some(id) => id,
-            None => {
-                log::warn!(
-                    "Response missing run_id in metadata, skipping response. Batch ID: {}",
-                    message.batch_id
-                );
-                continue;
-            }
-        };
-
-        let signal_message = match run_to_message.get(&run_id) {
-            Some(msg) => msg,
-            None => {
-                failed_runs.push(
-                    SignalRun::nil_with_id(run_id, trace_id.unwrap_or_default())
-                        .failed("No message found for run_id"),
-                );
-                log::error!("No message found for run_id {}, skipping", run_id);
-                continue;
-            }
-        };
-
-        let run = SignalRun::from_message(signal_message, signal_message.signal.id);
-
-        let (step_result, new_run_messages) = process_single_response(
-            inline_response,
-            signal_message,
-            &run,
-            clickhouse.clone(),
-            queue.clone(),
-            config.clone(),
-            message.batch_id.clone(),
-        )
-        .await;
-
-        new_messages.extend(new_run_messages);
-
-        match step_result {
-            StepResult::CompletedNoEvent => {
-                succeeded_runs.push(run.completed());
-            }
-            StepResult::CompletedWithEvent {
-                attributes,
-                summary,
-            } => {
-                match handle_create_event(
-                    signal_message,
-                    &run,
-                    attributes,
-                    summary,
-                    clickhouse.clone(),
-                    db.clone(),
-                    queue.clone(),
-                    run.internal_span_id,
-                    config.internal_project_id,
-                )
-                .await
-                {
-                    Ok(event_id) => {
-                        succeeded_runs.push(run.completed_with_event(event_id));
-                    }
-                    Err(e) => {
-                        log::error!("[SIGNAL JOB] Failed to create event: {:?}", e);
-                        failed_runs.push(run.failed(format!("Failed to create event: {}", e)));
-                    }
-                }
-            }
-            StepResult::RequiresNextStep { .. } => {
-                pending_run_ids.insert(run.run_id);
-            }
-            StepResult::Failed {
-                error,
-                finish_reason,
-                is_processing_error,
-            } => {
-                failure_metadata.insert(
-                    run.run_id,
-                    FailureMetadata {
-                        finish_reason,
-                        is_processing_error,
-                    },
-                );
-                failed_runs.push(run.failed(error));
-            }
-        }
-    }
-
-    // Insert new messages into ClickHouse
-    insert_signal_run_messages(clickhouse.clone(), &new_messages).await?;
-
-    // Insert succeeded runs into ClickHouse
-    let succeeded_runs_ch: Vec<CHSignalRun> = succeeded_runs
-        .iter()
-        .map(|r| CHSignalRun::from(r))
-        .collect();
-    insert_signal_runs(clickhouse.clone(), &succeeded_runs_ch).await?;
-    if is_feature_enabled(Feature::UsageLimit) {
-        let mut runs_by_project_id: HashMap<Uuid, usize> = HashMap::new();
-        for run in &succeeded_runs {
-            *runs_by_project_id.entry(run.project_id).or_insert(0) += 1;
-        }
-        let update_futures = runs_by_project_id.into_iter().map(|(project_id, runs)| {
-            let db = db.clone();
-            let clickhouse = clickhouse.clone();
-            let cache = cache.clone();
-            async move {
-                if let Err(e) =
-                    update_workspace_signal_runs_used(db, clickhouse, cache, project_id, runs).await
-                {
-                    log::error!("Failed to update workspace signal runs used: {}", e);
-                }
-            }
-        });
-        futures_util::future::join_all(update_futures).await;
-    }
-
-    // Push pending runs back to signals queue for next step processing
-    // If enqueue fails, add them to failed_runs so they're handled consistently
-    if !pending_run_ids.is_empty() {
-        for run_id in &pending_run_ids {
-            let msg = run_to_message.get(run_id).unwrap();
-
-            // Create next step message with incremented step
-            let mut next_step_msg = msg.clone();
-            next_step_msg.step += 1;
-
-            if let Err(e) = push_to_signals_queue(next_step_msg, queue.clone()).await {
-                log::error!(
-                    "[SIGNAL JOB] Failed to push pending run {} to signals queue: {:?}",
-                    run_id,
-                    e
-                );
-                // Mark as failed so status is updated, messages are cleaned up, and job stats are updated
-                let run = SignalRun::from_message(msg, msg.signal.id).next_step(); // Build with incremented step
-                failed_runs.push(run.failed(format!("Failed to enqueue for next step: {}", e)));
-            }
-        }
-    }
-
-    let (permanently_failed_runs, retried_count) =
-        retry_or_fail_runs(failed_runs, &run_to_message, &failure_metadata, queue).await;
-
-    let permanently_failed_runs_ch: Vec<CHSignalRun> = permanently_failed_runs
-        .iter()
-        .map(CHSignalRun::from)
-        .collect();
-    if let Err(e) = insert_signal_runs(clickhouse.clone(), &permanently_failed_runs_ch).await {
-        log::error!(
-            "[SIGNAL JOB] Failed to insert permanently failed runs: {:?}",
-            e
-        );
-    }
-
-    let final_runs_to_insert = [succeeded_runs, permanently_failed_runs].concat();
-    if !final_runs_to_insert.is_empty() {
-        let project_run_pairs: Vec<(Uuid, Uuid)> = final_runs_to_insert
-            .iter()
-            .map(|run| (run.project_id, run.run_id))
-            .collect();
-        if let Err(e) = delete_signal_run_messages(clickhouse.clone(), &project_run_pairs).await {
+        if let Err(e) = push_to_signals_queue(next_step_msg, queue.clone()).await {
             log::error!(
-                "[SIGNAL JOB] Failed to delete messages for final runs: {:?}",
+                "[SIGNAL JOB] Failed to push pending run {} to signals queue: {:?}",
+                run_id,
                 e
             );
+            let run = SignalRun::from_message(msg, msg.signal.id).next_step();
+            processed
+                .failed_runs
+                .push(run.failed(format!("Failed to enqueue for next step: {}", e)));
         }
     }
 
-    let mut succeeded_by_job: HashMap<Uuid, i32> = HashMap::new();
-    for run in &final_runs_to_insert {
-        if let Some(job_id) = run.job_id {
-            if run.status == crate::signals::RunStatus::Completed {
-                *succeeded_by_job.entry(job_id).or_insert(0) += 1;
-            }
-        }
-    }
-    for (job_id, count) in succeeded_by_job {
-        if let Err(e) =
-            crate::db::signal_jobs::update_signal_job_stats(&db.pool, job_id, count, 0).await
-        {
-            log::error!("Failed to update job stats: {}", e);
-        }
-    }
+    let (permanently_failed_runs, retried_count) = retry_or_fail_runs(
+        processed.failed_runs,
+        &processed.run_to_message,
+        &processed.failure_metadata,
+        queue.clone(),
+    )
+    .await;
 
-    let mut failed_by_job: HashMap<Uuid, i32> = HashMap::new();
-    for run in &final_runs_to_insert {
-        if let Some(job_id) = run.job_id {
-            if run.status == crate::signals::RunStatus::Failed {
-                *failed_by_job.entry(job_id).or_insert(0) += 1;
-            }
-        }
-    }
-    for (job_id, count) in failed_by_job {
-        if let Err(e) =
-            crate::db::signal_jobs::update_signal_job_stats(&db.pool, job_id, 0, count).await
-        {
-            log::error!("Failed to update job stats: {}", e);
-        }
-    }
+    finalize_runs(
+        &processed.succeeded_runs,
+        &permanently_failed_runs,
+        processed.new_messages,
+        clickhouse.clone(),
+        db.clone(),
+        cache.clone(),
+    )
+    .await?;
 
     log::debug!(
         "[SIGNAL JOB] Batch processing complete. Succeeded: {}, Retried: {}, Permanently Failed: {}",
-        final_runs_to_insert
-            .iter()
-            .filter(|r| r.status == crate::signals::RunStatus::Completed)
-            .count(),
+        processed.succeeded_runs.len(),
         retried_count,
-        final_runs_to_insert
-            .iter()
-            .filter(|r| r.status == crate::signals::RunStatus::Failed)
-            .count()
+        permanently_failed_runs.len(),
     );
 
     Ok(())
-}
-
-async fn process_single_response(
-    provider_response: &ProviderInlineResponse,
-    signal_message: &SignalMessage,
-    run: &SignalRun,
-    clickhouse: clickhouse::Client,
-    queue: Arc<MessageQueue>,
-    config: Arc<SignalWorkerConfig>,
-    provider_batch_id: String,
-) -> (StepResult, Vec<CHSignalRunMessage>) {
-    let mut new_messages: Vec<CHSignalRunMessage> = Vec::new();
-
-    let mut finish_reason = None;
-    let mut function_call = None;
-    let mut text_response = None;
-    let mut content_val = None;
-    let mut usage = None;
-    let mut model_version = None;
-
-    if let Some(resp) = &provider_response.response {
-        usage = resp.usage_metadata.clone();
-        model_version = resp.model_version.clone();
-        if let Some(cands) = &resp.candidates {
-            if let Some(cand) = cands.first() {
-                finish_reason = cand.finish_reason.clone();
-                if let Some(content) = &cand.content {
-                    content_val = Some(serde_json::to_value(content).unwrap_or_default());
-                    if let Some(parts) = &content.parts {
-                        for part in parts {
-                            if let Some(fc) = &part.function_call {
-                                function_call = Some(fc.clone());
-                            } else if let Some(t) = &part.text {
-                                text_response = Some(t.clone());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    let has_error = provider_response.error.is_some();
-    let error_msg = provider_response.error.as_ref().map(|e| e.message.clone());
-
-    let span_output = if let Some(fc) = &function_call {
-        serde_json::to_value(fc).ok()
-    } else if let Some(t) = &text_response {
-        Some(serde_json::Value::String(t.clone()))
-    } else {
-        finish_reason
-            .as_ref()
-            .and_then(|fr| serde_json::to_value(fr).ok())
-    };
-
-    let span_error = if let Some(e) = &error_msg {
-        Some(e.clone())
-    } else if let Some(fr) = &finish_reason {
-        if fr.is_success() {
-            None
-        } else {
-            Some(format!("{:?}", fr))
-        }
-    } else {
-        None
-    };
-
-    emit_internal_span(
-        queue.clone(),
-        InternalSpan {
-            name: format!("step_{}.process_response", run.step),
-            trace_id: run.internal_trace_id,
-            run_id: run.run_id,
-            signal_name: signal_message.signal.name.clone(),
-            parent_span_id: Some(run.internal_span_id),
-            span_type: SpanType::LLM,
-            start_time: signal_message.request_start_time,
-            input: None,
-            output: span_output,
-            input_tokens: usage.as_ref().and_then(|u| u.prompt_token_count).map(|c| c),
-            input_cached_tokens: usage
-                .as_ref()
-                .and_then(|u| u.cache_read_input_tokens)
-                .map(|c| c as i64),
-            output_tokens: usage
-                .as_ref()
-                .and_then(|u| u.candidates_token_count)
-                .map(|c| c),
-            model: model_version.unwrap_or(llm_model()),
-            provider: llm_provider(),
-            internal_project_id: config.internal_project_id,
-            job_id: run.job_id,
-            error: span_error,
-            provider_batch_id: Some(provider_batch_id),
-        },
-    )
-    .await;
-
-    if has_error {
-        return (
-            StepResult::Failed {
-                error: error_msg.unwrap_or_else(|| "LLM provider error".to_string()),
-                finish_reason,
-                is_processing_error: false,
-            },
-            vec![],
-        );
-    }
-
-    if let Some(function_call) = function_call {
-        let llm_output_msg = CHSignalRunMessage::new(
-            signal_message.project_id,
-            run.run_id,
-            chrono::Utc::now(),
-            content_val
-                .as_ref()
-                .map(|v| v.to_string())
-                .unwrap_or_default(),
-        );
-        new_messages.push(llm_output_msg);
-
-        let tool_call_start_time = chrono::Utc::now();
-        let step_result =
-            handle_tool_call(signal_message, run, &function_call, clickhouse.clone()).await;
-
-        let tool_error = match &step_result {
-            StepResult::Failed { error, .. } => Some(error.clone()),
-            _ => None,
-        };
-
-        emit_internal_span(
-            queue.clone(),
-            InternalSpan {
-                name: function_call.name.clone(),
-                trace_id: run.internal_trace_id,
-                run_id: run.run_id,
-                signal_name: signal_message.signal.name.clone(),
-                parent_span_id: Some(run.internal_span_id),
-                span_type: SpanType::Tool,
-                start_time: tool_call_start_time,
-                input: Some(serde_json::json!(function_call)),
-                output: Some(serde_json::json!(step_result)),
-                input_tokens: None,
-                input_cached_tokens: None,
-                output_tokens: None,
-                model: llm_model(),
-                provider: llm_provider(),
-                internal_project_id: config.internal_project_id,
-                job_id: run.job_id,
-                error: tool_error,
-                provider_batch_id: None,
-            },
-        )
-        .await;
-
-        match step_result {
-            StepResult::Failed {
-                error,
-                finish_reason,
-                is_processing_error,
-            } => (
-                StepResult::Failed {
-                    error: format!("Tool call failed: {}", error),
-                    finish_reason,
-                    is_processing_error,
-                },
-                new_messages,
-            ),
-            StepResult::CompletedNoEvent => (StepResult::CompletedNoEvent, new_messages),
-            StepResult::CompletedWithEvent {
-                attributes,
-                summary,
-            } => (
-                StepResult::CompletedWithEvent {
-                    attributes,
-                    summary,
-                },
-                new_messages,
-            ),
-            StepResult::RequiresNextStep { reason } => {
-                match &reason {
-                    NextStepReason::ToolResult(tool_result) => {
-                        let function_response_content = Content {
-                            role: Some("user".to_string()),
-                            parts: Some(vec![Part {
-                                function_response: Some(FunctionResponse {
-                                    name: function_call.name.clone(),
-                                    response: tool_result.clone(),
-                                    id: function_call.id.clone(),
-                                }),
-                                ..Default::default()
-                            }]),
-                        };
-                        let tool_output_msg = CHSignalRunMessage::new(
-                            signal_message.project_id,
-                            run.run_id,
-                            chrono::Utc::now(),
-                            serde_json::to_string(&function_response_content).unwrap_or_default(),
-                        );
-                        new_messages.push(tool_output_msg);
-                    }
-                    NextStepReason::MalformedFunctionCallRetry => {}
-                }
-
-                if run.step >= config.max_allowed_steps {
-                    (
-                        StepResult::Failed {
-                            error: "Maximum step count exceeded".to_string(),
-                            finish_reason,
-                            is_processing_error: false,
-                        },
-                        new_messages,
-                    )
-                } else {
-                    (StepResult::RequiresNextStep { reason }, new_messages)
-                }
-            }
-        }
-    } else {
-        if let Some(fr) = &finish_reason {
-            if fr.is_malformed_function_call() {
-                if run.step >= config.max_allowed_steps {
-                    return (
-                        StepResult::Failed {
-                            error: "Maximum step count exceeded".to_string(),
-                            finish_reason: Some(fr.clone()),
-                            is_processing_error: false,
-                        },
-                        new_messages,
-                    );
-                }
-
-                let finish_message = text_response.clone().unwrap_or_else(|| format!("{:?}", fr));
-                let now = chrono::Utc::now();
-                let assistant_content = Content {
-                    role: Some("model".to_string()),
-                    parts: Some(vec![Part {
-                        text: Some(finish_message),
-                        ..Default::default()
-                    }]),
-                };
-                new_messages.push(CHSignalRunMessage::new(
-                    signal_message.project_id,
-                    run.run_id,
-                    now,
-                    serde_json::to_string(&assistant_content).unwrap_or_default(),
-                ));
-
-                let user_content = Content {
-                    role: Some("user".to_string()),
-                    parts: Some(vec![Part {
-                        text: Some(MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE.to_string()),
-                        ..Default::default()
-                    }]),
-                };
-                new_messages.push(CHSignalRunMessage::new(
-                    signal_message.project_id,
-                    run.run_id,
-                    now + chrono::Duration::milliseconds(1),
-                    serde_json::to_string(&user_content).unwrap_or_default(),
-                ));
-
-                return (
-                    StepResult::RequiresNextStep {
-                        reason: NextStepReason::MalformedFunctionCallRetry,
-                    },
-                    new_messages,
-                );
-            }
-        }
-
-        let error = format!(
-            "Expected function call in LLM response, got finish reason: {:?}. Text: {}",
-            finish_reason,
-            text_response.unwrap_or_default()
-        );
-        (
-            StepResult::Failed {
-                error,
-                finish_reason,
-                is_processing_error: false,
-            },
-            new_messages,
-        )
-    }
-}
-
-async fn handle_tool_call(
-    signal_message: &SignalMessage,
-    run: &SignalRun,
-    function_call: &FunctionCall,
-    clickhouse: clickhouse::Client,
-) -> StepResult {
-    match function_call.name.as_str() {
-        "get_full_spans" | "get_full_span_info" => {
-            let span_ids: Vec<String> = function_call
-                .args
-                .as_ref()
-                .and_then(|args| args.get("span_ids"))
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            if span_ids.is_empty() {
-                return StepResult::Failed {
-                    error: "No span_ids provided".to_string(),
-                    finish_reason: None,
-                    is_processing_error: true,
-                };
-            }
-
-            match get_full_spans(
-                clickhouse,
-                signal_message.project_id,
-                run.trace_id,
-                span_ids,
-            )
-            .await
-            {
-                Ok(spans) => StepResult::RequiresNextStep {
-                    reason: NextStepReason::ToolResult(serde_json::json!({ "spans": spans })),
-                },
-                Err(e) => StepResult::RequiresNextStep {
-                    reason: NextStepReason::ToolResult(
-                        serde_json::json!({ "error": e.to_string() }),
-                    ),
-                },
-            }
-        }
-        "submit_identification" => {
-            let identified = function_call
-                .args
-                .as_ref()
-                .and_then(|args| args.get("identified"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            let attributes = function_call
-                .args
-                .as_ref()
-                .and_then(|args| args.get("data").cloned())
-                .unwrap_or_default();
-            let summary = function_call
-                .args
-                .as_ref()
-                .and_then(|args| args.get("summary").or_else(|| args.get("_summary")))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-                .unwrap_or_default();
-
-            if identified {
-                StepResult::CompletedWithEvent {
-                    attributes,
-                    summary,
-                }
-            } else {
-                StepResult::CompletedNoEvent
-            }
-        }
-        unknown => StepResult::Failed {
-            error: format!("Unknown function: {}", unknown),
-            finish_reason: None,
-            is_processing_error: true,
-        },
-    }
-}
-
-async fn handle_create_event(
-    signal_message: &SignalMessage,
-    run: &SignalRun,
-    attributes: serde_json::Value,
-    summary: String,
-    clickhouse: clickhouse::Client,
-    db: Arc<DB>,
-    queue: Arc<MessageQueue>,
-    parent_span_id: Uuid,
-    internal_project_id: Option<Uuid>,
-) -> anyhow::Result<Uuid> {
-    let create_event_start_time = chrono::Utc::now();
-    let ch_spans = get_trace_span_ids_and_end_time(
-        clickhouse.clone(),
-        signal_message.project_id,
-        run.trace_id,
-    )
-    .await?;
-    if ch_spans.is_empty() {
-        anyhow::bail!("No spans found");
-    }
-
-    let root_span = &ch_spans[0];
-    let timestamp = nanoseconds_to_datetime(root_span.end_time);
-    let short_to_uuid: HashMap<String, Uuid> = ch_spans
-        .iter()
-        .map(|span| (span_short_id(&span.span_id), span.span_id))
-        .collect();
-    let attrs = replace_span_tags_with_links(
-        attributes,
-        &short_to_uuid,
-        signal_message.project_id,
-        run.trace_id,
-    )?;
-
-    let event_id = Uuid::new_v4();
-    let signal_event = CHSignalEvent::new(
-        event_id,
-        signal_message.project_id,
-        signal_message.signal.id,
-        run.trace_id,
-        run.run_id,
-        signal_message.signal.name.clone(),
-        attrs,
-        timestamp,
-        summary,
-    );
-    insert_signal_events(clickhouse, vec![signal_event.clone()]).await?;
-
-    process_event_notifications_and_clustering(
-        db,
-        queue.clone(),
-        signal_message.project_id,
-        run.trace_id,
-        signal_event,
-    )
-    .await?;
-
-    emit_internal_span(
-        queue,
-        InternalSpan {
-            name: "create_event".to_string(),
-            trace_id: run.internal_trace_id,
-            run_id: run.run_id,
-            signal_name: signal_message.signal.name.clone(),
-            parent_span_id: Some(parent_span_id),
-            span_type: SpanType::Default,
-            start_time: create_event_start_time,
-            input: Some(
-                serde_json::json!({ "id": event_id, "signal_id": signal_message.signal.id }),
-            ),
-            output: None,
-            input_tokens: None,
-            input_cached_tokens: None,
-            output_tokens: None,
-            model: llm_model(),
-            provider: llm_provider(),
-            internal_project_id,
-            job_id: run.job_id,
-            error: None,
-            provider_batch_id: None,
-        },
-    )
-    .await;
-
-    Ok(event_id)
 }

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use backoff::ExponentialBackoffBuilder;
 use std::{sync::Arc, time::Duration};
-use uuid::Uuid;
 
 use crate::{
     cache::Cache,
@@ -12,12 +11,12 @@ use crate::{
         SignalRun, SignalWorkerConfig,
         common::{ProcessRunResult, handle_failed_runs, process_run},
         llm_model, llm_provider,
-        pendings_consumer::process_succeeded_batch,
         provider::{
             LanguageModelClient, ProviderClient,
-            models::{ProviderBatchOutput, ProviderInlineResponse, ProviderRequestItem},
+            models::{ProviderBatchOutput, ProviderInlineResponse},
         },
-        queue::{SignalJobPendingBatchMessage, SignalMessage, push_to_realtime_queue},
+        queue::{SignalMessage, push_to_realtime_queue},
+        response_processor::{finalize_runs, process_provider_responses},
     },
     utils::get_unsigned_env_with_default,
     worker::{HandlerError, MessageHandler},
@@ -99,7 +98,7 @@ impl MessageHandler for SignalJobRealtimeHandler {
                         })?;
                 }
 
-                self.process_realtime_request(request, updated_message)
+                self.process_realtime_request(request.request, updated_message)
                     .await;
             }
             Err(e) => {
@@ -120,11 +119,15 @@ impl MessageHandler for SignalJobRealtimeHandler {
 }
 
 impl SignalJobRealtimeHandler {
-    async fn process_realtime_request(&self, request: ProviderRequestItem, message: SignalMessage) {
+    async fn process_realtime_request(
+        &self,
+        request: crate::signals::provider::models::ProviderRequest,
+        message: SignalMessage,
+    ) {
         let max_retry_count = get_unsigned_env_with_default("SIGNALS_MAX_RETRY_COUNT", 4);
         let model_str = llm_model();
         let llm_client = self.llm_client.clone();
-        let req_clone = request.request.clone();
+        let req_clone = request.clone();
 
         let generate_fn = || async {
             llm_client
@@ -161,23 +164,63 @@ impl SignalJobRealtimeHandler {
                     responses: vec![inline_response],
                 };
 
-                let pending_message = SignalJobPendingBatchMessage {
-                    messages: vec![message.clone()],
-                    batch_id: format!("realtime_{}", Uuid::new_v4()),
+                let batch_id = format!("realtime_{}", message.run_id);
+
+                let processed = match process_provider_responses(
+                    &[message.clone()],
+                    &batch_output.responses,
+                    &batch_id,
+                    self.clickhouse.clone(),
+                    self.queue.clone(),
+                    self.config.clone(),
+                    self.db.clone(),
+                )
+                .await
+                {
+                    Ok(p) => p,
+                    Err(e) => {
+                        log::error!("[SIGNAL JOB] Failed to process realtime response: {:?}", e);
+                        return;
+                    }
                 };
 
-                if let Err(e) = process_succeeded_batch(
-                    &pending_message,
-                    Some(batch_output),
-                    self.db.clone(),
-                    self.queue.clone(),
+                // Route pending runs back to the realtime queue (not the batch pipeline)
+                let mut extra_failed: Vec<SignalRun> = Vec::new();
+                for run_id in &processed.pending_run_ids {
+                    let msg = processed.run_to_message.get(run_id).unwrap();
+                    let mut next_step_msg = msg.clone();
+                    next_step_msg.step += 1;
+
+                    if let Err(e) = push_to_realtime_queue(next_step_msg, self.queue.clone()).await {
+                        log::error!(
+                            "[SIGNAL JOB] Failed to push pending realtime run {} to realtime queue: {:?}",
+                            run_id,
+                            e
+                        );
+                        let run = SignalRun::from_message(msg, msg.signal.id).next_step();
+                        extra_failed.push(run.failed(format!("Failed to enqueue for next step: {}", e)));
+                    }
+                }
+
+                // Permanently fail any response-processing failures (API-level retries are
+                // handled above by the backoff; no further retry routing needed here).
+                let permanently_failed: Vec<SignalRun> = processed
+                    .failed_runs
+                    .into_iter()
+                    .chain(extra_failed)
+                    .collect();
+
+                if let Err(e) = finalize_runs(
+                    &processed.succeeded_runs,
+                    &permanently_failed,
+                    processed.new_messages,
                     self.clickhouse.clone(),
-                    self.config.clone(),
+                    self.db.clone(),
                     self.cache.clone(),
                 )
                 .await
                 {
-                    log::error!("[SIGNAL JOB] Failed to process realtime response: {:?}", e);
+                    log::error!("[SIGNAL JOB] Failed to finalize realtime runs: {:?}", e);
                 }
             }
             Err(e) => {

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -184,21 +184,60 @@ impl SignalJobRealtimeHandler {
                     }
                 };
 
-                // Route pending runs back to the realtime queue (not the batch pipeline)
+                // Insert new conversation messages BEFORE routing any runs to queues.
+                // A consumer could pick up the run before finalize_runs persists them, causing
+                // process_run to read stale message history (e.g. missing retry guidance).
+                if let Err(e) =
+                    insert_signal_run_messages(self.clickhouse.clone(), &processed.new_messages)
+                        .await
+                {
+                    log::error!(
+                        "[SIGNAL JOB] Failed to insert messages for realtime run: {:?}",
+                        e
+                    );
+                    // Treat as fatal for this run — don't route it to queue with missing context.
+                    let permanently_failed: Vec<SignalRun> = processed
+                        .run_to_message
+                        .values()
+                        .map(|msg| {
+                            SignalRun::from_message(msg, msg.signal.id)
+                                .failed(format!("Failed to insert messages: {}", e))
+                        })
+                        .collect();
+                    if let Err(fe) = finalize_runs(
+                        &[],
+                        &permanently_failed,
+                        self.clickhouse.clone(),
+                        self.db.clone(),
+                        self.cache.clone(),
+                    )
+                    .await
+                    {
+                        log::error!(
+                            "[SIGNAL JOB] Failed to finalize after message insert error: {:?}",
+                            fe
+                        );
+                    }
+                    return;
+                }
+
+                // Route pending runs back to the realtime queue
                 let mut extra_failed: Vec<SignalRun> = Vec::new();
                 for run_id in &processed.pending_run_ids {
                     let msg = processed.run_to_message.get(run_id).unwrap();
                     let mut next_step_msg = msg.clone();
                     next_step_msg.step += 1;
 
-                    if let Err(e) = push_to_realtime_queue(next_step_msg, self.queue.clone()).await {
+                    if let Err(e) = push_to_realtime_queue(next_step_msg, self.queue.clone()).await
+                    {
                         log::error!(
                             "[SIGNAL JOB] Failed to push pending realtime run {} to realtime queue: {:?}",
                             run_id,
                             e
                         );
                         let run = SignalRun::from_message(msg, msg.signal.id).next_step();
-                        extra_failed.push(run.failed(format!("Failed to enqueue for next step: {}", e)));
+                        extra_failed
+                            .push(run.failed(format!("Failed to enqueue for next step: {}", e)));
                     }
                 }
 
@@ -213,7 +252,6 @@ impl SignalJobRealtimeHandler {
                 if let Err(e) = finalize_runs(
                     &processed.succeeded_runs,
                     &permanently_failed,
-                    processed.new_messages,
                     self.clickhouse.clone(),
                     self.db.clone(),
                     self.cache.clone(),

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -164,12 +164,10 @@ impl SignalJobRealtimeHandler {
                     responses: vec![inline_response],
                 };
 
-                let batch_id = format!("realtime_{}", message.run_id);
-
                 let processed = match process_provider_responses(
                     &[message.clone()],
                     &batch_output.responses,
-                    &batch_id,
+                    None,
                     self.clickhouse.clone(),
                     self.queue.clone(),
                     self.config.clone(),

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -205,18 +205,16 @@ pub async fn process_provider_responses(
 }
 
 /// Insert results into ClickHouse, clean up messages, and update job stats.
-/// This is the shared finalization step after routing of pending/failed runs has been handled.
+/// Callers must insert `new_messages` into ClickHouse **before** routing pending/failed runs to
+/// any queue, to avoid a race where a consumer picks up a run before its conversation history
+/// (e.g. tool results or retry guidance) has been persisted.
 pub async fn finalize_runs(
     succeeded_runs: &[SignalRun],
     permanently_failed_runs: &[SignalRun],
-    new_messages: Vec<CHSignalRunMessage>,
     clickhouse: clickhouse::Client,
     db: Arc<DB>,
     cache: Arc<Cache>,
 ) -> Result<(), HandlerError> {
-    // Insert new conversation messages
-    insert_signal_run_messages(clickhouse.clone(), &new_messages).await?;
-
     // Insert succeeded runs and update usage limits
     let succeeded_runs_ch: Vec<CHSignalRun> = succeeded_runs.iter().map(CHSignalRun::from).collect();
     insert_signal_runs(clickhouse.clone(), &succeeded_runs_ch).await?;

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -1,0 +1,765 @@
+use serde::Serialize;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+use uuid::Uuid;
+
+use crate::{
+    cache::Cache,
+    ch::signal_events::{CHSignalEvent, insert_signal_events},
+    ch::signal_run_messages::{CHSignalRunMessage, delete_signal_run_messages, insert_signal_run_messages},
+    ch::signal_runs::{CHSignalRun, insert_signal_runs},
+    db::DB,
+    db::spans::SpanType,
+    features::{Feature, is_feature_enabled},
+    mq::MessageQueue,
+    signals::{
+        SignalRun, SignalWorkerConfig, llm_model, llm_provider,
+        postprocess::process_event_notifications_and_clustering,
+        prompts::MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE,
+        provider::models::{
+            ProviderContent as Content, ProviderFinishReason as FinishReason,
+            ProviderFunctionCall as FunctionCall, ProviderFunctionResponse as FunctionResponse,
+            ProviderInlineResponse, ProviderPart as Part,
+        },
+        queue::SignalMessage,
+        spans::{get_trace_span_ids_and_end_time, span_short_id},
+        tools::get_full_spans,
+        utils::{InternalSpan, emit_internal_span, nanoseconds_to_datetime, replace_span_tags_with_links},
+    },
+    utils::limits::update_workspace_signal_runs_used,
+    worker::HandlerError,
+};
+
+#[derive(Debug, Serialize)]
+pub enum NextStepReason {
+    ToolResult(serde_json::Value),
+    MalformedFunctionCallRetry,
+}
+
+#[derive(Debug, Serialize)]
+pub enum StepResult {
+    CompletedNoEvent,
+    CompletedWithEvent {
+        attributes: serde_json::Value,
+        summary: String,
+    },
+    RequiresNextStep {
+        reason: NextStepReason,
+    },
+    Failed {
+        error: String,
+        finish_reason: Option<FinishReason>,
+        is_processing_error: bool,
+    },
+}
+
+pub struct FailureMetadata {
+    pub finish_reason: Option<FinishReason>,
+    pub is_processing_error: bool,
+}
+
+pub struct ProcessedResponses {
+    pub succeeded_runs: Vec<SignalRun>,
+    pub failed_runs: Vec<SignalRun>,
+    pub failure_metadata: HashMap<Uuid, FailureMetadata>,
+    pub pending_run_ids: HashSet<Uuid>,
+    pub run_to_message: HashMap<Uuid, SignalMessage>,
+    pub new_messages: Vec<CHSignalRunMessage>,
+}
+
+/// Process all provider responses for a batch of signal messages.
+/// Returns classified results without any queue routing — callers are responsible
+/// for routing pending and failed runs to the appropriate queue.
+pub async fn process_provider_responses(
+    messages: &[SignalMessage],
+    responses: &[ProviderInlineResponse],
+    batch_id: &str,
+    clickhouse: clickhouse::Client,
+    queue: Arc<MessageQueue>,
+    config: Arc<SignalWorkerConfig>,
+    db: Arc<DB>,
+) -> Result<ProcessedResponses, HandlerError> {
+    let mut run_to_message: HashMap<Uuid, SignalMessage> = HashMap::new();
+    for msg in messages.iter() {
+        run_to_message.insert(msg.run_id, msg.clone());
+    }
+
+    let mut new_messages = Vec::new();
+    let mut succeeded_runs: Vec<SignalRun> = Vec::new();
+    let mut failed_runs: Vec<SignalRun> = Vec::new();
+    let mut pending_run_ids: HashSet<Uuid> = HashSet::new();
+    let mut failure_metadata: HashMap<Uuid, FailureMetadata> = HashMap::new();
+
+    for inline_response in responses.iter() {
+        let run_id = inline_response
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("run_id"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| uuid::Uuid::parse_str(s).ok());
+        let trace_id = inline_response
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("trace_id"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| uuid::Uuid::parse_str(s).ok());
+
+        let run_id = match run_id {
+            Some(id) => id,
+            None => {
+                log::warn!(
+                    "Response missing run_id in metadata, skipping response. Batch ID: {}",
+                    batch_id
+                );
+                continue;
+            }
+        };
+
+        let signal_message = match run_to_message.get(&run_id) {
+            Some(msg) => msg,
+            None => {
+                failed_runs.push(
+                    SignalRun::nil_with_id(run_id, trace_id.unwrap_or_default())
+                        .failed("No message found for run_id"),
+                );
+                log::error!("No message found for run_id {}, skipping", run_id);
+                continue;
+            }
+        };
+
+        let run = SignalRun::from_message(signal_message, signal_message.signal.id);
+
+        let (step_result, new_run_messages) = process_single_response(
+            inline_response,
+            signal_message,
+            &run,
+            clickhouse.clone(),
+            queue.clone(),
+            config.clone(),
+            batch_id.to_string(),
+        )
+        .await;
+
+        new_messages.extend(new_run_messages);
+
+        match step_result {
+            StepResult::CompletedNoEvent => {
+                succeeded_runs.push(run.completed());
+            }
+            StepResult::CompletedWithEvent {
+                attributes,
+                summary,
+            } => {
+                match handle_create_event(
+                    signal_message,
+                    &run,
+                    attributes,
+                    summary,
+                    clickhouse.clone(),
+                    db.clone(),
+                    queue.clone(),
+                    run.internal_span_id,
+                    config.internal_project_id,
+                )
+                .await
+                {
+                    Ok(event_id) => {
+                        succeeded_runs.push(run.completed_with_event(event_id));
+                    }
+                    Err(e) => {
+                        log::error!("[SIGNAL JOB] Failed to create event: {:?}", e);
+                        failed_runs.push(run.failed(format!("Failed to create event: {}", e)));
+                    }
+                }
+            }
+            StepResult::RequiresNextStep { .. } => {
+                pending_run_ids.insert(run.run_id);
+            }
+            StepResult::Failed {
+                error,
+                finish_reason,
+                is_processing_error,
+            } => {
+                failure_metadata.insert(
+                    run.run_id,
+                    FailureMetadata {
+                        finish_reason,
+                        is_processing_error,
+                    },
+                );
+                failed_runs.push(run.failed(error));
+            }
+        }
+    }
+
+    Ok(ProcessedResponses {
+        succeeded_runs,
+        failed_runs,
+        failure_metadata,
+        pending_run_ids,
+        run_to_message,
+        new_messages,
+    })
+}
+
+/// Insert results into ClickHouse, clean up messages, and update job stats.
+/// This is the shared finalization step after routing of pending/failed runs has been handled.
+pub async fn finalize_runs(
+    succeeded_runs: &[SignalRun],
+    permanently_failed_runs: &[SignalRun],
+    new_messages: Vec<CHSignalRunMessage>,
+    clickhouse: clickhouse::Client,
+    db: Arc<DB>,
+    cache: Arc<Cache>,
+) -> Result<(), HandlerError> {
+    // Insert new conversation messages
+    insert_signal_run_messages(clickhouse.clone(), &new_messages).await?;
+
+    // Insert succeeded runs and update usage limits
+    let succeeded_runs_ch: Vec<CHSignalRun> = succeeded_runs.iter().map(CHSignalRun::from).collect();
+    insert_signal_runs(clickhouse.clone(), &succeeded_runs_ch).await?;
+    if is_feature_enabled(Feature::UsageLimit) {
+        let mut runs_by_project_id: HashMap<Uuid, usize> = HashMap::new();
+        for run in succeeded_runs {
+            *runs_by_project_id.entry(run.project_id).or_insert(0) += 1;
+        }
+        let update_futures = runs_by_project_id.into_iter().map(|(project_id, runs)| {
+            let db = db.clone();
+            let clickhouse = clickhouse.clone();
+            let cache = cache.clone();
+            async move {
+                if let Err(e) =
+                    update_workspace_signal_runs_used(db, clickhouse, cache, project_id, runs).await
+                {
+                    log::error!("Failed to update workspace signal runs used: {}", e);
+                }
+            }
+        });
+        futures_util::future::join_all(update_futures).await;
+    }
+
+    // Insert permanently failed runs
+    let permanently_failed_runs_ch: Vec<CHSignalRun> =
+        permanently_failed_runs.iter().map(CHSignalRun::from).collect();
+    if let Err(e) = insert_signal_runs(clickhouse.clone(), &permanently_failed_runs_ch).await {
+        log::error!(
+            "[SIGNAL JOB] Failed to insert permanently failed runs: {:?}",
+            e
+        );
+    }
+
+    // Delete messages for completed and permanently failed runs
+    let final_runs: Vec<&SignalRun> = succeeded_runs.iter().chain(permanently_failed_runs.iter()).collect();
+    if !final_runs.is_empty() {
+        let project_run_pairs: Vec<(Uuid, Uuid)> = final_runs
+            .iter()
+            .map(|run| (run.project_id, run.run_id))
+            .collect();
+        if let Err(e) = delete_signal_run_messages(clickhouse.clone(), &project_run_pairs).await {
+            log::error!(
+                "[SIGNAL JOB] Failed to delete messages for final runs: {:?}",
+                e
+            );
+        }
+    }
+
+    // Update job stats for succeeded runs
+    let mut succeeded_by_job: HashMap<Uuid, i32> = HashMap::new();
+    for run in succeeded_runs {
+        if let Some(job_id) = run.job_id {
+            if run.status == crate::signals::RunStatus::Completed {
+                *succeeded_by_job.entry(job_id).or_insert(0) += 1;
+            }
+        }
+    }
+    for (job_id, count) in succeeded_by_job {
+        if let Err(e) =
+            crate::db::signal_jobs::update_signal_job_stats(&db.pool, job_id, count, 0).await
+        {
+            log::error!("Failed to update job stats: {}", e);
+        }
+    }
+
+    // Update job stats for permanently failed runs
+    let mut failed_by_job: HashMap<Uuid, i32> = HashMap::new();
+    for run in permanently_failed_runs {
+        if let Some(job_id) = run.job_id {
+            if run.status == crate::signals::RunStatus::Failed {
+                *failed_by_job.entry(job_id).or_insert(0) += 1;
+            }
+        }
+    }
+    for (job_id, count) in failed_by_job {
+        if let Err(e) =
+            crate::db::signal_jobs::update_signal_job_stats(&db.pool, job_id, 0, count).await
+        {
+            log::error!("Failed to update job stats: {}", e);
+        }
+    }
+
+    log::debug!(
+        "[SIGNAL JOB] Finalized runs. Succeeded: {}, Permanently Failed: {}",
+        succeeded_runs.len(),
+        permanently_failed_runs.len(),
+    );
+
+    Ok(())
+}
+
+pub async fn process_single_response(
+    provider_response: &ProviderInlineResponse,
+    signal_message: &SignalMessage,
+    run: &SignalRun,
+    clickhouse: clickhouse::Client,
+    queue: Arc<MessageQueue>,
+    config: Arc<SignalWorkerConfig>,
+    provider_batch_id: String,
+) -> (StepResult, Vec<CHSignalRunMessage>) {
+    let mut new_messages: Vec<CHSignalRunMessage> = Vec::new();
+
+    let mut finish_reason = None;
+    let mut function_call = None;
+    let mut text_response = None;
+    let mut content_val = None;
+    let mut usage = None;
+    let mut model_version = None;
+
+    if let Some(resp) = &provider_response.response {
+        usage = resp.usage_metadata.clone();
+        model_version = resp.model_version.clone();
+        if let Some(cands) = &resp.candidates {
+            if let Some(cand) = cands.first() {
+                finish_reason = cand.finish_reason.clone();
+                if let Some(content) = &cand.content {
+                    content_val = Some(serde_json::to_value(content).unwrap_or_default());
+                    if let Some(parts) = &content.parts {
+                        for part in parts {
+                            if let Some(fc) = &part.function_call {
+                                function_call = Some(fc.clone());
+                            } else if let Some(t) = &part.text {
+                                text_response = Some(t.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let has_error = provider_response.error.is_some();
+    let error_msg = provider_response.error.as_ref().map(|e| e.message.clone());
+
+    let span_output = if let Some(fc) = &function_call {
+        serde_json::to_value(fc).ok()
+    } else if let Some(t) = &text_response {
+        Some(serde_json::Value::String(t.clone()))
+    } else {
+        finish_reason
+            .as_ref()
+            .and_then(|fr| serde_json::to_value(fr).ok())
+    };
+
+    let span_error = if let Some(e) = &error_msg {
+        Some(e.clone())
+    } else if let Some(fr) = &finish_reason {
+        if fr.is_success() {
+            None
+        } else {
+            Some(format!("{:?}", fr))
+        }
+    } else {
+        None
+    };
+
+    emit_internal_span(
+        queue.clone(),
+        InternalSpan {
+            name: format!("step_{}.process_response", run.step),
+            trace_id: run.internal_trace_id,
+            run_id: run.run_id,
+            signal_name: signal_message.signal.name.clone(),
+            parent_span_id: Some(run.internal_span_id),
+            span_type: SpanType::LLM,
+            start_time: signal_message.request_start_time,
+            input: None,
+            output: span_output,
+            input_tokens: usage.as_ref().and_then(|u| u.prompt_token_count).map(|c| c),
+            input_cached_tokens: usage
+                .as_ref()
+                .and_then(|u| u.cache_read_input_tokens)
+                .map(|c| c as i64),
+            output_tokens: usage
+                .as_ref()
+                .and_then(|u| u.candidates_token_count)
+                .map(|c| c),
+            model: model_version.unwrap_or(llm_model()),
+            provider: llm_provider(),
+            internal_project_id: config.internal_project_id,
+            job_id: run.job_id,
+            error: span_error,
+            provider_batch_id: Some(provider_batch_id),
+        },
+    )
+    .await;
+
+    if has_error {
+        return (
+            StepResult::Failed {
+                error: error_msg.unwrap_or_else(|| "LLM provider error".to_string()),
+                finish_reason,
+                is_processing_error: false,
+            },
+            vec![],
+        );
+    }
+
+    if let Some(function_call) = function_call {
+        let llm_output_msg = CHSignalRunMessage::new(
+            signal_message.project_id,
+            run.run_id,
+            chrono::Utc::now(),
+            content_val
+                .as_ref()
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+        );
+        new_messages.push(llm_output_msg);
+
+        let tool_call_start_time = chrono::Utc::now();
+        let step_result =
+            handle_tool_call(signal_message, run, &function_call, clickhouse.clone()).await;
+
+        let tool_error = match &step_result {
+            StepResult::Failed { error, .. } => Some(error.clone()),
+            _ => None,
+        };
+
+        emit_internal_span(
+            queue.clone(),
+            InternalSpan {
+                name: function_call.name.clone(),
+                trace_id: run.internal_trace_id,
+                run_id: run.run_id,
+                signal_name: signal_message.signal.name.clone(),
+                parent_span_id: Some(run.internal_span_id),
+                span_type: SpanType::Tool,
+                start_time: tool_call_start_time,
+                input: Some(serde_json::json!(function_call)),
+                output: Some(serde_json::json!(step_result)),
+                input_tokens: None,
+                input_cached_tokens: None,
+                output_tokens: None,
+                model: llm_model(),
+                provider: llm_provider(),
+                internal_project_id: config.internal_project_id,
+                job_id: run.job_id,
+                error: tool_error,
+                provider_batch_id: None,
+            },
+        )
+        .await;
+
+        match step_result {
+            StepResult::Failed {
+                error,
+                finish_reason,
+                is_processing_error,
+            } => (
+                StepResult::Failed {
+                    error: format!("Tool call failed: {}", error),
+                    finish_reason,
+                    is_processing_error,
+                },
+                new_messages,
+            ),
+            StepResult::CompletedNoEvent => (StepResult::CompletedNoEvent, new_messages),
+            StepResult::CompletedWithEvent {
+                attributes,
+                summary,
+            } => (
+                StepResult::CompletedWithEvent {
+                    attributes,
+                    summary,
+                },
+                new_messages,
+            ),
+            StepResult::RequiresNextStep { reason } => {
+                match &reason {
+                    NextStepReason::ToolResult(tool_result) => {
+                        let function_response_content = Content {
+                            role: Some("user".to_string()),
+                            parts: Some(vec![Part {
+                                function_response: Some(FunctionResponse {
+                                    name: function_call.name.clone(),
+                                    response: tool_result.clone(),
+                                    id: function_call.id.clone(),
+                                }),
+                                ..Default::default()
+                            }]),
+                        };
+                        let tool_output_msg = CHSignalRunMessage::new(
+                            signal_message.project_id,
+                            run.run_id,
+                            chrono::Utc::now(),
+                            serde_json::to_string(&function_response_content).unwrap_or_default(),
+                        );
+                        new_messages.push(tool_output_msg);
+                    }
+                    NextStepReason::MalformedFunctionCallRetry => {}
+                }
+
+                if run.step >= config.max_allowed_steps {
+                    (
+                        StepResult::Failed {
+                            error: "Maximum step count exceeded".to_string(),
+                            finish_reason,
+                            is_processing_error: false,
+                        },
+                        new_messages,
+                    )
+                } else {
+                    (StepResult::RequiresNextStep { reason }, new_messages)
+                }
+            }
+        }
+    } else {
+        if let Some(fr) = &finish_reason {
+            if fr.is_malformed_function_call() {
+                if run.step >= config.max_allowed_steps {
+                    return (
+                        StepResult::Failed {
+                            error: "Maximum step count exceeded".to_string(),
+                            finish_reason: Some(fr.clone()),
+                            is_processing_error: false,
+                        },
+                        new_messages,
+                    );
+                }
+
+                let finish_message = text_response.clone().unwrap_or_else(|| format!("{:?}", fr));
+                let now = chrono::Utc::now();
+                let assistant_content = Content {
+                    role: Some("model".to_string()),
+                    parts: Some(vec![Part {
+                        text: Some(finish_message),
+                        ..Default::default()
+                    }]),
+                };
+                new_messages.push(CHSignalRunMessage::new(
+                    signal_message.project_id,
+                    run.run_id,
+                    now,
+                    serde_json::to_string(&assistant_content).unwrap_or_default(),
+                ));
+
+                let user_content = Content {
+                    role: Some("user".to_string()),
+                    parts: Some(vec![Part {
+                        text: Some(MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE.to_string()),
+                        ..Default::default()
+                    }]),
+                };
+                new_messages.push(CHSignalRunMessage::new(
+                    signal_message.project_id,
+                    run.run_id,
+                    now + chrono::Duration::milliseconds(1),
+                    serde_json::to_string(&user_content).unwrap_or_default(),
+                ));
+
+                return (
+                    StepResult::RequiresNextStep {
+                        reason: NextStepReason::MalformedFunctionCallRetry,
+                    },
+                    new_messages,
+                );
+            }
+        }
+
+        let error = format!(
+            "Expected function call in LLM response, got finish reason: {:?}. Text: {}",
+            finish_reason,
+            text_response.unwrap_or_default()
+        );
+        (
+            StepResult::Failed {
+                error,
+                finish_reason,
+                is_processing_error: false,
+            },
+            new_messages,
+        )
+    }
+}
+
+pub async fn handle_tool_call(
+    signal_message: &SignalMessage,
+    run: &SignalRun,
+    function_call: &FunctionCall,
+    clickhouse: clickhouse::Client,
+) -> StepResult {
+    match function_call.name.as_str() {
+        "get_full_spans" | "get_full_span_info" => {
+            let span_ids: Vec<String> = function_call
+                .args
+                .as_ref()
+                .and_then(|args| args.get("span_ids"))
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            if span_ids.is_empty() {
+                return StepResult::Failed {
+                    error: "No span_ids provided".to_string(),
+                    finish_reason: None,
+                    is_processing_error: true,
+                };
+            }
+
+            match get_full_spans(
+                clickhouse,
+                signal_message.project_id,
+                run.trace_id,
+                span_ids,
+            )
+            .await
+            {
+                Ok(spans) => StepResult::RequiresNextStep {
+                    reason: NextStepReason::ToolResult(serde_json::json!({ "spans": spans })),
+                },
+                Err(e) => StepResult::RequiresNextStep {
+                    reason: NextStepReason::ToolResult(
+                        serde_json::json!({ "error": e.to_string() }),
+                    ),
+                },
+            }
+        }
+        "submit_identification" => {
+            let identified = function_call
+                .args
+                .as_ref()
+                .and_then(|args| args.get("identified"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let attributes = function_call
+                .args
+                .as_ref()
+                .and_then(|args| args.get("data").cloned())
+                .unwrap_or_default();
+            let summary = function_call
+                .args
+                .as_ref()
+                .and_then(|args| args.get("summary").or_else(|| args.get("_summary")))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+
+            if identified {
+                StepResult::CompletedWithEvent {
+                    attributes,
+                    summary,
+                }
+            } else {
+                StepResult::CompletedNoEvent
+            }
+        }
+        unknown => StepResult::Failed {
+            error: format!("Unknown function: {}", unknown),
+            finish_reason: None,
+            is_processing_error: true,
+        },
+    }
+}
+
+pub async fn handle_create_event(
+    signal_message: &SignalMessage,
+    run: &SignalRun,
+    attributes: serde_json::Value,
+    summary: String,
+    clickhouse: clickhouse::Client,
+    db: Arc<DB>,
+    queue: Arc<MessageQueue>,
+    parent_span_id: Uuid,
+    internal_project_id: Option<Uuid>,
+) -> anyhow::Result<Uuid> {
+    let create_event_start_time = chrono::Utc::now();
+    let ch_spans = get_trace_span_ids_and_end_time(
+        clickhouse.clone(),
+        signal_message.project_id,
+        run.trace_id,
+    )
+    .await?;
+    if ch_spans.is_empty() {
+        anyhow::bail!("No spans found");
+    }
+
+    let root_span = &ch_spans[0];
+    let timestamp = nanoseconds_to_datetime(root_span.end_time);
+    let short_to_uuid: HashMap<String, Uuid> = ch_spans
+        .iter()
+        .map(|span| (span_short_id(&span.span_id), span.span_id))
+        .collect();
+    let attrs = replace_span_tags_with_links(
+        attributes,
+        &short_to_uuid,
+        signal_message.project_id,
+        run.trace_id,
+    )?;
+
+    let event_id = Uuid::new_v4();
+    let signal_event = CHSignalEvent::new(
+        event_id,
+        signal_message.project_id,
+        signal_message.signal.id,
+        run.trace_id,
+        run.run_id,
+        signal_message.signal.name.clone(),
+        attrs,
+        timestamp,
+        summary,
+    );
+    insert_signal_events(clickhouse, vec![signal_event.clone()]).await?;
+
+    process_event_notifications_and_clustering(
+        db,
+        queue.clone(),
+        signal_message.project_id,
+        run.trace_id,
+        signal_event,
+    )
+    .await?;
+
+    emit_internal_span(
+        queue,
+        InternalSpan {
+            name: "create_event".to_string(),
+            trace_id: run.internal_trace_id,
+            run_id: run.run_id,
+            signal_name: signal_message.signal.name.clone(),
+            parent_span_id: Some(parent_span_id),
+            span_type: SpanType::Default,
+            start_time: create_event_start_time,
+            input: Some(
+                serde_json::json!({ "id": event_id, "signal_id": signal_message.signal.id }),
+            ),
+            output: None,
+            input_tokens: None,
+            input_cached_tokens: None,
+            output_tokens: None,
+            model: llm_model(),
+            provider: llm_provider(),
+            internal_project_id,
+            job_id: run.job_id,
+            error: None,
+            provider_batch_id: None,
+        },
+    )
+    .await;
+
+    Ok(event_id)
+}

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::{
     cache::Cache,
     ch::signal_events::{CHSignalEvent, insert_signal_events},
-    ch::signal_run_messages::{CHSignalRunMessage, delete_signal_run_messages, insert_signal_run_messages},
+    ch::signal_run_messages::{CHSignalRunMessage, delete_signal_run_messages},
     ch::signal_runs::{CHSignalRun, insert_signal_runs},
     db::DB,
     db::spans::SpanType,
@@ -26,7 +26,9 @@ use crate::{
         queue::SignalMessage,
         spans::{get_trace_span_ids_and_end_time, span_short_id},
         tools::get_full_spans,
-        utils::{InternalSpan, emit_internal_span, nanoseconds_to_datetime, replace_span_tags_with_links},
+        utils::{
+            InternalSpan, emit_internal_span, nanoseconds_to_datetime, replace_span_tags_with_links,
+        },
     },
     utils::limits::update_workspace_signal_runs_used,
     worker::HandlerError,
@@ -75,7 +77,7 @@ pub struct ProcessedResponses {
 pub async fn process_provider_responses(
     messages: &[SignalMessage],
     responses: &[ProviderInlineResponse],
-    batch_id: &str,
+    batch_id: Option<String>,
     clickhouse: clickhouse::Client,
     queue: Arc<MessageQueue>,
     config: Arc<SignalWorkerConfig>,
@@ -110,8 +112,8 @@ pub async fn process_provider_responses(
             Some(id) => id,
             None => {
                 log::warn!(
-                    "Response missing run_id in metadata, skipping response. Batch ID: {}",
-                    batch_id
+                    "Response missing run_id in metadata, skipping response. Batch ID: {:?}",
+                    &batch_id
                 );
                 continue;
             }
@@ -138,7 +140,7 @@ pub async fn process_provider_responses(
             clickhouse.clone(),
             queue.clone(),
             config.clone(),
-            batch_id.to_string(),
+            batch_id.clone(),
         )
         .await;
 
@@ -216,7 +218,8 @@ pub async fn finalize_runs(
     cache: Arc<Cache>,
 ) -> Result<(), HandlerError> {
     // Insert succeeded runs and update usage limits
-    let succeeded_runs_ch: Vec<CHSignalRun> = succeeded_runs.iter().map(CHSignalRun::from).collect();
+    let succeeded_runs_ch: Vec<CHSignalRun> =
+        succeeded_runs.iter().map(CHSignalRun::from).collect();
     insert_signal_runs(clickhouse.clone(), &succeeded_runs_ch).await?;
     if is_feature_enabled(Feature::UsageLimit) {
         let mut runs_by_project_id: HashMap<Uuid, usize> = HashMap::new();
@@ -239,8 +242,10 @@ pub async fn finalize_runs(
     }
 
     // Insert permanently failed runs
-    let permanently_failed_runs_ch: Vec<CHSignalRun> =
-        permanently_failed_runs.iter().map(CHSignalRun::from).collect();
+    let permanently_failed_runs_ch: Vec<CHSignalRun> = permanently_failed_runs
+        .iter()
+        .map(CHSignalRun::from)
+        .collect();
     if let Err(e) = insert_signal_runs(clickhouse.clone(), &permanently_failed_runs_ch).await {
         log::error!(
             "[SIGNAL JOB] Failed to insert permanently failed runs: {:?}",
@@ -249,7 +254,10 @@ pub async fn finalize_runs(
     }
 
     // Delete messages for completed and permanently failed runs
-    let final_runs: Vec<&SignalRun> = succeeded_runs.iter().chain(permanently_failed_runs.iter()).collect();
+    let final_runs: Vec<&SignalRun> = succeeded_runs
+        .iter()
+        .chain(permanently_failed_runs.iter())
+        .collect();
     if !final_runs.is_empty() {
         let project_run_pairs: Vec<(Uuid, Uuid)> = final_runs
             .iter()
@@ -306,14 +314,14 @@ pub async fn finalize_runs(
     Ok(())
 }
 
-pub async fn process_single_response(
+async fn process_single_response(
     provider_response: &ProviderInlineResponse,
     signal_message: &SignalMessage,
     run: &SignalRun,
     clickhouse: clickhouse::Client,
     queue: Arc<MessageQueue>,
     config: Arc<SignalWorkerConfig>,
-    provider_batch_id: String,
+    provider_batch_id: Option<String>,
 ) -> (StepResult, Vec<CHSignalRunMessage>) {
     let mut new_messages: Vec<CHSignalRunMessage> = Vec::new();
 
@@ -383,21 +391,15 @@ pub async fn process_single_response(
             start_time: signal_message.request_start_time,
             input: None,
             output: span_output,
-            input_tokens: usage.as_ref().and_then(|u| u.prompt_token_count).map(|c| c),
-            input_cached_tokens: usage
-                .as_ref()
-                .and_then(|u| u.cache_read_input_tokens)
-                .map(|c| c as i64),
-            output_tokens: usage
-                .as_ref()
-                .and_then(|u| u.candidates_token_count)
-                .map(|c| c),
+            input_tokens: usage.as_ref().and_then(|u| u.prompt_token_count),
+            input_cached_tokens: usage.as_ref().and_then(|u| u.cache_read_input_tokens),
+            output_tokens: usage.as_ref().and_then(|u| u.candidates_token_count),
             model: model_version.unwrap_or(llm_model()),
             provider: llm_provider(),
             internal_project_id: config.internal_project_id,
             job_id: run.job_id,
             error: span_error,
-            provider_batch_id: Some(provider_batch_id),
+            provider_batch_id,
         },
     )
     .await;

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -28,7 +28,7 @@ pub struct InternalSpan {
     pub input: Option<Value>,
     pub output: Option<Value>,
     pub input_tokens: Option<i32>,
-    pub input_cached_tokens: Option<i64>,
+    pub input_cached_tokens: Option<i32>,
     pub output_tokens: Option<i32>,
     pub model: String,
     pub provider: String,
@@ -169,6 +169,7 @@ pub async fn emit_internal_span(queue: Arc<MessageQueue>, span: InternalSpan) ->
             "signal.batch_id".to_string(),
             Value::String(provider_batch_id.to_string()),
         );
+        attrs.insert("gen_ai.request.batch".to_string(), Value::Bool(true));
     }
 
     attrs.insert(
@@ -176,9 +177,6 @@ pub async fn emit_internal_span(queue: Arc<MessageQueue>, span: InternalSpan) ->
         Value::String(span.model),
     );
     attrs.insert("gen_ai.system".to_string(), Value::String(span.provider));
-
-    // set batch attribute to true because signal runs always use batch api
-    attrs.insert("gen_ai.request.batch".to_string(), Value::Bool(true));
 
     if let Some(parent_span_id) = span.parent_span_id {
         attrs.insert(


### PR DESCRIPTION
A lot of code is moved around, but unchanged, we should probably use our new thing to review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core signal run processing, queue routing, and ClickHouse persistence, so regressions could affect retries, step progression, or job stats despite largely moved logic. Risk is mitigated by keeping behavior equivalent and adding ordering to avoid consumers reading stale conversation history.
> 
> **Overview**
> **Unifies batch + realtime response processing** by extracting the inline provider-response parsing/tool-call/event creation logic into a new `signals/response_processor` module (`process_provider_responses`, `finalize_runs`).
> 
> **Changes execution ordering** so new conversation messages are inserted into ClickHouse *before* routing pending/next-step runs back onto queues, preventing a race where the next consumer step reads stale history (e.g., missing retry guidance/tool results).
> 
> **Fixes realtime next-step routing** to push `RequiresNextStep` runs back to the realtime queue (instead of the batch pipeline), and updates realtime finalization to permanently fail response-processing errors after API-level backoff.
> 
> Also adjusts internal tracing span fields: `input_cached_tokens` is now `i32`, and `gen_ai.request.batch` is only set when a `provider_batch_id` is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ede08dd6eacc7b9e9e6a340193c735e0fa223c69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->