### PR TITLE
fix: missing thought signature in signal gemini calls

### DIFF
--- a/app-server/src/signals/provider/models.rs
+++ b/app-server/src/signals/provider/models.rs
@@ -51,6 +51,10 @@ pub struct ProviderPart {
     pub function_call: Option<ProviderFunctionCall>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_response: Option<ProviderFunctionResponse>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thought: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thought_signature: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: additive schema change to `ProviderPart` only, affecting (de)serialization for provider payloads; main risk is unexpected provider API behavior if these fields are set incorrectly.
> 
> **Overview**
> Adds optional `thought` and `thought_signature` fields to `ProviderPart` (with serde defaults) so provider request/response payloads can carry Gemini “thinking mode” metadata that was previously dropped during (de)serialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11a6ede1d991ef46559148fc9d1234019c0f2cc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->