### PR TITLE
fetch session images on request only

### DIFF
--- a/frontend/components/shared/traces/session-player.tsx
+++ b/frontend/components/shared/traces/session-player.tsx
@@ -49,6 +49,7 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
   const [currentUrl, setCurrentUrl] = useState("");
   const [urlChanges, setUrlChanges] = useState<UrlChange[]>([]);
   const [activeTab, setActiveTab] = useState(hasBrowserSession ? "browser-session" : "images");
+  const [imagesTabOpened, setImagesTabOpened] = useState(!hasBrowserSession);
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
   const [speed, setSpeed] = useLocalStorage("session-player-speed", 1);
 
@@ -256,7 +257,10 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
         )}
 
         <button
-          onClick={() => setActiveTab("images")}
+          onClick={() => {
+            setActiveTab("images");
+            setImagesTabOpened(true);
+          }}
           className={`mx-2 inline-flex items-center justify-center whitespace-nowrap border-b-2 py-1.5 text-sm transition-all gap-2 font-medium ${
             activeTab === "images"
               ? "border-secondary-foreground text-foreground"
@@ -352,11 +356,9 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
           )}
         </div>
 
-        {activeTab === "images" && (
-          <div className="h-full">
-            <SpanImagesVideoPlayer traceId={traceId} spanIds={llmSpanIds} isShared />
-          </div>
-        )}
+        <div className={`h-full ${activeTab === "images" ? "block" : "hidden"}`}>
+          <SpanImagesVideoPlayer traceId={traceId} spanIds={llmSpanIds} isShared enabled={imagesTabOpened} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/shared/traces/session-player.tsx
+++ b/frontend/components/shared/traces/session-player.tsx
@@ -352,9 +352,11 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
           )}
         </div>
 
-        <div className={`h-full ${activeTab === "images" ? "block" : "hidden"}`}>
-          <SpanImagesVideoPlayer traceId={traceId} spanIds={llmSpanIds} isShared />
-        </div>
+        {activeTab === "images" && (
+          <div className="h-full">
+            <SpanImagesVideoPlayer traceId={traceId} spanIds={llmSpanIds} isShared />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/components/traces/session-player.tsx
+++ b/frontend/components/traces/session-player.tsx
@@ -355,9 +355,11 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
           )}
         </div>
 
-        <div className={`h-full ${activeTab === "images" ? "block" : "hidden"}`}>
-          <SpanImagesVideoPlayer traceId={traceId} spanIds={llmSpanIds} />
-        </div>
+        {activeTab === "images" && (
+          <div className="h-full">
+            <SpanImagesVideoPlayer traceId={traceId} spanIds={llmSpanIds} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/components/traces/session-player.tsx
+++ b/frontend/components/traces/session-player.tsx
@@ -54,6 +54,7 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
   const [currentUrl, setCurrentUrl] = useState("");
   const [urlChanges, setUrlChanges] = useState<UrlChange[]>([]);
   const [activeTab, setActiveTab] = useState(hasBrowserSession ? "browser-session" : "images");
+  const [imagesTabOpened, setImagesTabOpened] = useState(!hasBrowserSession);
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
   const [speed, setSpeed] = useLocalStorage("session-player-speed", 1);
 
@@ -261,7 +262,10 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
         )}
 
         <button
-          onClick={() => setActiveTab("images")}
+          onClick={() => {
+            setActiveTab("images");
+            setImagesTabOpened(true);
+          }}
           className={`mx-2 inline-flex items-center justify-center whitespace-nowrap border-b-2 py-1.5 text-sm transition-all gap-2 font-medium ${
             activeTab === "images"
               ? "border-secondary-foreground text-foreground"
@@ -355,11 +359,9 @@ const SessionPlayer = ({ hasBrowserSession, traceId, llmSpanIds = [], onClose }:
           )}
         </div>
 
-        {activeTab === "images" && (
-          <div className="h-full">
-            <SpanImagesVideoPlayer traceId={traceId} spanIds={llmSpanIds} />
-          </div>
-        )}
+        <div className={`h-full ${activeTab === "images" ? "block" : "hidden"}`}>
+          <SpanImagesVideoPlayer traceId={traceId} spanIds={llmSpanIds} enabled={imagesTabOpened} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/traces/span-images-video-player.tsx
+++ b/frontend/components/traces/span-images-video-player.tsx
@@ -23,11 +23,12 @@ interface SpanImagesVideoPlayerProps {
   traceId: string;
   spanIds: string[];
   isShared?: boolean;
+  enabled?: boolean;
 }
 
 const speedOptions = [1, 2, 4, 8, 16];
 const frameInterval = 41.67; // 24fps;
-const SpanImagesVideoPlayer = ({ traceId, spanIds, isShared = false }: SpanImagesVideoPlayerProps) => {
+const SpanImagesVideoPlayer = ({ traceId, spanIds, isShared = false, enabled = true }: SpanImagesVideoPlayerProps) => {
   const { projectId } = useParams();
   const [preloadedImages, setPreloadedImages] = useState<Map<string, HTMLImageElement>>(new Map());
   const [isPlaying, setIsPlaying] = useState(false);
@@ -47,7 +48,7 @@ const SpanImagesVideoPlayer = ({ traceId, spanIds, isShared = false }: SpanImage
   const store = useTraceViewBaseStoreRaw();
 
   const swrKey =
-    spanIds.length > 0
+    enabled && spanIds.length > 0
       ? {
           url: isShared
             ? `/api/shared/traces/${traceId}/spans/images`

--- a/frontend/lib/actions/span/images.ts
+++ b/frontend/lib/actions/span/images.ts
@@ -27,7 +27,7 @@ export async function getSpanImages(input: z.infer<typeof GetSpanImagesSchema>):
 
   const chResult = await clickhouseClient.query({
     query: `
-      SELECT span_id, name, start_time, end_time, input, output
+      SELECT span_id, name, start_time, end_time, input
       FROM spans
       WHERE span_id IN {spanIds: Array(UUID)} AND project_id = {projectId: UUID} AND trace_id = {traceId: UUID}
       ORDER BY start_time ASC
@@ -42,7 +42,6 @@ export async function getSpanImages(input: z.infer<typeof GetSpanImagesSchema>):
     start_time: string;
     end_time: string;
     input: string;
-    output: string;
   }>;
 
   return chData.flatMap((spanData) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/performance change that defers image fetching until the Images tab is opened; main risk is missing images if any flows relied on eager loading or on `output` being queried for images.
> 
> **Overview**
> **Span images are now fetched on-demand.** Both session player variants track whether the Images tab has ever been opened and pass `enabled` to `SpanImagesVideoPlayer` so SWR only requests/preloads images after the tab is selected (or immediately when there is no browser session).
> 
> **Backend query is slimmed down.** `getSpanImages` no longer selects/parses `output`, reducing the data pulled from ClickHouse for image extraction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb7d8f95a0e94de0f2531db86068e5d0eb4d47d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->