### PR TITLE
fix: render labeling queue payload with messages mode for LLM traces

### DIFF
--- a/frontend/components/queue/queue.tsx
+++ b/frontend/components/queue/queue.tsx
@@ -34,19 +34,21 @@ function looksLikeMessageArray(value: unknown): boolean {
 }
 
 /**
- * Determine the best default rendering mode for a queue item payload.
+ * Determine the best default rendering mode for a queue item payload
+ * and extract the relevant value to pass to ContentRenderer.
+ *
  * If the payload (or its data/target fields) contain LLM message arrays,
- * default to "messages" mode for consistent rendering with the trace view.
+ * returns "messages" mode with the extracted message array so that
+ * ContentRenderer receives the correct data shape.
  */
-function getPayloadDefaultMode(payload: unknown): string {
-  if (looksLikeMessageArray(payload)) return "messages";
+function getPayloadRendering(payload: unknown): { mode: string; value: unknown } {
+  if (looksLikeMessageArray(payload)) return { mode: "messages", value: payload };
   if (typeof payload === "object" && payload !== null) {
     const obj = payload as Record<string, unknown>;
-    if (looksLikeMessageArray(obj.data) || looksLikeMessageArray(obj.target)) {
-      return "messages";
-    }
+    if (looksLikeMessageArray(obj.data)) return { mode: "messages", value: obj.data };
+    if (looksLikeMessageArray(obj.target)) return { mode: "messages", value: obj.target };
   }
-  return "json";
+  return { mode: "json", value: payload };
 }
 
 function QueueInner() {
@@ -125,6 +127,8 @@ function QueueInner() {
     // No source - manually created
     return null;
   }, [currentItem, projectId]);
+
+  const payloadRendering = useMemo(() => getPayloadRendering(currentItem?.payload), [currentItem?.payload]);
 
   const onChange = useCallback(
     (v: string) => {
@@ -313,13 +317,14 @@ function QueueInner() {
               </div>
               <div className="flex flex-1 overflow-hidden mt-2">
                 <ContentRenderer
+                  key={currentItem?.id}
                   presetKey={`labeling-queue-${storeQueue?.id}`}
                   codeEditorClassName="rounded-b"
                   className="rounded"
-                  defaultMode={getPayloadDefaultMode(currentItem?.payload)}
+                  defaultMode={payloadRendering.mode}
                   modes={["MESSAGES", "JSON", "YAML", "TEXT"]}
                   readOnly
-                  value={JSON.stringify(currentItem?.payload, null, 2)}
+                  value={JSON.stringify(payloadRendering.value, null, 2)}
                 />
               </div>
             </>

--- a/frontend/components/queue/queue.tsx
+++ b/frontend/components/queue/queue.tsx
@@ -22,6 +22,33 @@ import AnnotationInterface from "./annotation-interface";
 import { QueueStoreProvider, useQueueStore } from "./queue-store";
 import SchemaDefinitionDialog from "./schema-definition-dialog";
 
+/**
+ * Check if a value looks like an LLM chat message array.
+ * Returns true for arrays of objects with "role" and "content" fields,
+ * which is the standard format used by OpenAI, Anthropic, etc.
+ */
+function looksLikeMessageArray(value: unknown): boolean {
+  if (!Array.isArray(value)) return false;
+  if (value.length === 0) return false;
+  return value.every((item) => typeof item === "object" && item !== null && "role" in item && "content" in item);
+}
+
+/**
+ * Determine the best default rendering mode for a queue item payload.
+ * If the payload (or its data/target fields) contain LLM message arrays,
+ * default to "messages" mode for consistent rendering with the trace view.
+ */
+function getPayloadDefaultMode(payload: unknown): string {
+  if (looksLikeMessageArray(payload)) return "messages";
+  if (typeof payload === "object" && payload !== null) {
+    const obj = payload as Record<string, unknown>;
+    if (looksLikeMessageArray(obj.data) || looksLikeMessageArray(obj.target)) {
+      return "messages";
+    }
+  }
+  return "json";
+}
+
 function QueueInner() {
   const { projectId } = useParams();
   const { toast } = useToast();
@@ -289,7 +316,8 @@ function QueueInner() {
                   presetKey={`labeling-queue-${storeQueue?.id}`}
                   codeEditorClassName="rounded-b"
                   className="rounded"
-                  defaultMode="json"
+                  defaultMode={getPayloadDefaultMode(currentItem?.payload)}
+                  modes={["MESSAGES", "JSON", "YAML", "TEXT"]}
                   readOnly
                   value={JSON.stringify(currentItem?.payload, null, 2)}
                 />


### PR DESCRIPTION
## Summary

- Auto-detects when a labeling queue item payload contains LLM message arrays and defaults to the `messages` rendering mode (same as the trace view)
- Adds mode switcher (MESSAGES / JSON / YAML / TEXT) so users can toggle between formatted and raw views
- No backend changes — this is a frontend-only display fix

## Problem

When an LLM trace is added to the labeling queue, the output renders as raw JSON:
```json
[{"role":"assistant","content":"{\"score\":2}"}]
```

But the same trace in the evaluations view renders cleanly via the Messages component, showing just the content under the role label.

## Solution

Added a `looksLikeMessageArray()` detector that checks if the payload (or its `data`/`target` fields) contains arrays of objects with `role` + `content` fields. When detected, the ContentRenderer defaults to `"messages"` mode instead of `"json"`.

Users can still switch to raw JSON/YAML/TEXT via the mode dropdown — this aligns with the "show raw data" toggle approach mentioned in #639.

## Test Plan

- [ ] Add an LLM trace to a labeling queue → should render with messages mode by default
- [ ] Toggle to JSON mode → should show raw message array
- [ ] Add a non-LLM trace → should default to JSON mode as before
- [ ] Manually created queue items → should default to JSON mode

Fixes #639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, frontend-only rendering changes limited to the labeling queue payload viewer; main risk is incorrect auto-detection causing an unexpected default view for some payload shapes.
> 
> **Overview**
> Labeling queue payloads now **auto-detect LLM chat message arrays** (top-level or under `data`/`target`) and default `ContentRenderer` to `messages` mode instead of always `json`.
> 
> The payload viewer adds an explicit mode switcher (`MESSAGES`/`JSON`/`YAML`/`TEXT`), passes the extracted payload value to render, and forces a remount on item change via `key={currentItem?.id}` to avoid stale renderer state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cc0059dcf953689b795a2d371bf6f723a28d9c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->