### PR TITLE
feat: Add metric widget to dashboard

### DIFF
--- a/frontend/components/chart-builder/charts/index.tsx
+++ b/frontend/components/chart-builder/charts/index.tsx
@@ -4,6 +4,7 @@ import { useChartBuilderStoreContext } from "@/components/chart-builder/chart-bu
 import BarChart from "@/components/chart-builder/charts/bar-chart";
 import HorizontalBarChart from "@/components/chart-builder/charts/horizontal-bar-chart";
 import LineChart from "@/components/chart-builder/charts/line-chart";
+import MetricChart from "@/components/chart-builder/charts/metric-chart";
 import {
   generateChartConfig,
   transformDataForBreakdown,
@@ -19,13 +20,19 @@ interface ChartRendererCoreProps {
 }
 
 export const ChartRendererCore = ({ config, data, columns }: ChartRendererCoreProps) => {
+  const isMetric = config.type === ChartType.Metric;
+
   const {
     chartData,
     keys,
     chartConfig: uiChartConfig,
   } = useMemo(() => {
-    if (!config.type || !config.x || !config.y) {
+    if (!config.type || !config.y || (!isMetric && !config.x)) {
       return { chartData: [], keys: new Set<string>(), chartConfig: {} };
+    }
+
+    if (isMetric) {
+      return { chartData: data, keys: new Set([config.y]), chartConfig: {} };
     }
 
     const xColumn = columns.find((col) => col.name === config.x);
@@ -37,28 +44,39 @@ export const ChartRendererCore = ({ config, data, columns }: ChartRendererCorePr
     }
 
     if (breakdownColumn) {
-      return transformDataForBreakdown(data, config.x, config.y, config.breakdown!);
+      return transformDataForBreakdown(data, config.x!, config.y, config.breakdown!);
     }
 
-    return transformDataForSimpleChart(data, config.x, [config.y]);
-  }, [config, data, columns]);
+    return transformDataForSimpleChart(data, config.x!, [config.y]);
+  }, [config, data, columns, isMetric]);
 
-  if (!config.type || !config.x || !config.y) {
+  if (!config.type || !config.y || (!isMetric && !config.x)) {
     return (
       <div className="flex items-center justify-center h-full w-full text-muted-foreground">
         <div className="text-center">
           <p className="text">Invalid chart configuration</p>
           {!config.type && <p className="text-sm mt-1">• Chart type is required</p>}
-          {!config.x && <p className="text-sm mt-1">• X-axis column is required</p>}
+          {!isMetric && !config.x && <p className="text-sm mt-1">• X-axis column is required</p>}
           {!config.y && <p className="text-sm mt-1">• Y-axis column is required</p>}
         </div>
       </div>
     );
   }
 
+  if (isMetric) {
+    if (data.length === 0) {
+      return (
+        <div className="flex flex-1 h-full justify-center items-center bg-muted/30 rounded-lg">
+          <span className="text-muted-foreground">No data during this period</span>
+        </div>
+      );
+    }
+    return <MetricChart data={data} y={config.y} />;
+  }
+
   const props = {
     data: chartData,
-    x: config.x,
+    x: config.x!,
     y: config.y,
     breakdown: config.breakdown,
     total: config.total,

--- a/frontend/components/chart-builder/charts/metric-chart.tsx
+++ b/frontend/components/chart-builder/charts/metric-chart.tsx
@@ -1,0 +1,18 @@
+import React, { useMemo } from "react";
+
+interface MetricChartProps {
+  data: Record<string, any>[];
+  y: string;
+}
+
+const MetricChart = ({ data, y }: MetricChartProps) => {
+  const value = useMemo(() => data.reduce((sum, row) => sum + (Number(row[y]) || 0), 0), [data, y]);
+
+  return (
+    <div className="flex flex-1 items-center justify-center h-full">
+      <span className="font-medium text-4xl">{value.toLocaleString()}</span>
+    </div>
+  );
+};
+
+export default MetricChart;

--- a/frontend/components/chart-builder/export-chart-dialog.tsx
+++ b/frontend/components/chart-builder/export-chart-dialog.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import React, { type PropsWithChildren, useState } from "react";
 
 import { useChartBuilderStoreContext } from "@/components/chart-builder/chart-builder-store";
+import { ChartType } from "@/components/chart-builder/types";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -30,7 +31,12 @@ const ExportChartDialog = ({ children }: PropsWithChildren) => {
       return;
     }
 
-    if (!chartConfig.type || !chartConfig.x || !chartConfig.y) {
+    if (!chartConfig.type || !chartConfig.y) {
+      return;
+    }
+
+    // Non-Metric charts require an x-axis column
+    if (chartConfig.type !== ChartType.Metric && !chartConfig.x) {
       return;
     }
 

--- a/frontend/components/chart-builder/index.tsx
+++ b/frontend/components/chart-builder/index.tsx
@@ -1,4 +1,4 @@
-import { ChartBar, ChartColumn, ChartLine, Upload } from "lucide-react";
+import { ChartBar, ChartColumn, ChartLine, Hash, Upload } from "lucide-react";
 import React, { type ReactNode } from "react";
 
 import {
@@ -247,5 +247,9 @@ export const chartTypeLabelMap: Record<ChartType, { label: string; icon: ReactNo
   [ChartType.HorizontalBarChart]: {
     label: "Horizontal Bar Chart",
     icon: <ChartBar className="w-4 h-4 mr-2" />,
+  },
+  [ChartType.Metric]: {
+    label: "Metric",
+    icon: <Hash className="w-4 h-4 mr-2" />,
   },
 };

--- a/frontend/components/chart-builder/types.ts
+++ b/frontend/components/chart-builder/types.ts
@@ -2,6 +2,7 @@ export enum ChartType {
   "LineChart" = "line",
   "BarChart" = "bar",
   "HorizontalBarChart" = "horizontalBar",
+  "Metric" = "metric",
 }
 
 export interface ChartConfig {

--- a/frontend/components/chart-builder/utils.ts
+++ b/frontend/components/chart-builder/utils.ts
@@ -40,7 +40,14 @@ export const canSelectForYAxis = (column: ColumnInfo, chartType: ChartType | und
 export const isValidChartConfiguration = (config: ChartConfig, columns: ColumnInfo[]): boolean => {
   const { type, x, y, breakdown } = config;
 
-  if (!type || !x || !y) return false;
+  if (!type || !y) return false;
+
+  if (type === ChartType.Metric) {
+    const yColumn = columns.find((col) => col.name === y);
+    return !!yColumn;
+  }
+
+  if (!x) return false;
 
   const xColumn = columns.find((col) => col.name === x);
   const yColumn = columns.find((col) => col.name === y);

--- a/frontend/components/dashboard/editor/Form.tsx
+++ b/frontend/components/dashboard/editor/Form.tsx
@@ -21,6 +21,8 @@ import { type QueryStructure, type TimeRange } from "@/lib/actions/sql/types.ts"
 const needsTimeSeries = (chartType?: ChartType): boolean =>
   chartType === ChartType.LineChart || chartType === ChartType.BarChart;
 
+const isMetricType = (chartType?: ChartType): boolean => chartType === ChartType.Metric;
+
 const getDefaultTimeRange = (table: string): TimeRange => {
   const timeColumn = getTimeColumn(table);
   return {
@@ -77,10 +79,21 @@ export const Form = ({ isLoadingChart }: { isLoadingChart: boolean }) => {
       return null;
     }
 
-    const isTimeSeries = needsTimeSeries(chartType);
-    const isHorizontalBar = chartType === ChartType.HorizontalBarChart;
     const firstMetric = metrics[0];
     const metricValue = firstMetric.alias || (firstMetric.fn === "raw" ? "value" : firstMetric.column);
+
+    if (isMetricType(chartType)) {
+      return {
+        type: chartType,
+        x: undefined,
+        y: metricValue,
+        breakdown: undefined,
+        total: false,
+      };
+    }
+
+    const isTimeSeries = needsTimeSeries(chartType);
+    const isHorizontalBar = chartType === ChartType.HorizontalBarChart;
     const dimensionValue = isTimeSeries ? "time" : dimensions?.[0] || columns[0]?.name || "x";
 
     return {
@@ -112,9 +125,10 @@ export const Form = ({ isLoadingChart }: { isLoadingChart: boolean }) => {
 
     try {
       const isHorizontalBar = chartType === ChartType.HorizontalBarChart;
+      const isMetric = isMetricType(chartType);
       const allFilters = [...(filters || [])];
 
-      if (isHorizontalBar) {
+      if (isHorizontalBar || isMetric) {
         const timeColumn = getTimeColumn(table);
         allFilters.push(
           { field: timeColumn, op: "gte" as const, stringValue: "{start_time:DateTime64}" },
@@ -125,7 +139,7 @@ export const Form = ({ isLoadingChart }: { isLoadingChart: boolean }) => {
       const queryStructure: QueryStructure = {
         table,
         metrics,
-        dimensions: dimensions || [],
+        dimensions: isMetric ? [] : dimensions || [],
         filters: allFilters,
         orderBy: [],
         ...(orderBy && orderBy.length > 0 && { orderBy }),
@@ -153,7 +167,7 @@ export const Form = ({ isLoadingChart }: { isLoadingChart: boolean }) => {
       if (chartConfig) {
         setChartConfig({
           type: chartConfig.type!,
-          x: chartConfig.x!,
+          x: chartConfig.x,
           y: chartConfig.y!,
           breakdown: chartConfig.breakdown,
           total: chart.settings.config.total ?? false,

--- a/frontend/components/dashboard/editor/fields/ChartTypeField.tsx
+++ b/frontend/components/dashboard/editor/fields/ChartTypeField.tsx
@@ -1,4 +1,4 @@
-import { ChartBar, ChartColumn, ChartLine } from "lucide-react";
+import { ChartBar, ChartColumn, ChartLine, Hash } from "lucide-react";
 import { type ReactNode } from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -20,6 +20,10 @@ const chartTypeOptions: Record<ChartType, { label: string; icon: ReactNode }> = 
   [ChartType.HorizontalBarChart]: {
     label: "Horizontal Bar",
     icon: <ChartBar className="size-3.5" />,
+  },
+  [ChartType.Metric]: {
+    label: "Metric",
+    icon: <Hash className="size-3.5" />,
   },
 };
 

--- a/frontend/components/dashboard/editor/fields/index.tsx
+++ b/frontend/components/dashboard/editor/fields/index.tsx
@@ -126,16 +126,18 @@ export const QueryBuilderFields = ({ isFormValid, hasChartConfig }: QueryBuilder
       <TableSelect />
       <MetricsField />
       <FiltersField />
-      <DimensionsField />
+      {chartType !== ChartType.Metric && <DimensionsField />}
       {chartType === ChartType.HorizontalBarChart && <OrderByField />}
-      <LimitField />
+      {chartType !== ChartType.Metric && <LimitField />}
 
-      <div className="flex items-center gap-2">
-        <Checkbox id="showTotal" checked={total} onCheckedChange={(checked) => setTotal(checked as boolean)} />
-        <Label htmlFor="showTotal" className="text-xs text-secondary-foreground/80 cursor-pointer">
-          Show Total
-        </Label>
-      </div>
+      {chartType !== ChartType.Metric && (
+        <div className="flex items-center gap-2">
+          <Checkbox id="showTotal" checked={total} onCheckedChange={(checked) => setTotal(checked as boolean)} />
+          <Label htmlFor="showTotal" className="text-xs text-secondary-foreground/80 cursor-pointer">
+            Show Total
+          </Label>
+        </div>
+      )}
 
       {saveError && <div className="text-sm text-destructive">{saveError}</div>}
       <Button

--- a/frontend/lib/actions/dashboard/index.ts
+++ b/frontend/lib/actions/dashboard/index.ts
@@ -14,7 +14,7 @@ const GetChartsSchema = z.object({
 const ChartSettingsSchema = z.object({
   config: z.object({
     type: z.enum(ChartType),
-    x: z.string(),
+    x: z.string().optional(),
     y: z.string(),
     breakdown: z.string().optional(),
     total: z.boolean().optional(),


### PR DESCRIPTION
Add metric widget to dashboard to a specific metric such as total cost, total o/p tokens etc.
Fixes: #1499 
Preview of the widget:
<img width="529" height="264" alt="image" src="https://github.com/user-attachments/assets/29afed04-c4b2-43c3-86a7-771fefae548d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new chart type and changes validation/schema to allow `config.x` to be optional, which could affect existing chart save/load paths if any code still assumes `x` is always present.
> 
> **Overview**
> Adds a new `ChartType.Metric` that renders a single numeric KPI by summing the selected `y` column via a new `MetricChart` component, with empty-state handling.
> 
> Updates chart configuration/validation and export/persistence to make `x` optional for metric charts (UI validation, export dialog checks, and backend zod schema). Updates the dashboard editor to support metric charts by generating configs without dimensions, hiding dimension/limit/total controls, and emitting query structures with no dimensions while still applying the time filter behavior used for non-timeseries charts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93b7e39ac6299cd8b7acc8430b96fe49f6a8a644. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->