### PR TITLE
grant realtime (from trigger) for first N signals in project

### DIFF
--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -17,3 +17,4 @@ pub const WORKSPACE_DEPLOYMENTS_BY_WORKSPACE_CACHE_KEY: &str = "workspace_deploy
 pub const DATA_PLANE_AUTH_TOKEN_CACHE_KEY: &str = "data_plane_auth_token";
 pub const REPORT_SCHEDULER_LOCK_CACHE_KEY: &str = "report_scheduler_lock";
 pub const REPORT_SCHEDULER_LAST_CHECK_CACHE_KEY: &str = "report_scheduler_last_check";
+pub const PROJECT_HAS_SIGNAL_RUNS_CACHE_KEY: &str = "project_has_signal_runs";

--- a/app-server/src/ch/signal_runs.rs
+++ b/app-server/src/ch/signal_runs.rs
@@ -47,30 +47,6 @@ impl From<&SignalRun> for CHSignalRun {
     }
 }
 
-#[allow(dead_code)]
-#[instrument(skip(clickhouse))]
-pub async fn get_signal_runs_for_job(
-    clickhouse: clickhouse::Client,
-    project_id: Uuid,
-    signal_id: Uuid,
-    job_id: Uuid,
-) -> Result<Vec<CHSignalRun>> {
-    let runs = clickhouse
-        .query(
-            "SELECT project_id, signal_id, job_id, trigger_id, run_id, trace_id, status, event_id, error_message, updated_at
-             FROM signal_runs FINAL
-             WHERE project_id = ? AND signal_id = ? AND job_id = ?
-             ORDER BY updated_at ASC",
-        )
-        .bind(project_id)
-        .bind(signal_id)
-        .bind(job_id)
-        .fetch_all::<CHSignalRun>()
-        .await?;
-
-    Ok(runs)
-}
-
 #[instrument(skip(clickhouse, runs))]
 pub async fn insert_signal_runs(
     clickhouse: clickhouse::Client,
@@ -102,4 +78,34 @@ pub async fn insert_signal_runs(
             e
         )),
     }
+}
+
+#[derive(Row, Deserialize, Debug)]
+pub struct CHHasMoreRow {
+    has_more: bool,
+}
+
+pub async fn project_has_num_signal_runs(
+    clickhouse: clickhouse::Client,
+    project_id: Uuid,
+    number: usize,
+) -> Result<bool> {
+    let row = clickhouse
+        .query(
+            "SELECT count (*) >= ? AS has_more
+             FROM (
+                SELECT 1
+                FROM signal_runs FINAL
+                WHERE project_id = ?
+                -- small optimization to not iterate over many rows
+                LIMIT ?
+            )",
+        )
+        .bind(number)
+        .bind(project_id)
+        .bind(number + 1)
+        .fetch_one::<CHHasMoreRow>()
+        .await?;
+
+    Ok(row.has_more)
 }

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -7,13 +7,18 @@ use uuid::Uuid;
 
 use crate::{
     api::v1::traces::RabbitMqSpanMessage,
+    cache::{Cache, CacheTrait, keys::PROJECT_HAS_SIGNAL_RUNS_CACHE_KEY},
+    ch::signal_runs::project_has_num_signal_runs,
     db::{
         events::{Event, EventSource},
         spans::{Span, SpanType},
     },
     mq::{MessageQueue, MessageQueueTrait},
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
+    utils::get_unsigned_env_with_default,
 };
+
+const DEFAULT_NUM_SIGNAL_RUNS_TO_GRANT_REALTIME: usize = 20;
 
 // internal span for observability
 #[derive(Debug, Clone)]
@@ -248,4 +253,28 @@ pub async fn emit_internal_span(queue: Arc<MessageQueue>, span: InternalSpan) ->
     }
 
     span_id
