### PR TITLE
wip: reset usage on invoice finalized according to new meters

### DIFF
--- a/frontend/app/api/webhook/stripe/route.ts
+++ b/frontend/app/api/webhook/stripe/route.ts
@@ -59,17 +59,17 @@ async function addOveragePricesToSubscription(subscription: Stripe.Subscription)
   // Check if overage items already exist (idempotency – e.g. if the webhook is retried)
   const existingLookupKeys = new Set(freshSubscription.items.data.map((item) => item.price.lookup_key));
   if (
-    existingLookupKeys.has(tierConfig.overageBytesLookupKey) &&
+    existingLookupKeys.has(tierConfig.overageMegabytesLookupKey) &&
     existingLookupKeys.has(tierConfig.overageSignalRunsLookupKey)
   ) {
     return;
   }
 
   const overagePrices = await s.prices.list({
-    lookup_keys: [tierConfig.overageBytesLookupKey, tierConfig.overageSignalRunsLookupKey],
+    lookup_keys: [tierConfig.overageMegabytesLookupKey, tierConfig.overageSignalRunsLookupKey],
   });
 
-  const bytesOveragePrice = overagePrices.data.find((p) => p.lookup_key === tierConfig.overageBytesLookupKey);
+  const bytesOveragePrice = overagePrices.data.find((p) => p.lookup_key === tierConfig.overageMegabytesLookupKey);
   const signalRunsOveragePrice = overagePrices.data.find((p) => p.lookup_key === tierConfig.overageSignalRunsLookupKey);
 
   if (!bytesOveragePrice || !signalRunsOveragePrice) {
@@ -78,7 +78,7 @@ async function addOveragePricesToSubscription(subscription: Stripe.Subscription)
   }
 
   const items: Stripe.SubscriptionUpdateParams.Item[] = [];
