### PR TITLE
make events_to_clusters table RMT

### DIFF
--- a/frontend/lib/clickhouse/migrations/29_events_to_clusters_rmt.sql
+++ b/frontend/lib/clickhouse/migrations/29_events_to_clusters_rmt.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS new_events_to_clusters
+(
+    project_id UUID,
+    event_id   UUID,
+    cluster_id UUID,
+    content    String,
+    created_at DateTime64(9, 'UTC') default now64(9)
+)
+ENGINE = ReplacingMergeTree(created_at)
+ORDER BY (project_id, event_id, cluster_id)
+SETTINGS index_granularity = 8192;
+
+INSERT INTO new_events_to_clusters(
+    project_id,
+    event_id,
+    cluster_id,
+    content,
+    created_at
+)
+FROM events_to_clusters;
+
+RENAME TABLE events_to_clusters TO old_events_to_clusters;
+RENAME TABLE new_events_to_clusters TO events_to_clusters;
+
+DROP TABLE IF EXISTS old_events_to_clusters;

--- a/frontend/lib/clickhouse/migrations/29_events_to_clusters_rmt.sql
+++ b/frontend/lib/clickhouse/migrations/29_events_to_clusters_rmt.sql
@@ -17,6 +17,7 @@ INSERT INTO new_events_to_clusters(
     content,
     created_at
 )
+SELECT project_id, event_id, cluster_id, content, created_at
 FROM events_to_clusters;
 
 RENAME TABLE events_to_clusters TO old_events_to_clusters;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Performs an in-place ClickHouse table engine migration by copying and swapping tables, which can impact data correctness/availability if run on large tables or under concurrent writes.
> 
> **Overview**
> Migrates the ClickHouse `events_to_clusters` table from `MergeTree` to **`ReplacingMergeTree(created_at)`** by creating a replacement table, backfilling it from the existing data, swapping table names, and dropping the old table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c709b0cbb994b48eeb4613b749fa4d57de0bae16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->