### PR TITLE
feat: add aggregation metrics to evaluation score card

### DIFF
--- a/frontend/components/evaluation/score-card.tsx
+++ b/frontend/components/evaluation/score-card.tsx
@@ -15,6 +15,23 @@ interface ScoreCardProps {
   isLoading?: boolean;
 }
 
+type MetricEntry = {
+  readonly label: string;
+  readonly key: keyof EvaluationScoreStatistics;
+};
+
+const SECONDARY_METRICS: readonly MetricEntry[] = [
+  { label: "Median", key: "medianValue" },
+  { label: "Std Dev", key: "stdDeviation" },
+  { label: "Min", key: "minValue" },
+  { label: "Max", key: "maxValue" },
+] as const;
+
+function formatMetric(value: number | undefined): string {
+  if (!isValidNumber(value)) return "-";
+  return value.toFixed(2);
+}
+
 export default function ScoreCard({
   scores,
   selectedScore,
@@ -74,6 +91,20 @@ export default function ScoreCard({
               </div>
             )}
           </div>
+          {statistics && statistics.count > 0 && (
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1 mt-3 pt-3 border-t border-border">
+              {SECONDARY_METRICS.map(({ label, key }) => (
+                <div key={key} className="flex justify-between items-center">
+                  <span className="text-xs text-secondary-foreground">{label}</span>
+                  <span className="text-xs font-medium">{formatMetric(statistics[key])}</span>
+                </div>
+              ))}
+              <div className="flex justify-between items-center col-span-2 mt-1">
+                <span className="text-xs text-secondary-foreground">Count</span>
+                <span className="text-xs font-medium">{statistics.count}</span>
+              </div>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/frontend/lib/actions/evaluation/utils.ts
+++ b/frontend/lib/actions/evaluation/utils.ts
@@ -16,14 +16,35 @@ export function calculateScoreStatistics(
     })
     .filter((score): score is number => typeof score === "number" && !isNaN(score));
 
+  const empty: EvaluationScoreStatistics = {
+    averageValue: 0,
+    minValue: 0,
+    maxValue: 0,
+    stdDeviation: 0,
+    medianValue: 0,
+    count: 0,
+  };
+
   if (scores.length === 0) {
-    return { averageValue: 0 };
+    return empty;
   }
 
+  const count = scores.length;
   const sum = scores.reduce((acc, score) => acc + score, 0);
-  const averageValue = sum / scores.length;
+  const averageValue = sum / count;
+  const minValue = Math.min(...scores);
+  const maxValue = Math.max(...scores);
 
-  return { averageValue };
+  // Population standard deviation
+  const squaredDiffs = scores.reduce((acc, score) => acc + (score - averageValue) ** 2, 0);
+  const stdDeviation = Math.sqrt(squaredDiffs / count);
+
+  // Median via sorted copy
+  const sorted = [...scores].sort((a, b) => a - b);
+  const mid = Math.floor(count / 2);
+  const medianValue = count % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+
+  return { averageValue, minValue, maxValue, stdDeviation, medianValue, count };
 }
 
 // Helper function to calculate score distribution

--- a/frontend/lib/evaluation/types.ts
+++ b/frontend/lib/evaluation/types.ts
@@ -11,6 +11,11 @@ export type Evaluation = {
 
 export type EvaluationScoreStatistics = {
   averageValue: number;
+  minValue: number;
+  maxValue: number;
+  stdDeviation: number;
+  medianValue: number;
+  count: number;
 };
 
 export type EvaluationScoreDistributionBucket = {


### PR DESCRIPTION
## Summary

Adds additional aggregation metrics to the evaluation score card, addressing #637.

Currently the evaluation results page only shows the **average** of numeric scores. This PR adds:

- **Median** — robust central tendency, less sensitive to outliers
- **Standard Deviation** — measures score consistency/spread
- **Min / Max** — range boundaries  
- **Count** — number of data points

These metrics are displayed in a compact grid below the existing average display, preserving the current UI hierarchy.

## Design Decisions

- **All metrics are universally applicable** — no need to distinguish between error metrics, quality scores, or classifications. This avoids the complexity discussed in #637 around RMSE semantics.
- **Population std deviation** (not sample) — since we're computing over the full evaluation run, not a sample.
- **Zero-cost for empty results** — all fields default to 0 when no valid scores exist.
- **Comparison mode preserved** — the primary average + comparison arrow UI is untouched; secondary metrics appear below.

## Files Changed

| File | Change |
|---|---|
| `lib/evaluation/types.ts` | Added `minValue`, `maxValue`, `stdDeviation`, `medianValue`, `count` to `EvaluationScoreStatistics` |
| `lib/actions/evaluation/utils.ts` | Extended `calculateScoreStatistics()` to compute all metrics |
| `components/evaluation/score-card.tsx` | Added secondary metrics grid below average display |

## Test Plan

- [ ] Evaluation with numeric scores shows all 6 metrics (avg, median, std dev, min, max, count)
- [ ] Evaluation with no scores shows avg = 0 and no secondary metrics grid
- [ ] Comparison mode (two evaluations) still renders correctly with arrow + percentage change
- [ ] Metrics are accurate: verify against manual calculation on a small dataset

Addresses #637

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/data-display change that extends computed score statistics; main risk is any downstream code expecting `EvaluationScoreStatistics` to only contain `averageValue`.
> 
> **Overview**
> Extends `EvaluationScoreStatistics` to include `medianValue`, `stdDeviation`, `minValue`, `maxValue`, and `count`, and updates `calculateScoreStatistics()` to compute these aggregates (including population std dev and median).
> 
> Updates the evaluation score card to render a compact secondary-metrics grid (median/std dev/min/max + count) beneath the existing average/comparison display, hiding the grid when there are no valid scores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6b12155d871dc59308e6d81b3675102660d8ac8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->