### PR TITLE
Signals idempotent runs

### DIFF
--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -17,3 +17,5 @@ pub const WORKSPACE_DEPLOYMENTS_BY_WORKSPACE_CACHE_KEY: &str = "workspace_deploy
 pub const DATA_PLANE_AUTH_TOKEN_CACHE_KEY: &str = "data_plane_auth_token";
 pub const REPORT_SCHEDULER_LOCK_CACHE_KEY: &str = "report_scheduler_lock";
 pub const REPORT_SCHEDULER_LAST_CHECK_CACHE_KEY: &str = "report_scheduler_last_check";
+pub const SIGNAL_BATCH_LOCK_CACHE_KEY: &str = "signal_batch_lock";
+pub const SIGNAL_BATCH_SUBMITTED_CACHE_KEY: &str = "signal_batch_submitted";

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1277,6 +1277,7 @@ fn main() -> anyhow::Result<()> {
                     // Spawn LLM batch submissions workers
                     if let Some(llm_client) = llm_provider_client.as_ref() {
                         let db = db_for_consumer.clone();
+                        let cache = cache_for_consumer.clone();
                         let queue = mq_for_consumer.clone();
                         let clickhouse = clickhouse_for_consumer.clone();
                         let llm_client_clone = llm_client.clone();
@@ -1287,6 +1288,7 @@ fn main() -> anyhow::Result<()> {
                             move || {
                                 SignalJobSubmissionBatchHandler::new(
                                     db.clone(),
+                                    cache.clone(),
                                     queue.clone(),
                                     clickhouse.clone(),
                                     llm_client_clone.clone(),

--- a/app-server/src/signals/batching.rs
+++ b/app-server/src/signals/batching.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use uuid::Uuid;
 
 use crate::batch_worker::message_handler::{BatchMessageHandler, HandlerResult};
 use crate::batch_worker::{config::BatchingConfig, message_handler::MessageDelivery};
@@ -56,6 +57,7 @@ impl SignalBatchingHandler {
         match push_to_submissions_queue(
             SignalJobSubmissionBatchMessage {
                 messages: deliveries.iter().map(|d| d.message.clone()).collect(),
+                id: Uuid::new_v4(),
             },
             self.queue.clone(),
         )

--- a/app-server/src/signals/queue.rs
+++ b/app-server/src/signals/queue.rs
@@ -37,6 +37,9 @@ pub const DEFAULT_BATCH_SIZE: usize = 64;
 pub struct SignalJobSubmissionBatchMessage {
     /// All signal messages in this batch (may contain different projects/signals)
     pub messages: Vec<SignalMessage>,
+    /// Unique ID for this batch message, used for idempotency on redelivery
+    #[serde(default = "Uuid::new_v4")]
+    pub id: Uuid,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -7,6 +7,10 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::{
+    cache::{
+        CacheTrait,
+        keys::{SIGNAL_BATCH_LOCK_CACHE_KEY, SIGNAL_BATCH_SUBMITTED_CACHE_KEY},
+    },
     ch::signal_run_messages::{CHSignalRunMessage, insert_signal_run_messages},
     db::DB,
     mq::MessageQueue,
@@ -16,6 +20,7 @@ use crate::{
         queue::{
             SignalJobPendingBatchMessage, SignalJobSubmissionBatchMessage, SignalMessage,
             push_to_pending_queue, push_to_realtime_queue, push_to_signals_queue,
+            push_to_submissions_queue,
         },
         utils::extract_batch_id_from_operation,
     },
@@ -27,6 +32,7 @@ use crate::signals::common::{ProcessRunResult, handle_failed_runs, process_run};
 
 pub struct SignalJobSubmissionBatchHandler {
     pub db: Arc<DB>,
+    pub cache: Arc<crate::cache::Cache>,
     pub queue: Arc<MessageQueue>,
     pub clickhouse: clickhouse::Client,
     pub llm_client: Arc<ProviderClient>,
@@ -36,6 +42,7 @@ pub struct SignalJobSubmissionBatchHandler {
 impl SignalJobSubmissionBatchHandler {
     pub fn new(
         db: Arc<DB>,
+        cache: Arc<crate::cache::Cache>,
         queue: Arc<MessageQueue>,
         clickhouse: clickhouse::Client,
         llm_client: Arc<ProviderClient>,
@@ -43,6 +50,7 @@ impl SignalJobSubmissionBatchHandler {
     ) -> Self {
         Self {
             db,
+            cache,
             queue,
             clickhouse,
             llm_client,
@@ -57,13 +65,15 @@ impl MessageHandler for SignalJobSubmissionBatchHandler {
 
     async fn handle(&self, message: Self::Message) -> Result<(), HandlerError> {
         log::debug!(
-            "[SIGNAL JOB] Processing submission message. runs: {}",
+            "[SIGNAL JOB] Processing submission message. runs: {}, batch_message_id: {}",
             message.messages.len(),
+            message.id,
         );
 
         process(
             message,
             self.db.clone(),
+            self.cache.clone(),
             self.clickhouse.clone(),
             self.queue.clone(),
             self.llm_client.clone(),
@@ -73,7 +83,88 @@ impl MessageHandler for SignalJobSubmissionBatchHandler {
     }
 }
 
+const BATCH_LOCK_TTL_SECONDS: u64 = 7200;
+const BATCH_SUBMITTED_TTL_SECONDS: u64 = 86400;
+
 async fn process(
+    msg: SignalJobSubmissionBatchMessage,
+    db: Arc<DB>,
+    cache: Arc<crate::cache::Cache>,
+    clickhouse: clickhouse::Client,
+    queue: Arc<MessageQueue>,
+    llm_client: Arc<ProviderClient>,
+    config: Arc<SignalWorkerConfig>,
+) -> Result<(), HandlerError> {
+    let batch_message_id = msg.id;
+    let submitted_key = format!("{SIGNAL_BATCH_SUBMITTED_CACHE_KEY}:{batch_message_id}");
+    let lock_key = format!("{SIGNAL_BATCH_LOCK_CACHE_KEY}:{batch_message_id}");
+
+    // Check if this batch was already submitted (idempotency on redelivery)
+    if let Ok(Some(true)) = cache.get::<bool>(&submitted_key).await {
+        log::info!(
+            "[SIGNAL JOB] Batch {} already submitted, skipping",
+            batch_message_id
+        );
+        return Ok(());
+    }
+
+    // Acquire distributed lock to prevent concurrent processing
+    // This can happen if worker is taking long to process the batch and the message is redelivered to another worker
+    match cache
+        .try_acquire_lock(&lock_key, BATCH_LOCK_TTL_SECONDS)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
+            log::info!(
+                "[SIGNAL JOB] Batch {} is locked by another worker, re-publishing to back of queue",
+                batch_message_id,
+            );
+            if let Err(e) = push_to_submissions_queue(msg, queue).await {
+                log::error!(
+                    "[SIGNAL JOB] Failed to re-publish locked batch {}: {:?}",
+                    batch_message_id,
+                    e
+                );
+            }
+            return Ok(());
+        }
+        Err(e) => {
+            log::warn!(
+                "[SIGNAL JOB] Failed to acquire lock for batch {}: {:?}, proceeding without lock",
+                batch_message_id,
+                e
+            );
+        }
+    }
+
+    let result = process_batch(msg, db, clickhouse, queue, llm_client, config).await;
+
+    if result.is_ok() {
+        if let Err(e) = cache
+            .insert_with_ttl(&submitted_key, true, BATCH_SUBMITTED_TTL_SECONDS)
+            .await
+        {
+            log::warn!(
+                "[SIGNAL JOB] Failed to set submitted flag for batch {}: {:?}",
+                batch_message_id,
+                e
+            );
+        }
+    }
+
+    if let Err(e) = cache.release_lock(&lock_key).await {
+        log::warn!(
+            "[SIGNAL JOB] Failed to release lock for batch {}: {:?}",
+            batch_message_id,
+            e
+        );
+    }
+
+    result
+}
+
+async fn process_batch(
     msg: SignalJobSubmissionBatchMessage,
     db: Arc<DB>,
     clickhouse: clickhouse::Client,
@@ -137,12 +228,10 @@ async fn process(
 
     if requests.is_empty() {
         log::error!("[SIGNAL JOB] No requests to submit");
-        // All runs failed during processing, handle them before returning
         handle_failed_runs(clickhouse, db, failed_runs).await;
         return Ok(());
     }
 
-    // Insert new messages into ClickHouse
     if !all_new_messages.is_empty() {
         insert_signal_run_messages(clickhouse.clone(), &all_new_messages)
             .await
@@ -151,7 +240,6 @@ async fn process(
             })?;
     }
 
-    // Submit batch to LLM API
     let batch_result = submit_batch_to_llm(
         &llm_model(),
         llm_client,
@@ -163,12 +251,10 @@ async fn process(
 
     match batch_result {
         Ok(()) => {
-            // Batch submitted successfully, handle any runs that failed during processing
             handle_failed_runs(clickhouse, db, failed_runs).await;
             Ok(())
         }
         Err((batch_failed_runs, handler_error)) => {
-            // Only handle failed runs for permanent errors (transient errors will be retried)
             if matches!(handler_error, HandlerError::Permanent(_)) {
                 failed_runs.extend(batch_failed_runs);
                 handle_failed_runs(clickhouse, db, failed_runs).await;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds cache-based idempotency and distributed locking to the signals batch submission worker and changes clustering lock scoping/TTL behavior, which can affect message processing order and throughput under redelivery/concurrency.
> 
> **Overview**
> **Signals batch submissions are now idempotent on redelivery.** `SignalJobSubmissionBatchMessage` gains a persistent `id` (generated during batching, with a serde default for older messages), and the submissions consumer uses cache keys `signal_batch_lock`/`signal_batch_submitted` to (a) skip already-submitted batches and (b) prevent concurrent processing via a distributed lock; locked batches are re-published to the back of the submissions queue.
> 
> **Clustering locking is refined and made configurable.** The clustering lock key is now scoped by both `project_id` and `signal_id`, and lock TTL / max-wait are driven by `CLUSTERING_LOCK_TTL_SECONDS` and `CLUSTERING_LOCK_MAX_WAIT_SECONDS` (with defaults), with logs updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de559a6a5553f46b58698c7119ea737a4b251005. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->