### PR TITLE
Search snippets

### DIFF
--- a/app-server/src/routes/mod.rs
+++ b/app-server/src/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod probes;
 pub mod realtime;
 pub mod rollouts;
+pub mod search_snippets;
 pub mod signals;
 pub mod spans;
 pub mod sql;

--- a/app-server/src/routes/search_snippets.rs
+++ b/app-server/src/routes/search_snippets.rs
@@ -1,0 +1,100 @@
+const SNIPPET_CONTEXT_CHARS: usize = 50;
+
+/// Escape a string for use inside a ClickHouse single-quoted string literal.
+pub fn escape_clickhouse_string(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+/// Post-process a raw snippet substring from ClickHouse into a final snippet
+/// with `...` prefix/suffix and character-level highlight offsets.
+///
+/// - `raw_snippet`: the substring extracted by ClickHouse via `substringUTF8`
+/// - `char_pos`: 1-indexed character position of the match in the original text (0 = no match)
+/// - `snippet_max_chars`: max characters requested from ClickHouse (to infer suffix)
+/// - `needle_char_len`: character length of the search phrase (for highlight range)
+///
+/// Returns `(text_with_ellipsis, [highlight_start, highlight_end])` in character offsets.
+pub fn post_process_snippet(
+    raw_snippet: &str,
+    char_pos: u64,
+    snippet_max_chars: u64,
+    needle_char_len: usize,
+) -> Option<(String, [usize; 2])> {
+    if char_pos == 0 || raw_snippet.is_empty() {
+        return None;
+    }
+
+    let snippet_char_start = (char_pos as i64 - SNIPPET_CONTEXT_CHARS as i64).max(1) as u64;
+    let snippet_char_count = raw_snippet.chars().count() as u64;
+
+    let has_prefix = snippet_char_start > 1;
+    let has_suffix = snippet_char_count >= snippet_max_chars;
+
+    let prefix_len: usize = if has_prefix { 3 } else { 0 };
+    let highlight_start = prefix_len + (char_pos - snippet_char_start) as usize;
+    let highlight = [highlight_start, highlight_start + needle_char_len];
+
+    let mut text = String::new();
+    if has_prefix {
+        text.push_str("...");
+    }
+    text.push_str(raw_snippet);
+    if has_suffix {
+        text.push_str("...");
+    }
+
+    Some((text, highlight))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_clickhouse_string() {
+        assert_eq!(escape_clickhouse_string("it's"), "it\\'s");
+        assert_eq!(escape_clickhouse_string("a\\b"), "a\\\\b");
+        assert_eq!(escape_clickhouse_string(r#"say "hello""#), r#"say "hello""#);
+    }
+
+    #[test]
+    fn test_post_process_snippet_no_match() {
+        assert!(post_process_snippet("", 0, 100, 4).is_none());
+        assert!(post_process_snippet("hello", 0, 100, 4).is_none());
+    }
+
+    #[test]
+    fn test_post_process_snippet_at_start_no_suffix() {
+        // snippet_max_chars=105 but snippet is only 20 chars → no suffix
+        let result = post_process_snippet("Hello World test end", 1, 105, 5);
+        let (text, highlight) = result.unwrap();
+        assert!(!text.starts_with("..."));
+        assert!(!text.ends_with("..."));
+        assert_eq!(&text[..5], "Hello");
+        assert_eq!(highlight, [0, 5]);
+    }
+
+    #[test]
+    fn test_post_process_snippet_with_ellipsis() {
+        // snippet is exactly 106 chars (== snippet_max_chars) → has suffix
+        let snippet = "x".repeat(50) + "TARGET" + &"y".repeat(50);
+        let snippet_max_chars = snippet.chars().count() as u64;
+        let result = post_process_snippet(&snippet, 100, snippet_max_chars, 6);
+        let (text, highlight) = result.unwrap();
+        assert!(text.starts_with("..."));
+        assert!(text.ends_with("..."));
+        let chars: Vec<char> = text.chars().collect();
+        let highlighted: String = chars[highlight[0]..highlight[1]].iter().collect();
+        assert_eq!(highlighted, "TARGET");
+    }
+
+    #[test]
+    fn test_post_process_snippet_case_insensitive_highlight() {
+        // needle is "world" (5 chars), match is at char_pos=7 in "Hello WORLD test"
+        let result = post_process_snippet("Hello WORLD test", 7, 105, 5);
+        let (text, highlight) = result.unwrap();
+        let chars: Vec<char> = text.chars().collect();
+        let highlighted: String = chars[highlight[0]..highlight[1]].iter().collect();
+        assert_eq!(highlighted, "WORLD");
+    }
+}

--- a/app-server/src/routes/search_snippets.rs
+++ b/app-server/src/routes/search_snippets.rs
@@ -1,4 +1,4 @@
-const SNIPPET_CONTEXT_CHARS: usize = 50;
+use super::spans::SNIPPET_SIDE_SIZE;
 
 /// Escape a string for use inside a ClickHouse single-quoted string literal.
 pub fn escape_clickhouse_string(s: &str) -> String {
@@ -24,7 +24,7 @@ pub fn post_process_snippet(
         return None;
     }
 
-    let snippet_char_start = (char_pos as i64 - SNIPPET_CONTEXT_CHARS as i64).max(1) as u64;
+    let snippet_char_start = (char_pos as i64 - SNIPPET_SIDE_SIZE as i64).max(1) as u64;
     let snippet_char_count = raw_snippet.chars().count() as u64;
 
     let has_prefix = snippet_char_start > 1;

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -18,7 +18,7 @@ use crate::{
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
 };
 
-const DEFAULT_SEARCH_MAX_HITS: usize = 400;
+const DEFAULT_SEARCH_MAX_HITS: usize = 500;
 const DEFAULT_SEARCH_TIME_RANGE: chrono::Duration = chrono::Duration::days(7);
 
 // TODO: maybe remove all punctuation similar to the default tokenizer in the index?
@@ -146,12 +146,6 @@ pub struct SearchSpansRequest {
     pub offset: usize,
     #[serde(default)]
     pub get_snippets: bool,
-    #[serde(default)]
-    pub one_snippet_per_trace: bool,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 2] = ["input", "output"];
@@ -265,7 +259,7 @@ pub async fn search_spans(
 
     let t0: std::time::Instant = std::time::Instant::now();
     let hits = search_index(quickwit_client, &SPANS_INDEX_ID, search_body).await?;
-    log::info!(
+    log::debug!(
         "[search_spans] quickwit: {}ms, {} hits",
         t0.elapsed().as_millis(),
         hits.len()
@@ -287,14 +281,14 @@ pub async fn search_spans(
             })
             .collect();
 
-        log::info!("[search_spans] total: {}ms", t0.elapsed().as_millis());
+        log::debug!("[search_spans] total: {}ms", t0.elapsed().as_millis());
         return Ok(HttpResponse::Ok().json(results));
     }
 
-    let snippet_pairs: Vec<(Uuid, Uuid)> = if request.one_snippet_per_trace {
-        let mut seen_traces = HashSet::new();
+    const MAX_SNIPPET_TRACES: usize = 20;
+
+    let snippet_pairs: Vec<(Uuid, Uuid)> = if request.trace_id.is_some() {
         hits.iter()
-            .filter(|h| seen_traces.insert(h.trace_id.clone()))
             .filter_map(|h| {
                 let trace_id = Uuid::parse_str(&h.trace_id).ok()?;
                 let span_id = Uuid::parse_str(&h.span_id).ok()?;
@@ -302,7 +296,10 @@ pub async fn search_spans(
             })
             .collect()
     } else {
+        let mut seen_traces = HashSet::new();
         hits.iter()
+            .filter(|h| seen_traces.insert(h.trace_id.clone()))
+            .take(MAX_SNIPPET_TRACES)
             .filter_map(|h| {
                 let trace_id = Uuid::parse_str(&h.trace_id).ok()?;
                 let span_id = Uuid::parse_str(&h.span_id).ok()?;
@@ -314,7 +311,7 @@ pub async fn search_spans(
     let t1 = std::time::Instant::now();
     let snippet_rows =
         fetch_span_snippets(&clickhouse, project_id, &snippet_pairs, trimmed_query).await;
-    log::info!(
+    log::debug!(
         "[search_spans] clickhouse snippets: {}ms, {} rows",
         t1.elapsed().as_millis(),
         snippet_rows.len(),
@@ -369,7 +366,7 @@ pub async fn search_spans(
         })
         .collect();
 
-    log::info!("[search_spans] total: {}ms", t0.elapsed().as_millis());
+    log::debug!("[search_spans] total: {}ms", t0.elapsed().as_millis());
 
     Ok(HttpResponse::Ok().json(enriched_hits))
 }
@@ -408,8 +405,8 @@ async fn fetch_span_snippets(
         .map(|chunk| {
             let tuples = build_key_tuples(chunk);
             let query = build_snippet_query(phrase, &tuples);
-            println!(
-                "search_spans: snippet query: {:?}, project_id: {:?}",
+            log::debug!(
+                "[search_spans] snippet query: {:?}, project_id: {:?}",
                 query, project_id
             );
             async move {
@@ -430,7 +427,7 @@ async fn fetch_span_snippets(
     results.into_iter().flatten().collect()
 }
 
-const SNIPPET_SIDE_SIZE: u64 = 50;
+pub(super) const SNIPPET_SIDE_SIZE: u64 = 50;
 
 fn build_key_tuples(pairs: &[(Uuid, Uuid)]) -> String {
     pairs

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -204,11 +204,6 @@ pub async fn search_spans(
     let project_id = project_id.into_inner();
     let request = request.into_inner();
 
-    // tmp
-    if !request.get_snippets {
-        return Ok(HttpResponse::Ok().json(Vec::<SearchSpanHit>::new()));
-    }
-
     let trimmed_query = request.search_query.trim();
     if trimmed_query.is_empty() {
         return Ok(HttpResponse::Ok().json(Vec::<SearchSpanHit>::new()));

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use actix_web::{HttpResponse, post, web};
 use chrono::{DateTime, Utc};
@@ -11,14 +14,15 @@ use crate::{
     db::spans::{Span, SpanType},
     mq::{MessageQueue, MessageQueueTrait, utils::mq_max_payload},
     quickwit::{SPANS_INDEX_ID, client::QuickwitClient},
-    routes::{ResponseResult, error::Error},
+    routes::{ResponseResult, error::Error, search_snippets},
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
 };
 
-const DEFAULT_SEARCH_MAX_HITS: usize = 500;
+const DEFAULT_SEARCH_MAX_HITS: usize = 400;
 const DEFAULT_SEARCH_TIME_RANGE: chrono::Duration = chrono::Duration::days(7);
+
 // TODO: maybe remove all punctuation similar to the default tokenizer in the index?
-const QUICKWIT_RESERVED_CHARACTERS: &[char] = &['?', '`', '~', '!', '\\'];
+const QUICKWIT_RESERVED_CHARACTERS: &[char] = &['"', '?', '`', '~', '!', '\\'];
 // Quickwit documentation is very brief on this, it lists all of the reserved characters
 // with a note that you can escape them with a backslash. However, some of them break
 // the query parsing when escaped, so we need to remove them.
@@ -31,9 +35,11 @@ const QUICKWIT_RESERVED_UNESCAPABLE_CHARACTERS: &[char] = &[
     '\u{2014}', // — em dash
 ];
 
-/// Escape special characters for Quickwit query syntax
+const PARALLEL_SNIPPETS_QUERIES: usize = 1;
+
+/// Escape special characters for Quickwit query syntax and wrap in quotes for phrase search.
 fn escape_quickwit_query(query: &str) -> String {
-    query
+    let escaped: String = query
         .chars()
         .flat_map(|c| {
             if QUICKWIT_RESERVED_CHARACTERS.contains(&c) {
@@ -44,7 +50,8 @@ fn escape_quickwit_query(query: &str) -> String {
                 vec![c]
             }
         })
-        .collect()
+        .collect();
+    format!("\"{escaped}\"")
 }
 
 #[derive(Deserialize)]
@@ -135,10 +142,16 @@ pub struct SearchSpansRequest {
     pub search_query: String,
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
-    #[serde(default)]
-    pub search_in: Option<Vec<String>>,
     pub limit: usize,
     pub offset: usize,
+    #[serde(default)]
+    pub get_snippets: bool,
+    #[serde(default)]
+    pub one_snippet_per_trace: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 2] = ["input", "output"];
@@ -154,18 +167,51 @@ struct QuickwitResponse {
     hits: Vec<QuickwitHit>,
 }
 
+#[derive(Serialize)]
+struct SnippetInfo {
+    text: String,
+    highlight: [usize; 2],
+}
+
+#[derive(Serialize)]
+struct SearchSpanHit {
+    trace_id: String,
+    span_id: String,
+    input_snippet: Option<SnippetInfo>,
+    output_snippet: Option<SnippetInfo>,
+    snippet_count: usize,
+}
+
+#[derive(clickhouse::Row, Deserialize)]
+struct SpanSnippetRow {
+    #[serde(with = "clickhouse::serde::uuid")]
+    span_id: Uuid,
+    input_pos: u64,
+    input_count: u64,
+    input_snippet: String,
+    output_pos: u64,
+    output_count: u64,
+    output_snippet: String,
+}
+
 #[post("spans/search")]
 pub async fn search_spans(
     project_id: web::Path<Uuid>,
     request: web::Json<SearchSpansRequest>,
     quickwit_client: web::Data<Option<QuickwitClient>>,
+    clickhouse: web::Data<clickhouse::Client>,
 ) -> ResponseResult {
     let project_id = project_id.into_inner();
     let request = request.into_inner();
 
+    // tmp
+    if !request.get_snippets {
+        return Ok(HttpResponse::Ok().json(Vec::<SearchSpanHit>::new()));
+    }
+
     let trimmed_query = request.search_query.trim();
     if trimmed_query.is_empty() {
-        return Ok(HttpResponse::Ok().json(Vec::<String>::new()));
+        return Ok(HttpResponse::Ok().json(Vec::<SearchSpanHit>::new()));
     }
 
     // Escape characters reserved by quickwit
@@ -176,7 +222,7 @@ pub async fn search_spans(
         Some(client) => client,
         None => {
             log::warn!("Quickwit search requested but Quickwit client is not available");
-            return Ok(HttpResponse::Ok().json(Vec::<String>::new()));
+            return Ok(HttpResponse::Ok().json(Vec::<SearchSpanHit>::new()));
         }
     };
 
@@ -187,7 +233,7 @@ pub async fn search_spans(
 
     let sort_by = "start_time";
 
-    if let Some(trace_id) = request.trace_id {
+    if let Some(ref trace_id) = request.trace_id {
         query_parts.push(format!("trace_id:{}", trace_id));
     }
 
@@ -198,30 +244,8 @@ pub async fn search_spans(
         "sort_by": sort_by,
     });
 
-    // Handle search fields
-    let search_fields = if let Some(search_in) = request.search_in {
-        if search_in.is_empty() {
-            QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS.to_vec()
-        } else {
-            let valid_fields: Vec<&str> = QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS
-                .iter()
-                .filter(|&&f| search_in.iter().any(|requested| requested == f))
-                .cloned()
-                .collect();
-
-            if valid_fields.is_empty() {
-                QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS.to_vec()
-            } else {
-                valid_fields
-            }
-        }
-    } else {
-        QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS.to_vec()
-    };
-
-    // Quickwit expects search_field as a comma-separated string, not an array
-    let search_field_str = search_fields.join(",");
-    search_body["search_field"] = serde_json::Value::String(search_field_str);
+    let search_fields = QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS.join(",");
+    search_body["search_field"] = serde_json::Value::String(search_fields);
 
     // Handle pagination
     if request.limit != 0 {
@@ -234,19 +258,125 @@ pub async fn search_spans(
         search_body["start_offset"] = serde_json::Value::Number(request.offset.into());
     }
 
-    // Handle timestamps, defaults to last week if not provided
-    if let Some(s) = request.start_time {
-        search_body["start_timestamp"] = serde_json::Value::Number(s.timestamp().into());
-    } else {
-        search_body["start_timestamp"] =
-            serde_json::Value::Number((Utc::now() - DEFAULT_SEARCH_TIME_RANGE).timestamp().into());
-    }
-    if let Some(e) = request.end_time {
-        search_body["end_timestamp"] = serde_json::Value::Number(e.timestamp().into());
+    let effective_start = request
+        .start_time
+        .unwrap_or_else(|| Utc::now() - DEFAULT_SEARCH_TIME_RANGE);
+    let effective_end = request.end_time.unwrap_or_else(Utc::now);
+
+    search_body["start_timestamp"] = serde_json::Value::Number(effective_start.timestamp().into());
+    if request.end_time.is_some() {
+        search_body["end_timestamp"] = serde_json::Value::Number(effective_end.timestamp().into());
     }
 
+    let t0: std::time::Instant = std::time::Instant::now();
     let hits = search_index(quickwit_client, &SPANS_INDEX_ID, search_body).await?;
-    Ok(HttpResponse::Ok().json(hits))
+    log::info!(
+        "[search_spans] quickwit: {}ms, {} hits",
+        t0.elapsed().as_millis(),
+        hits.len()
+    );
+
+    if hits.is_empty() {
+        return Ok(HttpResponse::Ok().json(Vec::<SearchSpanHit>::new()));
+    }
+
+    if !request.get_snippets {
+        let results: Vec<SearchSpanHit> = hits
+            .into_iter()
+            .map(|h| SearchSpanHit {
+                trace_id: h.trace_id,
+                span_id: h.span_id,
+                input_snippet: None,
+                output_snippet: None,
+                snippet_count: 0,
+            })
+            .collect();
+
+        log::info!("[search_spans] total: {}ms", t0.elapsed().as_millis());
+        return Ok(HttpResponse::Ok().json(results));
+    }
+
+    let snippet_pairs: Vec<(Uuid, Uuid)> = if request.one_snippet_per_trace {
+        let mut seen_traces = HashSet::new();
+        hits.iter()
+            .filter(|h| seen_traces.insert(h.trace_id.clone()))
+            .filter_map(|h| {
+                let trace_id = Uuid::parse_str(&h.trace_id).ok()?;
+                let span_id = Uuid::parse_str(&h.span_id).ok()?;
+                Some((trace_id, span_id))
+            })
+            .collect()
+    } else {
+        hits.iter()
+            .filter_map(|h| {
+                let trace_id = Uuid::parse_str(&h.trace_id).ok()?;
+                let span_id = Uuid::parse_str(&h.span_id).ok()?;
+                Some((trace_id, span_id))
+            })
+            .collect()
+    };
+
+    let t1 = std::time::Instant::now();
+    let snippet_rows =
+        fetch_span_snippets(&clickhouse, project_id, &snippet_pairs, trimmed_query).await;
+    log::info!(
+        "[search_spans] clickhouse snippets: {}ms, {} rows",
+        t1.elapsed().as_millis(),
+        snippet_rows.len(),
+    );
+
+    let needle_char_len = trimmed_query.chars().count();
+    let snippet_max_chars = (needle_char_len as u64) + SNIPPET_SIDE_SIZE * 2;
+
+    let snippet_map: HashMap<String, SpanSnippetRow> = snippet_rows
+        .into_iter()
+        .map(|row| (row.span_id.to_string(), row))
+        .collect();
+
+    let enriched_hits: Vec<SearchSpanHit> = hits
+        .into_iter()
+        .map(|hit| {
+            if let Some(row) = snippet_map.get(&hit.span_id) {
+                let input_snippet = search_snippets::post_process_snippet(
+                    &row.input_snippet,
+                    row.input_pos,
+                    snippet_max_chars,
+                    needle_char_len,
+                )
+                .map(|(text, highlight)| SnippetInfo { text, highlight });
+
+                let output_snippet = search_snippets::post_process_snippet(
+                    &row.output_snippet,
+                    row.output_pos,
+                    snippet_max_chars,
+                    needle_char_len,
+                )
+                .map(|(text, highlight)| SnippetInfo { text, highlight });
+
+                let snippet_count = row.input_count + row.output_count;
+
+                SearchSpanHit {
+                    trace_id: hit.trace_id,
+                    span_id: hit.span_id,
+                    input_snippet,
+                    output_snippet,
+                    snippet_count: snippet_count as usize,
+                }
+            } else {
+                SearchSpanHit {
+                    trace_id: hit.trace_id,
+                    span_id: hit.span_id,
+                    input_snippet: None,
+                    output_snippet: None,
+                    snippet_count: 0,
+                }
+            }
+        })
+        .collect();
+
+    log::info!("[search_spans] total: {}ms", t0.elapsed().as_millis());
+
+    Ok(HttpResponse::Ok().json(enriched_hits))
 }
 
 async fn search_index(
@@ -265,4 +395,88 @@ async fn search_index(
         })?;
 
     Ok(quickwit_response.hits)
+}
+
+async fn fetch_span_snippets(
+    clickhouse: &clickhouse::Client,
+    project_id: Uuid,
+    pairs: &[(Uuid, Uuid)],
+    phrase: &str,
+) -> Vec<SpanSnippetRow> {
+    if pairs.is_empty() {
+        return Vec::new();
+    }
+
+    let chunk_size = (pairs.len() + PARALLEL_SNIPPETS_QUERIES - 1) / PARALLEL_SNIPPETS_QUERIES;
+    let futures: Vec<_> = pairs
+        .chunks(chunk_size.max(1))
+        .map(|chunk| {
+            let tuples = build_key_tuples(chunk);
+            let query = build_snippet_query(phrase, &tuples);
+            println!(
+                "search_spans: snippet query: {:?}, project_id: {:?}",
+                query, project_id
+            );
+            async move {
+                clickhouse
+                    .query(&query)
+                    .bind(project_id)
+                    .fetch_all::<SpanSnippetRow>()
+                    .await
+                    .unwrap_or_else(|e| {
+                        log::error!("Failed to fetch span snippets from ClickHouse: {:?}", e);
+                        Vec::new()
+                    })
+            }
+        })
+        .collect();
+
+    let results = futures_util::future::join_all(futures).await;
+    results.into_iter().flatten().collect()
+}
+
+const SNIPPET_SIDE_SIZE: u64 = 50;
+
+fn build_key_tuples(pairs: &[(Uuid, Uuid)]) -> String {
+    pairs
+        .iter()
+        .map(|(trace_id, span_id)| format!("('{trace_id}', '{span_id}')"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn build_snippet_query(phrase: &str, key_tuples: &str) -> String {
+    let input_cols = build_phrase_columns("input", phrase);
+    let output_cols = build_phrase_columns("output", phrase);
+
+    format!(
+        "SELECT span_id,
+                input_pos, input_count, input_snippet,
+                output_pos, output_count, output_snippet
+         FROM (
+           SELECT span_id, {input_cols}, {output_cols}
+           FROM spans_v2
+           WHERE project_id = ?
+             AND (trace_id, span_id) IN ({key_tuples})
+           ORDER BY start_time ASC
+         )"
+    )
+}
+
+fn build_phrase_columns(field: &str, phrase: &str) -> String {
+    let escaped = search_snippets::escape_clickhouse_string(phrase);
+    let phrase_char_len = phrase.chars().count() as u64;
+    let snippet_len = phrase_char_len + SNIPPET_SIDE_SIZE * 2;
+
+    format!(
+        "positionCaseInsensitive({field}, '{escaped}') as _{field}_byte_pos,
+         toUInt64(countSubstringsCaseInsensitive({field}, '{escaped}')) as {field}_count,
+         if(_{field}_byte_pos > 0,
+            toUInt64(lengthUTF8(substring({field}, 1, toUInt64(_{field}_byte_pos) - 1)) + 1),
+            toUInt64(0)) as {field}_pos,
+         if({field}_pos > 0,
+            substringUTF8({field}, greatest(toUInt64(1), {field}_pos - {side_size}), {snippet_len}),
+            '') as {field}_snippet",
+        side_size = SNIPPET_SIDE_SIZE,
+    )
 }

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -285,7 +285,7 @@ pub async fn search_spans(
         return Ok(HttpResponse::Ok().json(results));
     }
 
-    const MAX_SNIPPET_TRACES: usize = 20;
+    const MAX_SNIPPET_TRACES: usize = 64;
 
     let snippet_pairs: Vec<(Uuid, Uuid)> = if request.trace_id.is_some() {
         hits.iter()
@@ -320,15 +320,16 @@ pub async fn search_spans(
     let needle_char_len = trimmed_query.chars().count();
     let snippet_max_chars = (needle_char_len as u64) + SNIPPET_SIDE_SIZE * 2;
 
-    let snippet_map: HashMap<String, SpanSnippetRow> = snippet_rows
+    let mut snippet_map: HashMap<String, SpanSnippetRow> = snippet_rows
         .into_iter()
         .map(|row| (row.span_id.to_string(), row))
         .collect();
 
-    let enriched_hits: Vec<SearchSpanHit> = hits
-        .into_iter()
-        .map(|hit| {
-            if let Some(row) = snippet_map.get(&hit.span_id) {
+    let enriched_hits: Vec<SearchSpanHit> = snippet_pairs
+        .iter()
+        .map(|(trace_id, span_id)| {
+            let span_id_str = span_id.to_string();
+            if let Some(row) = snippet_map.remove(&span_id_str) {
                 let input_snippet = search_snippets::post_process_snippet(
                     &row.input_snippet,
                     row.input_pos,
@@ -348,16 +349,16 @@ pub async fn search_spans(
                 let snippet_count = row.input_count + row.output_count;
 
                 SearchSpanHit {
-                    trace_id: hit.trace_id,
-                    span_id: hit.span_id,
+                    trace_id: trace_id.to_string(),
+                    span_id: span_id_str,
                     input_snippet,
                     output_snippet,
                     snippet_count: snippet_count as usize,
                 }
             } else {
                 SearchSpanHit {
-                    trace_id: hit.trace_id,
-                    span_id: hit.span_id,
+                    trace_id: trace_id.to_string(),
+                    span_id: span_id_str,
                     input_snippet: None,
                     output_snippet: None,
                     snippet_count: 0,
@@ -407,7 +408,8 @@ async fn fetch_span_snippets(
             let query = build_snippet_query(phrase, &tuples);
             log::debug!(
                 "[search_spans] snippet query: {:?}, project_id: {:?}",
-                query, project_id
+                query,
+                project_id
             );
             async move {
                 clickhouse

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -23,7 +23,7 @@ const QUICKWIT_RESERVED_CHARACTERS: &[char] = &['?', '`', '~', '!', '\\'];
 // with a note that you can escape them with a backslash. However, some of them break
 // the query parsing when escaped, so we need to remove them.
 const QUICKWIT_RESERVED_UNESCAPABLE_CHARACTERS: &[char] = &[
-    '"', ':', '^', '{', '}', '[', ']', '(', ')',
+    ':', '^', '{', '}', '[', ']', '(', ')',
     // The below characters won't break parsing but change the meaning of the query
     // even when escaped, so safest to remove them.
     '+', '\u{002D}', // - hyphen-minus

--- a/frontend/components/traces/highlighted-snippet.tsx
+++ b/frontend/components/traces/highlighted-snippet.tsx
@@ -1,0 +1,25 @@
+interface HighlightedSnippetProps {
+  snippet: string;
+  highlight?: [number, number];
+  className?: string;
+}
+
+export function HighlightedSnippet({ snippet, highlight, className }: HighlightedSnippetProps) {
+  if (!highlight || highlight[0] >= highlight[1]) {
+    return <span className={className}>{snippet}</span>;
+  }
+
+  const [start, end] = highlight;
+  const chars = [...snippet];
+  const before = chars.slice(0, start).join("");
+  const match = chars.slice(start, end).join("");
+  const after = chars.slice(end).join("");
+
+  return (
+    <span className={className}>
+      {before}
+      <mark className="bg-primary/20 text-foreground rounded-sm px-0.5">{match}</mark>
+      {after}
+    </span>
+  );
+}

--- a/frontend/components/traces/trace-view/list/list-item.tsx
+++ b/frontend/components/traces/trace-view/list/list-item.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronRight, Settings, X } from "lucide-react";
 import React, { useMemo, useState } from "react";
 
 import { useOptionalDebuggerStore } from "@/components/debugger-sessions/debugger-session-view/store";
+import { HighlightedSnippet } from "@/components/traces/highlighted-snippet";
 import { NoSpanTooltip } from "@/components/traces/no-span-tooltip";
 import SpanTypeIcon from "@/components/traces/span-type-icon";
 import { DebuggerCheckpoint } from "@/components/traces/trace-view/debugger-checkpoint.tsx";
@@ -182,18 +183,35 @@ const ListItem = ({ span, output, onSpanSelect, onOpenSettings, isFirst = false,
           </div>
         </div>
 
-        {isExpanded && (
-          <div className="px-3 w-full p-2 pt-0 flex flex-col gap-2 h-full flex-1">
-            {isLoadingOutput ? (
-              <>
-                <Skeleton className="h-12 w-full" />
-              </>
-            ) : isNil(output) ? (
-              <div className="text-sm text-muted-foreground italic">No output available</div>
-            ) : (
-              <Markdown className="max-h-60" output={output} defaultValue={savedTemplate} />
-            )}
+        {span.searchSnippet ? (
+          <div className="px-3 w-full p-2 pt-0">
+            <div className="flex items-start gap-1.5">
+              <HighlightedSnippet
+                snippet={span.searchSnippet}
+                highlight={span.snippetHighlight}
+                className="text-xs text-secondary-foreground line-clamp-2 break-all"
+              />
+              {(span.snippetCount ?? 0) > 1 && (
+                <span className="shrink-0 text-[10px] bg-primary/10 text-primary font-medium rounded-full px-1.5 py-0.5 mt-0.5">
+                  +{(span.snippetCount ?? 1) - 1}
+                </span>
+              )}
+            </div>
           </div>
+        ) : (
+          isExpanded && (
+            <div className="px-3 w-full p-2 pt-0 flex flex-col gap-2 h-full flex-1">
+              {isLoadingOutput ? (
+                <>
+                  <Skeleton className="h-12 w-full" />
+                </>
+              ) : isNil(output) ? (
+                <div className="text-sm text-muted-foreground italic">No output available</div>
+              ) : (
+                <Markdown className="max-h-60" output={output} defaultValue={savedTemplate} />
+              )}
+            </div>
+          )
         )}
       </div>
     </div>

--- a/frontend/components/traces/trace-view/store/base.ts
+++ b/frontend/components/traces/trace-view/store/base.ts
@@ -48,6 +48,9 @@ export type TraceViewSpan = {
     cacheReadInputTokens?: number;
     hasLLMDescendants: boolean;
   };
+  searchSnippet?: string;
+  snippetHighlight?: [number, number];
+  snippetCount?: number;
 };
 
 export type TraceViewListSpan = {
@@ -66,6 +69,9 @@ export type TraceViewListSpan = {
     display: Array<{ spanId: string; name: string; count?: number }>;
     full: Array<{ spanId: string; name: string }>;
   } | null;
+  searchSnippet?: string;
+  snippetHighlight?: [number, number];
+  snippetCount?: number;
 };
 
 export type TraceViewTrace = {
@@ -242,6 +248,9 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
         totalCost: span.totalCost,
         pending: span.pending,
         pathInfo: pathInfoMap.get(span.spanId) ?? null,
+        searchSnippet: span.searchSnippet,
+        snippetHighlight: span.snippetHighlight,
+        snippetCount: span.snippetCount,
       }));
 
       return lightweightListSpans;

--- a/frontend/components/traces/trace-view/tree/span-card.tsx
+++ b/frontend/components/traces/trace-view/tree/span-card.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, Settings, X } from "lucide-react";
 import { useMemo, useRef } from "react";
 
 import { useOptionalDebuggerStore } from "@/components/debugger-sessions/debugger-session-view/store";
+import { HighlightedSnippet } from "@/components/traces/highlighted-snippet";
 import { DebuggerCheckpoint } from "@/components/traces/trace-view/debugger-checkpoint.tsx";
 import { type TraceViewSpan, useTraceViewBaseStore } from "@/components/traces/trace-view/store/base";
 import { type PathInfo } from "@/components/traces/trace-view/store/utils";
@@ -184,17 +185,34 @@ export function SpanCard({ span, branchMask, output, onSpanSelect, depth, pathIn
             </Button>
           </div>
 
-          {showContent && (
-            <div className="px-2 pt-0">
-              {isLoadingOutput && (
-                <div className="w-full pb-2">
-                  <Skeleton className="h-12 w-full" />
-                </div>
-              )}
-              {!isLoadingOutput && !isNil(output) && (
-                <Markdown className="max-h-48" output={output} defaultValue={savedTemplate} />
-              )}
+          {span.searchSnippet ? (
+            <div className="px-2 pt-0 pb-1">
+              <div className="flex items-start gap-1.5">
+                <HighlightedSnippet
+                  snippet={span.searchSnippet}
+                  highlight={span.snippetHighlight}
+                  className="text-xs text-secondary-foreground line-clamp-2 break-all"
+                />
+                {(span.snippetCount ?? 0) > 1 && (
+                  <span className="shrink-0 text-[10px] bg-primary/10 text-primary font-medium rounded-full px-1.5 py-0.5 mt-0.5">
+                    +{(span.snippetCount ?? 1) - 1}
+                  </span>
+                )}
+              </div>
             </div>
+          ) : (
+            showContent && (
+              <div className="px-2 pt-0">
+                {isLoadingOutput && (
+                  <div className="w-full pb-2">
+                    <Skeleton className="h-12 w-full" />
+                  </div>
+                )}
+                {!isLoadingOutput && !isNil(output) && (
+                  <Markdown className="max-h-48" output={output} defaultValue={savedTemplate} />
+                )}
+              </div>
+            )
           )}
         </div>
       </div>

--- a/frontend/components/traces/traces-table/columns.tsx
+++ b/frontend/components/traces/traces-table/columns.tsx
@@ -3,6 +3,7 @@ import { type ColumnDef } from "@tanstack/react-table";
 import { capitalize } from "lodash";
 
 import ClientTimestampFormatter from "@/components/client-timestamp-formatter";
+import { HighlightedSnippet } from "@/components/traces/highlighted-snippet";
 import SpanTypeIcon, { createSpanTypeIcon } from "@/components/traces/span-type-icon";
 import { Badge } from "@/components/ui/badge.tsx";
 import { type ColumnFilter } from "@/components/ui/infinite-datatable/ui/datatable-filter/utils";
@@ -255,6 +256,33 @@ export const STATIC_COLUMNS: ColumnDef<TraceRow, any>[] = [
     enableSorting: true,
     meta: { sql: "user_id" },
   },
+  {
+    accessorKey: "searchSnippet",
+    header: "Search preview",
+    id: "search_preview",
+    enableSorting: false,
+    cell: (row) => {
+      const snippet = row.getValue() as string | undefined;
+      const matchCount = row.row.original.searchMatchCount;
+      const highlight = row.row.original.searchSnippetHighlight;
+      if (!snippet) return null;
+      return (
+        <div className="flex items-center gap-1.5 min-w-0">
+          <HighlightedSnippet
+            snippet={snippet}
+            highlight={highlight}
+            className="text-xs text-secondary-foreground truncate"
+          />
+          {matchCount && matchCount > 1 && (
+            <span className="shrink-0 text-[10px] bg-primary/10 text-primary font-medium rounded-full px-1.5 py-0.5">
+              {matchCount} {matchCount === 1 ? "span" : "spans"}
+            </span>
+          )}
+        </div>
+      );
+    },
+    size: 250,
+  },
 ];
 
 /** @deprecated Use STATIC_COLUMNS and useTracesTableStore().columnDefs instead */
@@ -365,6 +393,7 @@ export const defaultTracesColumnOrder = [
   "status",
   "id",
   "top_span_type",
+  "search_preview",
   "root_span_input",
   "root_span_output",
   "start_time",

--- a/frontend/lib/actions/evaluation/search.ts
+++ b/frontend/lib/actions/evaluation/search.ts
@@ -1,5 +1,4 @@
 import { searchSpans } from "@/lib/actions/traces/search";
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { type TimeRange } from "@/lib/clickhouse/utils";
 
 export async function getSearchTraceIds(
@@ -15,7 +14,6 @@ export async function getSearchTraceIds(
     traceId: undefined,
     searchQuery: search,
     timeRange: getTimeRangeForEvaluation(evaluationCreatedAt),
-    searchType: searchIn as SpanSearchType[],
   });
 
   return [...new Set(spanHits.map((span) => span.trace_id))];

--- a/frontend/lib/actions/sessions/index.ts
+++ b/frontend/lib/actions/sessions/index.ts
@@ -46,7 +46,6 @@ export async function getSessions(input: z.infer<typeof GetSessionsSchema>): Pro
         projectId,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
       })
     : [];
 

--- a/frontend/lib/actions/signal-jobs/index.ts
+++ b/frontend/lib/actions/signal-jobs/index.ts
@@ -7,7 +7,6 @@ import { Operator } from "@/lib/actions/common/operators";
 import { FiltersSchema, TimeRangeSchema } from "@/lib/actions/common/types.ts";
 import { searchSpans } from "@/lib/actions/traces/search";
 import { buildTracesIdsQueryWithParams, DEFAULT_SEARCH_MAX_HITS } from "@/lib/actions/traces/utils";
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { getTimeRange } from "@/lib/clickhouse/utils";
 import { db } from "@/lib/db/drizzle";
 import { signalJobs } from "@/lib/db/migrations/schema";
@@ -100,7 +99,6 @@ export async function createSignalJob(
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startDate, endDate),
-        searchType: [] as SpanSearchType[],
       })
     : [];
   const traceIdsFromSearch = [...new Set(spanHits.map((span) => span.trace_id))];

--- a/frontend/lib/actions/spans/index.ts
+++ b/frontend/lib/actions/spans/index.ts
@@ -108,16 +108,15 @@ export async function getSpans(input: z.infer<typeof GetSpansSchema>): Promise<{
     pastHours,
   });
 
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const spansHits = search
     ? await searchSpans({
         projectId,
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
       })
     : [];
-  const spanIds = spanHits.map((span) => span.span_id);
+  const spanIds = spansHits.map((span) => span.span_id);
 
   if (search) {
     if (spanIds?.length === 0) {
@@ -278,16 +277,17 @@ export async function getTraceSpans(input: z.infer<typeof GetTraceSpansSchema>):
   const filters: Filter[] = compact(inputFilters);
 
   const timeRange = getOptionalTimeRange(pastHours, startDate, endDate);
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const traceSpanHits = search
     ? await searchSpans({
         projectId,
         traceId,
         searchQuery: search,
         ...(timeRange && { timeRange }),
-        searchType: searchIn as SpanSearchType[],
+        getSnippets: true,
+        onePerTrace: false,
       })
     : [];
-  const spanIds = spanHits.map((span) => span.span_id);
+  const spanIds = traceSpanHits.map((span) => span.span_id);
 
   if (search && spanIds?.length === 0) {
     return [];
@@ -323,7 +323,33 @@ export async function getTraceSpans(input: z.infer<typeof GetTraceSpansSchema>):
 
   const transformedSpans = spans.map((span) => transformSpanWithEvents(span as any, parentRewiring));
 
-  return aggregateSpanMetrics(transformedSpans);
+  const result = aggregateSpanMetrics(transformedSpans);
+
+  if (search && traceSpanHits.length > 0) {
+    const snippetMap = new Map(
+      traceSpanHits.map((hit) => {
+        const info = hit.output_snippet ?? hit.input_snippet;
+        return [
+          hit.span_id,
+          {
+            snippet: info?.text,
+            highlight: info?.highlight,
+            count: hit.snippet_count,
+          },
+        ];
+      })
+    );
+    for (const span of result) {
+      const snippetData = snippetMap.get(span.spanId);
+      if (snippetData) {
+        span.searchSnippet = snippetData.snippet;
+        span.snippetHighlight = snippetData.highlight;
+        span.snippetCount = snippetData.count;
+      }
+    }
+  }
+
+  return result;
 }
 
 export async function deleteSpans(input: z.infer<typeof DeleteSpansSchema>) {

--- a/frontend/lib/actions/traces/index.ts
+++ b/frontend/lib/actions/traces/index.ts
@@ -4,14 +4,13 @@ import { z } from "zod/v4";
 import { type Filter } from "@/lib/actions/common/filters";
 import { PaginationFiltersSchema, TimeRangeSchema } from "@/lib/actions/common/types";
 import { executeQuery } from "@/lib/actions/sql";
-import { searchSpans } from "@/lib/actions/traces/search";
+import { type SearchSpanHit, searchSpans } from "@/lib/actions/traces/search";
 import {
   buildTracesCountQueryWithParams,
   buildTracesQueryWithParams,
   type CustomColumn,
 } from "@/lib/actions/traces/utils";
 import { clickhouseClient } from "@/lib/clickhouse/client.ts";
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { getTimeRange } from "@/lib/clickhouse/utils";
 import { type TraceRow } from "@/lib/traces/types.ts";
 
@@ -67,13 +66,13 @@ export async function getTraces(input: z.infer<typeof GetTracesSchema>): Promise
   let limit = pageSize;
   let offset = Math.max(0, pageNumber * pageSize);
 
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const spanHits: SearchSpanHit[] = search
     ? await searchSpans({
         projectId,
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
+        getSnippets: true,
       })
     : [];
   const traceIds = [...new Set(spanHits.map((span) => span.trace_id))];
@@ -126,6 +125,7 @@ export async function getTraces(input: z.infer<typeof GetTracesSchema>): Promise
   const items = await executeQuery<TraceRow>({ query: mainQuery, parameters: mainParams, projectId });
 
   // If we have traceIds from search, sort items to match the search order
+  // and enrich with snippet data
   if (search && traceIds.length > 0) {
     const traceIdIndexMap = new Map(traceIds.map((id, index) => [id, index]));
     items.sort((a, b) => {
@@ -133,6 +133,36 @@ export async function getTraces(input: z.infer<typeof GetTracesSchema>): Promise
       const indexB = traceIdIndexMap.get(b.id) ?? Infinity;
       return indexA - indexB;
     });
+
+    const snippetsByTrace = new Map<
+      string,
+      { snippet: string; highlight?: [number, number]; matchingSpanCount: number }
+    >();
+    for (const hit of spanHits) {
+      const info = hit.output_snippet ?? hit.input_snippet;
+      if (!info) continue;
+      const existing = snippetsByTrace.get(hit.trace_id);
+      if (existing) {
+        existing.matchingSpanCount += 1;
+        existing.snippet = info.text;
+        existing.highlight = info.highlight;
+      } else {
+        snippetsByTrace.set(hit.trace_id, {
+          snippet: info.text,
+          highlight: info.highlight,
+          matchingSpanCount: 1,
+        });
+      }
+    }
+
+    for (const item of items) {
+      const snippetData = snippetsByTrace.get(item.id);
+      if (snippetData) {
+        item.searchSnippet = snippetData.snippet;
+        item.searchSnippetHighlight = snippetData.highlight;
+        item.searchMatchCount = snippetData.matchingSpanCount;
+      }
+    }
   }
 
   return {
@@ -154,16 +184,15 @@ export async function countTraces(input: z.infer<typeof GetTracesSchema>): Promi
 
   const filters: Filter[] = compact(inputFilters);
 
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const countSpanHits = search
     ? await searchSpans({
         projectId,
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
       })
     : [];
-  const traceIds = [...new Set(spanHits.map((span) => span.trace_id))];
+  const traceIds = [...new Set(countSpanHits.map((span) => span.trace_id))];
 
   if (search && traceIds?.length === 0) {
     return { count: 0 };

--- a/frontend/lib/actions/traces/search.ts
+++ b/frontend/lib/actions/traces/search.ts
@@ -1,20 +1,34 @@
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { type TimeRange } from "@/lib/clickhouse/utils";
 import { fetcherJSON } from "@/lib/utils";
+
+export type SnippetInfo = {
+  text: string;
+  highlight: [number, number];
+};
+
+export type SearchSpanHit = {
+  trace_id: string;
+  span_id: string;
+  input_snippet?: SnippetInfo;
+  output_snippet?: SnippetInfo;
+  snippet_count: number;
+};
 
 export const searchSpans = async ({
   projectId,
   traceId,
   searchQuery,
   timeRange,
-  searchType,
+  getSnippets = false,
+  onePerTrace = true,
 }: {
   projectId: string;
   traceId?: string;
   searchQuery: string;
   timeRange?: TimeRange;
-  searchType?: SpanSearchType[];
-}): Promise<{ trace_id: string; span_id: string }[]> => {
+  getSnippets?: boolean;
+  onePerTrace?: boolean;
+}): Promise<SearchSpanHit[]> => {
   const trimmedQuery = searchQuery.trim();
   if (!trimmedQuery) {
     return [];
@@ -40,14 +54,14 @@ export const searchSpans = async ({
     searchQuery: trimmedQuery,
     startTime,
     endTime,
-    searchIn: searchType?.map((t) => t.toString()),
-    // Pagination is currently disabled (defaults on app-server side): API paginates by traces, search engine by spans
     limit: 0,
     offset: 0,
+    getSnippets,
+    onePerTrace,
   };
 
   try {
-    return await fetcherJSON<{ trace_id: string; span_id: string }[]>(`/projects/${projectId}/spans/search`, {
+    return await fetcherJSON<SearchSpanHit[]>(`/projects/${projectId}/spans/search`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/frontend/lib/actions/traces/stats.ts
+++ b/frontend/lib/actions/traces/stats.ts
@@ -7,7 +7,6 @@ import { executeQuery } from "@/lib/actions/sql";
 import { GetTracesSchema } from "@/lib/actions/traces";
 import { searchSpans } from "@/lib/actions/traces/search";
 import { buildTracesStatsWhereConditions, generateEmptyTimeBuckets } from "@/lib/actions/traces/utils";
-import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { getTimeRange } from "@/lib/clickhouse/utils";
 
 export const GetTraceStatsSchema = GetTracesSchema.omit({
@@ -42,13 +41,12 @@ export async function getTraceStats(
 
   const filters: Filter[] = compact(inputFilters);
 
-  const spanHits: { trace_id: string; span_id: string }[] = search
+  const spanHits = search
     ? await searchSpans({
         projectId,
         traceId: undefined,
         searchQuery: search,
         timeRange: getTimeRange(pastHours, startTime, endTime),
-        searchType: searchIn as SpanSearchType[],
       })
     : [];
   const traceIds = [...new Set(spanHits.map((span) => span.trace_id))];

--- a/frontend/lib/traces/types.ts
+++ b/frontend/lib/traces/types.ts
@@ -145,6 +145,9 @@ export type TraceRow = {
   analysis?: string;
   rootSpanInput?: string;
   rootSpanOutput?: string;
+  searchSnippet?: string;
+  searchSnippetHighlight?: [number, number];
+  searchMatchCount?: number;
 };
 
 export type RealtimeTracePayload = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new server-side snippet extraction via ClickHouse and changes the `spans/search` response shape, which can impact search correctness and performance. Risk is moderate due to new query construction/escaping and additional DB load, but the change is scoped to search paths.
> 
> **Overview**
> Search now supports returning **highlighted text snippets** for span matches.
> 
> On the backend, `POST /spans/search` switches to phrase-quoted Quickwit queries, adds an optional `get_snippets` flow that fetches match positions/snippet substrings from ClickHouse, and returns enriched hits including `input_snippet`/`output_snippet` with highlight offsets plus a `snippet_count`. A new `routes/search_snippets.rs` module centralizes ClickHouse string escaping and snippet post-processing (ellipsis + char offsets).
> 
> On the frontend, span/trace types and search actions are updated to consume the new hit shape and request snippets where needed; trace list/table UIs render a “Search preview” using a new `HighlightedSnippet` component and show match counts instead of expanded output when a snippet is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03cbb22c5125010ca2b7d55e5c091d735bfb07f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->