### PR TITLE
reports feature flag

### DIFF
--- a/app-server/.env.example
+++ b/app-server/.env.example
@@ -30,3 +30,7 @@ QUICKWIT_SPANS_INDEX_ID=spans_v2
 
 # Optional, set this to enable the signals feature
 # GOOGLE_GENERATIVE_AI_API_KEY=
+
+# Optional, set this to enable the reports feature
+ENABLE_REPORTS=false
+RESEND_API_KEY=

--- a/app-server/.env.example
+++ b/app-server/.env.example
@@ -33,4 +33,4 @@ QUICKWIT_SPANS_INDEX_ID=spans_v2
 
 # Optional, set this to enable the reports feature
 ENABLE_REPORTS=false
-RESEND_API_KEY=
+# RESEND_API_KEY=

--- a/app-server/.env.example
+++ b/app-server/.env.example
@@ -32,5 +32,5 @@ QUICKWIT_SPANS_INDEX_ID=spans_v2
 # GOOGLE_GENERATIVE_AI_API_KEY=
 
 # Optional, set this to enable the reports feature
-ENABLE_REPORTS=false
+# ENABLE_REPORTS=true
 # RESEND_API_KEY=

--- a/app-server/src/features/mod.rs
+++ b/app-server/src/features/mod.rs
@@ -50,7 +50,10 @@ pub fn is_feature_enabled(feature: Feature) -> bool {
         Feature::Signals => {
             env::var("GOOGLE_GENERATIVE_AI_API_KEY").is_ok_and(|s| !s.is_empty())
         }
-        Feature::Reports => env::var("ENABLE_REPORTS").is_ok_and(|s| s == "true"),
+        Feature::Reports => {
+            env::var("ENABLE_REPORTS").is_ok_and(|s| s == "true")
+                && env::var("RESEND_API_KEY").is_ok_and(|s| !s.is_empty())
+        }
     }
 }
 

--- a/app-server/src/features/mod.rs
+++ b/app-server/src/features/mod.rs
@@ -19,6 +19,7 @@ pub enum Feature {
     Tracing,
     Clustering,
     Signals,
+    Reports,
 }
 
 pub fn is_feature_enabled(feature: Feature) -> bool {
@@ -49,6 +50,7 @@ pub fn is_feature_enabled(feature: Feature) -> bool {
         Feature::Signals => {
             env::var("GOOGLE_GENERATIVE_AI_API_KEY").is_ok_and(|s| !s.is_empty())
         }
+        Feature::Reports => env::var("ENABLE_REPORTS").is_ok_and(|s| s == "true"),
     }
 }
 

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -884,19 +884,6 @@ fn main() -> anyhow::Result<()> {
         .ok()
         .map(|key| Arc::new(resend_rs::Resend::new(key.as_str())));
 
-    // == Reports Scheduler ==
-    let db_for_scheduler = db.clone();
-    let queue_for_scheduler = queue.clone();
-    let cache_for_scheduler = cache.clone();
-    runtime_handle.spawn(async move {
-        reports::scheduler::run_reports_scheduler(
-            db_for_scheduler.pool.clone(),
-            queue_for_scheduler,
-            cache_for_scheduler,
-        )
-        .await;
-    });
-
     if !enable_producer() && !enable_consumer() {
         log::error!(
             "Neither producer nor consumer mode is enabled. Set OPERATION_MODE to 'producer' or 'consumer', or unset to run both"
@@ -908,6 +895,23 @@ fn main() -> anyhow::Result<()> {
 
     if enable_consumer() {
         log::info!("Enabling consumer mode, spinning up queue workers");
+
+        if is_feature_enabled(Feature::Reports) {
+            log::info!("Reports feature enabled - starting reports scheduler");
+            let db_for_scheduler = db.clone();
+            let queue_for_scheduler = queue.clone();
+            let cache_for_scheduler = cache.clone();
+            runtime_handle.spawn(async move {
+                reports::scheduler::run_reports_scheduler(
+                    db_for_scheduler.pool.clone(),
+                    queue_for_scheduler,
+                    cache_for_scheduler,
+                )
+                .await;
+            });
+        } else {
+            log::info!("Reports feature disabled - skipping reports scheduler");
+        }
 
         let worker_pool = Arc::new(WorkerPool::new(queue.clone()));
         let batch_worker_pool = Arc::new(BatchWorkerPool::new(queue.clone()));

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -995,7 +995,7 @@ fn main() -> anyhow::Result<()> {
             .unwrap_or(2);
 
         log::info!(
-            "Spans workers: {}, Data plane spans workers: {}, Spans indexer workers: {}, Browser events workers: {}, Signals workers: {}, Notification workers: {}, Clustering batching workers: {}, Clustering workers: {}, Trace Analysis LLM Batch Submissions workers: {}, Trace Analysis LLM Batch Pending workers: {}, Logs workers: {}",
+            "Spans workers: {}, Data plane spans workers: {}, Spans indexer workers: {}, Browser events workers: {}, Signals workers: {}, Notification workers: {}, Clustering batching workers: {}, Clustering workers: {}, Trace Analysis LLM Batch Submissions workers: {}, Trace Analysis LLM Batch Pending workers: {}, Logs workers: {}, Reports workers: {}",
             num_spans_workers,
             num_data_plane_spans_workers,
             num_spans_indexer_workers,
@@ -1006,7 +1006,8 @@ fn main() -> anyhow::Result<()> {
             num_clustering_workers,
             num_signal_job_submission_batch_workers,
             num_signal_job_pending_batch_workers,
-            num_logs_workers
+            num_logs_workers,
+            num_reports_workers
         );
 
         let queue_for_health = mq_for_http.clone();
@@ -1187,11 +1188,7 @@ fn main() -> anyhow::Result<()> {
                                     },
                                 )
                             },
-                            QueueConfig::new(
-                                SIGNALS_QUEUE,
-                                SIGNALS_EXCHANGE,
-                                SIGNALS_ROUTING_KEY,
-                            ),
+                            QueueConfig::new(SIGNALS_QUEUE, SIGNALS_EXCHANGE, SIGNALS_ROUTING_KEY),
                         );
                     } else {
                         log::warn!("Gemini client not available - skipping signals workers");
@@ -1384,16 +1381,12 @@ fn main() -> anyhow::Result<()> {
                                 cache: cache.clone(),
                                 clickhouse: clickhouse.clone(),
                             },
-                            QueueConfig::new(
-                                LOGS_QUEUE,
-                                LOGS_EXCHANGE,
-                                LOGS_ROUTING_KEY,
-                            ),
+                            QueueConfig::new(LOGS_QUEUE, LOGS_EXCHANGE, LOGS_ROUTING_KEY),
                         );
                     }
 
                     // Spawn reports workers
-                    {
+                    if is_feature_enabled(Feature::Reports) {
                         let db = db_for_consumer.clone();
                         let clickhouse = clickhouse_for_consumer.clone();
                         let queue = mq_for_consumer.clone();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes consumer startup behavior by conditionally starting the reports scheduler and workers based on new env-driven feature gating; misconfiguration could unintentionally disable reports processing or skip scheduler execution.
> 
> **Overview**
> Adds a new `Feature::Reports` flag driven by `ENABLE_REPORTS=true` and a non-empty `RESEND_API_KEY`, and documents these vars in `.env.example`.
> 
> Updates consumer startup to **only** launch the reports scheduler and spawn reports workers when the reports feature is enabled, and extends worker-count logging to include reports (plus minor `QueueConfig::new` formatting cleanups).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef0b9e0c15a928752920a6b520ecbec0ff45396c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->