### PR TITLE
report megabytes on switchTier

### DIFF
--- a/frontend/app/api/webhook/stripe/route.ts
+++ b/frontend/app/api/webhook/stripe/route.ts
@@ -59,17 +59,17 @@ async function addOveragePricesToSubscription(subscription: Stripe.Subscription)
   // Check if overage items already exist (idempotency – e.g. if the webhook is retried)
   const existingLookupKeys = new Set(freshSubscription.items.data.map((item) => item.price.lookup_key));
   if (
-    existingLookupKeys.has(tierConfig.overageBytesLookupKey) &&
+    existingLookupKeys.has(tierConfig.overageMegabytesLookupKey) &&
     existingLookupKeys.has(tierConfig.overageSignalRunsLookupKey)
   ) {
     return;
   }
 
   const overagePrices = await s.prices.list({
-    lookup_keys: [tierConfig.overageBytesLookupKey, tierConfig.overageSignalRunsLookupKey],
+    lookup_keys: [tierConfig.overageMegabytesLookupKey, tierConfig.overageSignalRunsLookupKey],
   });
 
-  const bytesOveragePrice = overagePrices.data.find((p) => p.lookup_key === tierConfig.overageBytesLookupKey);
+  const bytesOveragePrice = overagePrices.data.find((p) => p.lookup_key === tierConfig.overageMegabytesLookupKey);
   const signalRunsOveragePrice = overagePrices.data.find((p) => p.lookup_key === tierConfig.overageSignalRunsLookupKey);
 
   if (!bytesOveragePrice || !signalRunsOveragePrice) {
@@ -78,7 +78,7 @@ async function addOveragePricesToSubscription(subscription: Stripe.Subscription)
   }
 
   const items: Stripe.SubscriptionUpdateParams.Item[] = [];
-  if (!existingLookupKeys.has(tierConfig.overageBytesLookupKey)) {
+  if (!existingLookupKeys.has(tierConfig.overageMegabytesLookupKey)) {
     items.push({ price: bytesOveragePrice.id });
   }
   if (!existingLookupKeys.has(tierConfig.overageSignalRunsLookupKey)) {
@@ -139,7 +139,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       // Filter: must contain a line for a known overage price.
       // This excludes addon-only invoices and other unrelated invoices.
       const knownLookupKeys = new Set<string>(
-        Object.values(TIER_CONFIG).flatMap((c) => [c.overageBytesLookupKey, c.overageSignalRunsLookupKey])
+        Object.values(TIER_CONFIG).flatMap((c) => [c.overageMegabytesLookupKey, c.overageSignalRunsLookupKey])
       );
       let hasBytesOverage = false;
       let hasSignalRunsOverage = false;

--- a/frontend/lib/actions/checkout/index.ts
+++ b/frontend/lib/actions/checkout/index.ts
@@ -214,7 +214,7 @@ export const switchTier = async (input: z.infer<typeof SwitchTierSchema>): Promi
 
   const usage = await getWorkspaceUsage(workspaceId);
 
-  const newBytesOverage = Math.max(0, usage.totalBytesIngested - newTierConfig.includedBytes);
+  const newMegabytesOverage = Math.max(0, usage.totalBytesIngested - newTierConfig.includedBytes) / 1024 / 1024;
   const newSignalRunsOverage = Math.max(0, usage.totalSignalRuns - newTierConfig.includedSignalRuns);
 
   const subscription = await s.subscriptions.retrieve(workspace[0].subscriptionId);
@@ -224,18 +224,18 @@ export const switchTier = async (input: z.infer<typeof SwitchTierSchema>): Promi
   const newPrices = await s.prices.list({
     lookup_keys: [
       newTierConfig.lookupKey,
-      newTierConfig.overageBytesLookupKey,
+      newTierConfig.overageMegabytesLookupKey,
       newTierConfig.overageSignalRunsLookupKey,
     ],
   });
 
   const newFlatPrice = newPrices.data.find((p) => p.lookup_key === newTierConfig.lookupKey);
-  const newBytesOveragePrice = newPrices.data.find((p) => p.lookup_key === newTierConfig.overageBytesLookupKey);
+  const newMegabytesOveragePrice = newPrices.data.find((p) => p.lookup_key === newTierConfig.overageMegabytesLookupKey);
   const newSignalRunsOveragePrice = newPrices.data.find(
     (p) => p.lookup_key === newTierConfig.overageSignalRunsLookupKey
   );
 
-  if (!newFlatPrice || !newBytesOveragePrice || !newSignalRunsOveragePrice) {
+  if (!newFlatPrice || !newMegabytesOveragePrice || !newSignalRunsOveragePrice) {
     throw new Error("Could not resolve new tier prices in Stripe");
   }
 
@@ -249,7 +249,7 @@ export const switchTier = async (input: z.infer<typeof SwitchTierSchema>): Promi
   await s.subscriptions.update(workspace[0].subscriptionId, {
     items: [
       ...oldUsageItems.map((item) => ({ id: item.id, deleted: true as const })),
-      { price: newBytesOveragePrice.id },
+      { price: newMegabytesOveragePrice.id },
       { price: newSignalRunsOveragePrice.id },
     ],
     proration_behavior: "none",
@@ -275,7 +275,7 @@ export const switchTier = async (input: z.infer<typeof SwitchTierSchema>): Promi
       timestamp,
       payload: {
         stripe_customer_id: stripeCustomerId,
-        [METER_EVENT_NAMES.overageBytes.payloadKey]: String(newBytesOverage),
+        [METER_EVENT_NAMES.overageBytes.payloadKey]: String(newMegabytesOverage),
       },
     }),
     s.billing.meterEvents.create({

--- a/frontend/lib/actions/checkout/types.ts
+++ b/frontend/lib/actions/checkout/types.ts
@@ -3,14 +3,14 @@ import type Stripe from "stripe";
 export const TIER_CONFIG = {
   hobby: {
     lookupKey: "hobby_monthly_2026_02",
-    overageBytesLookupKey: "hobby_monthly_2026_03_overage_megabytes",
+    overageMegabytesLookupKey: "hobby_monthly_2026_03_overage_megabytes",
     overageSignalRunsLookupKey: "hobby_monthly_2026_02_overage_signal_runs",
     includedBytes: 3 * 1024 ** 3,
     includedSignalRuns: 1_000,
   },
   pro: {
     lookupKey: "pro_monthly_2026_02",
-    overageBytesLookupKey: "pro_monthly_2026_03_overage_megabytes",
+    overageMegabytesLookupKey: "pro_monthly_2026_03_overage_megabytes",
     overageSignalRunsLookupKey: "pro_monthly_2026_02_overage_signal_runs",
     includedBytes: 10 * 1024 ** 3,
     includedSignalRuns: 10_000,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Stripe subscription update and metered usage reporting paths; incorrect unit conversion or lookup key mismatches could cause incorrect billing for overage items.
> 
> **Overview**
> Switches data overage handling from *bytes-based* identifiers to *megabytes-based* ones by renaming `TIER_CONFIG` to use `overageMegabytesLookupKey` and updating all Stripe lookup-key references accordingly.
> 
> On `switchTier`, overage usage sent to Stripe is now calculated and reported in **megabytes** (bytes delta divided by `1024*1024`) while swapping the metered overage subscription item to the megabytes price. Webhook logic (`invoice.finalized` filtering and post-checkout overage item attachment) is updated to recognize the megabytes overage price keys for idempotency and invoice relevance checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72e0f5b781802c4342e1cc32ce67b8104786e69f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->