### PR TITLE
don't run signals on non-default trace types

### DIFF
--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -18,6 +18,7 @@ use crate::{
         spans::CHSpan,
         traces::{CHTrace, TraceAggregation},
     },
+    db::trace::TraceType,
     db::{
         DB,
         spans::{Span, SpanType},
@@ -107,7 +108,14 @@ pub async fn process_span_messages(
             send_trace_updates(&updated_traces, &pubsub).await;
 
             if is_feature_enabled(Feature::Signals) {
-                let traces_by_project = group_traces_by_project(&updated_traces);
+                let default_traces: Vec<Trace> = updated_traces
+                    .into_iter()
+                    .filter(|trace| {
+                        let default_val: u8 = TraceType::DEFAULT.into();
+                        trace.trace_type() == default_val as i16
+                    })
+                    .collect();
+                let traces_by_project = group_traces_by_project(&default_traces);
                 for (project_id, project_traces) in &traces_by_project {
                     check_and_push_signals(
                         *project_id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which traces can trigger Signals by filtering to `TraceType::DEFAULT`, which could unintentionally suppress signal runs for other trace types if any workflows relied on them.
> 
> **Overview**
> Limits Signals processing to *default* traces only. In `process_span_messages`, traces returned from `upsert_trace_statistics_batch` are now filtered to `TraceType::DEFAULT` before `group_traces_by_project`/`check_and_push_signals` runs, preventing non-default trace types (e.g., evaluation/event/playground) from triggering Signals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b39a49c9bdb2f191e4b924d71608cd2f3c704b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->