### PR TITLE
feat: show costs

### DIFF
--- a/frontend/components/traces/trace-view/tree/span-card.tsx
+++ b/frontend/components/traces/trace-view/tree/span-card.tsx
@@ -138,7 +138,6 @@ export function SpanCard({ span, branchMask, output, onSpanSelect, depth }: Span
               )
             ) : (
               <SpanStatsShield
-                className="hidden group-hover:flex"
                 startTime={span.startTime}
                 endTime={span.endTime}
                 tokens={llmMetrics?.tokens}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change: makes `SpanStatsShield` always visible in the trace tree, which could slightly affect layout density but doesn’t alter data or behavior.
> 
> **Overview**
> Updates the trace tree `SpanCard` to **always display** the `SpanStatsShield` (duration/tokens/cost) for non-pending spans, instead of only showing it on row hover by removing the `hidden group-hover:flex` styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b797edbcbcca012b332cfe95c80526bf8b19a879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->