+}
+
+pub async fn should_grant_realtime(
+    project_id: Uuid,
+    clickhouse: clickhouse::Client,
+    cache: Arc<Cache>,
+) -> anyhow::Result<bool> {
+    let num_runs_to_grant = get_unsigned_env_with_default(
+        "NUM_SIGNAL_RUNS_TO_GRANT_REALTIME",
+        DEFAULT_NUM_SIGNAL_RUNS_TO_GRANT_REALTIME,
+    );
+    let cache_key = format!("{PROJECT_HAS_SIGNAL_RUNS_CACHE_KEY}:{project_id}");
+    if cache.exists(&cache_key).await? {
+        Ok(false)
+    } else {
+        let has_more =
+            project_has_num_signal_runs(clickhouse, project_id, num_runs_to_grant).await?;
+        if has_more {
+            if let Err(e) = cache.insert(&cache_key, 1).await {
+                log::warn!("Failed to insert num signal runs cache {e}");
+            }
+        }
+        Ok(!has_more)
+    }
 }

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -273,6 +273,18 @@ async fn check_and_push_signals(
             return;
         }
     }
+    // First N runs in each project are granted realtime execution regardless of the setting
+    // We can be generous and grant even while some are being processed
+    let grant_realtime = should_grant_realtime(project_id, clickhouse.clone(), cache.clone())
+        .await
+        .map_err(|e| {
+            log::warn!(
+                "Failed to get signals count for project {}: {}",
+                project_id,
+                e
+            );
+        })
+        .unwrap_or_default();
 
     for trigger in triggers {
         let matching_traces = traces
@@ -331,19 +343,6 @@ async fn check_and_push_signals(
 
             // TODO: fetch a trigger config whether to process in realtime from Trigger definition
             let trigger_should_use_realtime = false;
-            // First N runs in each project are granted realtime execution regardless of the setting
-            // We can be generous and grant even while some are being processed
-            let grant_realtime =
-                should_grant_realtime(project_id, clickhouse.clone(), cache.clone())
-                    .await
-                    .map_err(|e| {
-                        log::warn!(
-                            "Failed to get signals count for project {}: {}",
-                            project_id,
-                            e
-                        );
-                    })
-                    .unwrap_or_default();
             let should_use_realtime = trigger_should_use_realtime || grant_realtime;
 
             // Lock acquired - enqueue signal trigger run

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -31,7 +31,7 @@ use crate::{
         IndexerQueuePayload, QuickwitIndexedEvent, QuickwitIndexedSpan,
         producer::publish_for_indexing,
     },
-    signals::provider::always_use_realtime,
+    signals::{provider::always_use_realtime, utils::should_grant_realtime},
     traces::{
         provider::convert_span_to_provider_format,
         realtime::{send_span_updates, send_trace_updates},
@@ -274,7 +274,7 @@ async fn check_and_push_signals(
         }
     }
 
-    for trigger in &triggers {
+    for trigger in triggers {
         let matching_traces = traces
             .iter()
             .filter(|trace| trace.matches_filters(spans, &trigger.filters));
@@ -330,7 +330,21 @@ async fn check_and_push_signals(
             }
 
             // TODO: fetch a trigger config whether to process in realtime from Trigger definition
-            let should_use_realtime = false;
+            let trigger_should_use_realtime = false;
+            // First N runs in each project are granted realtime execution regardless of the setting
+            // We can be generous and grant even while some are being processed
+            let grant_realtime =
+                should_grant_realtime(project_id, clickhouse.clone(), cache.clone())
+                    .await
+                    .map_err(|e| {
+                        log::warn!(
+                            "Failed to get signals count for project {}: {}",
+                            project_id,
+                            e
+                        );
+                    })
+                    .unwrap_or_default();
+            let should_use_realtime = trigger_should_use_realtime || grant_realtime;
 
             // Lock acquired - enqueue signal trigger run
             if let Err(e) = crate::signals::enqueue::enqueue_signal_trigger_run(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes signal-trigger execution behavior by conditionally enabling realtime based on ClickHouse counts and a new cache key, which could impact performance and trigger processing flow if the count/caching logic is wrong.
> 
> **Overview**
> **Grants realtime signal execution for new projects’ first runs.** The trace processor now calls `should_grant_realtime` to force realtime execution for the first *N* signal runs in a project (configurable via `NUM_SIGNAL_RUNS_TO_GRANT_REALTIME`, default 20), regardless of per-trigger settings.
> 
> This adds a ClickHouse helper (`project_has_num_signal_runs`) to cheaply check whether a project has reached the threshold, and introduces a per-project cache key (`project_has_signal_runs:{project_id}`) to avoid repeated counting once the threshold is met.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43a3690bf970091a24c1c56401917b60e7b23edd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->