### PR TITLE
fix: fix filters in signal events

### DIFF
--- a/frontend/components/signal/events-table/columns.tsx
+++ b/frontend/components/signal/events-table/columns.tsx
@@ -104,25 +104,25 @@ function createPayloadFilter(field: SchemaField): ColumnFilter {
     case "number":
       return {
         name: field.name,
-        key: `payload.${field.name}`,
+        key: field.name,
         dataType: "number",
       };
     case "boolean":
       return {
         name: field.name,
-        key: `payload.${field.name}`,
+        key: field.name,
         dataType: "boolean",
       };
     case "enum":
       return {
         name: field.name,
-        key: `payload.${field.name}`,
+        key: field.name,
         dataType: "string",
       };
     default:
       return {
         name: field.name,
-        key: `payload.${field.name}`,
+        key: field.name,
         dataType: "string",
       };
   }

--- a/frontend/components/signal/events-table/columns.tsx
+++ b/frontend/components/signal/events-table/columns.tsx
@@ -104,25 +104,25 @@ function createPayloadFilter(field: SchemaField): ColumnFilter {
     case "number":
       return {
         name: field.name,
-        key: field.name,
+        key: `payload.${field.name}`,
         dataType: "number",
       };
     case "boolean":
       return {
         name: field.name,
-        key: field.name,
+        key: `payload.${field.name}`,
         dataType: "boolean",
       };
     case "enum":
       return {
         name: field.name,
-        key: field.name,
+        key: `payload.${field.name}`,
         dataType: "string",
       };
     default:
       return {
         name: field.name,
-        key: field.name,
+        key: `payload.${field.name}`,
         dataType: "string",
       };
   }

--- a/frontend/lib/actions/common/query-builder.ts
+++ b/frontend/lib/actions/common/query-builder.ts
@@ -212,7 +212,8 @@ const createCustomFilter =
 const buildColumnFilters = (filters: Filter[], config: ColumnFilterConfig): ConditionResult => {
   const results = filters
     .map((filter, index) => {
-      const paramKey = `${filter.column}_${index}`;
+      const safeColumn = filter.column.replace(/[^a-zA-Z0-9_]/g, "_");
+      const paramKey = `${safeColumn}_${index}`;
       const processor = config.processors.get(filter.column) || config.defaultProcessor;
 
       return processor ? processor(filter, paramKey) : null;

--- a/frontend/lib/actions/events/utils.ts
+++ b/frontend/lib/actions/events/utils.ts
@@ -17,6 +17,7 @@ export const eventsColumnFilterConfig: ColumnFilterConfig = {
   ]),
   defaultProcessor: (filter, paramKey) => {
     const { column, value, dataType } = filter;
+    const fieldName = column.startsWith("payload.") ? column.slice("payload.".length) : column;
     const opSymbol = OperatorLabelMap[filter.operator];
 
     if (dataType === "number") {
@@ -24,7 +25,7 @@ export const eventsColumnFilterConfig: ColumnFilterConfig = {
       return {
         condition: `(simpleJSONExtractFloat(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:Float64})`,
         params: {
-          [`${paramKey}_key`]: column,
+          [`${paramKey}_key`]: fieldName,
           [`${paramKey}_val`]: numValue,
         },
       };
@@ -35,7 +36,7 @@ export const eventsColumnFilterConfig: ColumnFilterConfig = {
       return {
         condition: `(simpleJSONExtractBool(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:Bool})`,
         params: {
-          [`${paramKey}_key`]: column,
+          [`${paramKey}_key`]: fieldName,
           [`${paramKey}_val`]: boolStr,
         },
       };
@@ -46,7 +47,7 @@ export const eventsColumnFilterConfig: ColumnFilterConfig = {
         `(simpleJSONExtractString(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:String}` +
         ` OR simpleJSONExtractRaw(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:String})`,
       params: {
-        [`${paramKey}_key`]: column,
+        [`${paramKey}_key`]: fieldName,
         [`${paramKey}_val`]: String(value),
       },
     };

--- a/frontend/lib/actions/events/utils.ts
+++ b/frontend/lib/actions/events/utils.ts
@@ -17,47 +17,39 @@ export const eventsColumnFilterConfig: ColumnFilterConfig = {
   ]),
   defaultProcessor: (filter, paramKey) => {
     const { column, value, dataType } = filter;
+    const opSymbol = OperatorLabelMap[filter.operator];
 
-    // Handle payload field filters (payload.fieldName)
-    if (column.startsWith("payload.")) {
-      const fieldName = column.slice("payload.".length);
-      const opSymbol = OperatorLabelMap[filter.operator];
-
-      if (dataType === "number") {
-        const numValue = parseFloat(String(value));
-        return {
-          condition: `(simpleJSONExtractFloat(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:Float64})`,
-          params: {
-            [`${paramKey}_key`]: fieldName,
-            [`${paramKey}_val`]: numValue,
-          },
-        };
-      }
-
-      if (dataType === "boolean") {
-        const boolStr = String(value) === "true" ? "true" : "false";
-        return {
-          condition: `(simpleJSONExtractBool(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:Bool})`,
-          params: {
-            [`${paramKey}_key`]: fieldName,
-            [`${paramKey}_val`]: boolStr,
-          },
-        };
-      }
-
-      // Default: string comparison (covers dataType "string", "json", "enum", etc.)
+    if (dataType === "number") {
+      const numValue = parseFloat(String(value));
       return {
-        condition:
-          `(simpleJSONExtractString(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:String}` +
-          ` OR simpleJSONExtractRaw(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:String})`,
+        condition: `(simpleJSONExtractFloat(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:Float64})`,
         params: {
-          [`${paramKey}_key`]: fieldName,
-          [`${paramKey}_val`]: String(value),
+          [`${paramKey}_key`]: column,
+          [`${paramKey}_val`]: numValue,
         },
       };
     }
 
-    return { condition: null, params: {} };
+    if (dataType === "boolean") {
+      const boolStr = String(value) === "true" ? "true" : "false";
+      return {
+        condition: `(simpleJSONExtractBool(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:Bool})`,
+        params: {
+          [`${paramKey}_key`]: column,
+          [`${paramKey}_val`]: boolStr,
+        },
+      };
+    }
+
+    return {
+      condition:
+        `(simpleJSONExtractString(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:String}` +
+        ` OR simpleJSONExtractRaw(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:String})`,
+      params: {
+        [`${paramKey}_key`]: column,
+        [`${paramKey}_val`]: String(value),
+      },
+    };
   },
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how ClickHouse query parameters and conditions are generated for event filters, which can affect query correctness and runtime errors. Moderate risk due to touching shared query-building logic used across filtered queries.
> 
> **Overview**
> Fixes signal event filtering by **sanitizing filter-derived parameter keys** in the shared query builder (replacing non-alphanumeric characters in `filter.column` before composing `{paramKey}` placeholders), preventing invalid ClickHouse named parameters for columns like `payload.foo`.
> 
> Simplifies and corrects the events default filter processor so it always treats filters as `payload` lookups (stripping `payload.` when present) and generates typed JSON extraction conditions for `number` and `boolean`, falling back to string/raw comparisons for all other types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 670fcce9d1a3042c608fa24ddcc414e18aef172a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->