### PR TITLE
new spans index

### DIFF
--- a/app-server/.env.example
+++ b/app-server/.env.example
@@ -26,7 +26,7 @@ QUERY_ENGINE_URL=http://localhost:8903
 
 QUICKWIT_INGEST_URL=http://localhost:7281 # grpc
 QUICKWIT_SEARCH_URL=http://localhost:7280 # http
-QUICKWIT_SPANS_INDEX_ID=spans
+QUICKWIT_SPANS_INDEX_ID=spans_v2
 
 # Optional, set this to enable the signals feature
 # GOOGLE_GENERATIVE_AI_API_KEY=

--- a/app-server/src/quickwit/client.rs
+++ b/app-server/src/quickwit/client.rs
@@ -150,14 +150,14 @@ impl QuickwitClient {
     }
 
     #[instrument(skip(self, query_body))]
-    pub async fn search_spans(
+    pub async fn search_index(
         &self,
+        index_id: &str,
         query_body: serde_json::Value,
     ) -> anyhow::Result<serde_json::Value> {
         let url = format!(
             "{}/api/v1/{}/search",
-            self.inner.search_endpoint,
-            super::spans_index_id()
+            self.inner.search_endpoint, index_id
         );
 
         let response = self

--- a/app-server/src/quickwit/client.rs
+++ b/app-server/src/quickwit/client.rs
@@ -154,7 +154,11 @@ impl QuickwitClient {
         &self,
         query_body: serde_json::Value,
     ) -> anyhow::Result<serde_json::Value> {
-        let url = format!("{}/api/v1/spans/search", self.inner.search_endpoint);
+        let url = format!(
+            "{}/api/v1/{}/search",
+            self.inner.search_endpoint,
+            super::spans_index_id()
+        );
 
         let response = self
             .inner

--- a/app-server/src/quickwit/mod.rs
+++ b/app-server/src/quickwit/mod.rs
@@ -5,7 +5,7 @@ pub mod producer;
 mod proto;
 mod utils;
 
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 use chrono::{DateTime, Utc};
 use enum_dispatch::enum_dispatch;
@@ -21,17 +21,12 @@ use utils::extract_text_from_json_value;
 pub const SPANS_INDEXER_QUEUE: &str = "spans_indexer_queue";
 pub const SPANS_INDEXER_EXCHANGE: &str = "spans_indexer_exchange";
 pub const SPANS_INDEXER_ROUTING_KEY: &str = "spans_indexer_routing_key";
-const DEFAULT_SPANS_INDEX_ID: &str = "spans_v2";
 pub const OLD_SPANS_INDEX_ID: &str = "spans";
 pub const EVENTS_INDEX_ID: &str = "events";
 
-static SPANS_INDEX_ID: OnceLock<String> = OnceLock::new();
-
-pub fn spans_index_id() -> &'static str {
-    SPANS_INDEX_ID.get_or_init(|| {
-        std::env::var("QUICKWIT_SPANS_INDEX_ID").unwrap_or(DEFAULT_SPANS_INDEX_ID.to_string())
-    })
-}
+pub static SPANS_INDEX_ID: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("QUICKWIT_SPANS_INDEX_ID").unwrap_or("spans_v2".to_string())
+});
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QuickwitIndexedSpan {
@@ -123,7 +118,7 @@ impl IndexerQueuePayload {
     /// Get the index ID for this payload type
     pub fn index_id(&self) -> &'static str {
         match self {
-            IndexerQueuePayload::Spans(_) => spans_index_id(),
+            IndexerQueuePayload::Spans(_) => &SPANS_INDEX_ID,
             IndexerQueuePayload::Events(_) => EVENTS_INDEX_ID,
         }
     }

--- a/app-server/src/quickwit/mod.rs
+++ b/app-server/src/quickwit/mod.rs
@@ -22,6 +22,7 @@ pub const SPANS_INDEXER_QUEUE: &str = "spans_indexer_queue";
 pub const SPANS_INDEXER_EXCHANGE: &str = "spans_indexer_exchange";
 pub const SPANS_INDEXER_ROUTING_KEY: &str = "spans_indexer_routing_key";
 const DEFAULT_SPANS_INDEX_ID: &str = "spans_v2";
+pub const OLD_SPANS_INDEX_ID: &str = "spans";
 pub const EVENTS_INDEX_ID: &str = "events";
 
 static SPANS_INDEX_ID: OnceLock<String> = OnceLock::new();

--- a/app-server/src/quickwit/mod.rs
+++ b/app-server/src/quickwit/mod.rs
@@ -5,6 +5,8 @@ pub mod producer;
 mod proto;
 mod utils;
 
+use std::sync::OnceLock;
+
 use chrono::{DateTime, Utc};
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
@@ -19,8 +21,16 @@ use utils::extract_text_from_json_value;
 pub const SPANS_INDEXER_QUEUE: &str = "spans_indexer_queue";
 pub const SPANS_INDEXER_EXCHANGE: &str = "spans_indexer_exchange";
 pub const SPANS_INDEXER_ROUTING_KEY: &str = "spans_indexer_routing_key";
-pub const SPANS_INDEX_ID: &str = "spans";
+const DEFAULT_SPANS_INDEX_ID: &str = "spans_v2";
 pub const EVENTS_INDEX_ID: &str = "events";
+
+static SPANS_INDEX_ID: OnceLock<String> = OnceLock::new();
+
+pub fn spans_index_id() -> &'static str {
+    SPANS_INDEX_ID.get_or_init(|| {
+        std::env::var("QUICKWIT_SPANS_INDEX_ID").unwrap_or(DEFAULT_SPANS_INDEX_ID.to_string())
+    })
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QuickwitIndexedSpan {
@@ -30,7 +40,6 @@ pub struct QuickwitIndexedSpan {
     pub start_time: DateTime<Utc>,
     pub input: Option<String>,
     pub output: Option<String>,
-    pub attributes: Value,
 }
 
 impl From<&Span> for QuickwitIndexedSpan {
@@ -42,7 +51,6 @@ impl From<&Span> for QuickwitIndexedSpan {
             start_time: span.start_time,
             input: span.input.as_ref().map(json_value_to_string),
             output: span.output.as_ref().map(json_value_to_string),
-            attributes: span.attributes.to_value(),
         }
     }
 }
@@ -89,11 +97,7 @@ pub trait FlattenJson {
 }
 
 impl FlattenJson for QuickwitIndexedSpan {
-    fn flatten_json(&mut self) {
-        let attributes_text = extract_text_from_json_value(&self.attributes);
-        let attributes_text = attributes_text.replace('{', " { ").replace('}', " } ");
-        self.attributes = serde_json::Value::String(attributes_text);
-    }
+    fn flatten_json(&mut self) {}
 }
 
 impl FlattenJson for QuickwitIndexedEvent {
@@ -118,7 +122,7 @@ impl IndexerQueuePayload {
     /// Get the index ID for this payload type
     pub fn index_id(&self) -> &'static str {
         match self {
-            IndexerQueuePayload::Spans(_) => SPANS_INDEX_ID,
+            IndexerQueuePayload::Spans(_) => spans_index_id(),
             IndexerQueuePayload::Events(_) => EVENTS_INDEX_ID,
         }
     }

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -1,7 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, sync::LazyLock};
 
 use actix_web::{HttpResponse, post, web};
-use chrono::{DateTime, Duration, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
@@ -10,7 +10,7 @@ use crate::{
     api::v1::traces::RabbitMqSpanMessage,
     db::spans::{Span, SpanType},
     mq::{MessageQueue, MessageQueueTrait, utils::mq_max_payload},
-    quickwit::{OLD_SPANS_INDEX_ID, client::QuickwitClient, spans_index_id},
+    quickwit::{OLD_SPANS_INDEX_ID, SPANS_INDEX_ID, client::QuickwitClient},
     routes::{ResponseResult, error::Error},
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
 };
@@ -142,11 +142,12 @@ pub struct SearchSpansRequest {
 
 const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 2] = ["input", "output"];
 
-// Old spans indexed before this timestamp live in the old "spans" index.
-// Adjust this right before deploying the new index.
-fn new_index_cutover_ts() -> DateTime<Utc> {
-    Utc.with_ymd_and_hms(2026, 3, 16, 16, 0, 0).unwrap()
-}
+static NEW_INDEX_CUTOVER_TS: LazyLock<DateTime<Utc>> = LazyLock::new(|| {
+    std::env::var("QUICKWIT_NEW_INDEX_CUTOVER_TS")
+        .unwrap_or("2026-03-16T16:00:00Z".to_string())
+        .parse::<DateTime<Utc>>()
+        .expect("QUICKWIT_NEW_INDEX_CUTOVER_TS must be a valid RFC 3339 timestamp")
+});
 
 #[derive(Serialize, Deserialize)]
 struct QuickwitHit {
@@ -241,12 +242,12 @@ pub async fn search_spans(
 
     // TEMPORARY: Determine which index to query based on the timestamp
     // TODO: Remove this logic once we have switched to the new index completely.
-    let cutover = new_index_cutover_ts();
+    let cutover = *NEW_INDEX_CUTOVER_TS;
     let start = request.start_time;
     let end = request.end_time;
 
     let old_start = start;
-    let old_end = Some(end.map_or(cutover, |e| e.min(cutover + Duration::hours(2))));
+    let old_end = Some(end.map_or(cutover, |e| e.min(cutover)));
     let new_start = Some(start.map_or(cutover, |s| s.max(cutover)));
     let new_end = end;
 
@@ -260,7 +261,7 @@ pub async fn search_spans(
     let mut hits = if has_new_interval {
         let mut body = search_body.clone();
         set_body_timestamps(&mut body, new_start, new_end);
-        search_index(quickwit_client, spans_index_id(), body).await?
+        search_index(quickwit_client, &SPANS_INDEX_ID, body).await?
     } else {
         vec![]
     };

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -140,7 +140,7 @@ pub struct SearchSpansRequest {
     pub offset: usize,
 }
 
-const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 3] = ["input", "output", "attributes"];
+const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 2] = ["input", "output"];
 
 #[derive(Serialize, Deserialize)]
 struct QuickwitHit {
@@ -184,7 +184,7 @@ pub async fn search_spans(
         format!("({})", escaped_query),
     ];
 
-    let mut sort_by = "_score,start_time"; // default sort for scores and timestamp in quickwit is desc!
+    let mut sort_by = "start_time"; // default sort for scores and timestamp in quickwit is desc!
 
     if let Some(trace_id) = request.trace_id {
         query_parts.push(format!("trace_id:{}", trace_id));

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -184,11 +184,10 @@ pub async fn search_spans(
         format!("({})", escaped_query),
     ];
 
-    let mut sort_by = "start_time"; // default sort for scores and timestamp in quickwit is desc!
+    let sort_by = "start_time";
 
     if let Some(trace_id) = request.trace_id {
         query_parts.push(format!("trace_id:{}", trace_id));
-        sort_by = "start_time"; // sort by timestamp (desc) inside a single trace
     }
 
     let query_string = query_parts.join(" AND ");

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -250,32 +250,25 @@ pub async fn search_spans(
     let new_start = Some(start.map_or(cutover, |s| s.max(cutover)));
     let new_end = end;
 
-    let should_query_old = !matches!((old_start, old_end), (Some(s), Some(e)) if s >= e);
-    let should_query_new = !matches!((new_start, new_end), (Some(s), Some(e)) if s >= e);
+    let has_old_interval = !matches!((old_start, old_end), (Some(s), Some(e)) if s >= e);
+    let has_new_interval = !matches!((new_start, new_end), (Some(s), Some(e)) if s >= e);
 
-    let (new_hits, old_hits) = tokio::join!(
-        async {
-            if should_query_new {
-                let mut body = search_body.clone();
-                set_body_timestamps(&mut body, new_start, new_end);
-                search_index(quickwit_client, spans_index_id(), body).await
-            } else {
-                Ok(vec![])
-            }
-        },
-        async {
-            if should_query_old {
-                let mut body = search_body.clone();
-                set_body_timestamps(&mut body, old_start, old_end);
-                search_index(quickwit_client, OLD_SPANS_INDEX_ID, body).await
-            } else {
-                Ok(vec![])
-            }
-        },
-    );
+    let max_hits = search_body["max_hits"].as_u64().unwrap_or(DEFAULT_SEARCH_MAX_HITS as u64) as usize;
 
-    let mut hits = new_hits?;
-    hits.extend(old_hits?);
+    let mut hits = if has_new_interval {
+        let mut body = search_body.clone();
+        set_body_timestamps(&mut body, new_start, new_end);
+        search_index(quickwit_client, spans_index_id(), body).await?
+    } else {
+        vec![]
+    };
+
+    if has_old_interval && hits.len() < max_hits {
+        let mut body = search_body;
+        body["max_hits"] = serde_json::Value::Number((max_hits - hits.len()).into());
+        set_body_timestamps(&mut body, old_start, old_end);
+        hits.extend(search_index(quickwit_client, OLD_SPANS_INDEX_ID, body).await?);
+    }
 
     Ok(HttpResponse::Ok().json(hits))
 }

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -145,7 +145,7 @@ const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 2] = ["input", "output"];
 // Old spans indexed before this timestamp live in the old "spans" index.
 // Adjust this right before deploying the new index.
 fn new_index_cutover_ts() -> DateTime<Utc> {
-    Utc.with_ymd_and_hms(2026, 3, 16, 0, 0, 0).unwrap()
+    Utc.with_ymd_and_hms(2026, 3, 16, 16, 0, 0).unwrap()
 }
 
 #[derive(Serialize, Deserialize)]
@@ -253,7 +253,9 @@ pub async fn search_spans(
     let has_old_interval = !matches!((old_start, old_end), (Some(s), Some(e)) if s >= e);
     let has_new_interval = !matches!((new_start, new_end), (Some(s), Some(e)) if s >= e);
 
-    let max_hits = search_body["max_hits"].as_u64().unwrap_or(DEFAULT_SEARCH_MAX_HITS as u64) as usize;
+    let max_hits = search_body["max_hits"]
+        .as_u64()
+        .unwrap_or(DEFAULT_SEARCH_MAX_HITS as u64) as usize;
 
     let mut hits = if has_new_interval {
         let mut body = search_body.clone();

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use actix_web::{HttpResponse, post, web};
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Duration, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
@@ -246,7 +246,7 @@ pub async fn search_spans(
     let end = request.end_time;
 
     let old_start = start;
-    let old_end = Some(end.map_or(cutover, |e| e.min(cutover)));
+    let old_end = Some(end.map_or(cutover, |e| e.min(cutover + Duration::hours(2))));
     let new_start = Some(start.map_or(cutover, |s| s.max(cutover)));
     let new_end = end;
 

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use actix_web::{HttpResponse, post, web};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
@@ -10,7 +10,7 @@ use crate::{
     api::v1::traces::RabbitMqSpanMessage,
     db::spans::{Span, SpanType},
     mq::{MessageQueue, MessageQueueTrait, utils::mq_max_payload},
-    quickwit::client::QuickwitClient,
+    quickwit::{OLD_SPANS_INDEX_ID, client::QuickwitClient, spans_index_id},
     routes::{ResponseResult, error::Error},
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
 };
@@ -142,6 +142,12 @@ pub struct SearchSpansRequest {
 
 const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 2] = ["input", "output"];
 
+// Old spans indexed before this timestamp live in the old "spans" index.
+// Adjust this right before deploying the new index.
+fn new_index_cutover_ts() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 3, 16, 0, 0, 0).unwrap()
+}
+
 #[derive(Serialize, Deserialize)]
 struct QuickwitHit {
     trace_id: String,
@@ -222,14 +228,6 @@ pub async fn search_spans(
     let search_field_str = search_fields.join(",");
     search_body["search_field"] = serde_json::Value::String(search_field_str);
 
-    // Handle timestamps
-    if let Some(start) = request.start_time {
-        search_body["start_timestamp"] = serde_json::Value::Number(start.timestamp().into());
-    }
-    if let Some(end) = request.end_time {
-        search_body["end_timestamp"] = serde_json::Value::Number(end.timestamp().into());
-    }
-
     // Handle pagination
     if request.limit != 0 {
         search_body["max_hits"] = serde_json::Value::Number(request.limit.into())
@@ -241,19 +239,74 @@ pub async fn search_spans(
         search_body["start_offset"] = serde_json::Value::Number(request.offset.into());
     }
 
-    let response_value = quickwit_client
-        .search_spans(search_body)
-        .await
-        .map_err(|e| {
-            log::error!("Quickwit search error: {:?}", e);
-            Error::InternalAnyhowError(anyhow::anyhow!("Failed to search spans"))
-        })?;
+    // TEMPORARY: Determine which index to query based on the timestamp
+    // TODO: Remove this logic once we have switched to the new index completely.
+    let cutover = new_index_cutover_ts();
+    let start = request.start_time;
+    let end = request.end_time;
+
+    let old_start = start;
+    let old_end = Some(end.map_or(cutover, |e| e.min(cutover)));
+    let new_start = Some(start.map_or(cutover, |s| s.max(cutover)));
+    let new_end = end;
+
+    let should_query_old = !matches!((old_start, old_end), (Some(s), Some(e)) if s >= e);
+    let should_query_new = !matches!((new_start, new_end), (Some(s), Some(e)) if s >= e);
+
+    let (new_hits, old_hits) = tokio::join!(
+        async {
+            if should_query_new {
+                let mut body = search_body.clone();
+                set_body_timestamps(&mut body, new_start, new_end);
+                search_index(quickwit_client, spans_index_id(), body).await
+            } else {
+                Ok(vec![])
+            }
+        },
+        async {
+            if should_query_old {
+                let mut body = search_body.clone();
+                set_body_timestamps(&mut body, old_start, old_end);
+                search_index(quickwit_client, OLD_SPANS_INDEX_ID, body).await
+            } else {
+                Ok(vec![])
+            }
+        },
+    );
+
+    let mut hits = new_hits?;
+    hits.extend(old_hits?);
+
+    Ok(HttpResponse::Ok().json(hits))
+}
+
+fn set_body_timestamps(
+    body: &mut serde_json::Value,
+    start: Option<DateTime<Utc>>,
+    end: Option<DateTime<Utc>>,
+) {
+    if let Some(s) = start {
+        body["start_timestamp"] = serde_json::Value::Number(s.timestamp().into());
+    }
+    if let Some(e) = end {
+        body["end_timestamp"] = serde_json::Value::Number(e.timestamp().into());
+    }
+}
+
+async fn search_index(
+    client: &QuickwitClient,
+    index_id: &str,
+    body: serde_json::Value,
+) -> Result<Vec<QuickwitHit>, Error> {
+    let response_value = client.search_index(index_id, body).await.map_err(|e| {
+        log::error!("Quickwit search error (index {}): {:?}", index_id, e);
+        Error::InternalAnyhowError(anyhow::anyhow!("Failed to search spans"))
+    })?;
 
     let quickwit_response: QuickwitResponse =
         serde_json::from_value(response_value).map_err(|e| {
             Error::InternalAnyhowError(anyhow::anyhow!("Failed to parse Quickwit response: {}", e))
         })?;
 
-    let hits = quickwit_response.hits;
-    Ok(HttpResponse::Ok().json(hits))
+    Ok(quickwit_response.hits)
 }

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     db::{
         DB,
-        spans::Span,
+        spans::{Span, SpanType},
         trace::{Trace, upsert_trace_statistics_batch},
         workspaces::WorkspaceDeployment,
     },
@@ -42,6 +42,7 @@ use crate::{
 };
 
 const SIGNAL_TRIGGER_LOCK_TTL_SECONDS: u64 = 3600; // 1 hour
+const MAX_NON_LLM_SPAN_INDEX_SIZE_BYTES: usize = 5120; // 5KB
 
 #[instrument(skip(messages, db, clickhouse, cache, queue, pubsub, ch, config))]
 pub async fn process_span_messages(
@@ -157,7 +158,14 @@ pub async fn process_span_messages(
     send_span_updates(&spans_for_realtime, &pubsub).await;
 
     // Index spans and events in Quickwit
-    let quickwit_spans: Vec<QuickwitIndexedSpan> = recordable.iter().map(|s| (*s).into()).collect();
+    // Non-LLM spans are only indexed if their size is <= 5KB
+    let quickwit_spans: Vec<QuickwitIndexedSpan> = recordable
+        .iter()
+        .filter(|s| {
+            s.span_type == SpanType::LLM || s.size_bytes <= MAX_NON_LLM_SPAN_INDEX_SIZE_BYTES
+        })
+        .map(|s| (*s).into())
+        .collect();
     let quickwit_events: Vec<QuickwitIndexedEvent> = recordable
         .iter()
         .flat_map(|s| s.events.iter().map(|e| e.into()))

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -53,8 +53,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test:
-        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
+      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -67,7 +66,7 @@ services:
     environment:
       PORT: 8903
     healthcheck:
-      test: ["CMD", "sleep", "5"]
+      test: [ "CMD", "sleep", "5" ]
       interval: 10s
       timeout: 6s
       retries: 3
@@ -80,11 +79,11 @@ services:
       - "7281:7281" # OTLP / gRPC
     environment:
       QW_DATA_DIR: /quickwit/qwdata
-    command: ["run"]
+    command: [ "run" ]
     volumes:
       - quickwit-data:/quickwit/qwdata
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7280/health/livez"]
+      test: [ "CMD", "curl", "-f", "http://localhost:7280/health/livez" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -123,7 +122,7 @@ services:
       QUERY_ENGINE_URL: http://query-engine:8903
       QUICKWIT_SEARCH_URL: http://quickwit:7280
       QUICKWIT_INGEST_URL: http://quickwit:7281
-      QUICKWIT_SPANS_INDEX_ID: spans
+      QUICKWIT_SPANS_INDEX_ID: spans_v2
       GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY}
 
   frontend:

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -47,8 +47,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test:
-        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
+      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -62,7 +61,7 @@ services:
     environment:
       PORT: 8903
     healthcheck:
-      test: ["CMD", "sleep", "5"]
+      test: [ "CMD", "sleep", "5" ]
       interval: 10s
       timeout: 6s
       retries: 3
@@ -75,11 +74,11 @@ services:
       - "7281:7281" # OTLP / gRPC
     environment:
       QW_DATA_DIR: /quickwit/qwdata
-    command: ["run"]
+    command: [ "run" ]
     volumes:
       - quickwit-data:/quickwit/qwdata
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7280/health/livez"]
+      test: [ "CMD", "curl", "-f", "http://localhost:7280/health/livez" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -119,7 +118,7 @@ services:
       QUERY_ENGINE_URL: http://query-engine:8903
       QUICKWIT_SEARCH_URL: http://quickwit:7280
       QUICKWIT_INGEST_URL: http://quickwit:7281
-      QUICKWIT_SPANS_INDEX_ID: spans
+      QUICKWIT_SPANS_INDEX_ID: spans_v2
       GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY}
 
   frontend:

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -18,8 +18,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test:
-        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
+      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -60,11 +59,11 @@ services:
       - "7281:7281" # OTLP / gRPC
     environment:
       QW_DATA_DIR: /quickwit/qwdata
-    command: ["run"]
+    command: [ "run" ]
     volumes:
       - quickwit-data:/quickwit/qwdata
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7280/health/livez"]
+      test: [ "CMD", "curl", "-f", "http://localhost:7280/health/livez" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -77,7 +76,7 @@ services:
     environment:
       PORT: 8903
     healthcheck:
-      test: ["CMD", "sleep", "5"]
+      test: [ "CMD", "sleep", "5" ]
       interval: 10s
       timeout: 6s
       retries: 3
@@ -114,7 +113,7 @@ services:
       QUERY_ENGINE_URL: http://query-engine:8903
       QUICKWIT_SEARCH_URL: http://quickwit:7280
       QUICKWIT_INGEST_URL: http://quickwit:7281
-      QUICKWIT_SPANS_INDEX_ID: spans
+      QUICKWIT_SPANS_INDEX_ID: spans_v2
       GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY}
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test:
-        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
+      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -54,7 +53,7 @@ services:
     environment:
       PORT: 8903
     healthcheck:
-      test: ["CMD", "sleep", "5"]
+      test: [ "CMD", "sleep", "5" ]
       interval: 10s
       timeout: 6s
       retries: 3
@@ -67,11 +66,11 @@ services:
       - "7281:7281" # OTLP / gRPC
     environment:
       QW_DATA_DIR: /quickwit/qwdata
-    command: ["run"]
+    command: [ "run" ]
     volumes:
       - quickwit-data:/quickwit/qwdata
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7280/health/livez"]
+      test: [ "CMD", "curl", "-f", "http://localhost:7280/health/livez" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -135,7 +134,7 @@ services:
       QUERY_ENGINE_URL: http://query-engine:8903
       QUICKWIT_SEARCH_URL: http://quickwit:7280
       QUICKWIT_INGEST_URL: http://quickwit:7281
-      QUICKWIT_SPANS_INDEX_ID: spans
+      QUICKWIT_SPANS_INDEX_ID: spans_v2
       GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY}
 
 volumes:

--- a/frontend/lib/quickwit/indexes/spans.yaml
+++ b/frontend/lib/quickwit/indexes/spans.yaml
@@ -1,0 +1,46 @@
+version: "0.8"
+index_id: spans
+doc_mapping:
+  field_mappings:
+    - name: span_id
+      type: text
+      tokenizer: raw
+      fast: false
+    - name: project_id
+      type: text
+      tokenizer: raw
+      fast: true
+      stored: false
+    - name: trace_id
+      type: text
+      tokenizer: raw
+      fast: true
+    - name: start_time
+      type: datetime
+      fast: true
+      stored: false
+    - name: input
+      type: text
+      tokenizer: default
+      fast: false
+      stored: false
+      record: position
+    - name: output
+      type: text
+      tokenizer: default
+      fast: false
+      stored: false
+      record: position
+    - name: attributes
+      type: text
+      tokenizer: default
+      fast: false
+      stored: false
+      record: position
+  tag_fields: []
+  timestamp_field: start_time
+search_settings:
+  default_search_fields: [input, output, attributes]
+retention:
+  period: 90 days
+  schedule: daily

--- a/frontend/lib/quickwit/indexes/spans_v2.yaml
+++ b/frontend/lib/quickwit/indexes/spans_v2.yaml
@@ -1,6 +1,14 @@
 version: "0.8"
-index_id: spans
+index_id: spans_v2
 doc_mapping:
+  mode: dynamic
+  dynamic_mapping:
+    indexed: true
+    stored: false
+    tokenizer: default
+    record: position
+    expand_dots: true
+    fast: false
   field_mappings:
     - name: span_id
       type: text
@@ -31,16 +39,11 @@ doc_mapping:
       fast: false
       stored: false
       record: position
-    - name: attributes
-      type: text
-      tokenizer: default
-      fast: false
-      stored: false
-      record: position
   tag_fields: []
   timestamp_field: start_time
+  partition_key: hash_mod(project_id, 100)
 search_settings:
-  default_search_fields: [input, output, attributes]
+  default_search_fields: [input, output]
 retention:
   period: 90 days
   schedule: daily


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes span search/indexing behavior (new index schema, field set, sorting, and dual-query cutover logic) and introduces size-based filtering that can drop non-LLM spans from Quickwit results if misconfigured.
> 
> **Overview**
> **Moves span search/indexing to a new Quickwit index (`spans_v2`).** Defaults `QUICKWIT_SPANS_INDEX_ID` to `spans_v2` (env + compose) and adds a new Quickwit index definition (`frontend/lib/quickwit/indexes/spans_v2.yaml`).
> 
> **Changes what gets indexed and how it’s queried.** Span documents no longer include `attributes` (and default search fields drop `attributes`), span search now sorts by `start_time`, and non-LLM spans are only indexed if `size_bytes <= 5KB`.
> 
> **Adds a temporary dual-read migration path.** `spans/search` splits the requested time range around `QUICKWIT_NEW_INDEX_CUTOVER_TS` and queries `spans_v2` and/or the old `spans` index accordingly; Quickwit HTTP search is generalized from `search_spans` to `search_index(index_id, ...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0fe762116f858ec60a4f10dc738df22c9fe2fbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->