### PR TITLE
Search snippets regex

### DIFF
--- a/app-server/src/routes/mod.rs
+++ b/app-server/src/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod probes;
 pub mod realtime;
 pub mod rollouts;
+pub mod search_snippets;
 pub mod signals;
 pub mod spans;
 pub mod sql;

--- a/app-server/src/routes/search_snippets.rs
+++ b/app-server/src/routes/search_snippets.rs
@@ -1,0 +1,230 @@
+pub const SNIPPET_CONTEXT_CHARS: usize = 50;
+
+const RE2_META_CHARS: &[char] = &[
+    '\\', '.', '+', '*', '?', '(', ')', '|', '[', ']', '{', '}', '^', '$',
+];
+
+/// Escape a string for use inside a ClickHouse single-quoted string literal.
+pub fn escape_clickhouse_string(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+/// Escape a single token for re2, making alphabetic characters case-insensitive
+/// via inline char classes (`[aA]`) so we never need `(?i)` flags (which contain
+/// `?` that the clickhouse crate misinterprets as bind placeholders).
+fn escape_re2_token_ci(token: &str) -> String {
+    token
+        .chars()
+        .map(|c| {
+            if RE2_META_CHARS.contains(&c) {
+                format!("\\{c}")
+            } else if c.is_ascii_alphabetic() {
+                format!("[{}{}]", c.to_ascii_lowercase(), c.to_ascii_uppercase())
+            } else {
+                c.to_string()
+            }
+        })
+        .collect()
+}
+
+/// Tokenize `query` the same way Quickwit's default tokenizer does (split on
+/// non-alphanumeric boundaries) and build two ClickHouse-compatible (re2) regexes:
+///
+/// 1. **Match regex** – matches just the phrase with flexible non-alnum gaps.
+/// 2. **Context regex** – same core pattern wrapped with `[\s\S]{0,N}` on each
+///    side to pull surrounding context in a single `extract()` call.
+///
+/// Returns `None` when the query yields no alphanumeric tokens.
+/// The returned strings are raw regex; call `escape_clickhouse_string` before
+/// embedding them in a SQL string literal.
+///
+/// The regex avoids `(?i)` / `(?s)` flags entirely (uses inline `[aA]` classes
+/// and `[\s\S]` wildcards) because the `clickhouse` crate treats `?` as a bind
+/// parameter placeholder.
+pub fn build_search_regexes(query: &str) -> Option<(String, String)> {
+    let tokens: Vec<String> = query
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| escape_re2_token_ci(t))
+        .collect();
+
+    if tokens.is_empty() {
+        return None;
+    }
+
+    let core = if tokens.len() == 1 {
+        tokens[0].clone()
+    } else {
+        tokens.join("[^a-zA-Z0-9]+")
+    };
+
+    let match_regex = core.clone();
+    let context_regex = format!(
+        "[\\s\\S]{{0,{ctx}}}{core}[\\s\\S]{{0,{ctx}}}",
+        ctx = SNIPPET_CONTEXT_CHARS,
+    );
+
+    Some((match_regex, context_regex))
+}
+
+/// Post-process an `extract()`-produced snippet and matched text into a final
+/// snippet with `...` prefix/suffix and character-level highlight offsets.
+///
+/// Returns `(text_with_ellipsis, [highlight_start, highlight_end])` in character
+/// offsets, or `None` when either string is empty / no match found.
+pub fn post_process_snippet(
+    snippet: &str,
+    matched_text: &str,
+    context_char_size: usize,
+) -> Option<(String, [usize; 2])> {
+    if snippet.is_empty() || matched_text.is_empty() {
+        return None;
+    }
+
+    let byte_pos = snippet.to_lowercase().find(&matched_text.to_lowercase())?;
+
+    let char_pos = snippet[..byte_pos].chars().count();
+    let matched_char_len = matched_text.chars().count();
+    let snippet_char_len = snippet.chars().count();
+
+    let chars_before = char_pos;
+    let chars_after = snippet_char_len.saturating_sub(char_pos + matched_char_len);
+
+    let has_prefix = chars_before >= context_char_size;
+    let has_suffix = chars_after >= context_char_size;
+
+    let mut text = String::new();
+    if has_prefix {
+        text.push_str("...");
+    }
+    text.push_str(snippet);
+    if has_suffix {
+        text.push_str("...");
+    }
+
+    let prefix_offset = if has_prefix { 3 } else { 0 };
+    let highlight_start = prefix_offset + char_pos;
+    let highlight_end = highlight_start + matched_char_len;
+
+    Some((text, [highlight_start, highlight_end]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_clickhouse_string() {
+        assert_eq!(escape_clickhouse_string("it's"), "it\\'s");
+        assert_eq!(escape_clickhouse_string("a\\b"), "a\\\\b");
+        assert_eq!(escape_clickhouse_string(r#"say "hello""#), r#"say "hello""#);
+    }
+
+    // ── build_search_regexes ────────────────────────────────────────────
+
+    #[test]
+    fn test_regex_single_token() {
+        let (m, c) = build_search_regexes("hello").unwrap();
+        assert_eq!(m, "[hH][eE][lL][lL][oO]");
+        assert!(c.contains("[hH][eE][lL][lL][oO]"));
+        assert!(
+            !m.contains('?'),
+            "regex must not contain ? (clickhouse crate bind placeholder)"
+        );
+    }
+
+    #[test]
+    fn test_regex_multi_token() {
+        let (m, _) = build_search_regexes("git commit -m").unwrap();
+        assert_eq!(
+            m,
+            "[gG][iI][tT][^a-zA-Z0-9]+[cC][oO][mM][mM][iI][tT][^a-zA-Z0-9]+[mM]"
+        );
+    }
+
+    #[test]
+    fn test_regex_non_alnum_separators() {
+        let (m, _) = build_search_regexes("submit=true").unwrap();
+        assert_eq!(m, "[sS][uU][bB][mM][iI][tT][^a-zA-Z0-9]+[tT][rR][uU][eE]");
+    }
+
+    #[test]
+    fn test_regex_punctuation_only_returns_none() {
+        assert!(build_search_regexes("===").is_none());
+        assert!(build_search_regexes("...").is_none());
+    }
+
+    #[test]
+    fn test_regex_escapes_re2_metachar_in_token() {
+        let (m, _) = build_search_regexes("a]b").unwrap();
+        assert_eq!(m, "[aA][^a-zA-Z0-9]+[bB]");
+    }
+
+    #[test]
+    fn test_regex_context_uses_dotall_wildcard() {
+        let (_, c) = build_search_regexes("test").unwrap();
+        let expected_ctx = format!("[\\s\\S]{{0,{}}}", SNIPPET_CONTEXT_CHARS);
+        assert!(c.starts_with(&expected_ctx));
+        assert!(
+            !c.contains('?'),
+            "regex must not contain ? (clickhouse crate bind placeholder)"
+        );
+    }
+
+    #[test]
+    fn test_regex_numeric_tokens_pass_through() {
+        let (m, _) = build_search_regexes("404").unwrap();
+        assert_eq!(m, "404");
+    }
+
+    // ── post_process_snippet ────────────────────────────────────────────
+
+    #[test]
+    fn test_post_process_snippet_no_match() {
+        assert!(post_process_snippet("", "", 50).is_none());
+        assert!(post_process_snippet("hello world", "", 50).is_none());
+        assert!(post_process_snippet("", "hello", 50).is_none());
+    }
+
+    #[test]
+    fn test_post_process_snippet_simple_match() {
+        let result = post_process_snippet("Hello World test end", "Hello", 50);
+        let (text, highlight) = result.unwrap();
+        assert!(!text.starts_with("..."));
+        assert!(!text.ends_with("..."));
+        assert_eq!(&text[..5], "Hello");
+        assert_eq!(highlight, [0, 5]);
+    }
+
+    #[test]
+    fn test_post_process_snippet_with_both_ellipses() {
+        let before = "x".repeat(SNIPPET_CONTEXT_CHARS);
+        let after = "y".repeat(SNIPPET_CONTEXT_CHARS);
+        let snippet = format!("{before}TARGET{after}");
+        let result = post_process_snippet(&snippet, "TARGET", SNIPPET_CONTEXT_CHARS);
+        let (text, highlight) = result.unwrap();
+        assert!(text.starts_with("..."));
+        assert!(text.ends_with("..."));
+        let chars: Vec<char> = text.chars().collect();
+        let highlighted: String = chars[highlight[0]..highlight[1]].iter().collect();
+        assert_eq!(highlighted, "TARGET");
+    }
+
+    #[test]
+    fn test_post_process_snippet_case_insensitive_find() {
+        let result = post_process_snippet("Hello WORLD test", "world", 50);
+        let (text, highlight) = result.unwrap();
+        let chars: Vec<char> = text.chars().collect();
+        let highlighted: String = chars[highlight[0]..highlight[1]].iter().collect();
+        assert_eq!(highlighted, "WORLD");
+    }
+
+    #[test]
+    fn test_post_process_snippet_flexible_match() {
+        let result = post_process_snippet("submit: true is set", "submit: true", 50);
+        let (text, highlight) = result.unwrap();
+        let chars: Vec<char> = text.chars().collect();
+        let highlighted: String = chars[highlight[0]..highlight[1]].iter().collect();
+        assert_eq!(highlighted, "submit: true");
+    }
+}

--- a/app-server/src/routes/search_snippets.rs
+++ b/app-server/src/routes/search_snippets.rs
@@ -81,11 +81,18 @@ pub fn post_process_snippet(
         return None;
     }
 
-    let byte_pos = snippet.to_lowercase().find(&matched_text.to_lowercase())?;
-
-    let char_pos = snippet[..byte_pos].chars().count();
+    let matched_lower: Vec<char> = matched_text.to_lowercase().chars().collect();
     let matched_char_len = matched_text.chars().count();
-    let snippet_char_len = snippet.chars().count();
+    let snippet_chars: Vec<char> = snippet.chars().collect();
+
+    let char_pos = snippet_chars
+        .windows(matched_lower.len())
+        .position(|w| {
+            w.iter()
+                .zip(&matched_lower)
+                .all(|(a, b)| a.to_lowercase().eq(b.to_lowercase()))
+        })?;
+    let snippet_char_len = snippet_chars.len();
 
     let chars_before = char_pos;
     let chars_after = snippet_char_len.saturating_sub(char_pos + matched_char_len);

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -333,6 +333,7 @@ pub async fn search_spans(
 
     let enriched_hits: Vec<SearchSpanHit> = hits
         .into_iter()
+        .filter(|hit| seen_traces.contains(&hit.trace_id))
         .map(|hit| {
             if let Some(row) = snippet_map.get(&hit.span_id) {
                 let input_snippet = search_snippets::post_process_snippet(

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use actix_web::{HttpResponse, post, web};
 use chrono::{DateTime, Utc};
@@ -11,14 +14,15 @@ use crate::{
     db::spans::{Span, SpanType},
     mq::{MessageQueue, MessageQueueTrait, utils::mq_max_payload},
     quickwit::{SPANS_INDEX_ID, client::QuickwitClient},
-    routes::{ResponseResult, error::Error},
+    routes::{ResponseResult, error::Error, search_snippets},
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
 };
 
 const DEFAULT_SEARCH_MAX_HITS: usize = 500;
 const DEFAULT_SEARCH_TIME_RANGE: chrono::Duration = chrono::Duration::days(7);
+
 // TODO: maybe remove all punctuation similar to the default tokenizer in the index?
-const QUICKWIT_RESERVED_CHARACTERS: &[char] = &['?', '`', '~', '!', '\\'];
+const QUICKWIT_RESERVED_CHARACTERS: &[char] = &['"', '?', '`', '~', '!', '\\'];
 // Quickwit documentation is very brief on this, it lists all of the reserved characters
 // with a note that you can escape them with a backslash. However, some of them break
 // the query parsing when escaped, so we need to remove them.
@@ -31,9 +35,11 @@ const QUICKWIT_RESERVED_UNESCAPABLE_CHARACTERS: &[char] = &[
     '\u{2014}', // — em dash
 ];
 
-/// Escape special characters for Quickwit query syntax
+const PARALLEL_SNIPPETS_QUERIES: usize = 32;
+
+/// Escape special characters for Quickwit query syntax and wrap in quotes for phrase search.
 fn escape_quickwit_query(query: &str) -> String {
-    query
+    let escaped: String = query
         .chars()
         .flat_map(|c| {
             if QUICKWIT_RESERVED_CHARACTERS.contains(&c) {
@@ -44,7 +50,8 @@ fn escape_quickwit_query(query: &str) -> String {
                 vec![c]
             }
         })
-        .collect()
+        .collect();
+    format!("\"{escaped}\"")
 }
 
 #[derive(Deserialize)]
@@ -135,10 +142,12 @@ pub struct SearchSpansRequest {
     pub search_query: String,
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
-    #[serde(default)]
-    pub search_in: Option<Vec<String>>,
     pub limit: usize,
     pub offset: usize,
+    #[serde(default)]
+    pub get_snippets: bool,
+    #[serde(default)]
+    pub one_snippet_per_trace: bool,
 }
 
 const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 2] = ["input", "output"];
@@ -154,18 +163,43 @@ struct QuickwitResponse {
     hits: Vec<QuickwitHit>,
 }
 
+#[derive(Serialize)]
+struct SnippetInfo {
+    text: String,
+    highlight: [usize; 2],
+}
+
+#[derive(Serialize)]
+struct SearchSpanHit {
+    trace_id: String,
+    span_id: String,
+    input_snippet: Option<SnippetInfo>,
+    output_snippet: Option<SnippetInfo>,
+}
+
+#[derive(clickhouse::Row, Deserialize)]
+struct SpanSnippetRow {
+    #[serde(with = "clickhouse::serde::uuid")]
+    span_id: Uuid,
+    input_matched_text: String,
+    input_snippet: String,
+    output_matched_text: String,
+    output_snippet: String,
+}
+
 #[post("spans/search")]
 pub async fn search_spans(
     project_id: web::Path<Uuid>,
     request: web::Json<SearchSpansRequest>,
     quickwit_client: web::Data<Option<QuickwitClient>>,
+    clickhouse: web::Data<clickhouse::Client>,
 ) -> ResponseResult {
     let project_id = project_id.into_inner();
     let request = request.into_inner();
 
     let trimmed_query = request.search_query.trim();
     if trimmed_query.is_empty() {
-        return Ok(HttpResponse::Ok().json(Vec::<String>::new()));
+        return Ok(HttpResponse::Ok().json(Vec::<SearchSpanHit>::new()));
     }
 
     // Escape characters reserved by quickwit
@@ -176,7 +210,7 @@ pub async fn search_spans(
         Some(client) => client,
         None => {
             log::warn!("Quickwit search requested but Quickwit client is not available");
-            return Ok(HttpResponse::Ok().json(Vec::<String>::new()));
+            return Ok(HttpResponse::Ok().json(Vec::<SearchSpanHit>::new()));
         }
     };
 
@@ -187,7 +221,7 @@ pub async fn search_spans(
 
     let sort_by = "start_time";
 
-    if let Some(trace_id) = request.trace_id {
+    if let Some(ref trace_id) = request.trace_id {
         query_parts.push(format!("trace_id:{}", trace_id));
     }
 
@@ -198,30 +232,8 @@ pub async fn search_spans(
         "sort_by": sort_by,
     });
 
-    // Handle search fields
-    let search_fields = if let Some(search_in) = request.search_in {
-        if search_in.is_empty() {
-            QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS.to_vec()
-        } else {
-            let valid_fields: Vec<&str> = QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS
-                .iter()
-                .filter(|&&f| search_in.iter().any(|requested| requested == f))
-                .cloned()
-                .collect();
-
-            if valid_fields.is_empty() {
-                QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS.to_vec()
-            } else {
-                valid_fields
-            }
-        }
-    } else {
-        QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS.to_vec()
-    };
-
-    // Quickwit expects search_field as a comma-separated string, not an array
-    let search_field_str = search_fields.join(",");
-    search_body["search_field"] = serde_json::Value::String(search_field_str);
+    let search_fields = QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS.join(",");
+    search_body["search_field"] = serde_json::Value::String(search_fields);
 
     // Handle pagination
     if request.limit != 0 {
@@ -234,19 +246,133 @@ pub async fn search_spans(
         search_body["start_offset"] = serde_json::Value::Number(request.offset.into());
     }
 
-    // Handle timestamps, defaults to last week if not provided
-    if let Some(s) = request.start_time {
-        search_body["start_timestamp"] = serde_json::Value::Number(s.timestamp().into());
-    } else {
-        search_body["start_timestamp"] =
-            serde_json::Value::Number((Utc::now() - DEFAULT_SEARCH_TIME_RANGE).timestamp().into());
-    }
-    if let Some(e) = request.end_time {
-        search_body["end_timestamp"] = serde_json::Value::Number(e.timestamp().into());
+    let effective_start = request
+        .start_time
+        .unwrap_or_else(|| Utc::now() - DEFAULT_SEARCH_TIME_RANGE);
+    let effective_end = request.end_time.unwrap_or_else(Utc::now);
+
+    search_body["start_timestamp"] = serde_json::Value::Number(effective_start.timestamp().into());
+    if request.end_time.is_some() {
+        search_body["end_timestamp"] = serde_json::Value::Number(effective_end.timestamp().into());
     }
 
+    let t0: std::time::Instant = std::time::Instant::now();
     let hits = search_index(quickwit_client, &SPANS_INDEX_ID, search_body).await?;
-    Ok(HttpResponse::Ok().json(hits))
+    log::debug!(
+        "[search_spans] quickwit: {}ms, {} hits",
+        t0.elapsed().as_millis(),
+        hits.len()
+    );
+
+    if hits.is_empty() {
+        return Ok(HttpResponse::Ok().json(Vec::<SearchSpanHit>::new()));
+    }
+
+    if !request.get_snippets {
+        let results: Vec<SearchSpanHit> = hits
+            .into_iter()
+            .map(|h| SearchSpanHit {
+                trace_id: h.trace_id,
+                span_id: h.span_id,
+                input_snippet: None,
+                output_snippet: None,
+            })
+            .collect();
+
+        log::debug!("[search_spans] total: {}ms", t0.elapsed().as_millis());
+        return Ok(HttpResponse::Ok().json(results));
+    }
+
+    let snippet_pairs: Vec<(Uuid, Uuid)> = if request.one_snippet_per_trace {
+        let mut seen_traces = HashSet::new();
+        hits.iter()
+            .filter(|h| seen_traces.insert(h.trace_id.clone()))
+            .filter_map(|h| {
+                let trace_id = Uuid::parse_str(&h.trace_id).ok()?;
+                let span_id = Uuid::parse_str(&h.span_id).ok()?;
+                Some((trace_id, span_id))
+            })
+            .collect()
+    } else {
+        hits.iter()
+            .filter_map(|h| {
+                let trace_id = Uuid::parse_str(&h.trace_id).ok()?;
+                let span_id = Uuid::parse_str(&h.span_id).ok()?;
+                Some((trace_id, span_id))
+            })
+            .collect()
+    };
+
+    let (match_regex, context_regex) = match search_snippets::build_search_regexes(trimmed_query) {
+        Some(regexes) => regexes,
+        None => {
+            let results: Vec<SearchSpanHit> = hits
+                .into_iter()
+                .map(|h| SearchSpanHit {
+                    trace_id: h.trace_id,
+                    span_id: h.span_id,
+                    input_snippet: None,
+                    output_snippet: None,
+                })
+                .collect();
+            return Ok(HttpResponse::Ok().json(results));
+        }
+    };
+
+    let snippet_rows = fetch_span_snippets(
+        &clickhouse,
+        project_id,
+        &snippet_pairs,
+        &match_regex,
+        &context_regex,
+    )
+    .await;
+
+    let context_size = search_snippets::SNIPPET_CONTEXT_CHARS;
+
+    let snippet_map: HashMap<String, SpanSnippetRow> = snippet_rows
+        .into_iter()
+        .map(|row| (row.span_id.to_string(), row))
+        .collect();
+
+    let enriched_hits: Vec<SearchSpanHit> = hits
+        .into_iter()
+        .map(|hit| {
+            if let Some(row) = snippet_map.get(&hit.span_id) {
+                let input_snippet = search_snippets::post_process_snippet(
+                    &row.input_snippet,
+                    &row.input_matched_text,
+                    context_size,
+                )
+                .map(|(text, highlight)| SnippetInfo { text, highlight });
+
+                let output_snippet = search_snippets::post_process_snippet(
+                    &row.output_snippet,
+                    &row.output_matched_text,
+                    context_size,
+                )
+                .map(|(text, highlight)| SnippetInfo { text, highlight });
+
+                SearchSpanHit {
+                    trace_id: hit.trace_id,
+                    span_id: hit.span_id,
+                    input_snippet,
+                    output_snippet,
+                }
+            } else {
+                SearchSpanHit {
+                    trace_id: hit.trace_id,
+                    span_id: hit.span_id,
+                    input_snippet: None,
+                    output_snippet: None,
+                }
+            }
+        })
+        .collect();
+
+    log::debug!("[search_spans] total: {}ms", t0.elapsed().as_millis());
+
+    Ok(HttpResponse::Ok().json(enriched_hits))
 }
 
 async fn search_index(
@@ -265,4 +391,87 @@ async fn search_index(
         })?;
 
     Ok(quickwit_response.hits)
+}
+
+async fn fetch_span_snippets(
+    clickhouse: &clickhouse::Client,
+    project_id: Uuid,
+    pairs: &[(Uuid, Uuid)],
+    match_regex: &str,
+    context_regex: &str,
+) -> Vec<SpanSnippetRow> {
+    if pairs.is_empty() {
+        return Vec::new();
+    }
+
+    let match_escaped = search_snippets::escape_clickhouse_string(match_regex);
+    let context_escaped = search_snippets::escape_clickhouse_string(context_regex);
+
+    let chunk_size = (pairs.len() + PARALLEL_SNIPPETS_QUERIES - 1) / PARALLEL_SNIPPETS_QUERIES;
+    let futures: Vec<_> = pairs
+        .chunks(chunk_size.max(1))
+        .map(|chunk| {
+            let tuples = build_key_tuples(chunk);
+            let query = build_snippet_query(project_id, &match_escaped, &context_escaped, &tuples);
+            async move {
+                let t_start = std::time::Instant::now();
+                clickhouse
+                    .query(&query)
+                    .fetch_all::<SpanSnippetRow>()
+                    .await
+                    .inspect(|rows| {
+                        log::debug!(
+                            "[search_spans] clickhouse snippets: {}ms, {} rows",
+                            t_start.elapsed().as_millis(),
+                            rows.len()
+                        );
+                    })
+                    .unwrap_or_else(|e| {
+                        log::error!("Failed to fetch span snippets from ClickHouse: {:?}", e);
+                        Vec::new()
+                    })
+            }
+        })
+        .collect();
+
+    let results = futures_util::future::join_all(futures).await;
+    results.into_iter().flatten().collect()
+}
+
+fn build_key_tuples(pairs: &[(Uuid, Uuid)]) -> String {
+    pairs
+        .iter()
+        .map(|(trace_id, span_id)| format!("('{trace_id}', '{span_id}')"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn build_snippet_query(
+    project_id: Uuid,
+    match_regex: &str,
+    context_regex: &str,
+    key_tuples: &str,
+) -> String {
+    let input_cols = build_regex_columns("input", match_regex, context_regex);
+    let output_cols = build_regex_columns("output", match_regex, context_regex);
+
+    format!(
+        "SELECT span_id,
+                input_matched_text, input_snippet,
+                output_matched_text, output_snippet
+         FROM (
+           SELECT span_id, {input_cols}, {output_cols}
+           FROM spans_v2
+           WHERE project_id = '{project_id}'
+             AND (trace_id, span_id) IN ({key_tuples})
+           ORDER BY start_time ASC
+         )"
+    )
+}
+
+fn build_regex_columns(field: &str, match_regex: &str, context_regex: &str) -> String {
+    format!(
+        "extract({field}, '{match_regex}') AS {field}_matched_text,
+         extract({field}, '{context_regex}') AS {field}_snippet"
+    )
 }

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -411,7 +411,6 @@ async fn fetch_span_snippets(
             let query = build_snippet_query(project_id, &match_escaped, &context_escaped, &tuples);
             log::debug!("search_spans: snippet query: {:?}", query);
             async move {
-                return Vec::<SpanSnippetRow>::new();
                 let t_start = std::time::Instant::now();
                 clickhouse
                     .query(&query)

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -18,7 +18,8 @@ use crate::{
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
 };
 
-const DEFAULT_SEARCH_MAX_HITS: usize = 500;
+const DEFAULT_SEARCH_MAX_TRACES: usize = 64;
+const DEFAULT_SEARCH_MAX_SPANS: usize = 500;
 const DEFAULT_SEARCH_TIME_RANGE: chrono::Duration = chrono::Duration::days(7);
 
 // TODO: maybe remove all punctuation similar to the default tokenizer in the index?
@@ -35,7 +36,7 @@ const QUICKWIT_RESERVED_UNESCAPABLE_CHARACTERS: &[char] = &[
     '\u{2014}', // — em dash
 ];
 
-const PARALLEL_SNIPPETS_QUERIES: usize = 32;
+const PARALLEL_SNIPPETS_QUERIES: usize = 1;
 
 /// Escape special characters for Quickwit query syntax and wrap in quotes for phrase search.
 fn escape_quickwit_query(query: &str) -> String {
@@ -146,8 +147,6 @@ pub struct SearchSpansRequest {
     pub offset: usize,
     #[serde(default)]
     pub get_snippets: bool,
-    #[serde(default)]
-    pub one_snippet_per_trace: bool,
 }
 
 const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 2] = ["input", "output"];
@@ -195,7 +194,7 @@ pub async fn search_spans(
     clickhouse: web::Data<clickhouse::Client>,
 ) -> ResponseResult {
     let project_id = project_id.into_inner();
-    let request = request.into_inner();
+    let mut request = request.into_inner();
 
     let trimmed_query = request.search_query.trim();
     if trimmed_query.is_empty() {
@@ -239,7 +238,7 @@ pub async fn search_spans(
     if request.limit != 0 {
         search_body["max_hits"] = serde_json::Value::Number(request.limit.into())
     } else {
-        search_body["max_hits"] = serde_json::Value::Number(DEFAULT_SEARCH_MAX_HITS.into());
+        search_body["max_hits"] = serde_json::Value::Number(DEFAULT_SEARCH_MAX_SPANS.into());
     }
 
     if request.offset != 0 {
@@ -283,25 +282,22 @@ pub async fn search_spans(
         return Ok(HttpResponse::Ok().json(results));
     }
 
-    let snippet_pairs: Vec<(Uuid, Uuid)> = if request.one_snippet_per_trace {
-        let mut seen_traces = HashSet::new();
-        hits.iter()
-            .filter(|h| seen_traces.insert(h.trace_id.clone()))
-            .filter_map(|h| {
-                let trace_id = Uuid::parse_str(&h.trace_id).ok()?;
-                let span_id = Uuid::parse_str(&h.span_id).ok()?;
-                Some((trace_id, span_id))
-            })
-            .collect()
-    } else {
-        hits.iter()
-            .filter_map(|h| {
-                let trace_id = Uuid::parse_str(&h.trace_id).ok()?;
-                let span_id = Uuid::parse_str(&h.span_id).ok()?;
-                Some((trace_id, span_id))
-            })
-            .collect()
-    };
+    let mut seen_traces = HashSet::new();
+    let snippet_pairs: Vec<(Uuid, Uuid)> = hits
+        .iter()
+        .filter_map(|h| {
+            if request.trace_id.is_none() && !seen_traces.insert(h.trace_id.clone()) {
+                return None;
+            }
+            if seen_traces.len() > DEFAULT_SEARCH_MAX_TRACES {
+                return None;
+            }
+            seen_traces.insert(h.trace_id.clone());
+            let trace_id = Uuid::parse_str(&h.trace_id).ok()?;
+            let span_id = Uuid::parse_str(&h.span_id).ok()?;
+            Some((trace_id, span_id))
+        })
+        .collect();
 
     let (match_regex, context_regex) = match search_snippets::build_search_regexes(trimmed_query) {
         Some(regexes) => regexes,
@@ -413,7 +409,9 @@ async fn fetch_span_snippets(
         .map(|chunk| {
             let tuples = build_key_tuples(chunk);
             let query = build_snippet_query(project_id, &match_escaped, &context_escaped, &tuples);
+            log::debug!("search_spans: snippet query: {:?}", query);
             async move {
+                return Vec::<SpanSnippetRow>::new();
                 let t_start = std::time::Instant::now();
                 clickhouse
                     .query(&query)

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -23,7 +23,7 @@ const QUICKWIT_RESERVED_CHARACTERS: &[char] = &['?', '`', '~', '!', '\\'];
 // with a note that you can escape them with a backslash. However, some of them break
 // the query parsing when escaped, so we need to remove them.
 const QUICKWIT_RESERVED_UNESCAPABLE_CHARACTERS: &[char] = &[
-    '"', ':', '^', '{', '}', '[', ']', '(', ')',
+    ':', '^', '{', '}', '[', ']', '(', ')',
     // The below characters won't break parsing but change the meaning of the query
     // even when escaped, so safest to remove them.
     '+', '\u{002D}', // - hyphen-minus

--- a/frontend/components/traces/highlighted-snippet.tsx
+++ b/frontend/components/traces/highlighted-snippet.tsx
@@ -1,0 +1,25 @@
+interface HighlightedSnippetProps {
+  snippet: string;
+  highlight?: [number, number];
+  className?: string;
+}
+
+export function HighlightedSnippet({ snippet, highlight, className }: HighlightedSnippetProps) {
+  if (!highlight || highlight[0] >= highlight[1]) {
+    return <span className={className}>{snippet}</span>;
+  }
+
+  const [start, end] = highlight;
+  const chars = [...snippet];
+  const before = chars.slice(0, start).join("");
+  const match = chars.slice(start, end).join("");
+  const after = chars.slice(end).join("");
+
+  return (
+    <span className={className}>
+      {before}
+      <mark className="bg-primary/20 text-foreground rounded-sm px-0.5">{match}</mark>
+      {after}
+    </span>
+  );
+}

--- a/frontend/components/traces/trace-view/list/list-item.tsx
+++ b/frontend/components/traces/trace-view/list/list-item.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronRight, Settings, X } from "lucide-react";
 import React, { useMemo, useState } from "react";
 
 import { useOptionalDebuggerStore } from "@/components/debugger-sessions/debugger-session-view/store";
+import { HighlightedSnippet } from "@/components/traces/highlighted-snippet";
 import { NoSpanTooltip } from "@/components/traces/no-span-tooltip";
 import SpanTypeIcon from "@/components/traces/span-type-icon";
 import { DebuggerCheckpoint } from "@/components/traces/trace-view/debugger-checkpoint.tsx";
@@ -182,18 +183,28 @@ const ListItem = ({ span, output, onSpanSelect, onOpenSettings, isFirst = false,
           </div>
         </div>
 
-        {isExpanded && (
-          <div className="px-3 w-full p-2 pt-0 flex flex-col gap-2 h-full flex-1">
-            {isLoadingOutput ? (
-              <>
-                <Skeleton className="h-12 w-full" />
-              </>
-            ) : isNil(output) ? (
-              <div className="text-sm text-muted-foreground italic">No output available</div>
-            ) : (
-              <Markdown className="max-h-60" output={output} defaultValue={savedTemplate} />
-            )}
+        {span.searchSnippet ? (
+          <div className="px-3 w-full p-2 pt-0">
+            <HighlightedSnippet
+              snippet={span.searchSnippet}
+              highlight={span.snippetHighlight}
+              className="text-xs text-secondary-foreground line-clamp-2 break-all"
+            />
           </div>
+        ) : (
+          isExpanded && (
+            <div className="px-3 w-full p-2 pt-0 flex flex-col gap-2 h-full flex-1">
+              {isLoadingOutput ? (
+                <>
+                  <Skeleton className="h-12 w-full" />
+                </>
+              ) : isNil(output) ? (
+                <div className="text-sm text-muted-foreground italic">No output available</div>
+              ) : (
+                <Markdown className="max-h-60" output={output} defaultValue={savedTemplate} />
+              )}
+            </div>
+          )
         )}
       </div>
     </div>

--- a/frontend/components/traces/trace-view/store/base.ts
+++ b/frontend/components/traces/trace-view/store/base.ts
@@ -48,6 +48,8 @@ export type TraceViewSpan = {
     cacheReadInputTokens?: number;
     hasLLMDescendants: boolean;
   };
+  searchSnippet?: string;
+  snippetHighlight?: [number, number];
 };
 
 export type TraceViewListSpan = {
@@ -66,6 +68,8 @@ export type TraceViewListSpan = {
     display: Array<{ spanId: string; name: string; count?: number }>;
     full: Array<{ spanId: string; name: string }>;
   } | null;
+  searchSnippet?: string;
+  snippetHighlight?: [number, number];
 };
 
 export type TraceViewTrace = {
@@ -242,6 +246,8 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
         totalCost: span.totalCost,
         pending: span.pending,
         pathInfo: pathInfoMap.get(span.spanId) ?? null,
+        searchSnippet: span.searchSnippet,
+        snippetHighlight: span.snippetHighlight,
       }));
 
       return lightweightListSpans;

--- a/frontend/components/traces/trace-view/tree/span-card.tsx
+++ b/frontend/components/traces/trace-view/tree/span-card.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, Settings, X } from "lucide-react";
 import { useMemo, useRef } from "react";
 
 import { useOptionalDebuggerStore } from "@/components/debugger-sessions/debugger-session-view/store";
+import { HighlightedSnippet } from "@/components/traces/highlighted-snippet";
 import { DebuggerCheckpoint } from "@/components/traces/trace-view/debugger-checkpoint.tsx";
 import { type TraceViewSpan, useTraceViewBaseStore } from "@/components/traces/trace-view/store/base";
 import { type PathInfo } from "@/components/traces/trace-view/store/utils";
@@ -184,17 +185,27 @@ export function SpanCard({ span, branchMask, output, onSpanSelect, depth, pathIn
             </Button>
           </div>
 
-          {showContent && (
-            <div className="px-2 pt-0">
-              {isLoadingOutput && (
-                <div className="w-full pb-2">
-                  <Skeleton className="h-12 w-full" />
-                </div>
-              )}
-              {!isLoadingOutput && !isNil(output) && (
-                <Markdown className="max-h-48" output={output} defaultValue={savedTemplate} />
-              )}
+          {span.searchSnippet ? (
+            <div className="px-2 pt-0 pb-1">
+              <HighlightedSnippet
+                snippet={span.searchSnippet}
+                highlight={span.snippetHighlight}
+                className="text-xs text-secondary-foreground line-clamp-2 break-all"
+              />
             </div>
+          ) : (
+            showContent && (
+              <div className="px-2 pt-0">
+                {isLoadingOutput && (
+                  <div className="w-full pb-2">
+                    <Skeleton className="h-12 w-full" />
+                  </div>
+                )}
+                {!isLoadingOutput && !isNil(output) && (
+                  <Markdown className="max-h-48" output={output} defaultValue={savedTemplate} />
+                )}
+              </div>
+            )
           )}
         </div>
       </div>

--- a/frontend/components/traces/traces-table/columns.tsx
+++ b/frontend/components/traces/traces-table/columns.tsx
@@ -3,6 +3,7 @@ import { type ColumnDef } from "@tanstack/react-table";
 import { capitalize } from "lodash";
 
 import ClientTimestampFormatter from "@/components/client-timestamp-formatter";
+import { HighlightedSnippet } from "@/components/traces/highlighted-snippet";
 import SpanTypeIcon, { createSpanTypeIcon } from "@/components/traces/span-type-icon";
 import { Badge } from "@/components/ui/badge.tsx";
 import { type ColumnFilter } from "@/components/ui/infinite-datatable/ui/datatable-filter/utils";
@@ -255,6 +256,33 @@ export const STATIC_COLUMNS: ColumnDef<TraceRow, any>[] = [
     enableSorting: true,
     meta: { sql: "user_id" },
   },
+  {
+    accessorKey: "searchSnippet",
+    header: "Search preview",
+    id: "search_preview",
+    enableSorting: false,
+    cell: (row) => {
+      const snippet = row.getValue() as string | undefined;
+      const matchCount = row.row.original.searchMatchCount;
+      const highlight = row.row.original.searchSnippetHighlight;
+      if (!snippet) return null;
+      return (
+        <div className="flex items-center gap-1.5 min-w-0">
+          <HighlightedSnippet
+            snippet={snippet}
+            highlight={highlight}
+            className="text-xs text-secondary-foreground truncate"
+          />
+          {matchCount && matchCount > 1 && (
+            <span className="shrink-0 text-[10px] bg-primary/10 text-primary font-medium rounded-full px-1.5 py-0.5">
+              {matchCount} {matchCount === 1 ? "span" : "spans"}
+            </span>
+          )}
+        </div>
+      );
+    },
+    size: 250,
+  },
 ];
 
 /** @deprecated Use STATIC_COLUMNS and useTracesTableStore().columnDefs instead */
@@ -365,6 +393,7 @@ export const defaultTracesColumnOrder = [
   "status",
   "id",
   "top_span_type",
+  "search_preview",
   "root_span_input",
   "root_span_output",
   "start_time",

--- a/frontend/lib/actions/evaluation/search.ts
+++ b/frontend/lib/actions/evaluation/search.ts
@@ -1,5 +1,4 @@
 import { searchSpans } from "@/lib/actions/traces/search";
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { type TimeRange } from "@/lib/clickhouse/utils";
 
 export async function getSearchTraceIds(
@@ -15,7 +14,6 @@ export async function getSearchTraceIds(
     traceId: undefined,
     searchQuery: search,
     timeRange: getTimeRangeForEvaluation(evaluationCreatedAt),
-    searchType: searchIn as SpanSearchType[],
   });
 
   return [...new Set(spanHits.map((span) => span.trace_id))];

--- a/frontend/lib/actions/sessions/index.ts
+++ b/frontend/lib/actions/sessions/index.ts
@@ -46,7 +46,6 @@ export async function getSessions(input: z.infer<typeof GetSessionsSchema>): Pro
         projectId,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
       })
     : [];
 

--- a/frontend/lib/actions/signal-jobs/index.ts
+++ b/frontend/lib/actions/signal-jobs/index.ts
@@ -7,7 +7,6 @@ import { Operator } from "@/lib/actions/common/operators";
 import { FiltersSchema, TimeRangeSchema } from "@/lib/actions/common/types.ts";
 import { searchSpans } from "@/lib/actions/traces/search";
 import { buildTracesIdsQueryWithParams, DEFAULT_SEARCH_MAX_HITS } from "@/lib/actions/traces/utils";
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { getTimeRange } from "@/lib/clickhouse/utils";
 import { db } from "@/lib/db/drizzle";
 import { signalJobs } from "@/lib/db/migrations/schema";
@@ -100,7 +99,6 @@ export async function createSignalJob(
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startDate, endDate),
-        searchType: [] as SpanSearchType[],
       })
     : [];
   const traceIdsFromSearch = [...new Set(spanHits.map((span) => span.trace_id))];

--- a/frontend/lib/actions/spans/index.ts
+++ b/frontend/lib/actions/spans/index.ts
@@ -284,7 +284,6 @@ export async function getTraceSpans(input: z.infer<typeof GetTraceSpansSchema>):
         searchQuery: search,
         ...(timeRange && { timeRange }),
         getSnippets: true,
-        onePerTrace: false,
       })
     : [];
   const spanIds = traceSpanHits.map((span) => span.span_id);

--- a/frontend/lib/actions/spans/index.ts
+++ b/frontend/lib/actions/spans/index.ts
@@ -108,16 +108,15 @@ export async function getSpans(input: z.infer<typeof GetSpansSchema>): Promise<{
     pastHours,
   });
 
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const spansHits = search
     ? await searchSpans({
         projectId,
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
       })
     : [];
-  const spanIds = spanHits.map((span) => span.span_id);
+  const spanIds = spansHits.map((span) => span.span_id);
 
   if (search) {
     if (spanIds?.length === 0) {
@@ -278,16 +277,17 @@ export async function getTraceSpans(input: z.infer<typeof GetTraceSpansSchema>):
   const filters: Filter[] = compact(inputFilters);
 
   const timeRange = getOptionalTimeRange(pastHours, startDate, endDate);
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const traceSpanHits = search
     ? await searchSpans({
         projectId,
         traceId,
         searchQuery: search,
         ...(timeRange && { timeRange }),
-        searchType: searchIn as SpanSearchType[],
+        getSnippets: true,
+        onePerTrace: false,
       })
     : [];
-  const spanIds = spanHits.map((span) => span.span_id);
+  const spanIds = traceSpanHits.map((span) => span.span_id);
 
   if (search && spanIds?.length === 0) {
     return [];
@@ -323,7 +323,31 @@ export async function getTraceSpans(input: z.infer<typeof GetTraceSpansSchema>):
 
   const transformedSpans = spans.map((span) => transformSpanWithEvents(span as any, parentRewiring));
 
-  return aggregateSpanMetrics(transformedSpans);
+  const result = aggregateSpanMetrics(transformedSpans);
+
+  if (search && traceSpanHits.length > 0) {
+    const snippetMap = new Map(
+      traceSpanHits.map((hit) => {
+        const info = hit.output_snippet ?? hit.input_snippet;
+        return [
+          hit.span_id,
+          {
+            snippet: info?.text,
+            highlight: info?.highlight,
+          },
+        ];
+      })
+    );
+    for (const span of result) {
+      const snippetData = snippetMap.get(span.spanId);
+      if (snippetData) {
+        span.searchSnippet = snippetData.snippet;
+        span.snippetHighlight = snippetData.highlight;
+      }
+    }
+  }
+
+  return result;
 }
 
 export async function deleteSpans(input: z.infer<typeof DeleteSpansSchema>) {

--- a/frontend/lib/actions/traces/index.ts
+++ b/frontend/lib/actions/traces/index.ts
@@ -4,14 +4,13 @@ import { z } from "zod/v4";
 import { type Filter } from "@/lib/actions/common/filters";
 import { PaginationFiltersSchema, TimeRangeSchema } from "@/lib/actions/common/types";
 import { executeQuery } from "@/lib/actions/sql";
-import { searchSpans } from "@/lib/actions/traces/search";
+import { type SearchSpanHit, searchSpans } from "@/lib/actions/traces/search";
 import {
   buildTracesCountQueryWithParams,
   buildTracesQueryWithParams,
   type CustomColumn,
 } from "@/lib/actions/traces/utils";
 import { clickhouseClient } from "@/lib/clickhouse/client.ts";
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { getTimeRange } from "@/lib/clickhouse/utils";
 import { type TraceRow } from "@/lib/traces/types.ts";
 
@@ -67,13 +66,13 @@ export async function getTraces(input: z.infer<typeof GetTracesSchema>): Promise
   let limit = pageSize;
   let offset = Math.max(0, pageNumber * pageSize);
 
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const spanHits: SearchSpanHit[] = search
     ? await searchSpans({
         projectId,
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
+        getSnippets: true,
       })
     : [];
   const traceIds = [...new Set(spanHits.map((span) => span.trace_id))];
@@ -126,6 +125,7 @@ export async function getTraces(input: z.infer<typeof GetTracesSchema>): Promise
   const items = await executeQuery<TraceRow>({ query: mainQuery, parameters: mainParams, projectId });
 
   // If we have traceIds from search, sort items to match the search order
+  // and enrich with snippet data
   if (search && traceIds.length > 0) {
     const traceIdIndexMap = new Map(traceIds.map((id, index) => [id, index]));
     items.sort((a, b) => {
@@ -133,6 +133,36 @@ export async function getTraces(input: z.infer<typeof GetTracesSchema>): Promise
       const indexB = traceIdIndexMap.get(b.id) ?? Infinity;
       return indexA - indexB;
     });
+
+    const snippetsByTrace = new Map<
+      string,
+      { snippet: string; highlight?: [number, number]; matchingSpanCount: number }
+    >();
+    for (const hit of spanHits) {
+      const info = hit.output_snippet ?? hit.input_snippet;
+      if (!info) continue;
+      const existing = snippetsByTrace.get(hit.trace_id);
+      if (existing) {
+        existing.matchingSpanCount += 1;
+        existing.snippet = info.text;
+        existing.highlight = info.highlight;
+      } else {
+        snippetsByTrace.set(hit.trace_id, {
+          snippet: info.text,
+          highlight: info.highlight,
+          matchingSpanCount: 1,
+        });
+      }
+    }
+
+    for (const item of items) {
+      const snippetData = snippetsByTrace.get(item.id);
+      if (snippetData) {
+        item.searchSnippet = snippetData.snippet;
+        item.searchSnippetHighlight = snippetData.highlight;
+        item.searchMatchCount = snippetData.matchingSpanCount;
+      }
+    }
   }
 
   return {
@@ -154,16 +184,15 @@ export async function countTraces(input: z.infer<typeof GetTracesSchema>): Promi
 
   const filters: Filter[] = compact(inputFilters);
 
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const countSpanHits = search
     ? await searchSpans({
         projectId,
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
       })
     : [];
-  const traceIds = [...new Set(spanHits.map((span) => span.trace_id))];
+  const traceIds = [...new Set(countSpanHits.map((span) => span.trace_id))];
 
   if (search && traceIds?.length === 0) {
     return { count: 0 };

--- a/frontend/lib/actions/traces/search.ts
+++ b/frontend/lib/actions/traces/search.ts
@@ -19,14 +19,12 @@ export const searchSpans = async ({
   searchQuery,
   timeRange,
   getSnippets = false,
-  onePerTrace = true,
 }: {
   projectId: string;
   traceId?: string;
   searchQuery: string;
   timeRange?: TimeRange;
   getSnippets?: boolean;
-  onePerTrace?: boolean;
 }): Promise<SearchSpanHit[]> => {
   const trimmedQuery = searchQuery.trim();
   if (!trimmedQuery) {
@@ -56,7 +54,6 @@ export const searchSpans = async ({
     limit: 0,
     offset: 0,
     getSnippets,
-    onePerTrace,
   };
 
   try {

--- a/frontend/lib/actions/traces/search.ts
+++ b/frontend/lib/actions/traces/search.ts
@@ -1,20 +1,33 @@
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { type TimeRange } from "@/lib/clickhouse/utils";
 import { fetcherJSON } from "@/lib/utils";
+
+export type SnippetInfo = {
+  text: string;
+  highlight: [number, number];
+};
+
+export type SearchSpanHit = {
+  trace_id: string;
+  span_id: string;
+  input_snippet?: SnippetInfo;
+  output_snippet?: SnippetInfo;
+};
 
 export const searchSpans = async ({
   projectId,
   traceId,
   searchQuery,
   timeRange,
-  searchType,
+  getSnippets = false,
+  onePerTrace = true,
 }: {
   projectId: string;
   traceId?: string;
   searchQuery: string;
   timeRange?: TimeRange;
-  searchType?: SpanSearchType[];
-}): Promise<{ trace_id: string; span_id: string }[]> => {
+  getSnippets?: boolean;
+  onePerTrace?: boolean;
+}): Promise<SearchSpanHit[]> => {
   const trimmedQuery = searchQuery.trim();
   if (!trimmedQuery) {
     return [];
@@ -40,14 +53,14 @@ export const searchSpans = async ({
     searchQuery: trimmedQuery,
     startTime,
     endTime,
-    searchIn: searchType?.map((t) => t.toString()),
-    // Pagination is currently disabled (defaults on app-server side): API paginates by traces, search engine by spans
     limit: 0,
     offset: 0,
+    getSnippets,
+    onePerTrace,
   };
 
   try {
-    return await fetcherJSON<{ trace_id: string; span_id: string }[]>(`/projects/${projectId}/spans/search`, {
+    return await fetcherJSON<SearchSpanHit[]>(`/projects/${projectId}/spans/search`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/frontend/lib/actions/traces/stats.ts
+++ b/frontend/lib/actions/traces/stats.ts
@@ -7,7 +7,6 @@ import { executeQuery } from "@/lib/actions/sql";
 import { GetTracesSchema } from "@/lib/actions/traces";
 import { searchSpans } from "@/lib/actions/traces/search";
 import { buildTracesStatsWhereConditions, generateEmptyTimeBuckets } from "@/lib/actions/traces/utils";
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { getTimeRange } from "@/lib/clickhouse/utils";
 
 export const GetTraceStatsSchema = GetTracesSchema.omit({
@@ -42,13 +41,12 @@ export async function getTraceStats(
 
   const filters: Filter[] = compact(inputFilters);
 
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const spanHits = search
     ? await searchSpans({
         projectId,
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
       })
     : [];
   const traceIds = [...new Set(spanHits.map((span) => span.trace_id))];

--- a/frontend/lib/traces/types.ts
+++ b/frontend/lib/traces/types.ts
@@ -145,6 +145,9 @@ export type TraceRow = {
   analysis?: string;
   rootSpanInput?: string;
   rootSpanOutput?: string;
+  searchSnippet?: string;
+  searchSnippetHighlight?: [number, number];
+  searchMatchCount?: number;
 };
 
 export type RealtimeTracePayload = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new ClickHouse query path that builds/embeds regex and tuple filters into SQL to fetch snippets, which could affect query performance and has some injection/escaping risk if edge cases are missed. The change also alters the `spans/search` API response shape and multiple UI consumers, so regressions in search display are possible.
> 
> **Overview**
> Search results can now return **context snippets + highlight offsets** for matching span `input`/`output`, and the UI renders these as a preview.
> 
> On the backend, `POST /spans/search` now optionally enriches Quickwit hits (`getSnippets`) by querying ClickHouse `spans_v2` with generated re2 regexes (new `routes/search_snippets.rs`) and returns per-hit `input_snippet`/`output_snippet` data; it also tweaks Quickwit query escaping and caps snippet enrichment to a limited number of traces.
> 
> On the frontend, the search action is updated to request/consume snippet-enriched hits, trace/span types are extended to carry snippet metadata, and the traces table + trace view list/tree show a new **Search preview** using `HighlightedSnippet`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d22151af42f2f14a09c74826fa8821c5357a73a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->