### PR TITLE
migration for new clusters

### DIFF
--- a/frontend/lib/clickhouse/migrations/28_indexed_clusters.sql
+++ b/frontend/lib/clickhouse/migrations/28_indexed_clusters.sql
@@ -100,4 +100,4 @@ LEFT JOIN
         project_id,
         event_id
 ) AS c ON (signal_events.project_id = c.project_id) AND (signal_events.id = c.event_id)
-WHERE signal_events.project_id = {project_id:UUID}
+WHERE signal_events.project_id = {project_id:UUID};

--- a/frontend/lib/clickhouse/migrations/28_indexed_clusters.sql
+++ b/frontend/lib/clickhouse/migrations/28_indexed_clusters.sql
@@ -1,0 +1,54 @@
+CREATE TABLE IF NOT EXISTS signal_event_clusters
+(
+    `id` UUID,
+    `project_id` UUID,
+    `signal_id` UUID,
+    `name` String,
+    `level` UInt8,
+    `centroid` Array(BFloat16) CODEC(NONE),
+    `parent_id` UUID,
+    `num_signal_events` UInt32,
+    `num_children_clusters` UInt16,
+    `created_at` DateTime64(9, 'UTC'),
+    `updated_at` DateTime64(9, 'UTC'),
+    CONSTRAINT centroid_same_dim CHECK length(centroid) = 3072
+)
+ENGINE = ReplacingMergeTree(updated_at)
+PRIMARY KEY (project_id, signal_id)
+ORDER BY (project_id, signal_id, id);
+
+ALTER TABLE signal_event_clusters ADD INDEX centroid_cosine_hnsw centroid TYPE vector_similarity(
+    'hnsw',
+    cosineDistance,
+    3072
+);
+
+ALTER TABLE signal_event_clusters MATERIALIZE INDEX centroid_cosine_hnsw;
+
+INSERT INTO signal_event_clusters(
+    id,
+    project_id,
+    signal_id,
+    name,
+    level,
+    centroid,
+    parent_id,
+    num_signal_events,
+    num_children_clusters,
+    created_at,
+    updated_at
+) SELECT
+    id,
+    project_id,
+    signal_id,
+    name,
+    level,
+    centroid,
+    parent_id,
+    num_signal_events,
+    num_children_clusters,
+    created_at,
+    updated_at
+FROM clusters FINAL;
+
+DROP TABLE IF EXISTS clusters;

--- a/frontend/lib/clickhouse/migrations/28_indexed_clusters.sql
+++ b/frontend/lib/clickhouse/migrations/28_indexed_clusters.sql
@@ -52,3 +52,52 @@ INSERT INTO signal_event_clusters(
 FROM clusters FINAL;
 
 DROP TABLE IF EXISTS clusters;
+
+DROP VIEW IF EXISTS clusters_v0;
+
+CREATE VIEW IF NOT EXISTS clusters_v0
+SQL SECURITY INVOKER
+AS SELECT
+    id,
+    signal_id,
+    name,
+    level,
+    centroid,
+    parent_id,
+    num_signal_events,
+    num_children_clusters,
+    created_at,
+    updated_at
+FROM clusters
+FINAL
+WHERE project_id = {project_id:UUID};
+
+DROP VIEW IF EXISTS signal_events_v0;
+
+CREATE VIEW default.signal_events_v0
+SQL SECURITY INVOKER
+AS SELECT
+    id,
+    project_id,
+    signal_id,
+    trace_id,
+    run_id,
+    name,
+    payload,
+    timestamp,
+    c.clusters AS clusters
+FROM default.signal_events
+LEFT JOIN
+(
+    SELECT
+        project_id,
+        event_id,
+        arrayDistinct(groupArray(cluster_id)) AS clusters
+    FROM default.events_to_clusters
+    FINAL
+    WHERE project_id = {project_id:UUID}
+    GROUP BY
+        project_id,
+        event_id
+) AS c ON (signal_events.project_id = c.project_id) AND (signal_events.id = c.event_id)
+WHERE signal_events.project_id = {project_id:UUID}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it performs a destructive ClickHouse migration (copies data then drops the existing `clusters` table) and adds a new vector HNSW index, which can affect data availability and query performance during/after rollout.
> 
> **Overview**
> Introduces a new ClickHouse migration that replaces the existing clusters storage with `signal_event_clusters`, enforcing a fixed 3072-dimension centroid and adding a cosine-distance HNSW vector index for faster similarity search.
> 
> The migration backfills data from `clusters`, then drops the old table and recreates `clusters_v0` and `signal_events_v0` views (the latter now joins through `events_to_clusters` to expose cluster IDs per signal event).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cee03fe6e446289087348fb8489e484bdd28a6d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->