-  if (!existingLookupKeys.has(tierConfig.overageBytesLookupKey)) {
+  if (!existingLookupKeys.has(tierConfig.overageMegabytesLookupKey)) {
     items.push({ price: bytesOveragePrice.id });
   }
   if (!existingLookupKeys.has(tierConfig.overageSignalRunsLookupKey)) {
@@ -133,36 +133,8 @@ export async function POST(req: NextRequest): Promise<Response> {
     }
     case "invoice.finalized": {
       const invoice = event.data.object;
+      await handleInvoiceFinalized(invoice);
 
-      if (invoice.parent?.type !== "subscription_details") break;
-
-      // Filter: must contain a line for a known tier or overage price.
-      // This excludes addon-only invoices and other unrelated invoices.
-      const knownLookupKeys = new Set<string>(
-        Object.values(TIER_CONFIG).flatMap((c) => [c.lookupKey, c.overageBytesLookupKey, c.overageSignalRunsLookupKey])
-      );
-      const hasRelevantLine = invoice.lines.data.some((line) => {
-        const priceObj = (line as any).price ?? line.pricing?.price_details?.price;
-        const lookupKey = typeof priceObj === "object" && priceObj ? priceObj.lookup_key : null;
-        return lookupKey && knownLookupKeys.has(lookupKey);
-      });
-      if (!hasRelevantLine) break;
-
-      const workspaceId = invoice.metadata?.workspaceId ?? invoice.parent.subscription_details?.metadata?.workspaceId;
-      if (!workspaceId) {
-        console.log("invoice.finalized: no workspaceId in subscription metadata");
-        break;
-      }
-
-      // Use the period.start of the first subscription item line as the new resetTime
-      const subscriptionLine = invoice.lines.data.find((l) => l.parent?.type === "subscription_item_details");
-      const newResetTime = subscriptionLine?.period?.start;
-      if (!newResetTime) {
-        console.log("invoice.finalized: no subscription line period start found");
-        break;
-      }
-
-      await handleInvoiceFinalized(workspaceId, newResetTime);
       break;
     }
     case "customer.subscription.deleted":

--- a/frontend/lib/actions/checkout/index.ts
+++ b/frontend/lib/actions/checkout/index.ts
@@ -224,13 +224,13 @@ export const switchTier = async (input: z.infer<typeof SwitchTierSchema>): Promi
   const newPrices = await s.prices.list({
     lookup_keys: [
       newTierConfig.lookupKey,
-      newTierConfig.overageBytesLookupKey,
+      newTierConfig.overageMegabytesLookupKey,
       newTierConfig.overageSignalRunsLookupKey,
     ],
   });
 
   const newFlatPrice = newPrices.data.find((p) => p.lookup_key === newTierConfig.lookupKey);
-  const newBytesOveragePrice = newPrices.data.find((p) => p.lookup_key === newTierConfig.overageBytesLookupKey);
+  const newBytesOveragePrice = newPrices.data.find((p) => p.lookup_key === newTierConfig.overageMegabytesLookupKey);
   const newSignalRunsOveragePrice = newPrices.data.find(
     (p) => p.lookup_key === newTierConfig.overageSignalRunsLookupKey
   );

--- a/frontend/lib/actions/checkout/index.ts
+++ b/frontend/lib/actions/checkout/index.ts
@@ -6,14 +6,12 @@ import { z } from "zod/v4";
 
 import { stripe } from "@/lib/actions/checkout/stripe";
 import { deleteAllProjectsWorkspaceInfoFromCache } from "@/lib/actions/project";
-import { getWorkspaceUsage } from "@/lib/actions/workspace";
 import { checkUserWorkspaceRole } from "@/lib/actions/workspace/utils";
 import { db } from "@/lib/db/drizzle";
 import { subscriptionTiers, workspaces } from "@/lib/db/migrations/schema";
 
 import {
   type CancellationReason,
-  METER_EVENT_NAMES,
   type PaidTier,
   type SubscriptionDetails,
   TIER_CONFIG,
@@ -212,14 +210,7 @@ export const switchTier = async (input: z.infer<typeof SwitchTierSchema>): Promi
   const newTierConfig = TIER_CONFIG[newTier];
   const s = stripe();
 
-  const usage = await getWorkspaceUsage(workspaceId);
-
-  const newBytesOverage = Math.max(0, usage.totalBytesIngested - newTierConfig.includedBytes);
-  const newSignalRunsOverage = Math.max(0, usage.totalSignalRuns - newTierConfig.includedSignalRuns);
-
   const subscription = await s.subscriptions.retrieve(workspace[0].subscriptionId);
-
-  const stripeCustomerId = typeof subscription.customer === "string" ? subscription.customer : subscription.customer.id;
 
   const newPrices = await s.prices.list({
     lookup_keys: [
@@ -266,27 +257,6 @@ export const switchTier = async (input: z.infer<typeof SwitchTierSchema>): Promi
     ],
     proration_behavior: "always_invoice",
   });
-
-  const timestamp = Math.floor(Date.now() / 1000);
-
-  await Promise.all([
-    s.billing.meterEvents.create({
-      event_name: METER_EVENT_NAMES.overageBytes.eventName,
-      timestamp,
-      payload: {
-        stripe_customer_id: stripeCustomerId,
-        [METER_EVENT_NAMES.overageBytes.payloadKey]: String(newBytesOverage),
-      },
-    }),
-    s.billing.meterEvents.create({
-      event_name: METER_EVENT_NAMES.overageSignalRuns.eventName,
-      timestamp,
-      payload: {
-        stripe_customer_id: stripeCustomerId,
-        [METER_EVENT_NAMES.overageSignalRuns.payloadKey]: String(newSignalRunsOverage),
-      },
-    }),
-  ]);
 
   await deleteAllProjectsWorkspaceInfoFromCache(workspaceId);
 };

--- a/frontend/lib/actions/checkout/types.ts
+++ b/frontend/lib/actions/checkout/types.ts
@@ -3,15 +3,15 @@ import type Stripe from "stripe";
 export const TIER_CONFIG = {
   hobby: {
     lookupKey: "hobby_monthly_2026_02",
-    overageBytesLookupKey: "hobby_monthly_2026_02_overage_bytes",
-    overageSignalRunsLookupKey: "hobby_monthly_2026_02_overage_signal_runs",
+    overageMegabytesLookupKey: "hobby_monthly_2026_03_overage_megabytes",
+    overageSignalRunsLookupKey: "hobby_monthly_2026_03_overage_signal_runs",
     includedBytes: 3 * 1024 ** 3,
     includedSignalRuns: 1_000,
   },
   pro: {
     lookupKey: "pro_monthly_2026_02",
-    overageBytesLookupKey: "pro_monthly_2026_02_overage_bytes",
-    overageSignalRunsLookupKey: "pro_monthly_2026_02_overage_signal_runs",
+    overageMegabytesLookupKey: "pro_monthly_2026_03_overage_megabytes",
+    overageSignalRunsLookupKey: "pro_monthly_2026_03_overage_signal_runs",
     includedBytes: 10 * 1024 ** 3,
     includedSignalRuns: 10_000,
   },
@@ -46,11 +46,11 @@ export const ADDON_CONFIG: Record<
 
 export const METER_EVENT_NAMES = {
   overageBytes: {
-    eventName: "2026_02_overage_bytes",
+    eventName: "2026_03_overage_megabytes",
     payloadKey: "bytes",
   },
   overageSignalRuns: {
-    eventName: "2026_02_overage_signal_runs",
+    eventName: "2026_03_overage_signal_runs",
     payloadKey: "signal_runs",
   },
 } as const;
@@ -72,17 +72,29 @@ export const LOOKUP_KEY_DISPLAY_NAMES: Record<string, string> = {
   hobby_monthly_2026_02_legacy: "Hobby plan",
   pro_monthly_2025_04: "Pro plan",
   // Overage - bytes
+  hobby_monthly_2026_03_overage_megabytes: "Data overage",
+  pro_monthly_2026_03_overage_megabytes: "Data overage",
   hobby_monthly_2026_02_overage_bytes: "Data overage",
   pro_monthly_2026_02_overage_bytes: "Data overage",
   hobby_monthly_2025_04_overage_bytes: "Data overage",
   pro_monthly_2025_04_overage_bytes: "Data overage",
   // Overage - signal runs
+  hobby_monthly_2026_03_overage_signal_runs: "Signal runs overage",
+  pro_monthly_2026_03_overage_signal_runs: "Signal runs overage",
   hobby_monthly_2026_02_overage_signal_runs: "Signal runs overage",
   pro_monthly_2026_02_overage_signal_runs: "Signal runs overage",
   hobby_monthly_2025_04_overage_signal_runs: "Signal runs overage",
   pro_monthly_2025_04_overage_signal_runs: "Signal runs overage",
   // Addons
   [DATAPLANE_ADDON_LOOKUP_KEY]: "Data Plane addon",
+};
+
+export const USAGE_BASED_LOOKUP_KEY_TO_AGG_METER_NAME: Record<string, string> = {
+  hobby_monthly_2026_03_overage_megabytes: "2026_03_overage_megabytes",
+  pro_monthly_2026_03_overage_megabytes: "2026_03_overage_megabytes",
+
+  hobby_monthly_2026_03_overage_signal_runs: "2026_03_overage_signal_runs",
+  pro_monthly_2026_03_overage_signal_runs: "2026_03_overage_signal_runs",
 };
 
 export interface ItemDescription {

--- a/frontend/lib/actions/checkout/types.ts
+++ b/frontend/lib/actions/checkout/types.ts
@@ -44,17 +44,6 @@ export const ADDON_CONFIG: Record<
   },
 };
 
-export const METER_EVENT_NAMES = {
-  overageBytes: {
-    eventName: "2026_03_overage_megabytes",
-    payloadKey: "megabytes",
-  },
-  overageSignalRuns: {
-    eventName: "2026_03_overage_signal_runs",
-    payloadKey: "signal_runs",
-  },
-} as const;
-
 export const LOOKUP_KEY_TO_TIER_NAME: Record<string, string> = {
   hobby_monthly_2026_02: "Laminar Hobby tier",
   hobby_monthly_2026_02_legacy: "Laminar Hobby tier",

--- a/frontend/lib/actions/checkout/types.ts
+++ b/frontend/lib/actions/checkout/types.ts
@@ -47,7 +47,7 @@ export const ADDON_CONFIG: Record<
 export const METER_EVENT_NAMES = {
   overageBytes: {
     eventName: "2026_03_overage_megabytes",
-    payloadKey: "bytes",
+    payloadKey: "megabytes",
   },
   overageSignalRuns: {
     eventName: "2026_03_overage_signal_runs",

--- a/frontend/lib/actions/checkout/webhook.ts
+++ b/frontend/lib/actions/checkout/webhook.ts
@@ -29,7 +29,7 @@ export async function getUserSubscriptionInfo(
   return existingStripeCustomers.length > 0 ? existingStripeCustomers[0].user_subscription_info : undefined;
 }
 
-export const manageWorkspaceSubscriptionEvent = async ({
+const manageWorkspaceSubscriptionEvent = async ({
   stripeCustomerId,
   productId,
   subscriptionId,
@@ -96,6 +96,59 @@ type SubscriptionEvent =
   | Stripe.CustomerSubscriptionDeletedEvent
   | Stripe.CustomerSubscriptionCreatedEvent;
 
+const adjustMeterAllowances = async (
+  items: Stripe.SubscriptionItem[],
+  customer: string | Stripe.Customer | Stripe.DeletedCustomer | null,
+  workspaceId: string | undefined,
+  multiplier: 1 | -1
+) => {
+  if (!customer || !workspaceId) return;
+  const customerId = typeof customer === "string" ? customer : customer.id;
+
+  const s = stripe();
+
+  for (const item of items) {
+    const lookupKey = item.price?.lookup_key;
+    if (!lookupKey) continue;
+    const meterEventName = USAGE_BASED_LOOKUP_KEY_TO_AGG_METER_NAME[lookupKey];
+    if (!meterEventName) continue;
+
+    let includedAmount = 0;
+    let cacheKey = null;
+    let payloadKey = "megabytes";
+
+    for (const tier of Object.values(TIER_CONFIG)) {
+      if (tier.overageMegabytesLookupKey === lookupKey) {
+        includedAmount = tier.includedBytes / 1024 / 1024;
+        cacheKey = `${WORKSPACE_BYTES_USAGE_CACHE_KEY}:${workspaceId}`;
+        payloadKey = "megabytes";
+        break;
+      }
+      if (tier.overageSignalRunsLookupKey === lookupKey) {
+        includedAmount = tier.includedSignalRuns;
+        cacheKey = `${WORKSPACE_SIGNAL_RUNS_USAGE_CACHE_KEY}:${workspaceId}`;
+        payloadKey = "signal_runs";
+        break;
+      }
+    }
+
+    if (includedAmount > 0) {
+      await s.v2.billing.meterEvents.create({
+        event_name: meterEventName,
+        payload: {
+          stripe_customer_id: customerId,
+          [payloadKey]: String(includedAmount * multiplier),
+        },
+        identifier: `allowance-adj-${payloadKey}-${workspaceId}-${Date.now()}-${Math.random().toString(36).substring(7)}`,
+      });
+
+      if (cacheKey) {
+        await cache.remove(cacheKey);
+      }
+    }
+  }
+};
+
 export const handleSubscriptionChange = async (event: SubscriptionEvent, cancel: boolean = false) => {
   const subscription = event.data.object;
   const status = subscription.status;
@@ -106,6 +159,21 @@ export const handleSubscriptionChange = async (event: SubscriptionEvent, cancel:
     console.log(`Subscription ${subscription.id} status changed to`, status);
     return;
   }
+
+  if (event.type === "customer.subscription.created") {
+    await adjustMeterAllowances(subscription.items.data, subscription.customer, subscription.metadata?.workspaceId, -1);
+  } else if (event.type === "customer.subscription.updated") {
+    const previousAttributes = event.data.previous_attributes;
+    if (previousAttributes?.items?.data) {
+      const oldItems = previousAttributes.items.data;
+      const newItems = subscription.items.data;
+      await adjustMeterAllowances(oldItems, subscription.customer, subscription.metadata?.workspaceId, 1);
+      await adjustMeterAllowances(newItems, subscription.customer, subscription.metadata?.workspaceId, -1);
+    }
+  } else if (event.type === "customer.subscription.deleted" || cancel) {
+    await adjustMeterAllowances(subscription.items.data, subscription.customer, subscription.metadata?.workspaceId, 1);
+  }
+
   // A tier switch is performed in two separate Stripe update calls, so this handler may fire
   // in an intermediate state (e.g. old flat price + new metered items). Only use non-metered
   // items for tier resolution: metered overage prices are on different products that have no
@@ -240,19 +308,16 @@ export const handleInvoiceFinalized = async (invoice: Stripe.Invoice) => {
     const meterEventName = USAGE_BASED_LOOKUP_KEY_TO_AGG_METER_NAME[lookupKey];
     if (!meterEventName) continue;
 
-    let includedAmount = 0;
     let cacheKey = null;
     let payloadKey = "megabytes";
 
     for (const tier of Object.values(TIER_CONFIG)) {
       if (tier.overageMegabytesLookupKey === lookupKey) {
-        includedAmount = tier.includedBytes / 1024 / 1024;
         cacheKey = `${WORKSPACE_BYTES_USAGE_CACHE_KEY}:${workspaceId}`;
         payloadKey = "megabytes";
         break;
       }
       if (tier.overageSignalRunsLookupKey === lookupKey) {
-        includedAmount = tier.includedSignalRuns;
         cacheKey = `${WORKSPACE_SIGNAL_RUNS_USAGE_CACHE_KEY}:${workspaceId}`;
         payloadKey = "signal_runs";
         break;
@@ -260,7 +325,7 @@ export const handleInvoiceFinalized = async (invoice: Stripe.Invoice) => {
     }
 
     const quantity = line.quantity ?? 0;
-    const negativeUsage = -(quantity + includedAmount);
+    const negativeUsage = -quantity;
 
     await s.v2.billing.meterEvents.create({
       event_name: meterEventName,

--- a/frontend/lib/actions/checkout/webhook.ts
+++ b/frontend/lib/actions/checkout/webhook.ts
@@ -333,7 +333,7 @@ export const handleInvoiceFinalized = async (invoice: Stripe.Invoice) => {
         stripe_customer_id: customerId,
         [payloadKey]: String(negativeUsage),
       },
-      identifier: `monthly-reset-${payloadKey}-${workspaceId}-${new Date().toISOString().split("T")[0]}`,
+      identifier: `monthly-reset-${payloadKey}-${invoice.id}-${workspaceId}-${new Date().toISOString().split("T")[0]}`,
     });
 
     if (cacheKey) {

--- a/frontend/lib/actions/checkout/webhook.ts
+++ b/frontend/lib/actions/checkout/webhook.ts
@@ -6,7 +6,8 @@ import { cache, WORKSPACE_BYTES_USAGE_CACHE_KEY, WORKSPACE_SIGNAL_RUNS_USAGE_CAC
 import { db } from "@/lib/db/drizzle";
 import { users, userSubscriptionInfo, workspaceAddons, workspaces } from "@/lib/db/migrations/schema";
 
-import { DATAPLANE_ADDON_LOOKUP_KEY } from "./types";
+import { stripe } from "./stripe";
+import { DATAPLANE_ADDON_LOOKUP_KEY, TIER_CONFIG, USAGE_BASED_LOOKUP_KEY_TO_AGG_METER_NAME } from "./types";
 
 interface ManageWorkspaceSubscriptionEventArgs {
   stripeCustomerId: string;
@@ -56,7 +57,7 @@ export const manageWorkspaceSubscriptionEvent = async ({
     .set({
       subscriptionId,
       tierId: sql`CASE
-      WHEN ${cancel ?? false} THEN 1 
+      WHEN ${cancel ?? false} THEN 1
       ELSE (
         SELECT id
         FROM subscription_tiers
@@ -67,7 +68,7 @@ export const manageWorkspaceSubscriptionEvent = async ({
       // - the workspace is on the free tier
       // - the update is not a cancellation
       // - the webhook event contains actual tier change
-      ...(currentTier === "free" ? { resetTime: sql`now()` } : {}),
+      ...(currentTier === "free" ? { lastUsageCalculationTime: sql`now()` } : {}),
     })
     .where(eq(workspaces.id, workspaceId));
 
@@ -197,11 +198,83 @@ export const handleSubscriptionChange = async (event: SubscriptionEvent, cancel:
   }
 };
 
-export const handleInvoiceFinalized = async (workspaceId: string, periodStart: number) => {
-  await cache.remove(`${WORKSPACE_BYTES_USAGE_CACHE_KEY}:${workspaceId}`);
-  await cache.remove(`${WORKSPACE_SIGNAL_RUNS_USAGE_CACHE_KEY}:${workspaceId}`);
+export const handleInvoiceFinalized = async (invoice: Stripe.Invoice) => {
+  if (invoice.parent?.type !== "subscription_details") return;
+
+  const overageLookupKeys = new Set(Object.keys(USAGE_BASED_LOOKUP_KEY_TO_AGG_METER_NAME));
+  const matchingLines = invoice.lines.data.filter((line) => {
+    const priceObj = (line as any).price ?? line.pricing?.price_details?.price;
+    const lookupKey = typeof priceObj === "object" && priceObj ? priceObj.lookup_key : null;
+    return lookupKey && overageLookupKeys.has(lookupKey);
+  });
+
+  if (matchingLines.length === 0) return;
+
+  const workspaceId = invoice.metadata?.workspaceId ?? invoice.parent.subscription_details?.metadata?.workspaceId;
+  if (!workspaceId) {
+    console.log("invoice.finalized: no workspaceId in subscription metadata");
+    return;
+  }
+
+  const endTimes = matchingLines.map((line) => (line.period?.end ? line.period.end * 1000 : Date.now()));
+  endTimes.push(Date.now());
+  const minEndTime = Math.min(...endTimes);
+
+  await db
+    .update(workspaces)
+    .set({ lastUsageCalculationTime: new Date(minEndTime).toISOString() })
+    .where(eq(workspaces.id, workspaceId));
+
+  const s = stripe();
+  const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer?.id;
+
+  if (!customerId) {
+    console.log("invoice.finalized: no customer id found");
+    return;
+  }
+
+  for (const line of matchingLines) {
+    const priceObj = (line as any).price ?? line.pricing?.price_details?.price;
+    const lookupKey = typeof priceObj === "object" && priceObj ? priceObj.lookup_key : null;
+    if (!lookupKey) continue;
+    const meterEventName = USAGE_BASED_LOOKUP_KEY_TO_AGG_METER_NAME[lookupKey];
+    if (!meterEventName) continue;
+
+    let includedAmount = 0;
+    let cacheKey = null;
+    let payloadKey = "megabytes";
+
+    for (const tier of Object.values(TIER_CONFIG)) {
+      if (tier.overageMegabytesLookupKey === lookupKey) {
+        includedAmount = tier.includedBytes / 1024 / 1024;
+        cacheKey = `${WORKSPACE_BYTES_USAGE_CACHE_KEY}:${workspaceId}`;
+        payloadKey = "megabytes";
+        break;
+      }
+      if (tier.overageSignalRunsLookupKey === lookupKey) {
+        includedAmount = tier.includedSignalRuns;
+        cacheKey = `${WORKSPACE_SIGNAL_RUNS_USAGE_CACHE_KEY}:${workspaceId}`;
+        payloadKey = "signal_runs";
+        break;
+      }
+    }
+
+    const quantity = line.quantity ?? 0;
+    const negativeUsage = -(quantity + includedAmount);
+
+    await s.v2.billing.meterEvents.create({
+      event_name: meterEventName,
+      payload: {
+        stripe_customer_id: customerId,
+        [payloadKey]: String(negativeUsage),
+      },
+      identifier: `monthly-reset-${payloadKey}-${workspaceId}-${new Date().toISOString().split("T")[0]}`,
+    });
+
+    if (cacheKey) {
+      await cache.remove(cacheKey);
+    }
+  }
+
   await deleteAllProjectsWorkspaceInfoFromCache(workspaceId);
-  console.log(
-    `Billing cycle reset for workspace ${workspaceId}, new period start: ${new Date(periodStart * 1000).toISOString()}`
-  );
 };

--- a/frontend/lib/db/migrations/0075_shiny_silhouette.sql
+++ b/frontend/lib/db/migrations/0075_shiny_silhouette.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "traces" ADD CONSTRAINT "traces_pkey" PRIMARY KEY("id","project_id");--> statement-breakpoint
+ALTER TABLE "workspaces" ADD COLUMN "last_usage_calculation_time" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "traces" ADD CONSTRAINT "traces_project_id_id_unique" UNIQUE("id","project_id");--> statement-breakpoint

--- a/frontend/lib/db/migrations/meta/0075_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0075_snapshot.json
@@ -1,0 +1,4227 @@
+{
+  "id": "1e4ad556-57d0-4a6b-af3f-d576b64db14e",
+  "prevId": "0b94e105-b55c-4ce4-9dcc-b0516459900a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_chats": {
+      "name": "agent_chats",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_name": {
+          "name": "chat_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_status": {
+          "name": "machine_status",
+          "type": "agent_machine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agent_status": {
+          "name": "agent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        }
+      },
+      "indexes": {
+        "agent_chats_created_at_idx": {
+          "name": "agent_chats_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_updated_at_idx": {
+          "name": "agent_chats_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_user_id_idx": {
+          "name": "agent_chats_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chats_session_id_fkey": {
+          "name": "agent_chats_session_id_fkey",
+          "tableFrom": "agent_chats",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "agent_chats_user_id_fkey": {
+          "name": "agent_chats_user_id_fkey",
+          "tableFrom": "agent_chats",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_messages": {
+      "name": "agent_messages",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "agent_message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_messages_session_id_created_at_idx": {
+          "name": "agent_messages_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_messages_session_id_fkey": {
+          "name": "agent_messages_session_id_fkey",
+          "tableFrom": "agent_messages",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cdp_url": {
+          "name": "cdp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vnc_url": {
+          "name": "vnc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agent_status": {
+          "name": "agent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        }
+      },
+      "indexes": {
+        "agent_sessions_created_at_idx": {
+          "name": "agent_sessions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_updated_at_idx": {
+          "name": "agent_sessions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_targets": {
+      "name": "alert_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_targets_alert_id_fkey": {
+          "name": "alert_targets_alert_id_fkey",
+          "tableFrom": "alert_targets",
+          "tableTo": "alerts",
+          "columnsFrom": ["alert_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_targets_project_id_fkey": {
+          "name": "alert_targets_project_id_fkey",
+          "tableFrom": "alert_targets",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alerts_project_id_fkey": {
+          "name": "alerts_project_id_fkey",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "level": {
+          "name": "level",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_children_clusters": {
+          "name": "num_children_clusters",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_traces": {
+          "name": "num_traces",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clusters_project_id_level_idx": {
+          "name": "clusters_project_id_level_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int8_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clusters_project_id_name_idx": {
+          "name": "clusters_project_id_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clusters_project_id_fkey": {
+          "name": "clusters_project_id_fkey",
+          "tableFrom": "clusters",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "clusters_pkey": {
+          "name": "clusters_pkey",
+          "columns": ["id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_model_costs": {
+      "name": "custom_model_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costs": {
+          "name": "costs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_model_costs_project_id_fkey": {
+          "name": "custom_model_costs_project_id_fkey",
+          "tableFrom": "custom_model_costs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_model_costs_project_id_provider_model_unique": {
+          "name": "custom_model_costs_project_id_provider_model_unique",
+          "nullsNotDistinct": false,
+          "columns": ["project_id", "provider", "model"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_charts": {
+      "name": "dashboard_charts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_charts_project_id_fkey": {
+          "name": "dashboard_charts_project_id_fkey",
+          "tableFrom": "dashboard_charts",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_export_jobs": {
+      "name": "dataset_export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dataset_export_jobs_dataset_id_fkey": {
+          "name": "dataset_export_jobs_dataset_id_fkey",
+          "tableFrom": "dataset_export_jobs",
+          "tableTo": "datasets",
+          "columnsFrom": ["dataset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_export_jobs_project_id_fkey": {
+          "name": "dataset_export_jobs_project_id_fkey",
+          "tableFrom": "dataset_export_jobs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dataset_export_jobs_project_dataset_key": {
+          "name": "dataset_export_jobs_project_dataset_key",
+          "nullsNotDistinct": false,
+          "columns": ["dataset_id", "project_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_parquets": {
+      "name": "dataset_parquets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parquet_path": {
+          "name": "parquet_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dataset_parquets_dataset_id_fkey": {
+          "name": "dataset_parquets_dataset_id_fkey",
+          "tableFrom": "dataset_parquets",
+          "tableTo": "datasets",
+          "columnsFrom": ["dataset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_parquets_project_id_fkey": {
+          "name": "dataset_parquets_project_id_fkey",
+          "tableFrom": "dataset_parquets",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "indexed_on": {
+          "name": "indexed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "datasets_project_id_hash_idx": {
+          "name": "datasets_project_id_hash_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_project_id_fkey": {
+          "name": "datasets_project_id_fkey",
+          "tableFrom": "datasets",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "executor_output": {
+          "name": "executor_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_in_batch": {
+          "name": "index_in_batch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "evaluation_results_evaluation_id_idx": {
+          "name": "evaluation_results_evaluation_id_idx",
+          "columns": [
+            {
+              "expression": "evaluation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_evaluation_id_fkey": {
+          "name": "evaluation_results_evaluation_id_fkey",
+          "tableFrom": "evaluation_results",
+          "tableTo": "evaluations",
+          "columnsFrom": ["evaluation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluations": {
+      "name": "evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "evaluations_project_id_hash_idx": {
+          "name": "evaluations_project_id_hash_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluations_project_id_fkey": {
+          "name": "evaluations_project_id_fkey",
+          "tableFrom": "evaluations",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluator_scores": {
+      "name": "evaluator_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evaluator_id": {
+          "name": "evaluator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluator_scores_project_id_fkey": {
+          "name": "evaluator_scores_project_id_fkey",
+          "tableFrom": "evaluator_scores",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluator_span_paths": {
+      "name": "evaluator_span_paths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evaluator_id": {
+          "name": "evaluator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_path": {
+          "name": "span_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluator_span_paths_evaluator_id_fkey": {
+          "name": "evaluator_span_paths_evaluator_id_fkey",
+          "tableFrom": "evaluator_span_paths",
+          "tableTo": "evaluators",
+          "columnsFrom": ["evaluator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluator_span_paths_project_id_fkey": {
+          "name": "evaluator_span_paths_project_id_fkey",
+          "tableFrom": "evaluator_span_paths",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluators": {
+      "name": "evaluators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluator_type": {
+          "name": "evaluator_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluators_project_id_fkey": {
+          "name": "evaluators_project_id_fkey",
+          "tableFrom": "evaluators",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_cluster_configs": {
+      "name": "event_cluster_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_template": {
+          "name": "value_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_source": {
+          "name": "event_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_cluster_configs_project_id_fkey": {
+          "name": "event_cluster_configs_project_id_fkey",
+          "tableFrom": "event_cluster_configs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_cluster_configs_project_id_event_name_source_key": {
+          "name": "event_cluster_configs_project_id_event_name_source_key",
+          "nullsNotDistinct": false,
+          "columns": ["event_name", "project_id", "event_source"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_clusters": {
+      "name": "event_clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_children_clusters": {
+          "name": "num_children_clusters",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_events": {
+          "name": "num_events",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_source": {
+          "name": "event_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SEMANTIC'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_clusters_project_id_fkey": {
+          "name": "event_clusters_project_id_fkey",
+          "tableFrom": "event_clusters",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_definitions": {
+      "name": "event_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_semantic": {
+          "name": "is_semantic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "structured_output": {
+          "name": "structured_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_definitions_project_id_fkey": {
+          "name": "event_definitions_project_id_fkey",
+          "tableFrom": "event_definitions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_definitions_project_id_name_key": {
+          "name": "event_definitions_project_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": ["name", "project_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "events_span_id_idx": {
+          "name": "events_span_id_idx",
+          "columns": [
+            {
+              "expression": "span_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_span_id_project_id_idx": {
+          "name": "events_span_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "span_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeling_queue_items": {
+      "name": "labeling_queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "labeling_queue_items_queue_id_idempotency_key_idx": {
+          "name": "labeling_queue_items_queue_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "queue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(idempotency_key IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labelling_queue_items_queue_id_fkey": {
+          "name": "labelling_queue_items_queue_id_fkey",
+          "tableFrom": "labeling_queue_items",
+          "tableTo": "labeling_queues",
+          "columnsFrom": ["queue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeling_queues": {
+      "name": "labeling_queues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotation_schema": {
+          "name": "annotation_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labeling_queues_project_id_fkey": {
+          "name": "labeling_queues_project_id_fkey",
+          "tableFrom": "labeling_queues",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_prices": {
+      "name": "llm_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_price_per_million": {
+          "name": "input_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_price_per_million": {
+          "name": "output_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_cached_price_per_million": {
+          "name": "input_cached_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_prices": {
+          "name": "additional_prices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members_of_workspaces": {
+      "name": "members_of_workspaces",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_role": {
+          "name": "member_role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        }
+      },
+      "indexes": {
+        "members_of_workspaces_user_id_idx": {
+          "name": "members_of_workspaces_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_of_workspaces_user_id_fkey": {
+          "name": "members_of_workspaces_user_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "members_of_workspaces_workspace_id_fkey": {
+          "name": "members_of_workspaces_workspace_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_of_workspaces_user_workspace_unique": {
+          "name": "members_of_workspaces_user_workspace_unique",
+          "nullsNotDistinct": false,
+          "columns": ["workspace_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_costs": {
+      "name": "model_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costs": {
+          "name": "costs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_costs_model_unique": {
+          "name": "model_costs_model_unique",
+          "nullsNotDistinct": false,
+          "columns": ["model"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playgrounds": {
+      "name": "playgrounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_messages": {
+          "name": "prompt_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[{\"role\":\"user\",\"content\":\"\"}]'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1024
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1'"
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playgrounds_project_id_fkey": {
+          "name": "playgrounds_project_id_fkey",
+          "tableFrom": "playgrounds",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_api_keys": {
+      "name": "project_api_keys",
+      "schema": "",
+      "columns": {
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shorthand": {
+          "name": "shorthand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_ingest_only": {
+          "name": "is_ingest_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "project_api_keys_hash_idx": {
+          "name": "project_api_keys_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_project_api_keys_project_id_fkey": {
+          "name": "public_project_api_keys_project_id_fkey",
+          "tableFrom": "project_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_settings": {
+      "name": "project_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_settings_project_id_fkey": {
+          "name": "project_settings_project_id_fkey",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_workspace_id_idx": {
+          "name": "projects_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_fkey": {
+          "name": "projects_workspace_id_fkey",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_api_keys": {
+      "name": "provider_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hex": {
+          "name": "nonce_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_api_keys_project_id_fkey": {
+          "name": "provider_api_keys_project_id_fkey",
+          "tableFrom": "provider_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_templates": {
+      "name": "render_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "render_templates_project_id_fkey": {
+          "name": "render_templates_project_id_fkey",
+          "tableFrom": "render_templates",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_targets": {
+      "name": "report_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "report_targets_workspace_id_fkey": {
+          "name": "report_targets_workspace_id_fkey",
+          "tableFrom": "report_targets",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_targets_report_id_fkey": {
+          "name": "report_targets_report_id_fkey",
+          "tableFrom": "report_targets",
+          "tableTo": "reports",
+          "columnsFrom": ["report_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "weekdays": {
+          "name": "weekdays",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_workspace_id_fkey": {
+          "name": "reports_workspace_id_fkey",
+          "tableFrom": "reports",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollout_sessions": {
+      "name": "rollout_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollout_sessions_project_id_fkey": {
+          "name": "rollout_sessions_project_id_fkey",
+          "tableFrom": "rollout_sessions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.semantic_event_definitions": {
+      "name": "semantic_event_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structured_output_schema": {
+          "name": "structured_output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "semantic_event_definitions_project_id_fkey": {
+          "name": "semantic_event_definitions_project_id_fkey",
+          "tableFrom": "semantic_event_definitions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "semantic_event_definitions_pkey": {
+          "name": "semantic_event_definitions_pkey",
+          "columns": ["id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "semantic_event_definitions_project_id_name_key": {
+          "name": "semantic_event_definitions_project_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": ["project_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.semantic_event_trigger_spans": {
+      "name": "semantic_event_trigger_spans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "span_name": {
+          "name": "span_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_definition_id": {
+          "name": "event_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "semantic_event_trigger_spans_event_definition_id_project_i_fkey": {
+          "name": "semantic_event_trigger_spans_event_definition_id_project_i_fkey",
+          "tableFrom": "semantic_event_trigger_spans",
+          "tableTo": "semantic_event_definitions",
+          "columnsFrom": ["project_id", "event_definition_id"],
+          "columnsTo": ["id", "project_id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "semantic_event_trigger_spans_pkey": {
+          "name": "semantic_event_trigger_spans_pkey",
+          "columns": ["id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "semantic_event_trigger_spans_project_event_definition_span_key": {
+          "name": "semantic_event_trigger_spans_project_event_definition_span_key",
+          "nullsNotDistinct": false,
+          "columns": ["project_id", "span_name", "event_definition_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_evals": {
+      "name": "shared_evals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shared_evals_project_id_fkey": {
+          "name": "shared_evals_project_id_fkey",
+          "tableFrom": "shared_evals",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_payloads": {
+      "name": "shared_payloads",
+      "schema": "",
+      "columns": {
+        "payload_id": {
+          "name": "payload_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shared_payloads_project_id_fkey": {
+          "name": "shared_payloads_project_id_fkey",
+          "tableFrom": "shared_payloads",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_traces": {
+      "name": "shared_traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shared_traces_project_id_fkey": {
+          "name": "shared_traces_project_id_fkey",
+          "tableFrom": "shared_traces",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_jobs": {
+      "name": "signal_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_traces": {
+          "name": "total_traces",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_traces": {
+          "name": "processed_traces",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_traces": {
+          "name": "failed_traces",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_triggers": {
+      "name": "signal_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "clustering_key": {
+          "name": "clustering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signals": {
+      "name": "signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structured_output_schema": {
+          "name": "structured_output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signals_project_id_name_key": {
+          "name": "signals_project_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": ["project_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_integrations": {
+      "name": "slack_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nonce_hex": {
+          "name": "nonce_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_integrations_workspace_id_fkey": {
+          "name": "slack_integrations_workspace_id_fkey",
+          "tableFrom": "slack_integrations",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_integrations_workspace_id_key": {
+          "name": "slack_integrations_workspace_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["workspace_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sql_templates": {
+      "name": "sql_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sql_templates_project_id_fkey": {
+          "name": "sql_templates_project_id_fkey",
+          "tableFrom": "sql_templates",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "subscription_tiers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_retention_days": {
+          "name": "log_retention_days",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes_ingested": {
+          "name": "bytes_ingested",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_byte_price": {
+          "name": "extra_byte_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "signal_runs": {
+          "name": "signal_runs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "extra_signal_run_price": {
+          "name": "extra_signal_run_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_classes": {
+      "name": "tag_classes",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rgb(190, 194, 200)'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tag_classes_project_id_fkey": {
+          "name": "tag_classes_project_id_fkey",
+          "tableFrom": "tag_classes",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tag_classes_pkey": {
+          "name": "tag_classes_pkey",
+          "columns": ["name", "project_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "label_classes_name_project_id_unique": {
+          "name": "label_classes_name_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name", "project_id"]
+        },
+        "tag_classes_name_project_id_unique": {
+          "name": "tag_classes_name_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name", "project_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traces": {
+      "name": "traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_token_count": {
+          "name": "total_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trace_type": {
+          "name": "trace_type",
+          "type": "trace_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "input_cost": {
+          "name": "input_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_cost": {
+          "name": "output_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "has_browser_session": {
+          "name": "has_browser_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_span_id": {
+          "name": "top_span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_spans": {
+          "name": "num_spans",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_span_name": {
+          "name": "top_span_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_span_type": {
+          "name": "top_span_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "span_names": {
+          "name": "span_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_span_input": {
+          "name": "root_span_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_span_output": {
+          "name": "root_span_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "traces_project_id_idx": {
+          "name": "traces_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_session_id_idx": {
+          "name": "traces_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_traces_project_id_fkey": {
+          "name": "new_traces_project_id_fkey",
+          "tableFrom": "traces",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "traces_pkey": {
+          "name": "traces_pkey",
+          "columns": ["id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "traces_project_id_id_unique": {
+          "name": "traces_project_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "project_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traces_agent_chats": {
+      "name": "traces_agent_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "traces_agent_chats_project_id_fkey": {
+          "name": "traces_agent_chats_project_id_fkey",
+          "tableFrom": "traces_agent_chats",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traces_agent_messages": {
+      "name": "traces_agent_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "traces_agent_messages_project_id_fkey": {
+          "name": "traces_agent_messages_project_id_fkey",
+          "tableFrom": "traces_agent_messages",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscription_info": {
+      "name": "user_subscription_info",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_subscription_info_stripe_customer_id_idx": {
+          "name": "user_subscription_info_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscription_info_fkey": {
+          "name": "user_subscription_info_fkey",
+          "tableFrom": "user_subscription_info",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_addons": {
+      "name": "workspace_addons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addon_slug": {
+          "name": "addon_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_addons_workspace_id_fkey": {
+          "name": "workspace_addons_workspace_id_fkey",
+          "tableFrom": "workspace_addons",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_deployments": {
+      "name": "workspace_deployments",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLOUD'"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_key_nonce": {
+          "name": "private_key_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_plane_url": {
+          "name": "data_plane_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_plane_url_nonce": {
+          "name": "data_plane_url_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_invitations_workspace_id_fkey": {
+          "name": "workspace_invitations_workspace_id_fkey",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_seats": {
+          "name": "additional_seats",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "reset_time": {
+          "name": "reset_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_usage_calculation_time": {
+          "name": "last_usage_calculation_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_tier_id_fkey": {
+          "name": "workspaces_tier_id_fkey",
+          "tableFrom": "workspaces",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": ["tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_machine_status": {
+      "name": "agent_machine_status",
+      "schema": "public",
+      "values": ["not_started", "running", "paused", "stopped"]
+    },
+    "public.agent_message_type": {
+      "name": "agent_message_type",
+      "schema": "public",
+      "values": ["user", "assistant", "step", "error"]
+    },
+    "public.span_type": {
+      "name": "span_type",
+      "schema": "public",
+      "values": [
+        "DEFAULT",
+        "LLM",
+        "PIPELINE",
+        "EXECUTOR",
+        "EVALUATOR",
+        "EVALUATION",
+        "TOOL",
+        "HUMAN_EVALUATOR",
+        "EVENT"
+      ]
+    },
+    "public.tag_source": {
+      "name": "tag_source",
+      "schema": "public",
+      "values": ["MANUAL", "AUTO", "CODE"]
+    },
+    "public.trace_type": {
+      "name": "trace_type",
+      "schema": "public",
+      "values": ["DEFAULT", "EVENT", "EVALUATION", "PLAYGROUND"]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": ["member", "owner", "admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1773418233295,
       "tag": "0074_normal_gertrude_yorkes",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1773918761685,
+      "tag": "0075_shiny_silhouette",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/db/migrations/relations.ts
+++ b/frontend/lib/db/migrations/relations.ts
@@ -1,197 +1,264 @@
 import { relations } from "drizzle-orm/relations";
 import {
-  datasets,
-  datasetParquets,
   projects,
-  agentSessions,
-  agentChats,
-  users,
-  signals,
-  userUsage,
-  tracesAgentMessages,
+  rolloutSessions,
+  sharedEvals,
   workspaces,
-  slackIntegrations,
-  evaluators,
-  evaluatorSpanPaths,
-  evaluatorScores,
-  workspaceInvitations,
+  workspaceAddons,
+  datasets,
+  users,
+  membersOfWorkspaces,
+  providerApiKeys,
+  alerts,
+  userSubscriptionInfo,
+  customModelCosts,
+  alertTargets,
+  reportTargets,
+  reports,
+  apiKeys,
   renderTemplates,
-  tracesAgentChats,
   labelingQueues,
   labelingQueueItems,
-  agentMessages,
-  summaryTriggerSpans,
-  sharedEvals,
-  apiKeys,
-  evaluationResults,
-  evaluationScores,
-  subscriptionTiers,
-  providerApiKeys,
-  userSubscriptionInfo,
-  sharedTraces,
-  datasetExportJobs,
-  customModelCosts,
-  reports,
-  tracesSummaries,
-  reportTargets,
-  alerts,
-  datasetDatapoints,
+  workspaceInvitations,
   evaluations,
-  projectApiKeys,
-  membersOfWorkspaces,
-  workspaceUsage,
-  alertTargets,
-  sqlTemplates,
-  eventClusterConfigs,
-  workspaceAddons,
-  playgrounds,
-  signalJobs,
-  eventDefinitions,
-  dashboardCharts,
+  evaluationResults,
+  evaluators,
+  evaluatorSpanPaths,
+  subscriptionTiers,
   sharedPayloads,
+  playgrounds,
+  evaluatorScores,
+  sqlTemplates,
+  dashboardCharts,
+  tracesAgentChats,
+  tracesAgentMessages,
+  sharedTraces,
   projectSettings,
+  eventDefinitions,
+  datasetExportJobs,
+  datasetParquets,
+  projectApiKeys,
+  slackIntegrations,
+  agentSessions,
+  agentChats,
+  agentMessages,
+  eventClusterConfigs,
   eventClusters,
-  rolloutSessions,
-  signalTriggers,
   tagClasses,
   semanticEventDefinitions,
   semanticEventTriggerSpans,
   clusters,
-  spans,
   traces,
 } from "./schema";
 
-export const datasetParquetsRelations = relations(datasetParquets, ({ one }) => ({
-  dataset: one(datasets, {
-    fields: [datasetParquets.datasetId],
-    references: [datasets.id],
-  }),
+export const rolloutSessionsRelations = relations(rolloutSessions, ({ one }) => ({
   project: one(projects, {
-    fields: [datasetParquets.projectId],
+    fields: [rolloutSessions.projectId],
     references: [projects.id],
   }),
-}));
-
-export const datasetsRelations = relations(datasets, ({ one, many }) => ({
-  datasetParquets: many(datasetParquets),
-  project: one(projects, {
-    fields: [datasets.projectId],
-    references: [projects.id],
-  }),
-  datasetExportJobs: many(datasetExportJobs),
-  datasetDatapoints: many(datasetDatapoints),
 }));
 
 export const projectsRelations = relations(projects, ({ one, many }) => ({
-  datasetParquets: many(datasetParquets),
-  signals: many(signals),
-  tracesAgentMessages: many(tracesAgentMessages),
-  evaluators: many(evaluators),
-  evaluatorSpanPaths: many(evaluatorSpanPaths),
-  evaluatorScores: many(evaluatorScores),
-  renderTemplates: many(renderTemplates),
-  tracesAgentChats: many(tracesAgentChats),
-  summaryTriggerSpans: many(summaryTriggerSpans),
+  rolloutSessions: many(rolloutSessions),
   sharedEvals: many(sharedEvals),
-  labelingQueues: many(labelingQueues),
   datasets: many(datasets),
   workspace: one(workspaces, {
     fields: [projects.workspaceId],
     references: [workspaces.id],
   }),
   providerApiKeys: many(providerApiKeys),
-  sharedTraces: many(sharedTraces),
-  datasetExportJobs: many(datasetExportJobs),
-  customModelCosts: many(customModelCosts),
-  tracesSummaries: many(tracesSummaries),
   alerts: many(alerts),
-  evaluations: many(evaluations),
-  projectApiKeys: many(projectApiKeys),
+  customModelCosts: many(customModelCosts),
   alertTargets: many(alertTargets),
-  sqlTemplates: many(sqlTemplates),
-  eventClusterConfigs: many(eventClusterConfigs),
-  playgrounds: many(playgrounds),
-  signalJobs: many(signalJobs),
-  eventDefinitions: many(eventDefinitions),
-  dashboardCharts: many(dashboardCharts),
+  renderTemplates: many(renderTemplates),
+  evaluators: many(evaluators),
+  evaluatorSpanPaths: many(evaluatorSpanPaths),
+  evaluations: many(evaluations),
   sharedPayloads: many(sharedPayloads),
+  playgrounds: many(playgrounds),
+  evaluatorScores: many(evaluatorScores),
+  sqlTemplates: many(sqlTemplates),
+  dashboardCharts: many(dashboardCharts),
+  labelingQueues: many(labelingQueues),
+  tracesAgentChats: many(tracesAgentChats),
+  tracesAgentMessages: many(tracesAgentMessages),
+  sharedTraces: many(sharedTraces),
   projectSettings: many(projectSettings),
+  eventDefinitions: many(eventDefinitions),
+  datasetExportJobs: many(datasetExportJobs),
+  datasetParquets: many(datasetParquets),
+  projectApiKeys: many(projectApiKeys),
+  eventClusterConfigs: many(eventClusterConfigs),
   eventClusters: many(eventClusters),
-  rolloutSessions: many(rolloutSessions),
-  signalTriggers: many(signalTriggers),
   tagClasses: many(tagClasses),
   semanticEventDefinitions: many(semanticEventDefinitions),
   clusters: many(clusters),
-  spans: many(spans),
   traces: many(traces),
 }));
 
-export const agentChatsRelations = relations(agentChats, ({ one }) => ({
-  agentSession: one(agentSessions, {
-    fields: [agentChats.sessionId],
-    references: [agentSessions.sessionId],
-  }),
-  user: one(users, {
-    fields: [agentChats.userId],
-    references: [users.id],
-  }),
-}));
-
-export const agentSessionsRelations = relations(agentSessions, ({ many }) => ({
-  agentChats: many(agentChats),
-  agentMessages: many(agentMessages),
-}));
-
-export const usersRelations = relations(users, ({ many }) => ({
-  agentChats: many(agentChats),
-  userUsages: many(userUsage),
-  apiKeys: many(apiKeys),
-  userSubscriptionInfos: many(userSubscriptionInfo),
-  membersOfWorkspaces: many(membersOfWorkspaces),
-}));
-
-export const signalsRelations = relations(signals, ({ one, many }) => ({
+export const sharedEvalsRelations = relations(sharedEvals, ({ one }) => ({
   project: one(projects, {
-    fields: [signals.projectId],
-    references: [projects.id],
-  }),
-  signalJobs: many(signalJobs),
-}));
-
-export const userUsageRelations = relations(userUsage, ({ one }) => ({
-  user: one(users, {
-    fields: [userUsage.userId],
-    references: [users.id],
-  }),
-}));
-
-export const tracesAgentMessagesRelations = relations(tracesAgentMessages, ({ one }) => ({
-  project: one(projects, {
-    fields: [tracesAgentMessages.projectId],
+    fields: [sharedEvals.projectId],
     references: [projects.id],
   }),
 }));
 
-export const slackIntegrationsRelations = relations(slackIntegrations, ({ one }) => ({
+export const workspaceAddonsRelations = relations(workspaceAddons, ({ one }) => ({
   workspace: one(workspaces, {
-    fields: [slackIntegrations.workspaceId],
+    fields: [workspaceAddons.workspaceId],
     references: [workspaces.id],
   }),
 }));
 
 export const workspacesRelations = relations(workspaces, ({ one, many }) => ({
-  slackIntegrations: many(slackIntegrations),
+  workspaceAddons: many(workspaceAddons),
+  projects: many(projects),
+  membersOfWorkspaces: many(membersOfWorkspaces),
+  reportTargets: many(reportTargets),
+  reports: many(reports),
   workspaceInvitations: many(workspaceInvitations),
   subscriptionTier: one(subscriptionTiers, {
     fields: [workspaces.tierId],
     references: [subscriptionTiers.id],
   }),
-  projects: many(projects),
-  reports: many(reports),
-  reportTargets: many(reportTargets),
+  slackIntegrations: many(slackIntegrations),
+}));
+
+export const datasetsRelations = relations(datasets, ({ one, many }) => ({
+  project: one(projects, {
+    fields: [datasets.projectId],
+    references: [projects.id],
+  }),
+  datasetExportJobs: many(datasetExportJobs),
+  datasetParquets: many(datasetParquets),
+}));
+
+export const membersOfWorkspacesRelations = relations(membersOfWorkspaces, ({ one }) => ({
+  user: one(users, {
+    fields: [membersOfWorkspaces.userId],
+    references: [users.id],
+  }),
+  workspace: one(workspaces, {
+    fields: [membersOfWorkspaces.workspaceId],
+    references: [workspaces.id],
+  }),
+}));
+
+export const usersRelations = relations(users, ({ many }) => ({
   membersOfWorkspaces: many(membersOfWorkspaces),
-  workspaceUsages: many(workspaceUsage),
-  workspaceAddons: many(workspaceAddons),
+  userSubscriptionInfos: many(userSubscriptionInfo),
+  apiKeys: many(apiKeys),
+  agentChats: many(agentChats),
+}));
+
+export const providerApiKeysRelations = relations(providerApiKeys, ({ one }) => ({
+  project: one(projects, {
+    fields: [providerApiKeys.projectId],
+    references: [projects.id],
+  }),
+}));
+
+export const alertsRelations = relations(alerts, ({ one, many }) => ({
+  project: one(projects, {
+    fields: [alerts.projectId],
+    references: [projects.id],
+  }),
+  alertTargets: many(alertTargets),
+}));
+
+export const userSubscriptionInfoRelations = relations(userSubscriptionInfo, ({ one }) => ({
+  user: one(users, {
+    fields: [userSubscriptionInfo.userId],
+    references: [users.id],
+  }),
+}));
+
+export const customModelCostsRelations = relations(customModelCosts, ({ one }) => ({
+  project: one(projects, {
+    fields: [customModelCosts.projectId],
+    references: [projects.id],
+  }),
+}));
+
+export const alertTargetsRelations = relations(alertTargets, ({ one }) => ({
+  alert: one(alerts, {
+    fields: [alertTargets.alertId],
+    references: [alerts.id],
+  }),
+  project: one(projects, {
+    fields: [alertTargets.projectId],
+    references: [projects.id],
+  }),
+}));
+
+export const reportTargetsRelations = relations(reportTargets, ({ one }) => ({
+  workspace: one(workspaces, {
+    fields: [reportTargets.workspaceId],
+    references: [workspaces.id],
+  }),
+  report: one(reports, {
+    fields: [reportTargets.reportId],
+    references: [reports.id],
+  }),
+}));
+
+export const reportsRelations = relations(reports, ({ one, many }) => ({
+  reportTargets: many(reportTargets),
+  workspace: one(workspaces, {
+    fields: [reports.workspaceId],
+    references: [workspaces.id],
+  }),
+}));
+
+export const apiKeysRelations = relations(apiKeys, ({ one }) => ({
+  user: one(users, {
+    fields: [apiKeys.userId],
+    references: [users.id],
+  }),
+}));
+
+export const renderTemplatesRelations = relations(renderTemplates, ({ one }) => ({
+  project: one(projects, {
+    fields: [renderTemplates.projectId],
+    references: [projects.id],
+  }),
+}));
+
+export const labelingQueueItemsRelations = relations(labelingQueueItems, ({ one }) => ({
+  labelingQueue: one(labelingQueues, {
+    fields: [labelingQueueItems.queueId],
+    references: [labelingQueues.id],
+  }),
+}));
+
+export const labelingQueuesRelations = relations(labelingQueues, ({ one, many }) => ({
+  labelingQueueItems: many(labelingQueueItems),
+  project: one(projects, {
+    fields: [labelingQueues.projectId],
+    references: [projects.id],
+  }),
+}));
+
+export const workspaceInvitationsRelations = relations(workspaceInvitations, ({ one }) => ({
+  workspace: one(workspaces, {
+    fields: [workspaceInvitations.workspaceId],
+    references: [workspaces.id],
+  }),
+}));
+
+export const evaluationResultsRelations = relations(evaluationResults, ({ one }) => ({
+  evaluation: one(evaluations, {
+    fields: [evaluationResults.evaluationId],
+    references: [evaluations.id],
+  }),
+}));
+
+export const evaluationsRelations = relations(evaluations, ({ one, many }) => ({
+  evaluationResults: many(evaluationResults),
+  project: one(projects, {
+    fields: [evaluations.projectId],
+    references: [projects.id],
+  }),
 }));
 
 export const evaluatorsRelations = relations(evaluators, ({ one, many }) => ({
@@ -213,6 +280,24 @@ export const evaluatorSpanPathsRelations = relations(evaluatorSpanPaths, ({ one 
   }),
 }));
 
+export const subscriptionTiersRelations = relations(subscriptionTiers, ({ many }) => ({
+  workspaces: many(workspaces),
+}));
+
+export const sharedPayloadsRelations = relations(sharedPayloads, ({ one }) => ({
+  project: one(projects, {
+    fields: [sharedPayloads.projectId],
+    references: [projects.id],
+  }),
+}));
+
+export const playgroundsRelations = relations(playgrounds, ({ one }) => ({
+  project: one(projects, {
+    fields: [playgrounds.projectId],
+    references: [projects.id],
+  }),
+}));
+
 export const evaluatorScoresRelations = relations(evaluatorScores, ({ one }) => ({
   project: one(projects, {
     fields: [evaluatorScores.projectId],
@@ -220,16 +305,16 @@ export const evaluatorScoresRelations = relations(evaluatorScores, ({ one }) => 
   }),
 }));
 
-export const workspaceInvitationsRelations = relations(workspaceInvitations, ({ one }) => ({
-  workspace: one(workspaces, {
-    fields: [workspaceInvitations.workspaceId],
-    references: [workspaces.id],
+export const sqlTemplatesRelations = relations(sqlTemplates, ({ one }) => ({
+  project: one(projects, {
+    fields: [sqlTemplates.projectId],
+    references: [projects.id],
   }),
 }));
 
-export const renderTemplatesRelations = relations(renderTemplates, ({ one }) => ({
+export const dashboardChartsRelations = relations(dashboardCharts, ({ one }) => ({
   project: one(projects, {
-    fields: [renderTemplates.projectId],
+    fields: [dashboardCharts.projectId],
     references: [projects.id],
   }),
 }));
@@ -241,85 +326,30 @@ export const tracesAgentChatsRelations = relations(tracesAgentChats, ({ one }) =
   }),
 }));
 
-export const labelingQueueItemsRelations = relations(labelingQueueItems, ({ one }) => ({
-  labelingQueue: one(labelingQueues, {
-    fields: [labelingQueueItems.queueId],
-    references: [labelingQueues.id],
-  }),
-}));
-
-export const labelingQueuesRelations = relations(labelingQueues, ({ one, many }) => ({
-  labelingQueueItems: many(labelingQueueItems),
+export const tracesAgentMessagesRelations = relations(tracesAgentMessages, ({ one }) => ({
   project: one(projects, {
-    fields: [labelingQueues.projectId],
+    fields: [tracesAgentMessages.projectId],
     references: [projects.id],
-  }),
-}));
-
-export const agentMessagesRelations = relations(agentMessages, ({ one }) => ({
-  agentSession: one(agentSessions, {
-    fields: [agentMessages.sessionId],
-    references: [agentSessions.sessionId],
-  }),
-}));
-
-export const summaryTriggerSpansRelations = relations(summaryTriggerSpans, ({ one }) => ({
-  project: one(projects, {
-    fields: [summaryTriggerSpans.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const sharedEvalsRelations = relations(sharedEvals, ({ one }) => ({
-  project: one(projects, {
-    fields: [sharedEvals.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const apiKeysRelations = relations(apiKeys, ({ one }) => ({
-  user: one(users, {
-    fields: [apiKeys.userId],
-    references: [users.id],
-  }),
-}));
-
-export const evaluationScoresRelations = relations(evaluationScores, ({ one }) => ({
-  evaluationResult: one(evaluationResults, {
-    fields: [evaluationScores.resultId],
-    references: [evaluationResults.id],
-  }),
-}));
-
-export const evaluationResultsRelations = relations(evaluationResults, ({ one, many }) => ({
-  evaluationScores: many(evaluationScores),
-  evaluation: one(evaluations, {
-    fields: [evaluationResults.evaluationId],
-    references: [evaluations.id],
-  }),
-}));
-
-export const subscriptionTiersRelations = relations(subscriptionTiers, ({ many }) => ({
-  workspaces: many(workspaces),
-}));
-
-export const providerApiKeysRelations = relations(providerApiKeys, ({ one }) => ({
-  project: one(projects, {
-    fields: [providerApiKeys.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const userSubscriptionInfoRelations = relations(userSubscriptionInfo, ({ one }) => ({
-  user: one(users, {
-    fields: [userSubscriptionInfo.userId],
-    references: [users.id],
   }),
 }));
 
 export const sharedTracesRelations = relations(sharedTraces, ({ one }) => ({
   project: one(projects, {
     fields: [sharedTraces.projectId],
+    references: [projects.id],
+  }),
+}));
+
+export const projectSettingsRelations = relations(projectSettings, ({ one }) => ({
+  project: one(projects, {
+    fields: [projectSettings.projectId],
+    references: [projects.id],
+  }),
+}));
+
+export const eventDefinitionsRelations = relations(eventDefinitions, ({ one }) => ({
+  project: one(projects, {
+    fields: [eventDefinitions.projectId],
     references: [projects.id],
   }),
 }));
@@ -335,60 +365,15 @@ export const datasetExportJobsRelations = relations(datasetExportJobs, ({ one })
   }),
 }));
 
-export const customModelCostsRelations = relations(customModelCosts, ({ one }) => ({
-  project: one(projects, {
-    fields: [customModelCosts.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const reportsRelations = relations(reports, ({ one, many }) => ({
-  workspace: one(workspaces, {
-    fields: [reports.workspaceId],
-    references: [workspaces.id],
-  }),
-  reportTargets: many(reportTargets),
-}));
-
-export const tracesSummariesRelations = relations(tracesSummaries, ({ one }) => ({
-  project: one(projects, {
-    fields: [tracesSummaries.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const reportTargetsRelations = relations(reportTargets, ({ one }) => ({
-  report: one(reports, {
-    fields: [reportTargets.reportId],
-    references: [reports.id],
-  }),
-  workspace: one(workspaces, {
-    fields: [reportTargets.workspaceId],
-    references: [workspaces.id],
-  }),
-}));
-
-export const alertsRelations = relations(alerts, ({ one, many }) => ({
-  project: one(projects, {
-    fields: [alerts.projectId],
-    references: [projects.id],
-  }),
-  alertTargets: many(alertTargets),
-}));
-
-export const datasetDatapointsRelations = relations(datasetDatapoints, ({ one }) => ({
+export const datasetParquetsRelations = relations(datasetParquets, ({ one }) => ({
   dataset: one(datasets, {
-    fields: [datasetDatapoints.datasetId],
+    fields: [datasetParquets.datasetId],
     references: [datasets.id],
   }),
-}));
-
-export const evaluationsRelations = relations(evaluations, ({ one, many }) => ({
   project: one(projects, {
-    fields: [evaluations.projectId],
+    fields: [datasetParquets.projectId],
     references: [projects.id],
   }),
-  evaluationResults: many(evaluationResults),
 }));
 
 export const projectApiKeysRelations = relations(projectApiKeys, ({ one }) => ({
@@ -398,39 +383,33 @@ export const projectApiKeysRelations = relations(projectApiKeys, ({ one }) => ({
   }),
 }));
 
-export const membersOfWorkspacesRelations = relations(membersOfWorkspaces, ({ one }) => ({
+export const slackIntegrationsRelations = relations(slackIntegrations, ({ one }) => ({
+  workspace: one(workspaces, {
+    fields: [slackIntegrations.workspaceId],
+    references: [workspaces.id],
+  }),
+}));
+
+export const agentChatsRelations = relations(agentChats, ({ one }) => ({
+  agentSession: one(agentSessions, {
+    fields: [agentChats.sessionId],
+    references: [agentSessions.sessionId],
+  }),
   user: one(users, {
-    fields: [membersOfWorkspaces.userId],
+    fields: [agentChats.userId],
     references: [users.id],
   }),
-  workspace: one(workspaces, {
-    fields: [membersOfWorkspaces.workspaceId],
-    references: [workspaces.id],
-  }),
 }));
 
-export const workspaceUsageRelations = relations(workspaceUsage, ({ one }) => ({
-  workspace: one(workspaces, {
-    fields: [workspaceUsage.workspaceId],
-    references: [workspaces.id],
-  }),
+export const agentSessionsRelations = relations(agentSessions, ({ many }) => ({
+  agentChats: many(agentChats),
+  agentMessages: many(agentMessages),
 }));
 
-export const alertTargetsRelations = relations(alertTargets, ({ one }) => ({
-  alert: one(alerts, {
-    fields: [alertTargets.alertId],
-    references: [alerts.id],
-  }),
-  project: one(projects, {
-    fields: [alertTargets.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const sqlTemplatesRelations = relations(sqlTemplates, ({ one }) => ({
-  project: one(projects, {
-    fields: [sqlTemplates.projectId],
-    references: [projects.id],
+export const agentMessagesRelations = relations(agentMessages, ({ one }) => ({
+  agentSession: one(agentSessions, {
+    fields: [agentMessages.sessionId],
+    references: [agentSessions.sessionId],
   }),
 }));
 
@@ -441,76 +420,9 @@ export const eventClusterConfigsRelations = relations(eventClusterConfigs, ({ on
   }),
 }));
 
-export const workspaceAddonsRelations = relations(workspaceAddons, ({ one }) => ({
-  workspace: one(workspaces, {
-    fields: [workspaceAddons.workspaceId],
-    references: [workspaces.id],
-  }),
-}));
-
-export const playgroundsRelations = relations(playgrounds, ({ one }) => ({
-  project: one(projects, {
-    fields: [playgrounds.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const signalJobsRelations = relations(signalJobs, ({ one }) => ({
-  project: one(projects, {
-    fields: [signalJobs.projectId],
-    references: [projects.id],
-  }),
-  signal: one(signals, {
-    fields: [signalJobs.signalId],
-    references: [signals.id],
-  }),
-}));
-
-export const eventDefinitionsRelations = relations(eventDefinitions, ({ one }) => ({
-  project: one(projects, {
-    fields: [eventDefinitions.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const dashboardChartsRelations = relations(dashboardCharts, ({ one }) => ({
-  project: one(projects, {
-    fields: [dashboardCharts.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const sharedPayloadsRelations = relations(sharedPayloads, ({ one }) => ({
-  project: one(projects, {
-    fields: [sharedPayloads.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const projectSettingsRelations = relations(projectSettings, ({ one }) => ({
-  project: one(projects, {
-    fields: [projectSettings.projectId],
-    references: [projects.id],
-  }),
-}));
-
 export const eventClustersRelations = relations(eventClusters, ({ one }) => ({
   project: one(projects, {
     fields: [eventClusters.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const rolloutSessionsRelations = relations(rolloutSessions, ({ one }) => ({
-  project: one(projects, {
-    fields: [rolloutSessions.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const signalTriggersRelations = relations(signalTriggers, ({ one }) => ({
-  project: one(projects, {
-    fields: [signalTriggers.projectId],
     references: [projects.id],
   }),
 }));
@@ -540,13 +452,6 @@ export const semanticEventDefinitionsRelations = relations(semanticEventDefiniti
 export const clustersRelations = relations(clusters, ({ one }) => ({
   project: one(projects, {
     fields: [clusters.projectId],
-    references: [projects.id],
-  }),
-}));
-
-export const spansRelations = relations(spans, ({ one }) => ({
-  project: one(projects, {
-    fields: [spans.projectId],
     references: [projects.id],
   }),
 }));

--- a/frontend/lib/db/migrations/schema.ts
+++ b/frontend/lib/db/migrations/schema.ts
@@ -3,18 +3,16 @@ import {
   foreignKey,
   uuid,
   timestamp,
-  text,
-  index,
-  pgPolicy,
-  unique,
   jsonb,
-  bigint,
-  doublePrecision,
-  uniqueIndex,
-  boolean,
+  text,
   integer,
+  unique,
+  doublePrecision,
+  index,
+  boolean,
+  uniqueIndex,
+  bigint,
   real,
-  vector,
   primaryKey,
   smallint,
   pgEnum,
@@ -38,74 +36,37 @@ export const tagSource = pgEnum("tag_source", ["MANUAL", "AUTO", "CODE"]);
 export const traceType = pgEnum("trace_type", ["DEFAULT", "EVENT", "EVALUATION", "PLAYGROUND"]);
 export const workspaceRole = pgEnum("workspace_role", ["member", "owner", "admin"]);
 
-export const datasetParquets = pgTable(
-  "dataset_parquets",
+export const rolloutSessions = pgTable(
+  "rollout_sessions",
   {
     id: uuid().defaultRandom().primaryKey().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    datasetId: uuid("dataset_id").notNull(),
-    parquetPath: text("parquet_path").notNull(),
-    jobId: uuid("job_id").notNull(),
-    name: text(),
     projectId: uuid("project_id").notNull(),
+    params: jsonb().notNull(),
+    status: text().default("PENDING").notNull(),
+    name: text(),
   },
   (table) => [
-    foreignKey({
-      columns: [table.datasetId],
-      foreignColumns: [datasets.id],
-      name: "dataset_parquets_dataset_id_fkey",
-    }).onDelete("cascade"),
     foreignKey({
       columns: [table.projectId],
       foreignColumns: [projects.id],
-      name: "dataset_parquets_project_id_fkey",
-    }).onDelete("cascade"),
+      name: "rollout_sessions_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
   ]
 );
 
-export const testCronJobs = pgTable("test_cron_jobs", {
-  id: uuid().defaultRandom(),
-  cronString: text("cron_string"),
-  projectId: uuid("project_id"),
+export const signalJobs = pgTable("signal_jobs", {
+  id: uuid().defaultRandom().primaryKey().notNull(),
+  signalId: uuid("signal_id").notNull(),
+  projectId: uuid("project_id").notNull(),
+  totalTraces: integer("total_traces").default(0).notNull(),
+  processedTraces: integer("processed_traces").default(0).notNull(),
+  failedTraces: integer("failed_traces").default(0).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
 });
-
-export const agentChats = pgTable(
-  "agent_chats",
-  {
-    sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
-    chatName: text("chat_name").default("New chat").notNull(),
-    userId: uuid("user_id").notNull(),
-    machineStatus: agentMachineStatus("machine_status").default("not_started"),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    agentStatus: text("agent_status").default("idle").notNull(),
-  },
-  (table) => [
-    index("agent_chats_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
-    index("agent_chats_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
-    index("agent_chats_user_id_idx").using("hash", table.userId.asc().nullsLast().op("uuid_ops")),
-    foreignKey({
-      columns: [table.sessionId],
-      foreignColumns: [agentSessions.sessionId],
-      name: "agent_chats_session_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-    foreignKey({
-      columns: [table.userId],
-      foreignColumns: [users.id],
-      name: "agent_chats_user_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-    pgPolicy("select_by_next_api_key", {
-      as: "permissive",
-      for: "select",
-      to: ["authenticated"],
-      using: sql`is_user_id_accessible_for_api_key(api_key(), user_id)`,
-    }),
-  ]
-);
 
 export const signals = pgTable(
   "signals",
@@ -117,331 +78,7 @@ export const signals = pgTable(
     structuredOutputSchema: jsonb("structured_output_schema").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
   },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "signals_project_id_fkey",
-    }).onDelete("cascade"),
-    unique("signals_project_id_name_key").on(table.projectId, table.name),
-  ]
-);
-
-export const userUsage = pgTable(
-  "user_usage",
-  {
-    userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    indexChatMessageCount: bigint("index_chat_message_count", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    indexChatMessageCountSinceReset: bigint("index_chat_message_count_since_reset", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    prevIndexChatMessageCount: bigint("prev_index_chat_message_count", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    resetTime: timestamp("reset_time", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    resetReason: text("reset_reason").default("signup").notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.userId],
-      foreignColumns: [users.id],
-      name: "user_usage_user_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const tracesAgentMessages = pgTable(
-  "traces_agent_messages",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    role: text().notNull(),
-    parts: jsonb().notNull(),
-    chatId: uuid("chat_id").notNull(),
-    traceId: uuid("trace_id").notNull(),
-    projectId: uuid("project_id").notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "traces_agent_messages_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const userSubscriptionTiers = pgTable("user_subscription_tiers", {
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  id: bigint({ mode: "number" }).primaryKey().generatedByDefaultAsIdentity({
-    name: "user_subscription_tiers_id_seq",
-    startWith: 1,
-    increment: 1,
-    minValue: 1,
-    maxValue: 9223372036854775807,
-    cache: 1,
-  }),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  name: text().notNull(),
-  stripeProductId: text("stripe_product_id").default("").notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  indexChatMessages: bigint("index_chat_messages", { mode: "number" }).default(sql`'0'`),
-});
-
-export const slackIntegrations = pgTable(
-  "slack_integrations",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    token: text().notNull(),
-    teamId: text("team_id").notNull(),
-    teamName: text("team_name"),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    nonceHex: text("nonce_hex").notNull(),
-    workspaceId: uuid("workspace_id").notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.workspaceId],
-      foreignColumns: [workspaces.id],
-      name: "slack_integrations_workspace_id_fkey",
-    }).onDelete("cascade"),
-    unique("slack_integrations_workspace_id_key").on(table.workspaceId),
-  ]
-);
-
-export const evaluators = pgTable(
-  "evaluators",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    projectId: uuid("project_id").notNull(),
-    name: text().notNull(),
-    evaluatorType: text("evaluator_type").notNull(),
-    definition: jsonb().default({}),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "evaluators_project_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const evaluatorSpanPaths = pgTable(
-  "evaluator_span_paths",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    evaluatorId: uuid("evaluator_id").notNull(),
-    spanPath: jsonb("span_path").default({}),
-    projectId: uuid("project_id").notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.evaluatorId],
-      foreignColumns: [evaluators.id],
-      name: "evaluator_span_paths_evaluator_id_fkey",
-    }).onDelete("cascade"),
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "evaluator_span_paths_project_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const evaluatorScores = pgTable(
-  "evaluator_scores",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    evaluatorId: uuid("evaluator_id"),
-    spanId: uuid("span_id").notNull(),
-    score: doublePrecision().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    projectId: uuid("project_id").notNull(),
-    name: text().notNull(),
-    source: text().notNull(),
-    metadata: jsonb().default({}),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "evaluator_scores_project_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const workspaceInvitations = pgTable(
-  "workspace_invitations",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    workspaceId: uuid("workspace_id").defaultRandom().notNull(),
-    email: text().default("").notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.workspaceId],
-      foreignColumns: [workspaces.id],
-      name: "workspace_invitations_workspace_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const modelCosts = pgTable(
-  "model_costs",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    model: text().notNull(),
-    costs: jsonb().default({}).notNull(),
-  },
-  (table) => [unique("model_costs_model_unique").on(table.model)]
-);
-
-export const renderTemplates = pgTable(
-  "render_templates",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    projectId: uuid("project_id").defaultRandom().notNull(),
-    code: text().notNull(),
-    name: text().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "render_templates_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const tracesAgentChats = pgTable(
-  "traces_agent_chats",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    traceId: uuid("trace_id").notNull(),
-    projectId: uuid("project_id").notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "traces_agent_chats_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const agentSessions = pgTable(
-  "agent_sessions",
-  {
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
-    cdpUrl: text("cdp_url"),
-    vncUrl: text("vnc_url"),
-    machineId: text("machine_id"),
-    state: text(),
-    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    agentStatus: text("agent_status").default("idle").notNull(),
-  },
-  (table) => [
-    index("agent_sessions_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
-    index("agent_sessions_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
-  ]
-);
-
-export const labelingQueueItems = pgTable(
-  "labeling_queue_items",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    queueId: uuid("queue_id").defaultRandom().notNull(),
-    metadata: jsonb().default({}),
-    payload: jsonb().default({}),
-    idempotencyKey: text("idempotency_key"),
-  },
-  (table) => [
-    uniqueIndex("labeling_queue_items_queue_id_idempotency_key_idx")
-      .using(
-        "btree",
-        table.queueId.asc().nullsLast().op("uuid_ops"),
-        table.idempotencyKey.asc().nullsLast().op("text_ops")
-      )
-      .where(sql`(idempotency_key IS NOT NULL)`),
-    index("labeling_queue_items_queue_id_idx").using("btree", table.queueId.asc().nullsLast().op("uuid_ops")),
-    index("labeling_queue_items_queue_ordering_idx").using(
-      "btree",
-      table.queueId.asc().nullsLast().op("uuid_ops"),
-      table.createdAt.asc().nullsLast().op("uuid_ops"),
-      table.id.asc().nullsLast().op("timestamptz_ops")
-    ),
-    foreignKey({
-      columns: [table.queueId],
-      foreignColumns: [labelingQueues.id],
-      name: "labelling_queue_items_queue_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const agentMessages = pgTable(
-  "agent_messages",
-  {
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    sessionId: uuid("session_id").notNull(),
-    content: jsonb().default({}),
-    messageType: agentMessageType("message_type").notNull(),
-    traceId: uuid("trace_id"),
-  },
-  (table) => [
-    index("agent_messages_session_id_created_at_idx").using(
-      "btree",
-      table.createdAt.asc().nullsLast().op("timestamptz_ops"),
-      table.sessionId.asc().nullsLast().op("timestamptz_ops")
-    ),
-    foreignKey({
-      columns: [table.sessionId],
-      foreignColumns: [agentSessions.sessionId],
-      name: "agent_messages_session_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const summaryTriggerSpans = pgTable(
-  "summary_trigger_spans",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    spanName: text("span_name").notNull(),
-    eventName: text("event_name"),
-    projectId: uuid("project_id").notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "summary_trigger_spans_project_id_fkey",
-    }).onDelete("cascade"),
-  ]
+  (table) => [unique("signals_project_id_name_key").on(table.projectId, table.name)]
 );
 
 export const sharedEvals = pgTable(
@@ -456,79 +93,18 @@ export const sharedEvals = pgTable(
       columns: [table.projectId],
       foreignColumns: [projects.id],
       name: "shared_evals_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
+    }).onDelete("cascade"),
   ]
 );
 
-export const apiKeys = pgTable(
-  "api_keys",
-  {
-    apiKey: text("api_key").primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    userId: uuid("user_id").notNull(),
-    name: text().default("default").notNull(),
-  },
-  (table) => [
-    index("api_keys_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
-    foreignKey({
-      columns: [table.userId],
-      foreignColumns: [users.id],
-      name: "api_keys_user_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-    pgPolicy("Enable insert for authenticated users only", {
-      as: "permissive",
-      for: "all",
-      to: ["service_role"],
-      using: sql`true`,
-      withCheck: sql`true`,
-    }),
-  ]
-);
-
-export const labelingQueues = pgTable(
-  "labeling_queues",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    name: text().notNull(),
-    projectId: uuid("project_id").notNull(),
-    annotationSchema: jsonb("annotation_schema"),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "labeling_queues_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const events = pgTable(
-  "events",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    timestamp: timestamp({ withTimezone: true, mode: "string" }).notNull(),
-    name: text().notNull(),
-    attributes: jsonb().default({}).notNull(),
-    spanId: uuid("span_id").notNull(),
-    projectId: uuid("project_id").notNull(),
-  },
-  (table) => [
-    index("events_span_id_idx").using("btree", table.spanId.asc().nullsLast().op("uuid_ops")),
-    index("events_span_id_project_id_idx").using(
-      "btree",
-      table.projectId.asc().nullsLast().op("uuid_ops"),
-      table.spanId.asc().nullsLast().op("uuid_ops")
-    ),
-  ]
-);
+export const signalTriggers = pgTable("signal_triggers", {
+  id: uuid().defaultRandom().primaryKey().notNull(),
+  projectId: uuid("project_id").notNull(),
+  value: jsonb().notNull(),
+  signalId: uuid("signal_id").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  clusteringKey: text("clustering_key"),
+});
 
 export const llmPrices = pgTable("llm_prices", {
   id: uuid().defaultRandom().primaryKey().notNull(),
@@ -542,27 +118,35 @@ export const llmPrices = pgTable("llm_prices", {
   additionalPrices: jsonb("additional_prices").default({}).notNull(),
 });
 
-export const evaluationScores = pgTable(
-  "evaluation_scores",
+export const workspaceAddons = pgTable(
+  "workspace_addons",
   {
     id: uuid().defaultRandom().primaryKey().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    resultId: uuid("result_id").defaultRandom().notNull(),
-    name: text().default("").notNull(),
-    score: doublePrecision(),
-    labelId: uuid("label_id"),
+    workspaceId: uuid("workspace_id").notNull(),
+    addonSlug: text("addon_slug").notNull(),
   },
   (table) => [
-    index("evaluation_scores_result_id_idx").using("hash", table.resultId.asc().nullsLast().op("uuid_ops")),
     foreignKey({
-      columns: [table.resultId],
-      foreignColumns: [evaluationResults.id],
-      name: "evaluation_scores_result_id_fkey",
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "workspace_addons_workspace_id_fkey",
     })
       .onUpdate("cascade")
       .onDelete("cascade"),
-    unique("evaluation_scores_names_unique_idx").on(table.resultId, table.name),
   ]
+);
+
+export const modelCosts = pgTable(
+  "model_costs",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    model: text().notNull(),
+    costs: jsonb().default({}).notNull(),
+  },
+  (table) => [unique("model_costs_model_unique").on(table.model)]
 );
 
 export const datasets = pgTable(
@@ -586,53 +170,6 @@ export const datasets = pgTable(
   ]
 );
 
-export const workspaces = pgTable(
-  "workspaces",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    name: text().notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    tierId: bigint("tier_id", { mode: "number" })
-      .default(sql`'1'`)
-      .notNull(),
-    subscriptionId: text("subscription_id"),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    additionalSeats: bigint("additional_seats", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    resetTime: timestamp("reset_time", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.tierId],
-      foreignColumns: [subscriptionTiers.id],
-      name: "workspaces_tier_id_fkey",
-    }).onUpdate("cascade"),
-  ]
-);
-
-export const users = pgTable(
-  "users",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    name: text().notNull(),
-    email: text().notNull(),
-    subscriptionId: text("subscription_id"),
-    avatarUrl: text("avatar_url"),
-  },
-  (table) => [
-    unique("users_email_key").on(table.email),
-    pgPolicy("Enable insert for authenticated users only", {
-      as: "permissive",
-      for: "insert",
-      to: ["service_role"],
-      withCheck: sql`true`,
-    }),
-  ]
-);
-
 export const projects = pgTable(
   "projects",
   {
@@ -647,317 +184,6 @@ export const projects = pgTable(
       columns: [table.workspaceId],
       foreignColumns: [workspaces.id],
       name: "projects_workspace_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const providerApiKeys = pgTable(
-  "provider_api_keys",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    name: text().notNull(),
-    projectId: uuid("project_id").defaultRandom().notNull(),
-    nonceHex: text("nonce_hex").notNull(),
-    value: text().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "provider_api_keys_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const userSubscriptionInfo = pgTable(
-  "user_subscription_info",
-  {
-    userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    stripeCustomerId: text("stripe_customer_id").notNull(),
-    activated: boolean().default(false).notNull(),
-  },
-  (table) => [
-    index("user_subscription_info_stripe_customer_id_idx").using(
-      "btree",
-      table.stripeCustomerId.asc().nullsLast().op("text_ops")
-    ),
-    foreignKey({
-      columns: [table.userId],
-      foreignColumns: [users.id],
-      name: "user_subscription_info_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const sharedTraces = pgTable(
-  "shared_traces",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    projectId: uuid("project_id").defaultRandom().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "shared_traces_project_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const workspaceDeployments = pgTable("workspace_deployments", {
-  workspaceId: uuid("workspace_id").primaryKey().notNull(),
-  mode: text().default("CLOUD").notNull(),
-  privateKey: text("private_key").default("").notNull(),
-  privateKeyNonce: text("private_key_nonce").default("").notNull(),
-  publicKey: text("public_key").default("").notNull(),
-  dataPlaneUrl: text("data_plane_url").default("").notNull(),
-  dataPlaneUrlNonce: text("data_plane_url_nonce").default("").notNull(),
-});
-
-export const datasetExportJobs = pgTable(
-  "dataset_export_jobs",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    datasetId: uuid("dataset_id").notNull(),
-    projectId: uuid("project_id").notNull(),
-    status: text().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.datasetId],
-      foreignColumns: [datasets.id],
-      name: "dataset_export_jobs_dataset_id_fkey",
-    }).onDelete("cascade"),
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "dataset_export_jobs_project_id_fkey",
-    }).onDelete("cascade"),
-    unique("dataset_export_jobs_project_dataset_key").on(table.datasetId, table.projectId),
-  ]
-);
-
-export const customModelCosts = pgTable(
-  "custom_model_costs",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    projectId: uuid("project_id").notNull(),
-    provider: text().default("").notNull(),
-    model: text().notNull(),
-    costs: jsonb().default({}).notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "custom_model_costs_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-    unique("custom_model_costs_project_id_provider_model_unique").on(table.projectId, table.provider, table.model),
-  ]
-);
-
-export const reports = pgTable(
-  "reports",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    workspaceId: uuid("workspace_id").notNull(),
-    type: text().notNull(),
-    weekdays: integer().array().notNull(),
-    hour: integer().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.workspaceId],
-      foreignColumns: [workspaces.id],
-      name: "reports_workspace_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const tracesSummaries = pgTable(
-  "traces_summaries",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    traceId: uuid("trace_id").defaultRandom().notNull(),
-    summary: text(),
-    projectId: uuid("project_id").notNull(),
-    spanIdsMap: jsonb("span_ids_map"),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "traces_summaries_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const reportTargets = pgTable(
-  "report_targets",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    workspaceId: uuid("workspace_id").notNull(),
-    reportId: uuid("report_id").notNull(),
-    type: text().notNull(),
-    integrationId: uuid("integration_id"),
-    channelId: text("channel_id"),
-    channelName: text("channel_name"),
-    email: text(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.reportId],
-      foreignColumns: [reports.id],
-      name: "report_targets_report_id_fkey",
-    }).onDelete("cascade"),
-    foreignKey({
-      columns: [table.workspaceId],
-      foreignColumns: [workspaces.id],
-      name: "report_targets_workspace_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const alerts = pgTable(
-  "alerts",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    projectId: uuid("project_id").notNull(),
-    name: text().notNull(),
-    type: text().notNull(),
-    sourceId: uuid("source_id").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "alerts_project_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const datasetDatapoints = pgTable(
-  "dataset_datapoints",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    datasetId: uuid("dataset_id").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    data: jsonb().notNull(),
-    indexedOn: text("indexed_on"),
-    target: jsonb().default({}),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    indexInBatch: bigint("index_in_batch", { mode: "number" }),
-    metadata: jsonb().default({}),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.datasetId],
-      foreignColumns: [datasets.id],
-      name: "dataset_datapoints_dataset_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const evaluations = pgTable(
-  "evaluations",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    projectId: uuid("project_id").notNull(),
-    name: text().notNull(),
-    groupId: text("group_id").default("default").notNull(),
-    metadata: jsonb(),
-  },
-  (table) => [
-    index("evaluations_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "evaluations_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-    pgPolicy("select_by_next_api_key", {
-      as: "permissive",
-      for: "select",
-      to: ["anon", "authenticated"],
-      using: sql`is_evaluation_id_accessible_for_api_key(api_key(), id)`,
-    }),
-  ]
-);
-
-export const evaluationResults = pgTable(
-  "evaluation_results",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    evaluationId: uuid("evaluation_id").notNull(),
-    data: jsonb().notNull(),
-    target: jsonb().default({}).notNull(),
-    executorOutput: jsonb("executor_output"),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    indexInBatch: bigint("index_in_batch", { mode: "number" }),
-    traceId: uuid("trace_id").notNull(),
-    index: integer().default(0).notNull(),
-    metadata: jsonb(),
-  },
-  (table) => [
-    index("evaluation_results_evaluation_id_idx").using("btree", table.evaluationId.asc().nullsLast().op("uuid_ops")),
-    foreignKey({
-      columns: [table.evaluationId],
-      foreignColumns: [evaluations.id],
-      name: "evaluation_results_evaluation_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-    pgPolicy("select_by_next_api_key", {
-      as: "permissive",
-      for: "select",
-      to: ["anon", "authenticated"],
-      using: sql`is_evaluation_id_accessible_for_api_key(api_key(), evaluation_id)`,
-    }),
-  ]
-);
-
-export const projectApiKeys = pgTable(
-  "project_api_keys",
-  {
-    value: text().default("").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    name: text(),
-    projectId: uuid("project_id").notNull(),
-    shorthand: text().default("").notNull(),
-    hash: text().default("").notNull(),
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    isIngestOnly: boolean("is_ingest_only").default(false).notNull(),
-  },
-  (table) => [
-    index("project_api_keys_hash_idx").using("hash", table.hash.asc().nullsLast().op("text_ops")),
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "public_project_api_keys_project_id_fkey",
     })
       .onUpdate("cascade")
       .onDelete("cascade"),
@@ -993,94 +219,100 @@ export const membersOfWorkspaces = pgTable(
   ]
 );
 
-export const workspaceUsage = pgTable(
-  "workspace_usage",
+export const providerApiKeys = pgTable(
+  "provider_api_keys",
   {
-    workspaceId: uuid("workspace_id").defaultRandom().primaryKey().notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    spanCount: bigint("span_count", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    spanCountSinceReset: bigint("span_count_since_reset", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    resetTime: timestamp("reset_time", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    resetReason: text("reset_reason").default("signup").notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    stepCount: bigint("step_count", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    prevStepCount: bigint("prev_step_count", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    stepCountSinceReset: bigint("step_count_since_reset", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    bytesIngested: bigint("bytes_ingested", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    bytesIngestedSinceReset: bigint("bytes_ingested_since_reset", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    spansBytesIngested: bigint("spans_bytes_ingested", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    spansBytesIngestedSinceReset: bigint("spans_bytes_ingested_since_reset", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    browserSessionEventsBytesIngested: bigint("browser_session_events_bytes_ingested", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    browserSessionEventsBytesIngestedSinceReset: bigint("browser_session_events_bytes_ingested_since_reset", {
-      mode: "number",
-    })
-      .default(sql`'0'`)
-      .notNull(),
-    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-    prevSpanCount: bigint("prev_span_count", { mode: "number" })
-      .default(sql`'0'`)
-      .notNull(),
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    nonceHex: text("nonce_hex").notNull(),
+    value: text().notNull(),
   },
   (table) => [
     foreignKey({
-      columns: [table.workspaceId],
-      foreignColumns: [workspaces.id],
-      name: "user_usage_workspace_id_fkey",
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "provider_api_keys_project_id_fkey",
     })
       .onUpdate("cascade")
       .onDelete("cascade"),
   ]
 );
 
-export const tags = pgTable("tags", {
-  id: uuid().defaultRandom().primaryKey().notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  classId: uuid("class_id").notNull(),
-  spanId: uuid("span_id").notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  userId: uuid("user_id").defaultRandom(),
-  source: tagSource().default("MANUAL").notNull(),
-  reasoning: text(),
-  projectId: uuid("project_id").notNull(),
-});
+export const alerts = pgTable(
+  "alerts",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    projectId: uuid("project_id").notNull(),
+    name: text().notNull(),
+    sourceId: uuid("source_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    type: text().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "alerts_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const userSubscriptionInfo = pgTable(
+  "user_subscription_info",
+  {
+    userId: uuid("user_id").defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    stripeCustomerId: text("stripe_customer_id").notNull(),
+    activated: boolean().default(false).notNull(),
+  },
+  (table) => [
+    index("user_subscription_info_stripe_customer_id_idx").using(
+      "btree",
+      table.stripeCustomerId.asc().nullsLast().op("text_ops")
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "user_subscription_info_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const customModelCosts = pgTable(
+  "custom_model_costs",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").notNull(),
+    provider: text().default("").notNull(),
+    model: text().notNull(),
+    costs: jsonb().default({}).notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "custom_model_costs_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    unique("custom_model_costs_project_id_provider_model_unique").on(table.projectId, table.provider, table.model),
+  ]
+);
 
 export const alertTargets = pgTable(
   "alert_targets",
   {
     id: uuid().defaultRandom().primaryKey().notNull(),
-    projectId: uuid("project_id").notNull(),
     alertId: uuid("alert_id").notNull(),
+    projectId: uuid("project_id").notNull(),
     type: text().notNull(),
-    integrationId: uuid("integration_id"),
+    integrationId: uuid("integration_id").notNull(),
     channelId: text("channel_id"),
     channelName: text("channel_name"),
     email: text(),
@@ -1100,14 +332,393 @@ export const alertTargets = pgTable(
   ]
 );
 
-export const sqlTemplates = pgTable(
-  "sql_templates",
+export const reportTargets = pgTable(
+  "report_targets",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+    reportId: uuid("report_id").notNull(),
+    type: text().notNull(),
+    integrationId: uuid("integration_id"),
+    channelId: text("channel_id"),
+    channelName: text("channel_name"),
+    email: text(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "report_targets_workspace_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.reportId],
+      foreignColumns: [reports.id],
+      name: "report_targets_report_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const reports = pgTable(
+  "reports",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+    type: text().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    weekdays: integer().array().notNull(),
+    hour: integer().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "reports_workspace_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const apiKeys = pgTable(
+  "api_keys",
+  {
+    apiKey: text("api_key").primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    userId: uuid("user_id").notNull(),
+    name: text().default("default").notNull(),
+  },
+  (table) => [
+    index("api_keys_user_id_idx").using("btree", table.userId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "api_keys_user_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const events = pgTable(
+  "events",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    spanId: uuid("span_id").notNull(),
+    timestamp: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    name: text().notNull(),
+    attributes: jsonb().default({}).notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    index("events_span_id_idx").using("btree", table.spanId.asc().nullsLast().op("uuid_ops")),
+    index("events_span_id_project_id_idx").using(
+      "btree",
+      table.projectId.asc().nullsLast().op("uuid_ops"),
+      table.spanId.asc().nullsLast().op("uuid_ops")
+    ),
+  ]
+);
+
+export const renderTemplates = pgTable(
+  "render_templates",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+    code: text().notNull(),
+    name: text().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "render_templates_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const labelingQueueItems = pgTable(
+  "labeling_queue_items",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    queueId: uuid("queue_id").defaultRandom().notNull(),
+    metadata: jsonb().default({}),
+    payload: jsonb().default({}),
+    idempotencyKey: text("idempotency_key"),
+  },
+  (table) => [
+    uniqueIndex("labeling_queue_items_queue_id_idempotency_key_idx")
+      .using(
+        "btree",
+        table.queueId.asc().nullsLast().op("text_ops"),
+        table.idempotencyKey.asc().nullsLast().op("text_ops")
+      )
+      .where(sql`(idempotency_key IS NOT NULL)`),
+    foreignKey({
+      columns: [table.queueId],
+      foreignColumns: [labelingQueues.id],
+      name: "labelling_queue_items_queue_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const workspaceInvitations = pgTable(
+  "workspace_invitations",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    workspaceId: uuid("workspace_id").defaultRandom().notNull(),
+    email: text(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "workspace_invitations_workspace_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const users = pgTable(
+  "users",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    email: text().notNull(),
+    subscriptionId: text("subscription_id"),
+    avatarUrl: text("avatar_url"),
+  },
+  (table) => [unique("users_email_key").on(table.email)]
+);
+
+export const evaluationResults = pgTable(
+  "evaluation_results",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    evaluationId: uuid("evaluation_id").notNull(),
+    data: jsonb().default({}).notNull(),
+    target: jsonb().default({}).notNull(),
+    executorOutput: jsonb("executor_output"),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    indexInBatch: bigint("index_in_batch", { mode: "number" }),
+    traceId: uuid("trace_id").notNull(),
+    index: integer().default(0).notNull(),
+    metadata: jsonb(),
+  },
+  (table) => [
+    index("evaluation_results_evaluation_id_idx").using("btree", table.evaluationId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.evaluationId],
+      foreignColumns: [evaluations.id],
+      name: "evaluation_results_evaluation_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const evaluators = pgTable(
+  "evaluators",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    projectId: uuid("project_id").notNull(),
+    name: text().notNull(),
+    evaluatorType: text("evaluator_type").notNull(),
+    definition: jsonb().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "evaluators_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const evaluatorSpanPaths = pgTable(
+  "evaluator_span_paths",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    evaluatorId: uuid("evaluator_id").notNull(),
+    projectId: uuid("project_id").notNull(),
+    spanPath: jsonb("span_path").default({}),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.evaluatorId],
+      foreignColumns: [evaluators.id],
+      name: "evaluator_span_paths_evaluator_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "evaluator_span_paths_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const subscriptionTiers = pgTable("subscription_tiers", {
+  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+  id: bigint({ mode: "number" })
+    .primaryKey()
+    .generatedByDefaultAsIdentity({
+      name: "subscription_tiers_id_seq",
+      startWith: 1,
+      increment: 1,
+      minValue: 1,
+      maxValue: 9223372036854775807,
+      cache: 1,
+    }),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  name: text().notNull(),
+  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+  logRetentionDays: bigint("log_retention_days", { mode: "number" }).notNull(),
+  stripeProductId: text("stripe_product_id"),
+  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+  bytesIngested: bigint("bytes_ingested", { mode: "number" })
+    .default(sql`'0'`)
+    .notNull(),
+  extraBytePrice: doublePrecision("extra_byte_price")
+    .default(sql`'0'`)
+    .notNull(),
+  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+  signalRuns: bigint("signal_runs", { mode: "number" }).default(0).notNull(),
+  extraSignalRunPrice: doublePrecision("extra_signal_run_price").default(0).notNull(),
+});
+
+export const workspaces = pgTable(
+  "workspaces",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    tierId: bigint("tier_id", { mode: "number" })
+      .default(sql`'1'`)
+      .notNull(),
+    subscriptionId: text("subscription_id"),
+    // You can use { mode: "bigint" } if numbers are exceeding js number limitations
+    additionalSeats: bigint("additional_seats", { mode: "number" })
+      .default(sql`'0'`)
+      .notNull(),
+    resetTime: timestamp("reset_time", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    lastUsageCalculationTime: timestamp("last_usage_calculation_time", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.tierId],
+      foreignColumns: [subscriptionTiers.id],
+      name: "workspaces_tier_id_fkey",
+    }).onUpdate("cascade"),
+  ]
+);
+
+export const evaluations = pgTable(
+  "evaluations",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    projectId: uuid("project_id").notNull(),
+    name: text().notNull(),
+    groupId: text("group_id").default("default").notNull(),
+    metadata: jsonb(),
+  },
+  (table) => [
+    index("evaluations_project_id_hash_idx").using("hash", table.projectId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "evaluations_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const sharedPayloads = pgTable(
+  "shared_payloads",
+  {
+    payloadId: uuid("payload_id").defaultRandom().primaryKey().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "shared_payloads_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const playgrounds = pgTable(
+  "playgrounds",
   {
     id: uuid().defaultRandom().primaryKey().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
     name: text().notNull(),
     projectId: uuid("project_id").notNull(),
+    promptMessages: jsonb("prompt_messages")
+      .default([{ role: "user", content: "" }])
+      .notNull(),
+    modelId: text("model_id"),
+    outputSchema: text("output_schema"),
+    tools: jsonb().default({}),
+    toolChoice: jsonb("tool_choice").default("none"),
+    maxTokens: integer("max_tokens").default(1024),
+    temperature: real().default(sql`'1'`),
+    providerOptions: jsonb("provider_options").default({}),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "playgrounds_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const evaluatorScores = pgTable(
+  "evaluator_scores",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    evaluatorId: uuid("evaluator_id"),
+    projectId: uuid("project_id").notNull(),
+    spanId: uuid("span_id").notNull(),
+    score: doublePrecision().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    source: text().notNull(),
+    metadata: jsonb().default({}),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "evaluator_scores_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const sqlTemplates = pgTable(
+  "sql_templates",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    name: text().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
     query: text().notNull(),
+    projectId: uuid("project_id").notNull(),
   },
   (table) => [
     foreignKey({
@@ -1115,6 +726,321 @@ export const sqlTemplates = pgTable(
       foreignColumns: [projects.id],
       name: "sql_templates_project_id_fkey",
     }).onDelete("cascade"),
+  ]
+);
+
+export const dashboardCharts = pgTable(
+  "dashboard_charts",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    name: text().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    query: text().notNull(),
+    settings: jsonb().notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "dashboard_charts_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const labelingQueues = pgTable(
+  "labeling_queues",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    projectId: uuid("project_id").notNull(),
+    annotationSchema: jsonb("annotation_schema"),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "labeling_queues_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const tracesAgentChats = pgTable(
+  "traces_agent_chats",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    traceId: uuid("trace_id").notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "traces_agent_chats_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const tracesAgentMessages = pgTable(
+  "traces_agent_messages",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    role: text().notNull(),
+    parts: jsonb().notNull(),
+    chatId: uuid("chat_id").notNull(),
+    traceId: uuid("trace_id").notNull(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "traces_agent_messages_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const sharedTraces = pgTable(
+  "shared_traces",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    projectId: uuid("project_id").defaultRandom().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "shared_traces_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const projectSettings = pgTable(
+  "project_settings",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    name: text(),
+    value: text(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "project_settings_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const eventDefinitions = pgTable(
+  "event_definitions",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text().notNull(),
+    prompt: text(),
+    projectId: uuid("project_id").notNull(),
+    isSemantic: boolean("is_semantic").default(false).notNull(),
+    structuredOutput: jsonb("structured_output"),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "event_definitions_project_id_fkey",
+    }).onDelete("cascade"),
+    unique("event_definitions_project_id_name_key").on(table.name, table.projectId),
+  ]
+);
+
+export const datasetExportJobs = pgTable(
+  "dataset_export_jobs",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    datasetId: uuid("dataset_id").notNull(),
+    projectId: uuid("project_id").notNull(),
+    status: text().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.datasetId],
+      foreignColumns: [datasets.id],
+      name: "dataset_export_jobs_dataset_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "dataset_export_jobs_project_id_fkey",
+    }).onDelete("cascade"),
+    unique("dataset_export_jobs_project_dataset_key").on(table.datasetId, table.projectId),
+  ]
+);
+
+export const datasetParquets = pgTable(
+  "dataset_parquets",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    datasetId: uuid("dataset_id").notNull(),
+    parquetPath: text("parquet_path").notNull(),
+    jobId: uuid("job_id").notNull(),
+    name: text(),
+    projectId: uuid("project_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.datasetId],
+      foreignColumns: [datasets.id],
+      name: "dataset_parquets_dataset_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "dataset_parquets_project_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
+export const projectApiKeys = pgTable(
+  "project_api_keys",
+  {
+    value: text(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    name: text(),
+    projectId: uuid("project_id").notNull(),
+    shorthand: text(),
+    hash: text(),
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    isIngestOnly: boolean("is_ingest_only").default(false).notNull(),
+  },
+  (table) => [
+    index("project_api_keys_hash_idx").using("hash", table.hash.asc().nullsLast().op("text_ops")),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "public_project_api_keys_project_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const slackIntegrations = pgTable(
+  "slack_integrations",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    token: text().notNull(),
+    teamId: text("team_id").notNull(),
+    teamName: text("team_name"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    nonceHex: text("nonce_hex").notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.workspaceId],
+      foreignColumns: [workspaces.id],
+      name: "slack_integrations_workspace_id_fkey",
+    }).onDelete("cascade"),
+    unique("slack_integrations_workspace_id_key").on(table.workspaceId),
+  ]
+);
+
+export const workspaceDeployments = pgTable("workspace_deployments", {
+  workspaceId: uuid("workspace_id").primaryKey().notNull(),
+  mode: text().default("CLOUD").notNull(),
+  privateKey: text("private_key"),
+  privateKeyNonce: text("private_key_nonce"),
+  publicKey: text("public_key"),
+  dataPlaneUrl: text("data_plane_url"),
+  dataPlaneUrlNonce: text("data_plane_url_nonce"),
+});
+
+export const agentSessions = pgTable(
+  "agent_sessions",
+  {
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
+    cdpUrl: text("cdp_url"),
+    vncUrl: text("vnc_url"),
+    machineId: text("machine_id"),
+    state: text(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    agentStatus: text("agent_status").default("idle").notNull(),
+  },
+  (table) => [
+    index("agent_sessions_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
+    index("agent_sessions_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
+  ]
+);
+
+export const agentChats = pgTable(
+  "agent_chats",
+  {
+    sessionId: uuid("session_id").defaultRandom().primaryKey().notNull(),
+    chatName: text("chat_name").default("New chat").notNull(),
+    userId: uuid("user_id").notNull(),
+    machineStatus: agentMachineStatus("machine_status").default("not_started"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    agentStatus: text("agent_status").default("idle").notNull(),
+  },
+  (table) => [
+    index("agent_chats_created_at_idx").using("btree", table.createdAt.asc().nullsLast().op("timestamptz_ops")),
+    index("agent_chats_updated_at_idx").using("btree", table.updatedAt.asc().nullsLast().op("timestamptz_ops")),
+    index("agent_chats_user_id_idx").using("hash", table.userId.asc().nullsLast().op("uuid_ops")),
+    foreignKey({
+      columns: [table.sessionId],
+      foreignColumns: [agentSessions.sessionId],
+      name: "agent_chats_session_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "agent_chats_user_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
+  ]
+);
+
+export const agentMessages = pgTable(
+  "agent_messages",
+  {
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    sessionId: uuid("session_id").notNull(),
+    content: jsonb().default({}),
+    messageType: agentMessageType("message_type").notNull(),
+    traceId: uuid("trace_id"),
+  },
+  (table) => [
+    index("agent_messages_session_id_created_at_idx").using(
+      "btree",
+      table.createdAt.asc().nullsLast().op("timestamptz_ops"),
+      table.sessionId.asc().nullsLast().op("timestamptz_ops")
+    ),
+    foreignKey({
+      columns: [table.sessionId],
+      foreignColumns: [agentSessions.sessionId],
+      name: "agent_messages_session_id_fkey",
+    })
+      .onUpdate("cascade")
+      .onDelete("cascade"),
   ]
 );
 
@@ -1142,183 +1068,6 @@ export const eventClusterConfigs = pgTable(
   ]
 );
 
-export const workspaceAddons = pgTable(
-  "workspace_addons",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    workspaceId: uuid("workspace_id").notNull(),
-    addonSlug: text("addon_slug").notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.workspaceId],
-      foreignColumns: [workspaces.id],
-      name: "workspace_addons_workspace_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const subscriptionTiers = pgTable("subscription_tiers", {
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  id: bigint({ mode: "number" }).primaryKey().generatedByDefaultAsIdentity({
-    name: "subscription_tiers_id_seq",
-    startWith: 1,
-    increment: 1,
-    minValue: 1,
-    maxValue: 9223372036854775807,
-    cache: 1,
-  }),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  name: text().notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  logRetentionDays: bigint("log_retention_days", { mode: "number" }).notNull(),
-  stripeProductId: text("stripe_product_id").default("").notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  bytesIngested: bigint("bytes_ingested", { mode: "number" })
-    .default(sql`'0'`)
-    .notNull(),
-  extraBytePrice: doublePrecision("extra_byte_price")
-    .default(sql`'0'`)
-    .notNull(),
-  // You can use { mode: "bigint" } if numbers are exceeding js number limitations
-  signalRuns: bigint("signal_runs", { mode: "number" }).notNull(),
-  extraSignalRunPrice: doublePrecision("extra_signal_run_price").default(0).notNull(),
-});
-
-export const playgrounds = pgTable(
-  "playgrounds",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    name: text().notNull(),
-    projectId: uuid("project_id").notNull(),
-    promptMessages: jsonb("prompt_messages")
-      .default([{ role: "user", content: "" }])
-      .notNull(),
-    modelId: text("model_id").default("").notNull(),
-    outputSchema: text("output_schema"),
-    maxTokens: integer("max_tokens").default(1024),
-    temperature: real().default(sql`'1'`),
-    providerOptions: jsonb("provider_options").default({}),
-    toolChoice: jsonb("tool_choice").default("none"),
-    tools: jsonb().default({}),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "playgrounds_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const signalJobs = pgTable(
-  "signal_jobs",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    signalId: uuid("signal_id").notNull(),
-    projectId: uuid("project_id").notNull(),
-    totalTraces: integer("total_traces").default(0).notNull(),
-    processedTraces: integer("processed_traces").default(0).notNull(),
-    failedTraces: integer("failed_traces").default(0).notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  },
-  (table) => [
-    index("signal_jobs_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
-    index("signal_jobs_signal_id_idx").using("btree", table.signalId.asc().nullsLast().op("uuid_ops")),
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "signal_jobs_project_id_fkey",
-    }).onDelete("cascade"),
-    foreignKey({
-      columns: [table.signalId],
-      foreignColumns: [signals.id],
-      name: "signal_jobs_signal_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const eventDefinitions = pgTable(
-  "event_definitions",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    name: text().notNull(),
-    prompt: text(),
-    projectId: uuid("project_id").notNull(),
-    isSemantic: boolean("is_semantic").default(false).notNull(),
-    structuredOutput: jsonb("structured_output"),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "event_definitions_project_id_fkey",
-    }).onDelete("cascade"),
-    unique("event_definitions_project_id_name_key").on(table.name, table.projectId),
-  ]
-);
-
-export const dashboardCharts = pgTable(
-  "dashboard_charts",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    name: text().notNull(),
-    query: text().notNull(),
-    settings: jsonb().notNull(),
-    projectId: uuid("project_id").notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "dashboard_charts_project_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const sharedPayloads = pgTable(
-  "shared_payloads",
-  {
-    payloadId: uuid("payload_id").defaultRandom().primaryKey().notNull(),
-    projectId: uuid("project_id").defaultRandom().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "shared_payloads_project_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
-export const projectSettings = pgTable(
-  "project_settings",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    name: text(),
-    value: text(),
-    projectId: uuid("project_id").defaultRandom().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "project_settings_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
 export const eventClusters = pgTable(
   "event_clusters",
   {
@@ -1335,7 +1084,7 @@ export const eventClusters = pgTable(
     centroid: jsonb().notNull(),
     name: text().notNull(),
     eventName: text("event_name").notNull(),
-    eventSource: text("event_source").default("").notNull(),
+    eventSource: text("event_source").default("SEMANTIC").notNull(),
   },
   (table) => [
     foreignKey({
@@ -1348,53 +1097,14 @@ export const eventClusters = pgTable(
   ]
 );
 
-export const rolloutSessions = pgTable(
-  "rollout_sessions",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    projectId: uuid("project_id").notNull(),
-    params: jsonb().notNull(),
-    status: text().default("PENDING").notNull(),
-    name: text(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "rollout_sessions_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-  ]
-);
-
-export const signalTriggers = pgTable(
-  "signal_triggers",
-  {
-    id: uuid().defaultRandom().primaryKey().notNull(),
-    projectId: uuid("project_id").notNull(),
-    value: jsonb().notNull(),
-    signalId: uuid("signal_id").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-  },
-  (table) => [
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "signal_triggers_project_id_fkey",
-    }).onDelete("cascade"),
-  ]
-);
-
 export const tagClasses = pgTable(
   "tag_classes",
   {
     createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
     name: text().notNull(),
     projectId: uuid("project_id").notNull(),
-    description: text(),
     color: text().default("rgb(190, 194, 200)").notNull(),
+    description: text(),
   },
   (table) => [
     foreignKey({
@@ -1405,6 +1115,7 @@ export const tagClasses = pgTable(
       .onUpdate("cascade")
       .onDelete("cascade"),
     primaryKey({ columns: [table.name, table.projectId], name: "tag_classes_pkey" }),
+    unique("label_classes_name_project_id_unique").on(table.name, table.projectId),
     unique("tag_classes_name_project_id_unique").on(table.name, table.projectId),
   ]
 );
@@ -1478,8 +1189,8 @@ export const clusters = pgTable(
   (table) => [
     index("clusters_project_id_level_idx").using(
       "btree",
-      table.projectId.asc().nullsLast().op("int8_ops"),
-      table.level.asc().nullsLast().op("uuid_ops")
+      table.projectId.asc().nullsLast().op("uuid_ops"),
+      table.level.asc().nullsLast().op("int8_ops")
     ),
     index("clusters_project_id_name_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
     foreignKey({
@@ -1488,64 +1199,6 @@ export const clusters = pgTable(
       name: "clusters_project_id_fkey",
     }),
     primaryKey({ columns: [table.id, table.projectId], name: "clusters_pkey" }),
-  ]
-);
-
-export const spans = pgTable(
-  "spans",
-  {
-    spanId: uuid("span_id").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
-    parentSpanId: uuid("parent_span_id"),
-    name: text().notNull(),
-    attributes: jsonb(),
-    input: jsonb(),
-    output: jsonb(),
-    spanType: spanType("span_type").notNull(),
-    startTime: timestamp("start_time", { withTimezone: true, mode: "string" }).notNull(),
-    endTime: timestamp("end_time", { withTimezone: true, mode: "string" }).notNull(),
-    traceId: uuid("trace_id").notNull(),
-    inputPreview: text("input_preview"),
-    outputPreview: text("output_preview"),
-    projectId: uuid("project_id").notNull(),
-    inputUrl: text("input_url"),
-    outputUrl: text("output_url"),
-    status: text(),
-  },
-  (table) => [
-    index("spans_name_idx").using("btree", table.name.asc().nullsLast().op("text_ops")),
-    index("spans_project_id_start_time_idx").using(
-      "btree",
-      table.projectId.asc().nullsLast().op("uuid_ops"),
-      table.startTime.asc().nullsLast().op("timestamptz_ops")
-    ),
-    index("spans_root_project_id_start_time_trace_id_idx")
-      .using(
-        "btree",
-        table.projectId.asc().nullsLast().op("uuid_ops"),
-        table.startTime.asc().nullsLast().op("uuid_ops"),
-        table.traceId.asc().nullsLast().op("uuid_ops")
-      )
-      .where(sql`(parent_span_id IS NULL)`),
-    index("spans_trace_id_start_time_idx").using(
-      "btree",
-      table.traceId.asc().nullsLast().op("timestamptz_ops"),
-      table.startTime.asc().nullsLast().op("uuid_ops")
-    ),
-    foreignKey({
-      columns: [table.projectId],
-      foreignColumns: [projects.id],
-      name: "spans_project_id_fkey",
-    })
-      .onUpdate("cascade")
-      .onDelete("cascade"),
-    primaryKey({ columns: [table.spanId, table.projectId], name: "spans_pkey" }),
-    pgPolicy("select_by_next_api_key", {
-      as: "permissive",
-      for: "select",
-      to: ["public"],
-      using: sql`is_project_id_accessible_for_api_key(api_key(), project_id)`,
-    }),
   ]
 );
 
@@ -1566,6 +1219,7 @@ export const traces = pgTable(
       .default(sql`'0'`)
       .notNull(),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+    traceType: traceType("trace_type"),
     // You can use { mode: "bigint" } if numbers are exceeding js number limitations
     inputTokenCount: bigint("input_token_count", { mode: "number" })
       .default(sql`'0'`)
@@ -1591,18 +1245,12 @@ export const traces = pgTable(
     numSpans: bigint("num_spans", { mode: "number" }),
     topSpanName: text("top_span_name"),
     topSpanType: smallint("top_span_type"),
-    traceType: traceType("trace_type"),
     type: smallint(),
     spanNames: jsonb("span_names"),
     rootSpanInput: text("root_span_input"),
     rootSpanOutput: text("root_span_output"),
   },
   (table) => [
-    index("traces_pkey").using(
-      "btree",
-      table.id.asc().nullsLast().op("uuid_ops"),
-      table.projectId.asc().nullsLast().op("uuid_ops")
-    ),
     index("traces_project_id_idx").using("btree", table.projectId.asc().nullsLast().op("uuid_ops")),
     index("traces_session_id_idx").using("btree", table.sessionId.asc().nullsLast().op("text_ops")),
     foreignKey({
@@ -1612,12 +1260,7 @@ export const traces = pgTable(
     })
       .onUpdate("cascade")
       .onDelete("cascade"),
-    primaryKey({ columns: [table.id, table.projectId], name: "traces_pkey_constraint" }),
-    pgPolicy("select_by_next_api_key", {
-      as: "permissive",
-      for: "select",
-      to: ["anon", "authenticated"],
-      using: sql`is_project_id_accessible_for_api_key(api_key(), project_id)`,
-    }),
+    primaryKey({ columns: [table.id, table.projectId], name: "traces_pkey" }),
+    unique("traces_project_id_id_unique").on(table.id, table.projectId),
   ]
 );


### PR DESCRIPTION
Meters are now updated to be sum, thus the updated logic of reset. Also, the column for reset was renamed on workspaces table.

This is an early WIP pending further testing, opening as ready for bots to have a look at obvious logic issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes Stripe billing/meter event generation and subscription webhook behavior, which can directly affect customer usage accounting and invoicing. Also adds a new DB column used for usage calculations, requiring careful rollout/migration coordination.
> 
> **Overview**
> Switches overage pricing from byte-based lookup keys to new **megabyte-based** lookup keys in `TIER_CONFIG`, and updates subscription item provisioning/tier switching to use those new Stripe prices.
> 
> Refactors Stripe webhook handling so `invoice.finalized` calls a new `handleInvoiceFinalized(invoice)` that detects overage lines, updates `workspaces.lastUsageCalculationTime`, and emits negative aggregate `meterEvents` to reset monthly usage; subscription change handling now also emits meter events to adjust included-usage allowances when metered items are added/removed.
> 
> Adds migration `0075` to introduce `workspaces.last_usage_calculation_time` (and adjusts subscription activation logic to set it for free→paid), plus related schema snapshot/relations regeneration and a composite PK/unique constraint on `traces`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bad7a4673597a2c6c432ae126db7497627191ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->