### PR TITLE
Signal agent add cost and duration

### DIFF
--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -24,6 +24,8 @@ pub struct CompressedSpan {
     pub span_type: String,
     pub start: String,
     pub duration: f64,
+    pub total_cost: f64,
+    pub total_tokens: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -249,6 +251,8 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
                 span_type: get_span_type(ch_span.span_type).to_string(),
                 start: format_ns_timestamp(ch_span.start_time),
                 duration: duration_secs,
+                total_cost: ch_span.total_cost,
+                total_tokens: ch_span.total_tokens,
                 input,
                 output,
                 status: if ch_span.status == "<null>" || ch_span.status.is_empty() {
@@ -265,12 +269,20 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
 
 /// Create skeleton string representation of spans
 pub fn spans_to_skeleton_string(spans: &[CompressedSpan]) -> String {
-    let mut skeleton = String::from("legend: span_name (id, parent_id, type)\n");
+    let mut skeleton = String::from(
+        "legend: span_name (id, parent_id, type, duration_sec, cost_usd, total_tokens)\n",
+    );
     for span in spans {
         let parent_str = span.parent.as_deref().unwrap_or("None");
         skeleton.push_str(&format!(
-            "- {} ({}, {}, {})\n",
-            span.name, span.id, parent_str, span.span_type
+            "- {} ({}, {}, {}, {:.3}, {:.6}, {})\n",
+            span.name,
+            span.id,
+            parent_str,
+            span.span_type,
+            span.duration,
+            span.total_cost,
+            span.total_tokens
         ));
     }
     skeleton

--- a/frontend/components/signals/prompts.ts
+++ b/frontend/components/signals/prompts.ts
@@ -12,9 +12,9 @@ const templates: EventTemplate[] = [
     name: "Failure Detector",
     shortName: "Failure",
     icon: "alert-circle",
-    description: "Spot errors, looping, wrong tool usage, and slow actions",
+    description: "Spot errors, loops, wrong tool usage, and slow actions",
     prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
-looping or repeated calls, wrong tool selection, logic errors, \
+loops or repeated calls, wrong tool selection, logic errors, \
 and abnormally slow or expensive spans. Only report problems visible in the trace data.`,
     structuredOutputSchema: JSON.stringify(
       {

--- a/frontend/components/signals/prompts.ts
+++ b/frontend/components/signals/prompts.ts
@@ -14,8 +14,8 @@ const templates: EventTemplate[] = [
     icon: "alert-circle",
     description: "Spot errors, looping, wrong tool usage, and slow actions",
     prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
-  looping or repeated calls, wrong tool selection, logic errors, \
-  and abnormally slow spans. Only report problems visible in the trace data.`,
+looping or repeated calls, wrong tool selection, logic errors, \
+and abnormally slow spans. Only report problems visible in the trace data.`,
     structuredOutputSchema: JSON.stringify(
       {
         type: "object",

--- a/frontend/components/signals/prompts.ts
+++ b/frontend/components/signals/prompts.ts
@@ -15,7 +15,7 @@ const templates: EventTemplate[] = [
     description: "Spot errors, looping, wrong tool usage, and slow actions",
     prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
 looping or repeated calls, wrong tool selection, logic errors, \
-and abnormally slow spans. Only report problems visible in the trace data.`,
+and abnormally slow or expensive spans. Only report problems visible in the trace data.`,
     structuredOutputSchema: JSON.stringify(
       {
         type: "object",

--- a/frontend/components/signals/prompts.ts
+++ b/frontend/components/signals/prompts.ts
@@ -12,9 +12,10 @@ const templates: EventTemplate[] = [
     name: "Failure Detector",
     shortName: "Failure",
     icon: "alert-circle",
-    description: "Detect failures, errors, and things that went wrong",
-    prompt: `Analyze this trace for failures, errors, or things that went wrong.
-Include tool failures, API errors, logical mistakes, and dead ends.`,
+    description: "Spot errors, looping, wrong tool usage, and slow actions",
+    prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
+  looping or repeated calls, wrong tool selection, logic errors, \
+  and abnormally slow spans. Only report problems visible in the trace data.`,
     structuredOutputSchema: JSON.stringify(
       {
         type: "object",
@@ -22,12 +23,12 @@ Include tool failures, API errors, logical mistakes, and dead ends.`,
         properties: {
           description: {
             type: "string",
-            description: "Description of what failed and why",
+            description: "Description of the issue: what happened, which span(s) are involved, and the impact",
           },
           category: {
             type: "string",
-            enum: ["tool_error", "api_error", "logic_error", "timeout", "other"],
-            description: "Category of the failure",
+            enum: ["tool_error", "api_error", "logic_error", "looping", "wrong_tool", "timeout", "other"],
+            description: "Category of the issue",
           },
         },
       },

--- a/frontend/lib/actions/trace/agent/spans.ts
+++ b/frontend/lib/actions/trace/agent/spans.ts
@@ -86,6 +86,8 @@ interface SpanInfo {
   end: string;
   status: string;
   parent: string;
+  totalCost: number;
+  totalTokens: number;
 }
 
 // Full span with input/output details
@@ -107,7 +109,9 @@ const fetchSpanInfos = async (projectId: string, traceId: string): Promise<SpanI
         start_time as start,
         end_time as end,
         status,
-        parent_span_id as parent
+        parent_span_id as parent,
+        total_cost as totalCost,
+        total_tokens as totalTokens
       FROM spans
       WHERE trace_id = {trace_id: UUID}
       ORDER BY start_time ASC
@@ -140,6 +144,8 @@ const fetchSpans = async (projectId: string, traceId: string, spanIds: string[])
         end_time as end,
         status,
         parent_span_id as parent,
+        total_cost as totalCost,
+        total_tokens as totalTokens,
         input,
         output
       FROM spans
@@ -213,16 +219,20 @@ function calculateDuration(start: string, end: string): number {
 /** Format a ClickHouse DateTime64 string to a readable UTC string. */
 function formatUtcTimestamp(chTimestamp: string): string {
   const d = new Date(chTimestamp + "Z"); // CH returns UTC without the Z suffix
-  return d.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, " UTC");
+  return d
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d{3}Z$/, " UTC");
 }
 
 function spanInfosToSkeletonString(spanInfos: SpanInfo[], spanIdToSeqId: Record<string, number>): string {
-  let result = "legend: span_name (id, parent_id, type)\n";
+  let result = "legend: span_name (id, parent_id, type, duration_sec, cost_usd, total_tokens)\n";
   for (let i = 0; i < spanInfos.length; i++) {
     const info = spanInfos[i];
     const seqId = i + 1;
     const parentSeqId = info.parent ? (spanIdToSeqId[info.parent] ?? null) : null;
-    result += `- ${info.name} (${seqId}, ${parentSeqId ?? "null"}, ${info.type})\n`;
+    const duration = calculateDuration(info.start, info.end);
+    result += `- ${info.name} (${seqId}, ${parentSeqId ?? "null"}, ${info.type}, ${duration.toFixed(3)}, ${info.totalCost.toFixed(6)}, ${info.totalTokens})\n`;
   }
   return result;
 }
@@ -296,14 +306,10 @@ export const getTraceStructureAsString = async (projectId: string, traceId: stri
     if (!seenPaths.has(info.path)) {
       seenPaths.add(info.path);
       // Truncate tool span input; strip base64 images and truncate LLM input
-      spanView.input = isTool
-        ? truncateValue(span.input)
-        : truncateLlmInput(replaceBase64Images(span.input));
+      spanView.input = isTool ? truncateValue(span.input) : truncateLlmInput(replaceBase64Images(span.input));
     }
     // Truncate tool span output; strip base64 images from LLM output
-    spanView.output = isTool
-      ? truncateValue(span.output)
-      : replaceBase64Images(span.output);
+    spanView.output = isTool ? truncateValue(span.output) : replaceBase64Images(span.output);
 
     if (span.exception) {
       spanView.exception = span.exception;

--- a/frontend/lib/actions/trace/agent/spans.ts
+++ b/frontend/lib/actions/trace/agent/spans.ts
@@ -244,6 +244,8 @@ interface DetailedSpanView {
   type: string;
   start: string;
   duration: number;
+  totalCost: number;
+  totalTokens: number;
   parent: number | null;
   status?: string;
   input?: unknown;
@@ -293,6 +295,8 @@ export const getTraceStructureAsString = async (projectId: string, traceId: stri
       type: info.type.toLowerCase(),
       start: formatUtcTimestamp(info.start),
       duration: calculateDuration(info.start, info.end),
+      totalCost: info.totalCost,
+      totalTokens: info.totalTokens,
       parent: parentSeqId,
     };
 

--- a/frontend/lib/actions/workspaces/index.ts
+++ b/frontend/lib/actions/workspaces/index.ts
@@ -36,7 +36,7 @@ type CreateWorkspaceResult = {
 const DEFAULT_SIGNAL = {
   name: "Failure Detector",
   prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
-looping or repeated calls, wrong tool selection, logic errors, \
+loops or repeated calls, wrong tool selection, logic errors, \
 and abnormally slow or expensive spans. Only report problems visible in the trace data.`,
   structuredOutputSchema: {
     type: "object",

--- a/frontend/lib/actions/workspaces/index.ts
+++ b/frontend/lib/actions/workspaces/index.ts
@@ -37,7 +37,7 @@ const DEFAULT_SIGNAL = {
   name: "Failure Detector",
   prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
 looping or repeated calls, wrong tool selection, logic errors, \
-and abnormally slow spans. Only report problems visible in the trace data.`,
+and abnormally slow or expensive spans. Only report problems visible in the trace data.`,
   structuredOutputSchema: {
     type: "object",
     required: ["description", "category"],

--- a/frontend/lib/actions/workspaces/index.ts
+++ b/frontend/lib/actions/workspaces/index.ts
@@ -35,20 +35,21 @@ type CreateWorkspaceResult = {
 
 const DEFAULT_SIGNAL = {
   name: "Failure Detector",
-  prompt: `Analyze this trace for failures, errors, or things that went wrong.
-Include tool failures, API errors, logical mistakes, and dead ends.`,
+  prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
+looping or repeated calls, wrong tool selection, logic errors, \
+and abnormally slow spans. Only report problems visible in the trace data.`,
   structuredOutputSchema: {
     type: "object",
     required: ["description", "category"],
     properties: {
       description: {
         type: "string",
-        description: "Description of what failed and why",
+        description: "Description of the issue: what happened, which span(s) are involved, and the impact",
       },
       category: {
         type: "string",
-        enum: ["tool_error", "api_error", "logic_error", "timeout", "other"],
-        description: "Category of the failure",
+        enum: ["tool_error", "api_error", "logic_error", "looping", "wrong_tool", "timeout", "other"],
+        description: "Category of the issue",
       },
     },
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes span serialization and ClickHouse queries to require `total_cost`/`total_tokens`, which could break trace rendering if columns are missing or null/unexpected. Prompt/schema changes may also affect downstream parsing of signal results.
> 
> **Overview**
> Trace span outputs now include **cost and token usage**: backend `CompressedSpan` adds `total_cost`/`total_tokens` and the skeleton string legend/rows include duration, cost, and token counts.
> 
> Frontend trace span fetching and trace-structure formatting now query and propagate `totalCost`/`totalTokens`, and skeleton lines include computed duration plus cost/token values.
> 
> The default **Failure Detector** signal template/prompt and structured output schema are updated to focus on loops/wrong tool usage and slow/expensive spans, with new issue categories (`looping`, `wrong_tool`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b091e9b05b9eefbff1e2d42742e7032a8bfca0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->