### PR TITLE
Feat/sticky messages

### DIFF
--- a/frontend/components/traces/span-view/common.tsx
+++ b/frontend/components/traces/span-view/common.tsx
@@ -290,26 +290,32 @@ export const MessageWrapper = ({
   const isCapped = !isExpanded && isOverflowing;
 
   return (
-    <div className="relative border rounded bg-card">
+    <div className="relative border rounded">
       <RoleHeader role={role} className={stickyHeader ? "sticky top-0 z-10" : undefined} />
       <div ref={containerRef} className="overflow-hidden" style={!isExpanded ? { maxHeight } : undefined}>
         <div className="flex flex-col divide-y">{children}</div>
       </div>
       {isCapped && (
-        <button
-          onClick={() => setIsExpanded(true)}
-          className="sticky bottom-0 z-10 w-full h-4 bg-transparent bg-gradient-to-t from-background to-transparent rounded-b cursor-pointer flex items-end justify-center"
-        >
-          <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />
-        </button>
+        <div className="sticky bottom-0 z-30 flex flex-col items-center rounded-b">
+          <button
+            onClick={() => setIsExpanded(true)}
+            className="w-full flex items-center justify-center gap-1 py-1 bg-background/40 text-xs text-secondary-foreground cursor-pointer rounded-b transition-colors"
+          >
+            <ChevronDown className="w-3.5 h-3.5" />
+          </button>
+        </div>
       )}
       {isExpanded && isOverflowing && (
-        <button
-          onClick={() => setIsExpanded(false)}
-          className="sticky bottom-0 z-10 w-full h-4 bg-gradient-to-t from-background to-transparent rounded-b cursor-pointer flex items-end justify-center"
-        >
-          <ChevronUp className="w-3.5 h-3.5 text-muted-foreground" />
-        </button>
+        <div className="sticky bottom-0 z-30 flex flex-col items-center rounded-b">
+          <button
+            onClick={() => setIsExpanded(false)}
+            className="w-full flex items-center justify-center gap-1 pb-2 bg-background/40 text-xs text-secondary-foreground cursor-pointer rounded-b transition-colors"
+          >
+            <span className="bg-background">
+              <ChevronUp className="w-3.5 h-3.5 p-1" />
+            </span>
+          </button>
+        </div>
       )}
     </div>
   );

--- a/frontend/components/traces/span-view/common.tsx
+++ b/frontend/components/traces/span-view/common.tsx
@@ -288,6 +288,7 @@ export const MessageWrapper = ({
   }, [checkOverflow]);
 
   const isCapped = !isExpanded && isOverflowing;
+  const showToggle = isOverflowing || isExpanded;
 
   return (
     <div className="relative border rounded">
@@ -295,25 +296,23 @@ export const MessageWrapper = ({
       <div ref={containerRef} className="overflow-hidden" style={!isExpanded ? { maxHeight } : undefined}>
         <div className="flex flex-col divide-y">{children}</div>
       </div>
-      {isCapped && (
+      {showToggle && (
         <div className="sticky bottom-0 z-30 flex flex-col items-center rounded-b">
+          {!isExpanded && (
+            <div
+              className="w-full pointer-events-none"
+              style={{
+                height: isCapped ? 48 : 24,
+                marginTop: isCapped ? -48 : 0,
+                background: "linear-gradient(to bottom, transparent, hsl(var(--secondary)))",
+              }}
+            />
+          )}
           <button
-            onClick={() => setIsExpanded(true)}
-            className="w-full flex items-center justify-center gap-1 py-1 bg-background/40 text-xs text-secondary-foreground cursor-pointer rounded-b transition-colors"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            className="py-1.5 bg-secondary w-full flex items-center justify-center gap-1 text-xs text-secondary-foreground cursor-pointer rounded-b transition-colors -mt-2"
           >
-            <ChevronDown className="w-3.5 h-3.5" />
-          </button>
-        </div>
-      )}
-      {isExpanded && isOverflowing && (
-        <div className="sticky bottom-0 z-30 flex flex-col items-center rounded-b">
-          <button
-            onClick={() => setIsExpanded(false)}
-            className="w-full flex items-center justify-center gap-1 pb-2 bg-background/40 text-xs text-secondary-foreground cursor-pointer rounded-b transition-colors"
-          >
-            <span className="bg-background">
-              <ChevronUp className="w-3.5 h-3.5 p-1" />
-            </span>
+            {isExpanded ? <ChevronUp className="size-3.5" /> : <ChevronDown className="size-3.5" />}
           </button>
         </div>
       )}

--- a/frontend/components/traces/span-view/common.tsx
+++ b/frontend/components/traces/span-view/common.tsx
@@ -74,7 +74,7 @@ const PureToolCallContentPart = ({
   messageIndex = 0,
   contentPartIndex = 0,
 }: ToolCallContentPartProps) => (
-  <div className="flex flex-col gap-2 p-2 bg-background">
+  <div className="flex flex-col gap-2 p-2 bg-background rounded-b">
     <span
       className="flex items-center gap-1.5 text-xs font-medium"
       style={{ color: ROLE_COLORS.tool.badgeText, opacity: 0.85 }}
@@ -112,7 +112,7 @@ const PureToolResultContentPart = ({
   presetKey,
   children,
 }: ToolResultContentPartProps) => (
-  <div className="flex flex-col gap-2 p-2 bg-background">
+  <div className="flex flex-col gap-2 p-2 bg-background rounded-b">
     <span
       className="flex items-center gap-1.5 text-xs font-medium"
       style={{ color: ROLE_COLORS.tool.badgeText, opacity: 0.85 }}
@@ -185,7 +185,7 @@ export const RoleHeader = ({ role, className }: RoleHeaderProps) => {
   if (role) {
     const colors = getRoleColors(role);
     return (
-      <div className={cn("flex items-center px-2 py-1 gap-2 border-b bg-background", className)}>
+      <div className={cn("flex items-center px-2 py-1 gap-2 border-b bg-background rounded-t", className)}>
         <span className="text-sm font-medium" style={{ color: colors.badgeText }}>
           {capitalize(role)}
         </span>
@@ -226,7 +226,7 @@ const PureThinkingContentPart = ({
   messageIndex = 0,
   contentPartIndex = 0,
 }: ThinkingContentPartProps) => (
-  <div className="flex flex-col gap-2 p-2 bg-background">
+  <div className="flex flex-col gap-2 p-2 bg-background rounded-b">
     <span className="flex items-center text-xs">
       <Brain size={12} className="min-w-3 mr-2" />
       {label}
@@ -258,10 +258,12 @@ export const MessageWrapper = ({
   children,
   role,
   maxHeight = DEFAULT_MESSAGE_MAX_HEIGHT,
+  stickyHeader = true,
 }: PropsWithChildren<{
   role?: string;
   presetKey: string;
   maxHeight?: number;
+  stickyHeader?: boolean;
 }>) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -288,27 +290,23 @@ export const MessageWrapper = ({
   const isCapped = !isExpanded && isOverflowing;
 
   return (
-    <div className="relative">
-      <div
-        ref={containerRef}
-        className={cn("border rounded overflow-hidden bg-card", isExpanded && isOverflowing && "pb-4")}
-        style={!isExpanded ? { maxHeight } : undefined}
-      >
-        <RoleHeader role={role} />
+    <div className="relative border rounded bg-card">
+      <RoleHeader role={role} className={stickyHeader ? "sticky top-0 z-10" : undefined} />
+      <div ref={containerRef} className="overflow-hidden" style={!isExpanded ? { maxHeight } : undefined}>
         <div className="flex flex-col divide-y">{children}</div>
-        {isCapped && (
-          <button
-            onClick={() => setIsExpanded(true)}
-            className="absolute bottom-px left-px right-px h-16 bg-gradient-to-t from-background to-transparent rounded-b cursor-pointer flex items-end justify-center"
-          >
-            <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />
-          </button>
-        )}
       </div>
+      {isCapped && (
+        <button
+          onClick={() => setIsExpanded(true)}
+          className="sticky bottom-0 z-10 w-full h-4 bg-transparent bg-gradient-to-t from-background to-transparent rounded-b cursor-pointer flex items-end justify-center"
+        >
+          <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />
+        </button>
+      )}
       {isExpanded && isOverflowing && (
         <button
           onClick={() => setIsExpanded(false)}
-          className="absolute bottom-px left-px right-px h-8 bg-gradient-to-t from-background to-transparent rounded-b cursor-pointer flex items-end justify-center"
+          className="sticky bottom-0 z-10 w-full h-4 bg-gradient-to-t from-background to-transparent rounded-b cursor-pointer flex items-end justify-center"
         >
           <ChevronUp className="w-3.5 h-3.5 text-muted-foreground" />
         </button>

--- a/frontend/components/traces/span-view/messages.tsx
+++ b/frontend/components/traces/span-view/messages.tsx
@@ -295,11 +295,13 @@ function PureMessages({ messages, presetKey, hideScrollToBottom = false, maxHeig
     <>
       <div className="size-full relative">
         <div
+          className="absolute top-0 left-0 right-0 z-20 bg-background transition-opacity duration-150"
           ref={overlayRef}
-          className="absolute top-0 left-2 right-2 z-20 flex items-center px-2 py-1 gap-2 border-b border bg-background rounded-t shadow-sm transition-opacity duration-150"
           style={{ opacity: 0, pointerEvents: "none" }}
         >
-          <span ref={labelRef} className="text-sm font-medium" />
+          <div className="mx-2 flex items-center px-2 py-1 gap-2 border bg-background rounded-t shadow-sm">
+            <span ref={labelRef} className="text-sm font-medium" />
+          </div>
         </div>
         <div
           ref={parentRef}

--- a/frontend/components/traces/span-view/messages.tsx
+++ b/frontend/components/traces/span-view/messages.tsx
@@ -1,12 +1,12 @@
-import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { type ModelMessage } from "ai";
 import { isEqual, isNil } from "lodash";
 import { ChevronDown } from "lucide-react";
-import React, { memo, type Ref, useMemo, useRef } from "react";
+import React, { memo, useCallback, useMemo, useRef } from "react";
 import { type z } from "zod/v4";
 
 import AnthropicContentParts from "@/components/traces/span-view/anthropic-parts";
-import { MessageWrapper } from "@/components/traces/span-view/common";
+import { getRoleColors, MessageWrapper } from "@/components/traces/span-view/common";
 import GeminiContentParts from "@/components/traces/span-view/gemini-parts";
 import ContentParts from "@/components/traces/span-view/generic-parts";
 import LangChainContentParts from "@/components/traces/span-view/langchain-parts";
@@ -200,14 +200,39 @@ interface MessagesProps {
   maxHeight?: number;
 }
 
+const HEADER_HEIGHT = 28;
+
+function updateOverlay(
+  overlayEl: HTMLDivElement | null,
+  labelEl: HTMLSpanElement | null,
+  role: string | undefined,
+  show: boolean
+) {
+  if (!overlayEl || !labelEl) return;
+  if (!show || !role) {
+    overlayEl.style.opacity = "0";
+    overlayEl.style.pointerEvents = "none";
+    return;
+  }
+  const colors = getRoleColors(role);
+  overlayEl.style.opacity = "1";
+  overlayEl.style.pointerEvents = "auto";
+  labelEl.style.color = colors.badgeText;
+  labelEl.textContent = role.charAt(0).toUpperCase() + role.slice(1);
+}
+
 function PureMessages({ messages, presetKey, hideScrollToBottom = false, maxHeight }: MessagesProps) {
   const parentRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const labelRef = useRef<HTMLSpanElement>(null);
 
   const processedResult = useMemo(() => processMessages(messages), [messages]);
   const toolNameMap = useMemo(() => buildToolNameMap(processedResult), [processedResult]);
 
   const searchState = useSpanSearchState();
   const searchTerm = searchState?.searchTerm || "";
+
+  const prevOverlayRef = useRef<{ role?: string; show: boolean }>({ show: false });
 
   const virtualizer = useVirtualizer({
     count: processedResult.messages.length,
@@ -218,46 +243,105 @@ function PureMessages({ messages, presetKey, hideScrollToBottom = false, maxHeig
 
   const items = virtualizer.getVirtualItems();
 
-  const scrollToBottom = () => {
+  const handleScroll = useCallback(() => {
+    const el = parentRef.current;
+    if (!el) return;
+
+    const scrollTop = el.scrollTop;
+    const cache = virtualizer.measurementsCache;
+
+    let role: string | undefined;
+    let show = false;
+
+    let lo = 0;
+    let hi = cache.length - 1;
+    let found = -1;
+
+    while (lo <= hi) {
+      const mid = (lo + hi) >>> 1;
+      if (cache[mid].start <= scrollTop) {
+        found = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+
+    if (found >= 0) {
+      const message = processedResult.messages[found] as { role?: string };
+      role = message?.role;
+      const itemStart = cache[found].start;
+      const itemEnd = cache[found].end;
+      // Show overlay slightly before the header fully scrolls out of view,
+      // keep it through the padding gap, hide when next card's header appears.
+      const nextStart = found + 1 < cache.length ? cache[found + 1].start : itemEnd;
+      show = scrollTop > itemStart + HEADER_HEIGHT * 0.1 && scrollTop < nextStart - HEADER_HEIGHT * 1.5;
+    }
+
+    const prev = prevOverlayRef.current;
+    if (prev.role !== role || prev.show !== show) {
+      prevOverlayRef.current = { role, show };
+      updateOverlay(overlayRef.current, labelRef.current, role, show);
+    }
+  }, [processedResult.messages, virtualizer]);
+
+  const scrollToBottom = useCallback(() => {
     virtualizer.scrollToIndex(processedResult.messages.length - 1, {
       align: "end",
     });
-  };
+  }, [processedResult.messages.length, virtualizer]);
 
   return (
     <>
-      <div
-        ref={parentRef}
-        className="size-full relative overflow-y-auto styled-scrollbar p-2"
-        style={{
-          contain: "strict",
-          overflowAnchor: "none",
-        }}
-      >
+      <div className="size-full relative">
         <div
+          ref={overlayRef}
+          className="absolute top-0 left-2 right-2 z-20 flex items-center px-2 py-1 gap-2 border-b border bg-background rounded-t shadow-sm transition-opacity duration-150"
+          style={{ opacity: 0, pointerEvents: "none" }}
+        >
+          <span ref={labelRef} className="text-sm font-medium" />
+        </div>
+        <div
+          ref={parentRef}
+          onScroll={handleScroll}
+          className="size-full overflow-y-auto styled-scrollbar px-2"
           style={{
-            height: virtualizer.getTotalSize(),
-            width: "100%",
-            position: "relative",
+            contain: "strict",
+            overflowAnchor: "none",
           }}
         >
           <div
             style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
+              height: virtualizer.getTotalSize(),
               width: "100%",
-              transform: `translateY(${items[0]?.start ?? 0}px)`,
+              position: "relative",
             }}
           >
-            <MessagesRenderer
-              {...processedResult}
-              ref={virtualizer.measureElement}
-              virtualItems={items}
-              presetKey={presetKey}
-              maxHeight={maxHeight}
-              toolNameMap={toolNameMap}
-            />
+            <div
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${items[0]?.start ?? 0}px)`,
+              }}
+            >
+              {items.map((item) => {
+                const message = processedResult.messages[item.index] as { role?: string };
+                return (
+                  <div key={item.key} data-index={item.index} ref={virtualizer.measureElement} className="pb-4">
+                    <MessageWrapper
+                      role={message?.role}
+                      presetKey={`collapse-${item.index}-${presetKey}`}
+                      maxHeight={maxHeight}
+                      stickyHeader={false}
+                    >
+                      {renderMessageContent(processedResult, item.index, presetKey, toolNameMap)}
+                    </MessageWrapper>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </div>
       </div>
@@ -274,99 +358,6 @@ function PureMessages({ messages, presetKey, hideScrollToBottom = false, maxHeig
     </>
   );
 }
-
-const MessagesRenderer = ({
-  messages,
-  type,
-  presetKey,
-  ref,
-  virtualItems,
-  maxHeight,
-  toolNameMap,
-}: ProcessedMessages & {
-  presetKey: string;
-  virtualItems: VirtualItem[];
-  ref: Ref<HTMLDivElement>;
-  maxHeight?: number;
-  toolNameMap: Map<string, string>;
-}) => {
-  switch (type) {
-    case "openai":
-      return virtualItems.map((row) => {
-        const message = messages[row.index];
-        return (
-          <div key={row.key} data-index={row.index} ref={ref} className="pb-4">
-            <MessageWrapper role={message.role} presetKey={`collapse-${row.index}-${presetKey}`} maxHeight={maxHeight}>
-              <OpenAIContentParts
-                parentIndex={row.index}
-                presetKey={presetKey}
-                message={message}
-                toolNameMap={toolNameMap}
-              />
-            </MessageWrapper>
-          </div>
-        );
-      });
-
-    case "langchain":
-      return virtualItems.map((row) => {
-        const message = messages[row.index];
-        return (
-          <div key={row.key} data-index={row.index} ref={ref} className="pb-4">
-            <MessageWrapper role={message.role} presetKey={`collapse-${row.index}-${presetKey}`} maxHeight={maxHeight}>
-              <LangChainContentParts
-                parentIndex={row.index}
-                presetKey={presetKey}
-                message={message}
-                toolNameMap={toolNameMap}
-              />
-            </MessageWrapper>
-          </div>
-        );
-      });
-
-    case "anthropic":
-      return virtualItems.map((row) => {
-        const message = messages[row.index];
-        return (
-          <div key={row.key} data-index={row.index} ref={ref} className="pb-4">
-            <MessageWrapper role={message.role} presetKey={`collapse-${row.index}-${presetKey}`} maxHeight={maxHeight}>
-              <AnthropicContentParts
-                parentIndex={row.index}
-                presetKey={presetKey}
-                message={message}
-                toolNameMap={toolNameMap}
-              />
-            </MessageWrapper>
-          </div>
-        );
-      });
-
-    case "gemini":
-      return virtualItems.map((row) => {
-        const message = messages[row.index];
-        return (
-          <div key={row.key} data-index={row.index} ref={ref} className="pb-4">
-            <MessageWrapper role={message.role} presetKey={`collapse-${row.index}-${presetKey}`} maxHeight={maxHeight}>
-              <GeminiContentParts parentIndex={row.index} presetKey={presetKey} message={message} />
-            </MessageWrapper>
-          </div>
-        );
-      });
-
-    case "generic":
-      return virtualItems.map((row) => {
-        const message = messages[row.index];
-        return (
-          <div key={row.key} data-index={row.index} ref={ref} className="pb-4">
-            <MessageWrapper role={message.role} presetKey={`collapse-${row.index}-${presetKey}`} maxHeight={maxHeight}>
-              <ContentParts parentIndex={row.index} presetKey={presetKey} message={message} />
-            </MessageWrapper>
-          </div>
-        );
-      });
-  }
-};
 const Messages = memo(PureMessages, (prevProps, nextProps) => {
   if (isNil(prevProps.messages) && isNil(nextProps.messages)) return true;
   if (isNil(prevProps.messages) || isNil(nextProps.messages)) return false;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate UI/UX refactor in virtualized scrolling code; risk is mainly regressions in scroll behavior, measurement, and expand/collapse interaction rather than security or data handling.
> 
> **Overview**
> Adds a *sticky role header* experience in the span message list: individual message cards no longer use per-card sticky headers; instead `messages.tsx` renders a top overlay header that updates on scroll based on the current virtualized item’s role.
> 
> Refactors `MessageWrapper` to support optional `stickyHeader`, updates card styling (rounded header/body), and replaces the previous gradient-only expand control with a persistent bottom toggle (Chevron up/down) that can both expand and collapse long messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 661ce38ebc3c0dee1eca3e21e26a9d03a9fe647c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->