### PR TITLE
feat: fix reader mode

### DIFF
--- a/frontend/lib/actions/spans/previews/index.ts
+++ b/frontend/lib/actions/spans/previews/index.ts
@@ -181,7 +181,14 @@ const applyCachedKeys = async (
       const isProviderType = PROVIDER_SPAN_TYPES.has(spanTypes[span.spanId] ?? "");
       const match = isProviderType ? matchProviderKey(span.parsedData) : null;
       const rendered = validateMustacheKey(cachedKey, match?.data ?? span.parsedData);
-      resolved[span.spanId] = rendered ?? toJsonPreview(span.parsedData);
+      if (rendered) {
+        resolved[span.spanId] = rendered;
+      } else if (match) {
+        const providerRendered = validateMustacheKey(match.key, match.data ?? span.parsedData);
+        resolved[span.spanId] = providerRendered ?? toJsonPreview(span.parsedData);
+      } else {
+        resolved[span.spanId] = toJsonPreview(span.parsedData);
+      }
     } else {
       uncached.push(span);
     }

--- a/frontend/lib/actions/spans/previews/utils.ts
+++ b/frontend/lib/actions/spans/previews/utils.ts
@@ -49,7 +49,9 @@ const describeShape = (value: unknown): string => {
   if (typeof value === "boolean") return "boolean";
 
   if (Array.isArray(value)) {
-    return isEmpty(value) ? "[]" : `[]${describeShape(value[0])}`;
+    if (isEmpty(value)) return "[]";
+    const uniqueShapes = [...new Set(value.map(describeShape))].sort();
+    return uniqueShapes.length === 1 ? `[]${uniqueShapes[0]}` : `[](${uniqueShapes.join("|")})`;
   }
 
   if (isPlainObject(value)) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes preview rendering selection and alters schema fingerprint generation for arrays, which can affect cache hits/misses and what users see in span previews.
> 
> **Overview**
> Improves span preview rendering when a cached mustache key no longer renders: for provider spans, it now falls back to the matched provider key before defaulting to a JSON preview.
> 
> Updates schema fingerprinting (`describeShape`) to account for heterogeneous arrays by incorporating the set of element shapes (instead of only the first element), which can change cached rendering-key reuse and trigger regeneration for some spans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc91da9dfeadf7f83a8c0dc8448677223690ed5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->