### PR TITLE
feat(dashboard): add duplicate widget option

### DIFF
--- a/frontend/components/dashboard/chart-header.tsx
+++ b/frontend/components/dashboard/chart-header.tsx
@@ -1,4 +1,4 @@
-import { Edit, EllipsisVertical, GripVertical, Pen, Trash2 } from "lucide-react";
+import { Copy, Edit, EllipsisVertical, GripVertical, Pen, Trash2 } from "lucide-react";
 import Link from "next/link";
 import React, { type FocusEvent, type KeyboardEventHandler, useCallback, useEffect, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
@@ -16,8 +16,7 @@ import { useToast } from "@/lib/hooks/use-toast";
 import { cn } from "@/lib/utils";
 
 interface ChartHeaderProps {
-  name: string;
-  id: string;
+  chart: DashboardChart;
   projectId: string;
 }
 
@@ -36,11 +35,41 @@ const updateChart = async (id: string, projectId: string, name: string) => {
   });
 };
 
-const ChartHeader = ({ name, id, projectId }: ChartHeaderProps) => {
+const ChartHeader = ({ chart, projectId }: ChartHeaderProps) => {
+  const { id, name, settings, query } = chart;
   const { toast } = useToast();
   const inputRef = useRef<HTMLInputElement>(null);
   const [isEditing, setIsEditing] = useState(false);
   const { mutate } = useSWRConfig();
+
+  const handleDuplicateChart = useCallback(async () => {
+    try {
+      await mutate<DashboardChart[]>(
+        `/api/projects/${projectId}/dashboard-charts`,
+        async (currentData) => {
+          const response = await fetch(`/api/projects/${projectId}/dashboard-charts`, {
+            method: "POST",
+            body: JSON.stringify({
+              name: `${name} (copy)`,
+              query,
+              config: settings.config,
+            }),
+          });
+          const created = await response.json() as DashboardChart;
+          return [...(currentData || []), created];
+        },
+        {
+          revalidate: true,
+        }
+      );
+    } catch (e) {
+      toast({
+        title: "Failed to duplicate chart. Please try again.",
+        variant: "destructive",
+      });
+    }
+  }, [id, mutate, name, projectId, query, settings, toast]);
+
   const handleDeleteChart = useCallback(async () => {
     try {
       await mutate<DashboardChart[]>(
@@ -160,6 +189,16 @@ const ChartHeader = ({ name, id, projectId }: ChartHeaderProps) => {
                 Edit
               </DropdownMenuItem>
             </Link>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDuplicateChart();
+              }}
+              className="cursor-pointer"
+            >
+              <Copy className="h-3.5 w-3.5 mr-1 text-inherit" />
+              Duplicate
+            </DropdownMenuItem>
             <DropdownMenuItem
               onClick={(e) => {
                 e.stopPropagation();

--- a/frontend/components/dashboard/chart-header.tsx
+++ b/frontend/components/dashboard/chart-header.tsx
@@ -55,6 +55,9 @@ const ChartHeader = ({ chart, projectId }: ChartHeaderProps) => {
               config: settings.config,
             }),
           });
+          if (!response.ok) {
+            throw new Error(`Failed to duplicate chart: ${response.status}`);
+          }
           const created = await response.json() as DashboardChart;
           return [...(currentData || []), created];
         },

--- a/frontend/components/dashboard/chart.tsx
+++ b/frontend/components/dashboard/chart.tsx
@@ -89,7 +89,7 @@ const Chart = ({ chart }: ChartProps) => {
 
   return (
     <div className="flex flex-col border gap-2 rounded-lg p-4 h-full border-dashed border-border relative">
-      <ChartHeader name={name} id={id} projectId={projectId as string} />
+      <ChartHeader chart={chart} projectId={projectId as string} />
       {error ? (
         <div className="flex flex-1 flex-col items-center justify-center text-center">
           <p className="text text-muted-foreground">Error loading chart data</p>


### PR DESCRIPTION
## Summary
- Adds a **Duplicate** option to the chart dropdown menu (between Edit and Delete)
- Uses the existing `POST /api/projects/:projectId/dashboard-charts` endpoint to create a copy with the same query, config, and a " (copy)" suffix on the name
- New chart is placed at the default layout position (0,0) and existing charts are repositioned automatically by the backend

## Changes
- `chart-header.tsx`: Accept full `chart` prop instead of just `name`/`id`, add `Copy` icon import, add `handleDuplicateChart` callback and "Duplicate" menu item
- `chart.tsx`: Pass `chart` object to `ChartHeader`

Closes #1498

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that adds a new dashboard action calling an existing create-chart endpoint; main risk is cache consistency/optimistic update behavior and handling of API failures.
> 
> **Overview**
> Adds a **Duplicate** action to the dashboard chart header menu, creating a new chart via `POST /api/projects/:projectId/dashboard-charts` with the same `query` and `settings.config` and a `" (copy)"` name suffix, and updating the SWR cache (with revalidation) plus error toast on failure.
> 
> Refactors `ChartHeader` to accept the full `chart` object (instead of `id`/`name`) and updates `chart.tsx` to pass that object through.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47fe02bbf1e4acb3bca8a1e2bdc7081fdc64129c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->