### PR TITLE
add attributes on sql query span

### DIFF
--- a/app-server/src/api/v1/sql.rs
+++ b/app-server/src/api/v1/sql.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use actix_web::{HttpResponse, post, web};
 use opentelemetry::{
-    global,
-    trace::{Tracer, mark_span_as_active},
+    KeyValue, global,
+    trace::{Span, Tracer, mark_span_as_active},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -44,7 +44,9 @@ pub async fn execute_sql_query(
     let SqlQueryRequest { query, parameters } = req.into_inner();
 
     let tracer = global::tracer("tracer");
-    let span = tracer.start("api_sql_query");
+    let mut span = tracer.start("api_sql_query");
+    span.set_attribute(KeyValue::new("project_id", project_id.to_string()));
+    span.set_attribute(KeyValue::new("query", query.clone()));
     let _guard = mark_span_as_active(span);
 
     match clickhouse_ro.as_ref() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Low functional risk, but it adds the full SQL query as a trace attribute which can increase telemetry volume and may expose sensitive data if queries contain it.
> 
> **Overview**
> Adds OpenTelemetry span attributes to the `api_sql_query` trace in `execute_sql_query`, recording `project_id` and the raw `query` string for better observability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38083d01f6465dc4d8e3248a037f0b32892dc0c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->