### PR TITLE
ci: publish multi-arch container images

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
@@ -52,6 +58,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- set up QEMU in the image publish workflow
- set up Docker Buildx before image builds
- publish `app-server`, `frontend`, and `query-engine` images as `linux/amd64,linux/arm64` multi-arch manifests

Fixes #139.

## Why
The self-hosting compose files pull `ghcr.io/lmnr-ai/*` images without pinning a platform, but the current publish workflow builds only the default single-arch image variant. That leaves ARM hosts pulling amd64-only images and failing at runtime with `exec format error`, which matches the failure reports in #139.

This patch keeps the runtime and compose files unchanged and fixes the problem where it actually originates: the image publish pipeline.

## Validation
- reviewed `docker-compose.yml` / `docker-compose-full.yml` to confirm the failing services pull `ghcr.io/lmnr-ai/app-server` and `ghcr.io/lmnr-ai/frontend`
- reviewed `.github/workflows/build-push.yml` to confirm the workflow currently omits Buildx/QEMU and does not set `platforms`
- docs/config only unaffected; this is a release-pipeline change

## Note
After merge, maintainers will need a new release publish to republish the GHCR tags as multi-arch manifests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes to the release publish pipeline; main risk is longer builds or unexpected Buildx/QEMU issues affecting image publishing.
> 
> **Overview**
> Updates the release `build-push` GitHub Actions workflow to publish **multi-architecture** Docker images.
> 
> The pipeline now sets up `QEMU` and `Docker Buildx` and builds/pushes images for `linux/amd64` and `linux/arm64` via `docker/build-push-action`, producing multi-arch manifests for the existing GHCR images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e5479b5f3b8ee50bae76f6c532abe8f0ac4ef78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->