### PR TITLE
search

### DIFF
--- a/app-server/Cargo.lock
+++ b/app-server/Cargo.lock
@@ -369,7 +369,6 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha3",
  "sodiumoxide",
  "sqlx",
@@ -4906,19 +4905,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5875,12 +5861,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/app-server/Cargo.toml
+++ b/app-server/Cargo.toml
@@ -47,7 +47,6 @@ sentry = {version = "0.46.0", features = ["opentelemetry"]}
 schemars = {version = "1", features = ["uuid1"]}
 serde = "1.0"
 serde_json = {version = "1.0.149", features = ["preserve_order"]}
-serde_yaml = "0.9"
 sha3 = "0.10.8"
 sodiumoxide = "0.2.7"
 sqlx = {version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "json", "chrono", "bigdecimal", "tls-rustls"]}

--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -10,7 +10,6 @@ use crate::{
         signal_runs::{CHSignalRun, insert_signal_runs},
     },
     db::{DB, signal_jobs::update_signal_job_stats},
-    mq::MessageQueue,
     signals::{
         SignalRun,
         prompts::{IDENTIFICATION_PROMPT, SYSTEM_PROMPT},

--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -79,18 +79,9 @@ pub async fn process_run(
     project_id: Uuid,
     trace_id: Uuid,
     run_id: Uuid,
-    step: usize,
-    internal_trace_id: Uuid,
-    internal_span_id: Uuid,
-    job_id: Option<Uuid>,
     prompt: &str,
-    signal_name: &str,
     structured_output_schema: &serde_json::Value,
-    model: &str,
-    provider: &str,
     clickhouse: clickhouse::Client,
-    queue: Arc<MessageQueue>,
-    internal_project_id: Option<Uuid>,
 ) -> Result<ProcessRunResult, HandlerError> {
     let processing_start_time = Utc::now();
 

--- a/app-server/src/signals/enqueue.rs
+++ b/app-server/src/signals/enqueue.rs
@@ -72,6 +72,7 @@ async fn create_signal_run_and_message(
             error: None,
             provider_batch_id: None,
             metadata: Some(input_map),
+            tools: None,
         },
     )
     .await;

--- a/app-server/src/signals/enqueue.rs
+++ b/app-server/src/signals/enqueue.rs
@@ -39,6 +39,7 @@ async fn create_signal_run_and_message(
         ("run_id".to_string(), Value::String(run_id.to_string())),
         ("trace_id".to_string(), Value::String(trace_id.to_string())),
         ("signal_id".to_string(), Value::String(signal.id.to_string())),
+        ("project_id".to_string(), Value::String(project_id.to_string())),
     ]);
     if let Some(job_id) = job_id {
         input_map.insert("job_id".to_string(), Value::String(job_id.to_string()));

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -1,21 +1,17 @@
 pub const SYSTEM_PROMPT: &str = "You are an expert in analyzing traces of LLM powered applications, such as chatbots, AI agents, etc.
 
 <trace>
-Below are the spans of the trace.
+Below are all spans of the trace in YAML format.
 
-For LLM spans, only the first occurrence at each path includes full prompt. Subsequent LLM spans at the same path only show output.
+<data_conventions>
+- For LLM spans, only the first occurrence at each path includes the full prompt. Subsequent LLM spans at the same path have `input: '<omitted>'`. Input LLM messages longer than 3000 characters are truncated per-message.
+- Tool span inputs and outputs longer than 1024 characters are truncated.
+- LLM span outputs longer than 1024 characters are truncated.
+- Default spans have their inputs/outputs omitted as `<omitted N chars>`.
+- `<empty>` means the field is genuinely empty. Do NOT call retrieval tools on `<empty>` fields.
+- Prefer `regex_in_spans` over `get_full_spans` — it is far more token-efficient, returning only matching snippets instead of entire span content.
+</data_conventions>
 
-LLM input messages that are too long are truncated to 3000 characters.
-
-Tool spans input and output are truncated if they are longer than 1024 characters.
-
-<truncation_rules>
-Truncated data is ALWAYS marked with the tag `<truncated N more chars>` at the end of the value. If a span's input or output does NOT contain this tag, the data is complete and fully included — do NOT use `regex_in_spans` or `get_full_spans` to re-fetch it.
-
-Only use tools to retrieve more data when the `<truncated N more chars>` tag is present and the truncated portion likely contains the information you need.
-</truncation_rules>
-
-If the information that you need to perform proper identification is in a truncated field, prefer using `regex_in_spans` to search for specific patterns — this is much more token-efficient than fetching full spans, because it returns only matching snippets instead of appending potentially large span content to the context. Only use `get_full_spans` as a last resort when regex search is not feasible (e.g. you need to understand the full structure of a span's content).
 {{fullTraceData}}
 </trace>";
 
@@ -30,10 +26,10 @@ Follow the developer's prompt strictly. Extract only what the prompt asks for �
 <critical_output_requirements>
 EVERY SINGLE RESPONSE you produce MUST be a function call. You MUST NEVER output plain text. Plain text responses will cause a system crash. You have NO other way to communicate except through function calls.
 
-You have exactly three functions available:
+You have exactly three tools available:
 
-1. regex_in_spans — YOUR PREFERRED TOOL for finding specific information within span content. This is primarily a token-efficiency tool: instead of appending potentially large span data to the context, it lets you search for exactly what you need and returns only matching snippets. Use this FIRST whenever a span's data is truncated (marked with `<truncated N more chars>`).
-   IMPORTANT: Only use this on fields that ARE truncated. If a span's input or output does NOT contain the `<truncated N more chars>` tag, the data is already fully included — do NOT regex for it.
+1. regex_in_spans — YOUR PREFERRED TOOL for finding specific information within span content when provided data is truncated. This is primarily a token-efficiency tool: instead of appending potentially large span data to the context, it lets you search for exactly what you need and returns only matching snippets.
+   IMPORTANT: Only use this on spans that have truncated data (indicated by `output_truncated: true` or `input_truncated: true`). If `output_truncated` or `input_truncated` are absent, the data is already complete — do NOT regex for it.
    REQUIRED argument: "searches" (array of search objects). Each search object requires:
      - "span_id" (string) — the span ID to search within (6-character hex string, e.g. "a1b2c3")
      - "regex" (string) — regular expression pattern to match
@@ -41,8 +37,8 @@ You have exactly three functions available:
      - "reasoning" (string) — why this search is needed
    You can search multiple spans and patterns in a single call.
 
-2. get_full_spans — LAST RESORT ONLY. Call this ONLY when regex_in_spans cannot help — for example, when you need to understand the complete structure of a span's content and cannot formulate a regex to find what you need. This fetches the entire span content and is expensive. For LLM spans, only the last 2 messages are returned. In the trace skeleton it's indicated which spans have empty input or output, so you should not request full spans for spans that have empty input or output.
-   IMPORTANT: Do NOT use this on fields that are already fully included (i.e. no `<truncated N more chars>` tag).
+2. get_full_spans — LAST RESORT ONLY. Call this ONLY when regex_in_spans cannot help — for example, when you need to understand the complete structure of a span's content and cannot formulate a regex to find what you need. This fetches the entire span content and is expensive. For LLM spans, only the last 2 messages are returned. Do NOT use this on `<empty>` or `<omitted>` fields — there is nothing to fetch.
+   IMPORTANT: Do NOT use this on outputs that are already complete (no `output_truncated: true`).
    REQUIRED arguments: "reasoning" (string explaining why regex_in_spans is insufficient and you need the full span) and "span_ids" (array of span ID strings, e.g. ["a1b2c3", "d4e5f6"]). You MUST always provide both arguments.
 
 3. submit_identification — call this when you have made your final determination.
@@ -52,10 +48,8 @@ You have exactly three functions available:
      - "summary" (string) — a short summary of the identification result used for event clustering.
 
 <tool_selection_guidance>
-- If a span field does NOT have the `<truncated N more chars>` tag, its data is COMPLETE. Do not call any tool to re-fetch it.
-- If a span field IS truncated and you need the missing data, ALWAYS try regex_in_spans FIRST. It is far more token-efficient: it returns only matching snippets instead of the entire span content.
-- ONLY use get_full_spans if you genuinely cannot formulate a regex (e.g. you need to read free-form content with no predictable pattern, or your regex search returned no results and you still need the data).
-- NEVER call get_full_spans just because it's simpler — regex_in_spans is the right default choice for truncated data.
+- NEVER call `regex_in_spans` or `get_full_spans` tools on `<empty>` fields.
+- ONLY use `get_full_spans` if you genuinely cannot formulate a regex (e.g. you need to read free-form content with no predictable pattern, or your regex search returned no results and you still need the data).
 </tool_selection_guidance>
 
 NEVER omit required arguments. A function call without its required arguments is invalid and will cause a system error just like a plain text response.
@@ -83,9 +77,9 @@ Here's the developer's prompt that describes the information you need to extract
 
 REMINDER: Respond with a function call ONLY. Include ALL required arguments. No plain text."#;
 
-pub const REGEX_IN_SPANS_DESCRIPTION: &str = "Performs regex pattern matching within specific spans' input/output content. Returns only matching snippets with surrounding context, making it far more token-efficient than fetching full spans. Use this when a span's data is truncated (indicated by the `<truncated N more chars>` tag) and you need to find specific patterns, keywords, or values in the truncated portion. Do NOT use this on data that is already fully included (no truncation tag). You can search multiple spans and patterns in a single call.";
+pub const REGEX_IN_SPANS_DESCRIPTION: &str = "Performs regex pattern matching within specific spans' input/output content. Returns only matching snippets with surrounding context, making it far more token-efficient than fetching full spans. Use this ONLY when you don't have enough data because it's truncated. If flags `output_truncated` or `input_truncated` are absent, the data is complete — do NOT regex for it. You can search multiple spans and patterns in a single call.";
 
-pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when regex_in_spans cannot help (e.g. you need to understand the full structure of a span's content and cannot formulate a regex). Do NOT use this on fields that are already fully included (no `<truncated N more chars>` tag). For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
+pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when regex_in_spans cannot help (e.g. you need to understand the full structure of a span's content and cannot formulate a regex). Do NOT use this when `output_truncated` is absent — the data is already complete. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
 
 pub const SUBMIT_IDENTIFICATION_DESCRIPTION: &str = "REQUIRED: This is the ONLY valid way to complete your analysis — never respond with plain text. Submits the final identification result. You MUST always provide the required 'identified' boolean argument. When identified=true, you MUST also provide 'summary' (short string for event clustering) and 'data' (object matching the developer's schema). When identified=false, 'identified' is still required.";
 

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -10,7 +10,7 @@ Below are all spans of the trace in YAML format.
 - Default spans have their inputs/outputs omitted as `<omitted N chars>`.
 - `<empty>` means the field is genuinely empty. Do NOT call retrieval tools on `<empty>` or `<omitted>` fields.
 - When a field is truncated, the span will have `input_truncated: true` and/or `output_truncated: true`. If these flags are absent, the data is COMPLETE — do NOT call tools to re-fetch it.
-- Prefer `regex_in_spans` over `get_full_spans` — it is far more token-efficient, returning only matching snippets instead of entire span content.
+- Prefer `search_in_spans` over `get_full_spans` — it is far more token-efficient, returning only matching snippets instead of entire span content.
 </data_conventions>
 
 {{fullTraceData}}
@@ -29,18 +29,19 @@ EVERY SINGLE RESPONSE you produce MUST be a function call. You MUST NEVER output
 
 You have exactly three tools available:
 
-1. regex_in_spans — YOUR PREFERRED TOOL for finding specific information within span content when provided data is truncated. This is primarily a token-efficiency tool: instead of appending potentially large span data to the context, it lets you search for exactly what you need and returns only matching snippets.
-   IMPORTANT: Only use this on spans that have truncated data (indicated by `output_truncated: true` or `input_truncated: true`). If `output_truncated` or `input_truncated` are absent, the data is already complete — do NOT regex for it.
+1. search_in_spans — YOUR PREFERRED TOOL for finding specific information within span content when provided data is truncated. Token-efficient: returns only matching snippets instead of entire span content. Tries literal substring match first, then falls back to regex if provided.
+   IMPORTANT: Only use this on spans that have truncated data (`output_truncated: true` or `input_truncated: true`). If these flags are absent, the data is already complete — do NOT search for it.
    REQUIRED argument: "searches" (array of search objects). Each search object requires:
-     - "span_id" (string) — the span ID to search within (6-character hex string, e.g. "a1b2c3")
-     - "regex" (string) — regular expression pattern to match
+     - "span_id" (string) — the span ID (6-character hex string, e.g. "a1b2c3")
+     - "literal" (string) — plain text to search for (tried first, no escaping needed)
+     - "regex" (string, optional) — regex fallback if literal finds nothing (e.g. for wildcards or alternation)
      - "search_in" (string) — either "input" or "output"
      - "reasoning" (string) — why this search is needed
-   You can search multiple spans and patterns in a single call.
+   You can search multiple spans in a single call.
 
-2. get_full_spans — LAST RESORT ONLY. Call this ONLY when regex_in_spans cannot help — for example, when you need to understand the complete structure of a span's content and cannot formulate a regex to find what you need. This fetches the entire span content and is expensive. For LLM spans, only the last 2 messages are returned. Do NOT use this on `<empty>` or `<omitted>` fields — there is nothing to fetch.
+2. get_full_spans — LAST RESORT ONLY. Call this ONLY when search_in_spans cannot help — for example, when you need to understand the complete structure of a span's content and no search can find what you need. This fetches the entire span content and is expensive. For LLM spans, only the last 2 messages are returned. Do NOT use this on `<empty>` or `<omitted>` fields — there is nothing to fetch.
    IMPORTANT: Do NOT use this on fields that are already complete (no `input_truncated: true` or `output_truncated: true`).
-   REQUIRED arguments: "reasoning" (string explaining why regex_in_spans is insufficient and you need the full span) and "span_ids" (array of span ID strings, e.g. ["a1b2c3", "d4e5f6"]). You MUST always provide both arguments.
+   REQUIRED arguments: "reasoning" (string explaining why search_in_spans is insufficient and you need the full span) and "span_ids" (array of span ID strings, e.g. ["a1b2c3", "d4e5f6"]). You MUST always provide both arguments.
 
 3. submit_identification — call this when you have made your final determination.
    REQUIRED argument: "identified" (boolean). You MUST always provide this argument.
@@ -49,8 +50,8 @@ You have exactly three tools available:
      - "summary" (string) — a short summary of the identification result used for event clustering.
 
 <tool_selection_guidance>
-- NEVER call `regex_in_spans` or `get_full_spans` tools on `<empty>` fields.
-- ONLY use `get_full_spans` if you genuinely cannot formulate a regex (e.g. you need to read free-form content with no predictable pattern, or your regex search returned no results and you still need the data).
+- NEVER call `search_in_spans` or `get_full_spans` on `<empty>` or `<omitted>` fields.
+- ONLY use `get_full_spans` if search_in_spans cannot find what you need and you require the full span structure.
 </tool_selection_guidance>
 
 NEVER omit required arguments. A function call without its required arguments is invalid and will cause a system error just like a plain text response.
@@ -78,10 +79,10 @@ Here's the developer's prompt that describes the information you need to extract
 
 REMINDER: Respond with a function call ONLY. Include ALL required arguments. No plain text."#;
 
-pub const REGEX_IN_SPANS_DESCRIPTION: &str = "Performs regex pattern matching within specific spans' input/output content. Returns only matching snippets with surrounding context, making it far more token-efficient than fetching full spans. Use this ONLY when you don't have enough data because it's truncated. If flags `output_truncated` or `input_truncated` are absent, the data is complete — do NOT regex for it. You can search multiple spans and patterns in a single call.";
+pub const SEARCH_IN_SPANS_DESCRIPTION: &str = "Searches within span input/output content using literal substring match (tried first) with optional regex fallback. Returns matching snippets with surrounding context. Far more token-efficient than fetching full spans. Use ONLY when `output_truncated: true` or `input_truncated: true` — if these flags are absent, the data is complete. You can search multiple spans in a single call.";
 
-pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when regex_in_spans cannot help (e.g. you need to understand the full structure of a span's content and cannot formulate a regex). Do NOT use this when `input_truncated`/`output_truncated` flags are absent — the data is already complete. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
+pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when search_in_spans cannot find what you need. Do NOT use this when `input_truncated`/`output_truncated` flags are absent — the data is already complete. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
 
 pub const SUBMIT_IDENTIFICATION_DESCRIPTION: &str = "REQUIRED: This is the ONLY valid way to complete your analysis — never respond with plain text. Submits the final identification result. You MUST always provide the required 'identified' boolean argument. When identified=true, you MUST also provide 'summary' (short string for event clustering) and 'data' (object matching the developer's schema). When identified=false, 'identified' is still required.";
 
-pub const MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE: &str = "The previous function call was malformed. Please retry calling the same function. Make sure to use the expected function call formatting and include ALL required arguments. For regex_in_spans: 'searches' array is required, each with 'span_id', 'regex', 'search_in', and 'reasoning'. For get_full_spans: 'reasoning' and 'span_ids' are required. For submit_identification: 'identified' is required, and when identified=true, 'summary' and 'data' are also required.";
+pub const MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE: &str = "The previous function call was malformed. Please retry calling the same function. Make sure to use the expected function call formatting and include ALL required arguments. For search_in_spans: 'searches' array is required, each with 'span_id', 'literal', 'search_in', and 'reasoning'. For get_full_spans: 'reasoning' and 'span_ids' are required. For submit_identification: 'identified' is required, and when identified=true, 'summary' and 'data' are also required.";

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -8,7 +8,8 @@ Below are all spans of the trace in YAML format.
 - Tool span inputs and outputs longer than 1024 characters are truncated.
 - LLM span outputs longer than 1024 characters are truncated.
 - Default spans have their inputs/outputs omitted as `<omitted N chars>`.
-- `<empty>` means the field is genuinely empty. Do NOT call retrieval tools on `<empty>` fields.
+- `<empty>` means the field is genuinely empty. Do NOT call retrieval tools on `<empty>` or `<omitted>` fields.
+- When a field is truncated, the span will have `input_truncated: true` and/or `output_truncated: true`. If these flags are absent, the data is COMPLETE — do NOT call tools to re-fetch it.
 - Prefer `regex_in_spans` over `get_full_spans` — it is far more token-efficient, returning only matching snippets instead of entire span content.
 </data_conventions>
 
@@ -38,7 +39,7 @@ You have exactly three tools available:
    You can search multiple spans and patterns in a single call.
 
 2. get_full_spans — LAST RESORT ONLY. Call this ONLY when regex_in_spans cannot help — for example, when you need to understand the complete structure of a span's content and cannot formulate a regex to find what you need. This fetches the entire span content and is expensive. For LLM spans, only the last 2 messages are returned. Do NOT use this on `<empty>` or `<omitted>` fields — there is nothing to fetch.
-   IMPORTANT: Do NOT use this on outputs that are already complete (no `output_truncated: true`).
+   IMPORTANT: Do NOT use this on fields that are already complete (no `input_truncated: true` or `output_truncated: true`).
    REQUIRED arguments: "reasoning" (string explaining why regex_in_spans is insufficient and you need the full span) and "span_ids" (array of span ID strings, e.g. ["a1b2c3", "d4e5f6"]). You MUST always provide both arguments.
 
 3. submit_identification — call this when you have made your final determination.
@@ -79,7 +80,7 @@ REMINDER: Respond with a function call ONLY. Include ALL required arguments. No 
 
 pub const REGEX_IN_SPANS_DESCRIPTION: &str = "Performs regex pattern matching within specific spans' input/output content. Returns only matching snippets with surrounding context, making it far more token-efficient than fetching full spans. Use this ONLY when you don't have enough data because it's truncated. If flags `output_truncated` or `input_truncated` are absent, the data is complete — do NOT regex for it. You can search multiple spans and patterns in a single call.";
 
-pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when regex_in_spans cannot help (e.g. you need to understand the full structure of a span's content and cannot formulate a regex). Do NOT use this when `output_truncated` is absent — the data is already complete. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
+pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when regex_in_spans cannot help (e.g. you need to understand the full structure of a span's content and cannot formulate a regex). Do NOT use this when `input_truncated`/`output_truncated` flags are absent — the data is already complete. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
 
 pub const SUBMIT_IDENTIFICATION_DESCRIPTION: &str = "REQUIRED: This is the ONLY valid way to complete your analysis — never respond with plain text. Submits the final identification result. You MUST always provide the required 'identified' boolean argument. When identified=true, you MUST also provide 'summary' (short string for event clustering) and 'data' (object matching the developer's schema). When identified=false, 'identified' is still required.";
 

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -9,7 +9,7 @@ LLM input messages that are too long are truncated to 3000 characters.
 
 Tool spans input and output are truncated if they are longer than 1024 characters.
 
-If the information that you need to perform proper identification is truncated, you should use `get_full_spans` tool to get the full span information by span id if you need more details. However, if you have enough information to perform proper identification, you should not call this tool.
+If the information that you need to perform proper identification is truncated, prefer using `regex_in_spans` to search for specific patterns within span content — this is much cheaper and faster than fetching full spans. Only use `get_full_spans` as a last resort when regex search is not feasible (e.g. you need to understand the full structure of a span's content). If you already have enough information to perform proper identification, do not call either tool.
 {{fullTraceData}}
 </trace>";
 
@@ -24,16 +24,31 @@ Follow the developer's prompt strictly. Extract only what the prompt asks for �
 <critical_output_requirements>
 EVERY SINGLE RESPONSE you produce MUST be a function call. You MUST NEVER output plain text. Plain text responses will cause a system crash. You have NO other way to communicate except through function calls.
 
-You have exactly two functions available:
+You have exactly three functions available:
 
-1. get_full_spans — call this ONLY when the provided trace data is insufficient (e.g. due to truncation) and you need more details for specific spans. For LLM spans, only the last 2 messages are returned. In the trace skeleton it's indicated which spans have empty input or output, so you should not request full spans for spans that have empty input or output.
-   REQUIRED arguments: "reasoning" (string explaining why you need these spans) and "span_ids" (array of span ID strings, e.g. ["a1b2c3", "d4e5f6"]). You MUST always provide both arguments.
+1. regex_in_spans — YOUR PREFERRED TOOL for finding specific information within span content. Use this FIRST whenever trace data is truncated or you need to locate specific patterns, keywords, values, or structures within spans. This performs regex pattern matching on span input/output and returns matching snippets with surrounding context. It is much cheaper and faster than fetching full spans.
+   REQUIRED argument: "searches" (array of search objects). Each search object requires:
+     - "span_id" (string) — the span ID to search within (6-character hex string, e.g. "a1b2c3")
+     - "regex" (string) — regular expression pattern to match
+     - "search_in" (string) — either "input" or "output"
+     - "reasoning" (string) — why this search is needed
+   You can search multiple spans and patterns in a single call.
 
-2. submit_identification — call this when you have made your final determination.
+2. get_full_spans — LAST RESORT ONLY. Call this ONLY when regex_in_spans cannot help — for example, when you need to understand the complete structure of a span's content and cannot formulate a regex to find what you need. This fetches the entire span content and is expensive. For LLM spans, only the last 2 messages are returned. In the trace skeleton it's indicated which spans have empty input or output, so you should not request full spans for spans that have empty input or output.
+   REQUIRED arguments: "reasoning" (string explaining why regex_in_spans is insufficient and you need the full span) and "span_ids" (array of span ID strings, e.g. ["a1b2c3", "d4e5f6"]). You MUST always provide both arguments.
+
+3. submit_identification — call this when you have made your final determination.
    REQUIRED argument: "identified" (boolean). You MUST always provide this argument.
    When "identified" is true, you MUST also provide:
      - "data" (object) — the extracted information matching the developer's schema.
      - "summary" (string) — a short summary of the identification result used for event clustering.
+
+<tool_selection_guidance>
+When you need more information from spans:
+- ALWAYS try regex_in_spans FIRST. Think about what specific string, keyword, or pattern you're looking for and craft a regex for it.
+- ONLY use get_full_spans if you genuinely cannot formulate a regex (e.g. you need to read free-form content with no predictable pattern, or your regex search returned no results and you still need the data).
+- NEVER call get_full_spans just because it's simpler — regex_in_spans is the right default choice.
+</tool_selection_guidance>
 
 NEVER omit required arguments. A function call without its required arguments is invalid and will cause a system error just like a plain text response.
 
@@ -61,8 +76,10 @@ Here's the developer's prompt that describes the information you need to extract
 
 REMINDER: Respond with a function call ONLY. Include ALL required arguments. No plain text."#;
 
-pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. Only use this if the trace data already provided is NOT sufficient to make an identification decision — do NOT call this tool if you already have enough information. The compressed trace view may have truncated or omitted some data, so use this only when critical details are missing. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
+pub const REGEX_IN_SPANS_DESCRIPTION: &str = "Performs regex pattern matching within specific spans' input/output content. Returns matching snippets with surrounding context. Use this FIRST whenever you need to find specific patterns, keywords, or values within span data — it is much cheaper and faster than fetching full spans. You can search multiple spans and patterns in a single call.";
+
+pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this when regex_in_spans cannot help (e.g. you need to understand the full structure of a span's content). Prefer regex_in_spans for targeted searches. The compressed trace view may have truncated or omitted some data. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
 
 pub const SUBMIT_IDENTIFICATION_DESCRIPTION: &str = "REQUIRED: This is the ONLY valid way to complete your analysis — never respond with plain text. Submits the final identification result. You MUST always provide the required 'identified' boolean argument. When identified=true, you MUST also provide 'summary' (short string for event clustering) and 'data' (object matching the developer's schema). When identified=false, 'identified' is still required.";
 
-pub const MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE: &str = "The previous function call was malformed. Please retry calling the same function. Make sure to use the expected function call formatting and include ALL required arguments. For get_full_spans: 'reasoning' and 'span_ids' are required. For submit_identification: 'identified' is required, and when identified=true, 'summary' and 'data' are also required.";
+pub const MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE: &str = "The previous function call was malformed. Please retry calling the same function. Make sure to use the expected function call formatting and include ALL required arguments. For regex_in_spans: 'searches' array is required, each with 'span_id', 'regex', 'search_in', and 'reasoning'. For get_full_spans: 'reasoning' and 'span_ids' are required. For submit_identification: 'identified' is required, and when identified=true, 'summary' and 'data' are also required.";

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -66,9 +66,8 @@ There are no other valid response formats. ONLY function calls are accepted.
 </critical_output_requirements>
 
 <span_reference_format>
-If it's useful to reference specific spans in your response (for example, to help developers understand the flow of the trace), use the <span> xml tag format to help developers locate the relevant data in their trace.
+When you want to reference specific spans in your response (for example, to help developers understand the flow of the trace), use the <span> tag with the following format:
 
-Format:
 <span id='<span_id>' name='<span_name>' />
 
 For example:

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -9,7 +9,13 @@ LLM input messages that are too long are truncated to 3000 characters.
 
 Tool spans input and output are truncated if they are longer than 1024 characters.
 
-If the information that you need to perform proper identification is truncated, prefer using `regex_in_spans` to search for specific patterns within span content — this is much cheaper and faster than fetching full spans. Only use `get_full_spans` as a last resort when regex search is not feasible (e.g. you need to understand the full structure of a span's content). If you already have enough information to perform proper identification, do not call either tool.
+<truncation_rules>
+Truncated data is ALWAYS marked with the tag `<truncated N more chars>` at the end of the value. If a span's input or output does NOT contain this tag, the data is complete and fully included — do NOT use `regex_in_spans` or `get_full_spans` to re-fetch it.
+
+Only use tools to retrieve more data when the `<truncated N more chars>` tag is present and the truncated portion likely contains the information you need.
+</truncation_rules>
+
+If the information that you need to perform proper identification is in a truncated field, prefer using `regex_in_spans` to search for specific patterns — this is much more token-efficient than fetching full spans, because it returns only matching snippets instead of appending potentially large span content to the context. Only use `get_full_spans` as a last resort when regex search is not feasible (e.g. you need to understand the full structure of a span's content).
 {{fullTraceData}}
 </trace>";
 
@@ -26,7 +32,8 @@ EVERY SINGLE RESPONSE you produce MUST be a function call. You MUST NEVER output
 
 You have exactly three functions available:
 
-1. regex_in_spans — YOUR PREFERRED TOOL for finding specific information within span content. Use this FIRST whenever trace data is truncated or you need to locate specific patterns, keywords, values, or structures within spans. This performs regex pattern matching on span input/output and returns matching snippets with surrounding context. It is much cheaper and faster than fetching full spans.
+1. regex_in_spans — YOUR PREFERRED TOOL for finding specific information within span content. This is primarily a token-efficiency tool: instead of appending potentially large span data to the context, it lets you search for exactly what you need and returns only matching snippets. Use this FIRST whenever a span's data is truncated (marked with `<truncated N more chars>`).
+   IMPORTANT: Only use this on fields that ARE truncated. If a span's input or output does NOT contain the `<truncated N more chars>` tag, the data is already fully included — do NOT regex for it.
    REQUIRED argument: "searches" (array of search objects). Each search object requires:
      - "span_id" (string) — the span ID to search within (6-character hex string, e.g. "a1b2c3")
      - "regex" (string) — regular expression pattern to match
@@ -35,6 +42,7 @@ You have exactly three functions available:
    You can search multiple spans and patterns in a single call.
 
 2. get_full_spans — LAST RESORT ONLY. Call this ONLY when regex_in_spans cannot help — for example, when you need to understand the complete structure of a span's content and cannot formulate a regex to find what you need. This fetches the entire span content and is expensive. For LLM spans, only the last 2 messages are returned. In the trace skeleton it's indicated which spans have empty input or output, so you should not request full spans for spans that have empty input or output.
+   IMPORTANT: Do NOT use this on fields that are already fully included (i.e. no `<truncated N more chars>` tag).
    REQUIRED arguments: "reasoning" (string explaining why regex_in_spans is insufficient and you need the full span) and "span_ids" (array of span ID strings, e.g. ["a1b2c3", "d4e5f6"]). You MUST always provide both arguments.
 
 3. submit_identification — call this when you have made your final determination.
@@ -44,10 +52,10 @@ You have exactly three functions available:
      - "summary" (string) — a short summary of the identification result used for event clustering.
 
 <tool_selection_guidance>
-When you need more information from spans:
-- ALWAYS try regex_in_spans FIRST. Think about what specific string, keyword, or pattern you're looking for and craft a regex for it.
+- If a span field does NOT have the `<truncated N more chars>` tag, its data is COMPLETE. Do not call any tool to re-fetch it.
+- If a span field IS truncated and you need the missing data, ALWAYS try regex_in_spans FIRST. It is far more token-efficient: it returns only matching snippets instead of the entire span content.
 - ONLY use get_full_spans if you genuinely cannot formulate a regex (e.g. you need to read free-form content with no predictable pattern, or your regex search returned no results and you still need the data).
-- NEVER call get_full_spans just because it's simpler — regex_in_spans is the right default choice.
+- NEVER call get_full_spans just because it's simpler — regex_in_spans is the right default choice for truncated data.
 </tool_selection_guidance>
 
 NEVER omit required arguments. A function call without its required arguments is invalid and will cause a system error just like a plain text response.
@@ -76,9 +84,9 @@ Here's the developer's prompt that describes the information you need to extract
 
 REMINDER: Respond with a function call ONLY. Include ALL required arguments. No plain text."#;
 
-pub const REGEX_IN_SPANS_DESCRIPTION: &str = "Performs regex pattern matching within specific spans' input/output content. Returns matching snippets with surrounding context. Use this FIRST whenever you need to find specific patterns, keywords, or values within span data — it is much cheaper and faster than fetching full spans. You can search multiple spans and patterns in a single call.";
+pub const REGEX_IN_SPANS_DESCRIPTION: &str = "Performs regex pattern matching within specific spans' input/output content. Returns only matching snippets with surrounding context, making it far more token-efficient than fetching full spans. Use this when a span's data is truncated (indicated by the `<truncated N more chars>` tag) and you need to find specific patterns, keywords, or values in the truncated portion. Do NOT use this on data that is already fully included (no truncation tag). You can search multiple spans and patterns in a single call.";
 
-pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this when regex_in_spans cannot help (e.g. you need to understand the full structure of a span's content). Prefer regex_in_spans for targeted searches. The compressed trace view may have truncated or omitted some data. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
+pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when regex_in_spans cannot help (e.g. you need to understand the full structure of a span's content and cannot formulate a regex). Do NOT use this on fields that are already fully included (no `<truncated N more chars>` tag). For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
 
 pub const SUBMIT_IDENTIFICATION_DESCRIPTION: &str = "REQUIRED: This is the ONLY valid way to complete your analysis — never respond with plain text. Submits the final identification result. You MUST always provide the required 'identified' boolean argument. When identified=true, you MUST also provide 'summary' (short string for event clustering) and 'data' (object matching the developer's schema). When identified=false, 'identified' is still required.";
 

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -1,8 +1,6 @@
 pub const SYSTEM_PROMPT: &str = "You are an expert in analyzing traces of LLM powered applications, such as chatbots, AI agents, etc.
 
 <trace>
-Below are all spans of the trace in YAML format.
-
 <data_conventions>
 - For LLM spans, only the first occurrence at each path includes the full prompt. Subsequent LLM spans at the same path have `input: '<omitted>'`. Input LLM messages longer than 3000 characters are truncated per-message.
 - Tool span inputs and outputs longer than 1024 characters are truncated.
@@ -12,6 +10,8 @@ Below are all spans of the trace in YAML format.
 - When a field is truncated, the span will have `input_truncated: true` and/or `output_truncated: true`. If these flags are absent, the data is COMPLETE — do NOT call tools to re-fetch it.
 - Prefer `search_in_spans` over `get_full_spans` — it is far more token-efficient, returning only matching snippets instead of entire span content.
 </data_conventions>
+
+Below are all spans of the trace.
 
 {{fullTraceData}}
 </trace>";
@@ -50,8 +50,8 @@ You have exactly three tools available:
      - "summary" (string) — a short summary of the identification result used for event clustering.
 
 <tool_selection_guidance>
-- NEVER call `search_in_spans` or `get_full_spans` on `<empty>` or `<omitted>` fields.
-- ONLY use `get_full_spans` if search_in_spans cannot find what you need and you require the full span structure.
+- NEVER call `search_in_spans` or `get_full_spans` on `<empty>` fields.
+- ONLY use `get_full_spans` if you're absolute sure and tried different search terms in `search_in_spans` but it still cannot find what you need and you require the full span structure.
 </tool_selection_guidance>
 
 NEVER omit required arguments. A function call without its required arguments is invalid and will cause a system error just like a plain text response.

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -73,18 +73,9 @@ impl MessageHandler for SignalJobRealtimeHandler {
             project_id,
             trace_id,
             message.run_id,
-            message.step,
-            message.internal_trace_id,
-            message.internal_span_id,
-            message.job_id,
             &signal.prompt,
-            &signal.name,
             &signal.structured_output_schema,
-            &llm_model(),
-            &llm_provider(),
             self.clickhouse.clone(),
-            self.queue.clone(),
-            self.config.internal_project_id,
         )
         .await
         {

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -17,7 +17,7 @@ use crate::{
         },
         queue::{SignalMessage, push_to_realtime_queue},
         response_processor::{finalize_runs, process_provider_responses},
-        utils::{InternalSpan, emit_internal_span, request_to_span_input},
+        utils::{InternalSpan, emit_internal_span, request_to_span_input, request_to_tools_attr},
     },
     worker::{HandlerError, MessageHandler},
 };
@@ -127,6 +127,7 @@ impl SignalJobRealtimeHandler {
         message: &SignalMessage,
         config: &SignalWorkerConfig,
         input: serde_json::Value,
+        tools: Option<serde_json::Value>,
         error: Option<String>,
     ) -> InternalSpan {
         InternalSpan {
@@ -149,6 +150,7 @@ impl SignalJobRealtimeHandler {
             error,
             provider_batch_id: None,
             metadata: None,
+            tools,
         }
     }
 
@@ -159,6 +161,7 @@ impl SignalJobRealtimeHandler {
         backoff: ExponentialBackoff,
     ) {
         let span_input = request_to_span_input(&request);
+        let span_tools = request_to_tools_attr(&request);
 
         let model_str = llm_model();
         let llm_client = self.llm_client.clone();
@@ -181,7 +184,7 @@ impl SignalJobRealtimeHandler {
             Ok(response) => {
                 emit_internal_span(
                     self.queue.clone(),
-                    Self::build_submit_span(&message, &self.config, span_input.clone(), None),
+                    Self::build_submit_span(&message, &self.config, span_input.clone(), span_tools.clone(), None),
                 )
                 .await;
                 let inline_response = ProviderInlineResponse {
@@ -300,6 +303,7 @@ impl SignalJobRealtimeHandler {
                         &message,
                         &self.config,
                         span_input,
+                        span_tools,
                         Some(format!("{}", e)),
                     ),
                 )

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -26,7 +26,7 @@ use crate::{
         },
         queue::SignalMessage,
         spans::{get_trace_span_ids_and_end_time, span_short_id},
-        tools::{RegexSearchRequest, get_full_spans, regex_in_spans},
+        tools::{SpanSearchRequest, get_full_spans, search_in_spans},
         utils::{
             InternalSpan, emit_internal_span, nanoseconds_to_datetime, replace_span_tags_with_links,
         },
@@ -607,8 +607,8 @@ pub async fn handle_tool_call(
     clickhouse: clickhouse::Client,
 ) -> StepResult {
     match function_call.name.as_str() {
-        "regex_in_spans" => {
-            let searches: Vec<RegexSearchRequest> = function_call
+        "search_in_spans" | "regex_in_spans" => {
+            let searches: Vec<SpanSearchRequest> = function_call
                 .args
                 .as_ref()
                 .and_then(|args| args.get("searches"))
@@ -623,7 +623,7 @@ pub async fn handle_tool_call(
                 };
             }
 
-            match regex_in_spans(
+            match search_in_spans(
                 clickhouse,
                 signal_message.project_id,
                 run.trace_id,

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -1,7 +1,8 @@
+use regex::Regex;
 use serde::Serialize;
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 use uuid::Uuid;
 
@@ -25,7 +26,7 @@ use crate::{
         },
         queue::SignalMessage,
         spans::{get_trace_span_ids_and_end_time, span_short_id},
-        tools::get_full_spans,
+        tools::{RegexSearchRequest, get_full_spans, regex_in_spans},
         utils::{
             InternalSpan, emit_internal_span, nanoseconds_to_datetime, replace_span_tags_with_links,
         },
@@ -604,6 +605,40 @@ pub async fn handle_tool_call(
     clickhouse: clickhouse::Client,
 ) -> StepResult {
     match function_call.name.as_str() {
+        "regex_in_spans" => {
+            let searches: Vec<RegexSearchRequest> = function_call
+                .args
+                .as_ref()
+                .and_then(|args| args.get("searches"))
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+
+            if searches.is_empty() {
+                return StepResult::Failed {
+                    error: "No searches provided".to_string(),
+                    finish_reason: None,
+                    is_processing_error: true,
+                };
+            }
+
+            match regex_in_spans(
+                clickhouse,
+                signal_message.project_id,
+                run.trace_id,
+                searches,
+            )
+            .await
+            {
+                Ok(results) => StepResult::RequiresNextStep {
+                    reason: NextStepReason::ToolResult(serde_json::json!({ "results": results })),
+                },
+                Err(e) => StepResult::RequiresNextStep {
+                    reason: NextStepReason::ToolResult(
+                        serde_json::json!({ "error": e.to_string() }),
+                    ),
+                },
+            }
+        }
         "get_full_spans" | "get_full_span_info" => {
             let span_ids: Vec<String> = function_call
                 .args
@@ -612,7 +647,8 @@ pub async fn handle_tool_call(
                 .and_then(|v| v.as_array())
                 .map(|arr| {
                     arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .filter_map(|v| v.as_str())
+                        .flat_map(|s| parse_span_ids_from_str(s))
                         .collect()
                 })
                 .unwrap_or_default();
@@ -767,4 +803,19 @@ pub async fn handle_create_event(
     .await;
 
     Ok(event_id)
+}
+
+static SPAN_ID_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\b[0-9a-fA-F]{6}\b").unwrap());
+
+/// Extracts 6-char hex span short IDs from a string, regardless of formatting.
+///
+/// Uses regex to pull out hex tokens, so it handles any malformed LLM output:
+/// - `"672ca8\", \"355a29\", \"6dfb10\""`  (escaped quotes as separators)
+/// - `"204e1c' , '1ccaa0' , '953318'"`    (single quotes as separators)
+/// - `"672ca8"`                            (normal single ID)
+fn parse_span_ids_from_str(s: &str) -> Vec<String> {
+    SPAN_ID_RE
+        .find_iter(s)
+        .map(|m| m.as_str().to_string())
+        .collect()
 }

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -607,7 +607,7 @@ pub async fn handle_tool_call(
     clickhouse: clickhouse::Client,
 ) -> StepResult {
     match function_call.name.as_str() {
-        "search_in_spans" | "regex_in_spans" => {
+        "search_in_spans" => {
             let searches: Vec<SpanSearchRequest> = function_call
                 .args
                 .as_ref()

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -404,6 +404,7 @@ async fn process_single_response(
             error: span_error,
             provider_batch_id,
             metadata: None,
+            tools: None,
         },
     )
     .await;
@@ -462,6 +463,7 @@ async fn process_single_response(
                 error: tool_error,
                 provider_batch_id: None,
                 metadata: None,
+                tools: None,
             },
         )
         .await;
@@ -798,6 +800,7 @@ pub async fn handle_create_event(
             error: None,
             provider_batch_id: None,
             metadata: None,
+            tools: None,
         },
     )
     .await;

--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -78,7 +78,7 @@ fn truncate_value(value: &Value) -> Value {
 
     let truncated: String = value_str.chars().take(TRUNCATE_THRESHOLD).collect();
     let omitted = char_count - TRUNCATE_THRESHOLD;
-    Value::String(format!("{}... ({} chars truncated)", truncated, omitted))
+    Value::String(format!("{}<truncated {} more chars>", truncated, omitted))
 }
 
 /// Truncate LLM input messages. If the input is an array of messages, each message's
@@ -112,7 +112,7 @@ fn truncate_value_strings(value: &Value) -> Value {
         Value::String(s) if s.chars().count() > LLM_MESSAGE_MAX_CHARS => {
             let truncated: String = s.chars().take(LLM_MESSAGE_MAX_CHARS).collect();
             let omitted = s.chars().count() - LLM_MESSAGE_MAX_CHARS;
-            Value::String(format!("{}... ({} chars truncated)", truncated, omitted))
+            Value::String(format!("{}<truncated {} more chars>", truncated, omitted))
         }
         Value::Array(arr) => Value::Array(arr.iter().map(truncate_value_strings).collect()),
         Value::Object(map) => Value::Object(

--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use chrono::DateTime;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
 use uuid::Uuid;
 
 use crate::ch::spans::CHSpan;
@@ -14,28 +15,21 @@ const BASE64_IMAGE_PLACEHOLDER: &str = "[base64 image omitted]";
 /// Max chars to keep per message in LLM span inputs (~1K tokens).
 const LLM_MESSAGE_MAX_CHARS: usize = 3000;
 
-/// Compressed span identified by the last 4 hex chars of its UUID
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CompressedSpan {
     pub id: String,
     pub name: String,
     pub path: String,
-    #[serde(rename = "type")]
     pub span_type: String,
     pub start: String,
     pub duration: f64,
     pub total_cost: f64,
     pub total_tokens: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub input: Option<Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub output: Option<Value>,
-    #[serde(skip_serializing_if = "String::is_empty")]
+    pub input: String,
+    pub output: String,
+    pub output_truncated: bool,
     pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub exception: Option<Value>,
+    pub exception: Option<String>,
 }
 
 const SPAN_SHORT_ID_LEN: usize = 6;
@@ -55,6 +49,23 @@ fn format_ns_timestamp(ns: i64) -> String {
         .unwrap_or_else(|| ns.to_string())
 }
 
+fn omit_or_empty(raw: &str) -> String {
+    let value = try_parse_json(raw);
+    if is_empty_value(&value) {
+        return "<empty>".to_string();
+    }
+    let char_count = raw.chars().count();
+    format!("<omitted {} chars>", char_count)
+}
+
+fn is_empty_value(value: &Value) -> bool {
+    match value {
+        Value::Null => true,
+        Value::String(s) => s.is_empty(),
+        _ => false,
+    }
+}
+
 /// Get span type string
 pub fn get_span_type(span_type: u8) -> &'static str {
     match span_type {
@@ -64,8 +75,8 @@ pub fn get_span_type(span_type: u8) -> &'static str {
     }
 }
 
-/// Truncate a value if its string representation exceeds TRUNCATE_THRESHOLD
-fn truncate_value(value: &Value) -> Value {
+/// Returns (truncated_value, was_truncated).
+fn truncate_value(value: &Value, truncated: &mut bool) -> Value {
     let value_str = match value {
         Value::String(s) => s.clone(),
         _ => serde_json::to_string(value).unwrap_or_default(),
@@ -76,48 +87,51 @@ fn truncate_value(value: &Value) -> Value {
         return value.clone();
     }
 
-    let truncated: String = value_str.chars().take(TRUNCATE_THRESHOLD).collect();
+    *truncated = true;
+    let kept: String = value_str.chars().take(TRUNCATE_THRESHOLD).collect();
     let omitted = char_count - TRUNCATE_THRESHOLD;
-    Value::String(format!("{}<truncated {} more chars>", truncated, omitted))
+    Value::String(format!("{}<truncated {} more chars>", kept, omitted))
 }
 
-/// Truncate LLM input messages. If the input is an array of messages, each message's
-/// string fields are individually capped at LLM_MESSAGE_MAX_CHARS so that no single
-/// large message causes later messages to be lost.
-fn truncate_llm_input(value: &Value) -> Value {
+fn truncate_llm_input(value: &Value, truncated: &mut bool) -> Value {
     match value {
-        Value::Array(messages) => {
-            Value::Array(messages.iter().map(truncate_message_strings).collect())
-        }
+        Value::Array(messages) => Value::Array(
+            messages
+                .iter()
+                .map(|m| truncate_message_strings(m, truncated))
+                .collect(),
+        ),
         _ => value.clone(),
     }
 }
 
-/// Truncate large strings in a message, handling both plain string fields and
-/// multimodal content arrays (e.g. `[{"type":"text","text":"..."}]`).
-fn truncate_message_strings(message: &Value) -> Value {
+fn truncate_message_strings(message: &Value, truncated: &mut bool) -> Value {
     match message {
         Value::Object(map) => Value::Object(
             map.iter()
-                .map(|(k, v)| (k.clone(), truncate_value_strings(v)))
+                .map(|(k, v)| (k.clone(), truncate_value_strings(v, truncated)))
                 .collect(),
         ),
         _ => message.clone(),
     }
 }
 
-/// Recursively truncate any string that exceeds LLM_MESSAGE_MAX_CHARS.
-fn truncate_value_strings(value: &Value) -> Value {
+fn truncate_value_strings(value: &Value, truncated: &mut bool) -> Value {
     match value {
         Value::String(s) if s.chars().count() > LLM_MESSAGE_MAX_CHARS => {
-            let truncated: String = s.chars().take(LLM_MESSAGE_MAX_CHARS).collect();
+            *truncated = true;
+            let kept: String = s.chars().take(LLM_MESSAGE_MAX_CHARS).collect();
             let omitted = s.chars().count() - LLM_MESSAGE_MAX_CHARS;
-            Value::String(format!("{}<truncated {} more chars>", truncated, omitted))
+            Value::String(format!("{}<truncated {} more chars>", kept, omitted))
         }
-        Value::Array(arr) => Value::Array(arr.iter().map(truncate_value_strings).collect()),
+        Value::Array(arr) => Value::Array(
+            arr.iter()
+                .map(|v| truncate_value_strings(v, truncated))
+                .collect(),
+        ),
         Value::Object(map) => Value::Object(
             map.iter()
-                .map(|(k, v)| (k.clone(), truncate_value_strings(v)))
+                .map(|(k, v)| (k.clone(), truncate_value_strings(v, truncated)))
                 .collect(),
         ),
         other => other.clone(),
@@ -224,48 +238,52 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
                 span_uuid_to_short.get(&ch_span.parent_span_id).cloned()
             };
 
+            let mut output_truncated = false;
+
+            let is_tool = ch_span.span_type == 6;
+
             let (input, output) = if is_llm {
-                let input_data = truncate_llm_input(&strip_signature_fields(
-                    &replace_base64_images(&try_parse_json(&ch_span.input)),
-                ));
                 let output_data = strip_signature_fields(&try_parse_json(&ch_span.output));
 
                 if seen_llm_paths.contains(&path) {
-                    // Subsequent LLM span at same path: only output
-                    (None, Some(output_data))
+                    ("<omitted>".to_string(), value_to_string(&output_data))
                 } else {
-                    // First LLM span at this path: include truncated input and full output
                     seen_llm_paths.insert(path.clone());
-                    (Some(input_data), Some(output_data))
+                    let mut _unused = false;
+                    let input_data = truncate_llm_input(
+                        &strip_signature_fields(&replace_base64_images(&try_parse_json(
+                            &ch_span.input,
+                        ))),
+                        &mut _unused,
+                    );
+                    (value_to_string(&input_data), value_to_string(&output_data))
                 }
+            } else if is_tool {
+                let input_raw = try_parse_json(&ch_span.input);
+                let output_raw = try_parse_json(&ch_span.output);
+
+                let mut _unused = false;
+                let input = if is_empty_value(&input_raw) {
+                    "<empty>".to_string()
+                } else {
+                    value_to_string(&truncate_value(&input_raw, &mut _unused))
+                };
+
+                let output = if is_empty_value(&output_raw) {
+                    "<empty>".to_string()
+                } else {
+                    value_to_string(&truncate_value(&output_raw, &mut output_truncated))
+                };
+
+                (input, output)
             } else {
-                // Non-LLM span: truncate if needed
-                let input_data = try_parse_json(&ch_span.input);
-                let output_data = try_parse_json(&ch_span.output);
-
-                let truncated_input = truncate_value(&input_data);
-                let truncated_output = truncate_value(&output_data);
-
-                let input_opt = if truncated_input != Value::String("".to_string())
-                    && truncated_input != Value::Null
-                {
-                    Some(truncated_input)
-                } else {
-                    None
-                };
-
-                let output_opt = if truncated_output != Value::String("".to_string())
-                    && truncated_output != Value::Null
-                {
-                    Some(truncated_output)
-                } else {
-                    None
-                };
-
-                (input_opt, output_opt)
+                let input = omit_or_empty(&ch_span.input);
+                let output = omit_or_empty(&ch_span.output);
+                (input, output)
             };
 
-            let exception = extract_exception_from_events(&ch_span.events);
+            let exception =
+                extract_exception_from_events(&ch_span.events).map(|v| value_to_string(&v));
 
             CompressedSpan {
                 id: span_short_id(&ch_span.span_id),
@@ -278,6 +296,7 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
                 total_tokens: ch_span.total_tokens,
                 input,
                 output,
+                output_truncated,
                 status: if ch_span.status == "<null>" || ch_span.status.is_empty() {
                     String::new()
                 } else {
@@ -290,33 +309,45 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
         .collect()
 }
 
-/// Create skeleton string representation of spans
-pub fn spans_to_skeleton_string(spans: &[CompressedSpan]) -> String {
-    let mut skeleton = String::from(
-        "legend: span_name (id, parent_id, type, duration_sec, cost_usd, total_tokens, is_input_empty, is_output_empty)\n",
-    );
-    for span in spans {
-        let cost = if span.total_cost > 0.0 {
-            format!("{:.5}", span.total_cost)
-        } else {
-            "0".to_string()
-        };
-
-        let parent_str = span.parent.as_deref().unwrap_or("None");
-        skeleton.push_str(&format!(
-            "- {} ({}, {}, {}, {:.1}, {}, {}, {}, {})\n",
-            span.name,
-            span.id,
-            parent_str,
-            span.span_type,
-            span.duration,
-            cost,
-            span.total_tokens,
-            span.input.is_none(),
-            span.output.is_none()
-        ));
+fn value_to_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        _ => serde_json::to_string(value).unwrap_or_default(),
     }
-    skeleton
+}
+
+fn spans_to_string(spans: &[CompressedSpan]) -> String {
+    let mut out = String::new();
+    for span in spans {
+        let is_llm = span.span_type == "llm";
+        let _ = writeln!(out, "- id: {}", span.id);
+        let _ = writeln!(out, "  name: {}", span.name);
+        let _ = writeln!(out, "  path: {}", span.path);
+        let _ = writeln!(out, "  type: {}", span.span_type);
+        let _ = writeln!(out, "  start: {}", span.start);
+        let _ = writeln!(out, "  duration: {:.1}s", span.duration);
+        if is_llm {
+            let _ = writeln!(out, "  total_cost: {}", span.total_cost);
+            let _ = writeln!(out, "  total_tokens: {}", span.total_tokens);
+        }
+        if let Some(parent) = &span.parent {
+            let _ = writeln!(out, "  parent: {}", parent);
+        } else {
+            let _ = writeln!(out, "  parent: <it_is_the_root_span>");
+        }
+        if !span.status.is_empty() {
+            let _ = writeln!(out, "  status: {}", span.status);
+        }
+        if span.output_truncated {
+            let _ = writeln!(out, "  output_truncated: true");
+        }
+        if let Some(exception) = &span.exception {
+            let _ = writeln!(out, "  exception: {}", exception);
+        }
+        let _ = writeln!(out, "  input: {}", span.input);
+        let _ = writeln!(out, "  output: {}", span.output);
+    }
+    out
 }
 
 // TODO: move these two functions to CH Query engine for better integration
@@ -401,13 +432,12 @@ pub async fn get_trace_span_ids_and_end_time(
     Ok(spans)
 }
 
-/// Get trace structure as a formatted string with skeleton and YAML
+/// Get trace structure as YAML of all compressed spans
 pub async fn get_trace_structure_as_string(
     clickhouse: clickhouse::Client,
     project_id: Uuid,
     trace_id: Uuid,
 ) -> Result<String> {
-    // Fetch raw spans
     let ch_spans = get_trace_spans(clickhouse, project_id, trace_id).await?;
 
     if ch_spans.is_empty() {
@@ -417,26 +447,11 @@ pub async fn get_trace_structure_as_string(
         ));
     }
 
-    // Compress spans
     let compressed_spans = compress_span_content(&ch_spans);
+    let trace_str = spans_to_string(&compressed_spans);
 
-    // Create skeleton view
-    let trace_skeleton = spans_to_skeleton_string(&compressed_spans);
-
-    // Filter to only LLM and Tool spans for detailed view
-    let filtered_spans: Vec<&CompressedSpan> = compressed_spans
-        .iter()
-        .filter(|span| span.span_type != "default")
-        .collect();
-
-    // Convert to YAML
-    let trace_yaml = serde_yaml::to_string(&filtered_spans)?;
-
-    // Build final string
-    let trace_string = format!(
-        "Here is the skeleton view of the trace:\n<trace_skeleton>\n{}</trace_skeleton>\n\nHere are the detailed views of LLM and Tool spans:\n<spans>\n{}</spans>\n",
-        trace_skeleton, trace_yaml
-    );
-
-    Ok(trace_string)
+    Ok(format!(
+        "Here are all spans of the trace:\n<spans>\n{}</spans>\n",
+        trace_str
+    ))
 }

--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -26,6 +26,7 @@ pub struct CompressedSpan {
     pub total_tokens: i64,
     pub input: String,
     pub output: String,
+    pub input_truncated: bool,
     pub output_truncated: bool,
     pub status: String,
     pub parent: Option<String>,
@@ -238,35 +239,37 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
                 span_uuid_to_short.get(&ch_span.parent_span_id).cloned()
             };
 
+            let mut input_truncated = false;
             let mut output_truncated = false;
 
             let is_tool = ch_span.span_type == 6;
 
             let (input, output) = if is_llm {
                 let output_data = strip_signature_fields(&try_parse_json(&ch_span.output));
+                let output = value_to_string(
+                    &truncate_value(&output_data, &mut output_truncated),
+                );
 
                 if seen_llm_paths.contains(&path) {
-                    ("<omitted>".to_string(), value_to_string(&output_data))
+                    ("<omitted>".to_string(), output)
                 } else {
                     seen_llm_paths.insert(path.clone());
-                    let mut _unused = false;
                     let input_data = truncate_llm_input(
                         &strip_signature_fields(&replace_base64_images(&try_parse_json(
                             &ch_span.input,
                         ))),
-                        &mut _unused,
+                        &mut input_truncated,
                     );
-                    (value_to_string(&input_data), value_to_string(&output_data))
+                    (value_to_string(&input_data), output)
                 }
             } else if is_tool {
                 let input_raw = try_parse_json(&ch_span.input);
                 let output_raw = try_parse_json(&ch_span.output);
 
-                let mut _unused = false;
                 let input = if is_empty_value(&input_raw) {
                     "<empty>".to_string()
                 } else {
-                    value_to_string(&truncate_value(&input_raw, &mut _unused))
+                    value_to_string(&truncate_value(&input_raw, &mut input_truncated))
                 };
 
                 let output = if is_empty_value(&output_raw) {
@@ -296,6 +299,7 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
                 total_tokens: ch_span.total_tokens,
                 input,
                 output,
+                input_truncated,
                 output_truncated,
                 status: if ch_span.status == "<null>" || ch_span.status.is_empty() {
                     String::new()
@@ -337,6 +341,9 @@ fn spans_to_string(spans: &[CompressedSpan]) -> String {
         }
         if !span.status.is_empty() {
             let _ = writeln!(out, "  status: {}", span.status);
+        }
+        if span.input_truncated {
+            let _ = writeln!(out, "  input_truncated: true");
         }
         if span.output_truncated {
             let _ = writeln!(out, "  output_truncated: true");

--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -8,10 +8,9 @@ use uuid::Uuid;
 
 use crate::ch::spans::CHSpan;
 
-use super::utils::try_parse_json;
+use super::utils::{strip_noise, try_parse_json};
 
 const TRUNCATE_THRESHOLD: usize = 1024;
-const BASE64_IMAGE_PLACEHOLDER: &str = "[base64 image omitted]";
 /// Max chars to keep per message in LLM span inputs (~1K tokens).
 const LLM_MESSAGE_MAX_CHARS: usize = 3000;
 
@@ -139,68 +138,6 @@ fn truncate_value_strings(value: &Value, truncated: &mut bool) -> Value {
     }
 }
 
-const RAW_BASE64_IMAGE_PREFIXES: &[&str] = &[
-    "/9j/",        // JPEG
-    "iVBORw0KGgo", // PNG
-    "R0lGODlh",    // GIF
-    "UklGR",       // WebP
-    "PHN2Zz",      // SVG
-];
-
-/// Minimum length for a raw base64 string to be considered an image.
-const RAW_BASE64_MIN_LEN: usize = 64;
-
-/// Check whether a string looks like raw base64-encoded image data.
-fn is_raw_base64_image(s: &str) -> bool {
-    s.len() >= RAW_BASE64_MIN_LEN
-        && RAW_BASE64_IMAGE_PREFIXES
-            .iter()
-            .any(|prefix| s.starts_with(prefix))
-}
-
-/// Replace base64 image data within a JSON value with a placeholder.
-///
-/// Detects both data URLs (`data:image/...;base64,...`) and raw base64 image
-/// strings identified by well-known magic byte prefixes (JPEG, PNG, GIF, WebP, SVG).
-pub fn replace_base64_images(value: &Value) -> Value {
-    match value {
-        Value::String(s) => {
-            if let Some(idx) = s.find("base64,") {
-                let prefix = &s[..idx + "base64,".len()];
-                if prefix.starts_with("data:image") {
-                    return Value::String(BASE64_IMAGE_PLACEHOLDER.to_string());
-                }
-            }
-            if is_raw_base64_image(s) {
-                return Value::String(BASE64_IMAGE_PLACEHOLDER.to_string());
-            }
-            value.clone()
-        }
-        Value::Array(arr) => Value::Array(arr.iter().map(replace_base64_images).collect()),
-        Value::Object(map) => Value::Object(
-            map.iter()
-                .map(|(k, v)| (k.clone(), replace_base64_images(v)))
-                .collect(),
-        ),
-        _ => value.clone(),
-    }
-}
-
-/// Remove `signature` and `thought_signature` fields from LLM span inputs and outputs.
-/// These fields contain large hash values that waste context and provide no analytical value.
-pub fn strip_signature_fields(value: &Value) -> Value {
-    match value {
-        Value::Object(map) => Value::Object(
-            map.iter()
-                .filter(|(k, _)| k.as_str() != "signature" && k.as_str() != "thought_signature")
-                .map(|(k, v)| (k.clone(), strip_signature_fields(v)))
-                .collect(),
-        ),
-        Value::Array(arr) => Value::Array(arr.iter().map(strip_signature_fields).collect()),
-        _ => value.clone(),
-    }
-}
-
 /// Extract exception attributes from span events.
 /// Events are stored as `(timestamp, name, attributes)` tuples; we look for `name == "exception"`.
 pub fn extract_exception_from_events(events: &[(i64, String, String)]) -> Option<Value> {
@@ -245,7 +182,7 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
             let is_tool = ch_span.span_type == 6;
 
             let (input, output) = if is_llm {
-                let output_data = strip_signature_fields(&try_parse_json(&ch_span.output));
+                let output_data = try_parse_json(&strip_noise(&ch_span.output));
                 let output = value_to_string(
                     &truncate_value(&output_data, &mut output_truncated),
                 );
@@ -255,16 +192,14 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
                 } else {
                     seen_llm_paths.insert(path.clone());
                     let input_data = truncate_llm_input(
-                        &strip_signature_fields(&replace_base64_images(&try_parse_json(
-                            &ch_span.input,
-                        ))),
+                        &try_parse_json(&strip_noise(&ch_span.input)),
                         &mut input_truncated,
                     );
                     (value_to_string(&input_data), output)
                 }
             } else if is_tool {
-                let input_raw = try_parse_json(&ch_span.input);
-                let output_raw = try_parse_json(&ch_span.output);
+                let input_raw = try_parse_json(&strip_noise(&ch_span.input));
+                let output_raw = try_parse_json(&strip_noise(&ch_span.output));
 
                 let input = if is_empty_value(&input_raw) {
                     "<empty>".to_string()

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -32,7 +32,7 @@ use crate::{
     db::spans::SpanType,
     signals::{
         common::{ProcessRunResult, handle_failed_runs, process_run},
-        utils::{InternalSpan, emit_internal_span, request_to_span_input},
+        utils::{InternalSpan, emit_internal_span, request_to_span_input, request_to_tools_attr},
     },
 };
 
@@ -293,6 +293,9 @@ async fn emit_submit_spans(
                 error: error.clone(),
                 provider_batch_id: batch_id.clone(),
                 metadata: None,
+                tools: requests
+                    .get(i)
+                    .and_then(|r| request_to_tools_attr(&r.request)),
             },
         )
         .await;

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -192,18 +192,9 @@ async fn process_batch(
             project_id,
             trace_id,
             message.run_id,
-            message.step,
-            message.internal_trace_id,
-            message.internal_span_id,
-            message.job_id,
             &signal.prompt,
-            &signal.name,
             &signal.structured_output_schema,
-            &llm_model(),
-            &llm_provider(),
             clickhouse.clone(),
-            queue.clone(),
-            config.internal_project_id,
         )
         .await
         {

--- a/app-server/src/signals/tools.rs
+++ b/app-server/src/signals/tools.rs
@@ -6,11 +6,8 @@ use uuid::Uuid;
 
 use crate::ch::spans::CHSpan;
 
-use super::spans::{
-    extract_exception_from_events, get_span_type, replace_base64_images, span_short_id,
-    strip_signature_fields,
-};
-use super::utils::{nanoseconds_to_iso, try_parse_json};
+use super::spans::{extract_exception_from_events, get_span_type, span_short_id};
+use super::utils::{nanoseconds_to_iso, strip_noise, try_parse_json};
 use crate::signals::prompts::{
     GET_FULL_SPAN_INFO_DESCRIPTION, REGEX_IN_SPANS_DESCRIPTION, SUBMIT_IDENTIFICATION_DESCRIPTION,
 };
@@ -204,8 +201,7 @@ pub async fn get_full_spans(
             let exception = extract_exception_from_events(&ch_span.events);
 
             let is_llm = ch_span.span_type == 1;
-            let input =
-                strip_signature_fields(&replace_base64_images(&try_parse_json(&ch_span.input)));
+            let input = try_parse_json(&strip_noise(&ch_span.input));
             let input = if is_llm {
                 truncate_messages(input, 2)
             } else {
@@ -220,9 +216,7 @@ pub async fn get_full_spans(
                 end: nanoseconds_to_iso(ch_span.end_time),
                 status: ch_span.status.clone(),
                 input,
-                output: strip_signature_fields(&replace_base64_images(&try_parse_json(
-                    &ch_span.output,
-                ))),
+                output: try_parse_json(&strip_noise(&ch_span.output)),
                 parent,
                 exception,
             }
@@ -325,18 +319,11 @@ pub async fn regex_in_spans(
 
             let raw = match search.search_in.as_str() {
                 "input" => &ch_span.input,
-                "output" => &ch_span.output,
-                _ => {
-                    return RegexSearchResult {
-                        span_id: search.span_id.clone(),
-                        matches: vec![],
-                        error: Some(
-                            "Invalid search_in value, must be 'input' or 'output'".to_string(),
-                        ),
-                    };
-                }
+                _ => &ch_span.output,
             };
-            match find_regex_matches(raw, &search.regex) {
+            let content = strip_noise(raw);
+
+            match find_regex_matches(&content, &search.regex) {
                 Ok(matches) => RegexSearchResult {
                     span_id: search.span_id.clone(),
                     matches,

--- a/app-server/src/signals/tools.rs
+++ b/app-server/src/signals/tools.rs
@@ -336,9 +336,7 @@ pub async fn regex_in_spans(
                     };
                 }
             };
-            let content = decode_json_content(raw);
-
-            match find_regex_matches(&content, &search.regex) {
+            match find_regex_matches(raw, &search.regex) {
                 Ok(matches) => RegexSearchResult {
                     span_id: search.span_id.clone(),
                     matches,
@@ -354,43 +352,6 @@ pub async fn regex_in_spans(
         .collect();
 
     Ok(results)
-}
-
-/// Parse raw JSON from ClickHouse into a plain-text representation where
-/// JSON string values are fully decoded (escape sequences like `\n`, `\"`,
-/// `\\` become their actual characters). This ensures the regex the agent
-/// writes matches the content as it appears in the trace view.
-///
-/// Non-string JSON values (objects, arrays, numbers, bools, null) are
-/// rendered in a readable format without re-escaping string contents.
-fn decode_json_content(raw: &str) -> String {
-    if raw.is_empty() {
-        return String::new();
-    }
-    match serde_json::from_str::<Value>(raw) {
-        Ok(value) => json_value_to_text(&value),
-        Err(_) => raw.to_string(),
-    }
-}
-
-fn json_value_to_text(value: &Value) -> String {
-    match value {
-        Value::String(s) => s.clone(),
-        Value::Null => "null".to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Number(n) => n.to_string(),
-        Value::Array(arr) => {
-            let items: Vec<String> = arr.iter().map(json_value_to_text).collect();
-            format!("[{}]", items.join(", "))
-        }
-        Value::Object(map) => {
-            let pairs: Vec<String> = map
-                .iter()
-                .map(|(k, v)| format!("{}: {}", k, json_value_to_text(v)))
-                .collect();
-            format!("{{{}}}", pairs.join(", "))
-        }
-    }
 }
 
 fn find_regex_matches(
@@ -424,46 +385,11 @@ mod tests {
 
     #[test]
     fn test_regex_match_with_newlines_in_json_raw() {
-        // Raw ClickHouse content has literal \n escape sequences (backslash + n)
         let raw = r#"{"is_done":false,"success":null,"judgement":null,"error":null,"attachments":null,"images":null,"long_term_memory":null,"extracted_content":"Clicked a \"F2\nNew York, NY, USA\nThe AI pl...\"","include_extracted_content_only_once":false,"metadata":{"click_x":1112.5,"click_y":599.3828125},"include_in_memory":false}"#;
-        // The regex \n should match actual newlines after decode_json_content
-        let pattern = r"F2.*?\n.*?\n.*?AI pl\.\.\.";
+        let pattern = r"F2.*?\\n.*?\\n.*?AI pl\.\.\.";
 
-        let decoded = decode_json_content(raw);
-        let matches = find_regex_matches(&decoded, pattern).unwrap();
-
-        println!("Decoded content (around F2):");
-        if let Some(pos) = decoded.find("F2") {
-            let ctx_start = pos.saturating_sub(5);
-            let ctx_end = (pos + 60).min(decoded.len());
-            let slice = &decoded[ctx_start..ctx_end];
-            println!("  text: {:?}", slice);
-            println!("  bytes: {:?}", slice.as_bytes());
-        }
-
-        println!("Matches found: {}", matches.len());
-        for m in &matches {
-            println!("  snippet: {:?}", m.snippet);
-        }
-
+        let matches = find_regex_matches(raw, pattern).unwrap();
         assert!(!matches.is_empty(), "Expected at least one match");
-    }
-
-    #[test]
-    fn test_decode_json_content_converts_escapes() {
-        let raw = r#"{"msg":"hello\nworld"}"#;
-        let decoded = decode_json_content(raw);
-        // After decode, \n should be an actual newline character
-        assert!(decoded.contains('\n'));
-        assert!(decoded.contains("hello"));
-        assert!(decoded.contains("world"));
-    }
-
-    #[test]
-    fn test_decode_json_content_passthrough_invalid() {
-        let raw = "not valid json {{{";
-        let decoded = decode_json_content(raw);
-        assert_eq!(decoded, raw);
     }
 
     #[test]

--- a/app-server/src/signals/tools.rs
+++ b/app-server/src/signals/tools.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
@@ -10,7 +11,9 @@ use super::spans::{
     strip_signature_fields,
 };
 use super::utils::{nanoseconds_to_iso, try_parse_json};
-use crate::signals::prompts::{GET_FULL_SPAN_INFO_DESCRIPTION, SUBMIT_IDENTIFICATION_DESCRIPTION};
+use crate::signals::prompts::{
+    GET_FULL_SPAN_INFO_DESCRIPTION, REGEX_IN_SPANS_DESCRIPTION, SUBMIT_IDENTIFICATION_DESCRIPTION,
+};
 use crate::signals::provider::models::{ProviderFunctionDeclaration, ProviderTool};
 
 /// Full span info returned by get_full_spans tool
@@ -45,6 +48,43 @@ pub fn build_tool_definitions(output_schema: &Value) -> ProviderTool {
 
     let function_declarations = vec![
         ProviderFunctionDeclaration {
+            name: "regex_in_spans".to_string(),
+            description: REGEX_IN_SPANS_DESCRIPTION.to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "searches": {
+                        "type": "array",
+                        "description": "REQUIRED. List of regex search operations to perform.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "span_id": {
+                                    "type": "string",
+                                    "description": "The span ID (6-character hex string, e.g. 'a1b2c3') to search within."
+                                },
+                                "regex": {
+                                    "type": "string",
+                                    "description": "Regular expression pattern to match against the span's content. Uses standard regex syntax."
+                                },
+                                "search_in": {
+                                    "type": "string",
+                                    "enum": ["input", "output"],
+                                    "description": "Which field of the span to search within."
+                                },
+                                "reasoning": {
+                                    "type": "string",
+                                    "description": "Explanation of why this search is needed and what the agent expects to learn from the results."
+                                }
+                            },
+                            "required": ["span_id", "regex", "search_in", "reasoning"]
+                        }
+                    }
+                },
+                "required": ["searches"]
+            }),
+        },
+        ProviderFunctionDeclaration {
             name: "get_full_spans".to_string(),
             description: GET_FULL_SPAN_INFO_DESCRIPTION.to_string(),
             parameters: serde_json::json!({
@@ -52,7 +92,7 @@ pub fn build_tool_definitions(output_schema: &Value) -> ProviderTool {
                 "properties": {
                     "reasoning": {
                         "type": "string",
-                        "description": "REQUIRED. Explain why these spans need full details and how the additional information will help extract the signal event."
+                        "description": "REQUIRED. Explain why regex_in_spans is insufficient and why these spans need full details."
                     },
                     "span_ids": {
                         "type": "array",
@@ -190,4 +230,289 @@ pub async fn get_full_spans(
         .collect();
 
     Ok(result_spans)
+}
+
+const CONTEXT_PADDING: usize = 50;
+const MAX_MATCHES_PER_SEARCH: usize = 20;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegexSearchRequest {
+    pub span_id: String,
+    pub regex: String,
+    pub search_in: String,
+    pub reasoning: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RegexSearchResult {
+    pub span_id: String,
+    pub matches: Vec<RegexMatch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RegexMatch {
+    pub snippet: String,
+    pub offset: usize,
+}
+
+pub async fn regex_in_spans(
+    clickhouse: clickhouse::Client,
+    project_id: Uuid,
+    trace_id: Uuid,
+    searches: Vec<RegexSearchRequest>,
+) -> Result<Vec<RegexSearchResult>> {
+    let unique_span_ids: Vec<String> = searches
+        .iter()
+        .map(|s| s.span_id.clone())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    log::info!(
+        "regex_in_spans: {} searches across {} unique spans in trace {}",
+        searches.len(),
+        unique_span_ids.len(),
+        trace_id
+    );
+
+    let hex_literals: Vec<String> = unique_span_ids
+        .iter()
+        .filter(|id| id.chars().all(|c| c.is_ascii_hexdigit()))
+        .map(|id| format!("'{}'", id.to_lowercase()))
+        .collect();
+
+    if hex_literals.is_empty() {
+        return Ok(searches
+            .iter()
+            .map(|s| RegexSearchResult {
+                span_id: s.span_id.clone(),
+                matches: vec![],
+                error: Some("Invalid span_id format".to_string()),
+            })
+            .collect());
+    }
+
+    let in_clause = hex_literals.join(", ");
+    let query = format!(
+        "SELECT * FROM spans WHERE trace_id = ? AND project_id = ? AND lower(right(hex(span_id), 6)) IN ({}) ORDER BY start_time ASC",
+        in_clause
+    );
+
+    let ch_spans = clickhouse
+        .query(&query)
+        .bind(trace_id)
+        .bind(project_id)
+        .fetch_all::<CHSpan>()
+        .await?;
+
+    let span_map: std::collections::HashMap<String, &CHSpan> = ch_spans
+        .iter()
+        .map(|s| (span_short_id(&s.span_id), s))
+        .collect();
+
+    let results = searches
+        .iter()
+        .map(|search| {
+            let Some(ch_span) = span_map.get(&search.span_id.to_lowercase()) else {
+                return RegexSearchResult {
+                    span_id: search.span_id.clone(),
+                    matches: vec![],
+                    error: Some("Span not found".to_string()),
+                };
+            };
+
+            let raw = match search.search_in.as_str() {
+                "input" => &ch_span.input,
+                "output" => &ch_span.output,
+                _ => {
+                    return RegexSearchResult {
+                        span_id: search.span_id.clone(),
+                        matches: vec![],
+                        error: Some(
+                            "Invalid search_in value, must be 'input' or 'output'".to_string(),
+                        ),
+                    };
+                }
+            };
+            let content = decode_json_content(raw);
+
+            match find_regex_matches(&content, &search.regex) {
+                Ok(matches) => RegexSearchResult {
+                    span_id: search.span_id.clone(),
+                    matches,
+                    error: None,
+                },
+                Err(e) => RegexSearchResult {
+                    span_id: search.span_id.clone(),
+                    matches: vec![],
+                    error: Some(e),
+                },
+            }
+        })
+        .collect();
+
+    Ok(results)
+}
+
+/// Parse raw JSON from ClickHouse into a plain-text representation where
+/// JSON string values are fully decoded (escape sequences like `\n`, `\"`,
+/// `\\` become their actual characters). This ensures the regex the agent
+/// writes matches the content as it appears in the trace view.
+///
+/// Non-string JSON values (objects, arrays, numbers, bools, null) are
+/// rendered in a readable format without re-escaping string contents.
+fn decode_json_content(raw: &str) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+    match serde_json::from_str::<Value>(raw) {
+        Ok(value) => json_value_to_text(&value),
+        Err(_) => raw.to_string(),
+    }
+}
+
+fn json_value_to_text(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(json_value_to_text).collect();
+            format!("[{}]", items.join(", "))
+        }
+        Value::Object(map) => {
+            let pairs: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{}: {}", k, json_value_to_text(v)))
+                .collect();
+            format!("{{{}}}", pairs.join(", "))
+        }
+    }
+}
+
+fn find_regex_matches(
+    content: &str,
+    pattern: &str,
+) -> std::result::Result<Vec<RegexMatch>, String> {
+    let re = Regex::new(pattern).map_err(|e| format!("Invalid regex: {}", e))?;
+
+    let matches = re
+        .find_iter(content)
+        .take(MAX_MATCHES_PER_SEARCH)
+        .map(|m| {
+            let start = m.start().saturating_sub(CONTEXT_PADDING);
+            let end = (m.end() + CONTEXT_PADDING).min(content.len());
+            // Snap to char boundaries to avoid panics on multi-byte UTF-8
+            let start = content.floor_char_boundary(start);
+            let end = content.ceil_char_boundary(end);
+            RegexMatch {
+                snippet: content[start..end].to_string(),
+                offset: m.start(),
+            }
+        })
+        .collect();
+
+    Ok(matches)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_regex_match_with_newlines_in_json_raw() {
+        // Raw ClickHouse content has literal \n escape sequences (backslash + n)
+        let raw = r#"{"is_done":false,"success":null,"judgement":null,"error":null,"attachments":null,"images":null,"long_term_memory":null,"extracted_content":"Clicked a \"F2\nNew York, NY, USA\nThe AI pl...\"","include_extracted_content_only_once":false,"metadata":{"click_x":1112.5,"click_y":599.3828125},"include_in_memory":false}"#;
+        // The regex \n should match actual newlines after decode_json_content
+        let pattern = r"F2.*?\n.*?\n.*?AI pl\.\.\.";
+
+        let decoded = decode_json_content(raw);
+        let matches = find_regex_matches(&decoded, pattern).unwrap();
+
+        println!("Decoded content (around F2):");
+        if let Some(pos) = decoded.find("F2") {
+            let ctx_start = pos.saturating_sub(5);
+            let ctx_end = (pos + 60).min(decoded.len());
+            let slice = &decoded[ctx_start..ctx_end];
+            println!("  text: {:?}", slice);
+            println!("  bytes: {:?}", slice.as_bytes());
+        }
+
+        println!("Matches found: {}", matches.len());
+        for m in &matches {
+            println!("  snippet: {:?}", m.snippet);
+        }
+
+        assert!(!matches.is_empty(), "Expected at least one match");
+    }
+
+    #[test]
+    fn test_decode_json_content_converts_escapes() {
+        let raw = r#"{"msg":"hello\nworld"}"#;
+        let decoded = decode_json_content(raw);
+        // After decode, \n should be an actual newline character
+        assert!(decoded.contains('\n'));
+        assert!(decoded.contains("hello"));
+        assert!(decoded.contains("world"));
+    }
+
+    #[test]
+    fn test_decode_json_content_passthrough_invalid() {
+        let raw = "not valid json {{{";
+        let decoded = decode_json_content(raw);
+        assert_eq!(decoded, raw);
+    }
+
+    #[test]
+    fn test_regex_simple_match() {
+        let content = "hello world foo bar";
+        let pattern = r"world.*bar";
+        let matches = find_regex_matches(content, pattern).unwrap();
+        assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn test_regex_no_match() {
+        let content = "hello world";
+        let pattern = r"xyz";
+        let matches = find_regex_matches(content, pattern).unwrap();
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_regex_invalid_pattern() {
+        let content = "hello";
+        let pattern = r"[invalid";
+        let result = find_regex_matches(content, pattern);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_regex_context_padding() {
+        let content = "aaaaaaaaaa_PREFIX_match_here_SUFFIX_bbbbbbbbbb";
+        let pattern = r"match_here";
+        let matches = find_regex_matches(content, pattern).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert!(matches[0].snippet.contains("PREFIX"));
+        assert!(matches[0].snippet.contains("SUFFIX"));
+    }
+
+    #[test]
+    fn test_regex_max_matches_cap() {
+        let content = "ab ".repeat(MAX_MATCHES_PER_SEARCH + 10);
+        let pattern = r"ab";
+        let matches = find_regex_matches(content.trim(), pattern).unwrap();
+        assert_eq!(matches.len(), MAX_MATCHES_PER_SEARCH);
+    }
+
+    #[test]
+    fn test_regex_multibyte_utf8_boundary() {
+        let content = "价格是 hello 世界";
+        let pattern = r"hello";
+        let matches = find_regex_matches(content, pattern).unwrap();
+        assert_eq!(matches.len(), 1);
+    }
 }

--- a/app-server/src/signals/tools.rs
+++ b/app-server/src/signals/tools.rs
@@ -9,7 +9,7 @@ use crate::ch::spans::CHSpan;
 use super::spans::{extract_exception_from_events, get_span_type, span_short_id};
 use super::utils::{nanoseconds_to_iso, strip_noise, try_parse_json};
 use crate::signals::prompts::{
-    GET_FULL_SPAN_INFO_DESCRIPTION, REGEX_IN_SPANS_DESCRIPTION, SUBMIT_IDENTIFICATION_DESCRIPTION,
+    GET_FULL_SPAN_INFO_DESCRIPTION, SEARCH_IN_SPANS_DESCRIPTION, SUBMIT_IDENTIFICATION_DESCRIPTION,
 };
 use crate::signals::provider::models::{ProviderFunctionDeclaration, ProviderTool};
 
@@ -45,14 +45,14 @@ pub fn build_tool_definitions(output_schema: &Value) -> ProviderTool {
 
     let function_declarations = vec![
         ProviderFunctionDeclaration {
-            name: "regex_in_spans".to_string(),
-            description: REGEX_IN_SPANS_DESCRIPTION.to_string(),
+            name: "search_in_spans".to_string(),
+            description: SEARCH_IN_SPANS_DESCRIPTION.to_string(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "searches": {
                         "type": "array",
-                        "description": "REQUIRED. List of regex search operations to perform.",
+                        "description": "REQUIRED. List of search operations to perform.",
                         "items": {
                             "type": "object",
                             "properties": {
@@ -60,9 +60,13 @@ pub fn build_tool_definitions(output_schema: &Value) -> ProviderTool {
                                     "type": "string",
                                     "description": "The span ID (6-character hex string, e.g. 'a1b2c3') to search within."
                                 },
+                                "literal": {
+                                    "type": "string",
+                                    "description": "REQUIRED. Plain text substring to search for. This is tried first and handles most searches. No escaping needed — just the exact text you want to find."
+                                },
                                 "regex": {
                                     "type": "string",
-                                    "description": "Regular expression pattern to match against the span's content. Uses standard regex syntax."
+                                    "description": "Optional regex pattern used as fallback if the literal search finds nothing. Only provide this when you need pattern matching (e.g. wildcards, alternation). Write the regex as you would in a regex tester — JSON escaping is handled automatically."
                                 },
                                 "search_in": {
                                     "type": "string",
@@ -71,10 +75,10 @@ pub fn build_tool_definitions(output_schema: &Value) -> ProviderTool {
                                 },
                                 "reasoning": {
                                     "type": "string",
-                                    "description": "Explanation of why this search is needed and what the agent expects to learn from the results."
+                                    "description": "Explanation of why this search is needed."
                                 }
                             },
-                            "required": ["span_id", "regex", "search_in", "reasoning"]
+                            "required": ["span_id", "literal", "search_in", "reasoning"]
                         }
                     }
                 },
@@ -89,7 +93,7 @@ pub fn build_tool_definitions(output_schema: &Value) -> ProviderTool {
                 "properties": {
                     "reasoning": {
                         "type": "string",
-                        "description": "REQUIRED. Explain why regex_in_spans is insufficient and why these spans need full details."
+                        "description": "REQUIRED. Explain why search_in_spans is insufficient and why these spans need full details."
                     },
                     "span_ids": {
                         "type": "array",
@@ -226,37 +230,40 @@ pub async fn get_full_spans(
     Ok(result_spans)
 }
 
-const CONTEXT_PADDING: usize = 50;
-const MAX_MATCHES_PER_SEARCH: usize = 20;
+const CONTEXT_PADDING: usize = 100;
+const MAX_MATCHES_PER_SEARCH: usize = 10;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RegexSearchRequest {
+pub struct SpanSearchRequest {
     pub span_id: String,
-    pub regex: String,
+    pub literal: String,
+    #[serde(default)]
+    pub regex: Option<String>,
     pub search_in: String,
     pub reasoning: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct RegexSearchResult {
+pub struct SpanSearchResult {
     pub span_id: String,
-    pub matches: Vec<RegexMatch>,
+    pub matches: Vec<SearchMatch>,
+    pub matched_by: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct RegexMatch {
+pub struct SearchMatch {
     pub snippet: String,
     pub offset: usize,
 }
 
-pub async fn regex_in_spans(
+pub async fn search_in_spans(
     clickhouse: clickhouse::Client,
     project_id: Uuid,
     trace_id: Uuid,
-    searches: Vec<RegexSearchRequest>,
-) -> Result<Vec<RegexSearchResult>> {
+    searches: Vec<SpanSearchRequest>,
+) -> Result<Vec<SpanSearchResult>> {
     let unique_span_ids: Vec<String> = searches
         .iter()
         .map(|s| s.span_id.clone())
@@ -265,7 +272,7 @@ pub async fn regex_in_spans(
         .collect();
 
     log::info!(
-        "regex_in_spans: {} searches across {} unique spans in trace {}",
+        "search_in_spans: {} searches across {} unique spans in trace {}",
         searches.len(),
         unique_span_ids.len(),
         trace_id
@@ -280,9 +287,10 @@ pub async fn regex_in_spans(
     if hex_literals.is_empty() {
         return Ok(searches
             .iter()
-            .map(|s| RegexSearchResult {
+            .map(|s| SpanSearchResult {
                 span_id: s.span_id.clone(),
                 matches: vec![],
+                matched_by: String::new(),
                 error: Some("Invalid span_id format".to_string()),
             })
             .collect());
@@ -310,9 +318,10 @@ pub async fn regex_in_spans(
         .iter()
         .map(|search| {
             let Some(ch_span) = span_map.get(&search.span_id.to_lowercase()) else {
-                return RegexSearchResult {
+                return SpanSearchResult {
                     span_id: search.span_id.clone(),
                     matches: vec![],
+                    matched_by: String::new(),
                     error: Some("Span not found".to_string()),
                 };
             };
@@ -323,17 +332,43 @@ pub async fn regex_in_spans(
             };
             let content = strip_noise(raw);
 
-            match find_regex_matches(&content, &search.regex) {
-                Ok(matches) => RegexSearchResult {
+            let literal_matches = find_literal_matches(&content, &search.literal);
+            if !literal_matches.is_empty() {
+                return SpanSearchResult {
                     span_id: search.span_id.clone(),
-                    matches,
+                    matches: literal_matches,
+                    matched_by: "literal".to_string(),
                     error: None,
-                },
-                Err(e) => RegexSearchResult {
-                    span_id: search.span_id.clone(),
-                    matches: vec![],
-                    error: Some(e),
-                },
+                };
+            }
+
+            if let Some(pattern) = &search.regex {
+                match find_regex_matches(&content, pattern) {
+                    Ok(matches) if !matches.is_empty() => {
+                        return SpanSearchResult {
+                            span_id: search.span_id.clone(),
+                            matches,
+                            matched_by: "regex".to_string(),
+                            error: None,
+                        };
+                    }
+                    Err(e) => {
+                        return SpanSearchResult {
+                            span_id: search.span_id.clone(),
+                            matches: vec![],
+                            matched_by: String::new(),
+                            error: Some(format!("Literal: no matches. Regex error: {}", e)),
+                        };
+                    }
+                    _ => {}
+                }
+            }
+
+            SpanSearchResult {
+                span_id: search.span_id.clone(),
+                matches: vec![],
+                matched_by: String::new(),
+                error: Some("No matches found".to_string()),
             }
         })
         .collect();
@@ -341,10 +376,30 @@ pub async fn regex_in_spans(
     Ok(results)
 }
 
+fn find_literal_matches(content: &str, literal: &str) -> Vec<SearchMatch> {
+    if literal.is_empty() {
+        return vec![];
+    }
+    content
+        .match_indices(literal)
+        .take(MAX_MATCHES_PER_SEARCH)
+        .map(|(offset, _)| {
+            let start = offset.saturating_sub(CONTEXT_PADDING);
+            let end = (offset + literal.len() + CONTEXT_PADDING).min(content.len());
+            let start = content.floor_char_boundary(start);
+            let end = content.ceil_char_boundary(end);
+            SearchMatch {
+                snippet: content[start..end].to_string(),
+                offset,
+            }
+        })
+        .collect()
+}
+
 fn find_regex_matches(
     content: &str,
     pattern: &str,
-) -> std::result::Result<Vec<RegexMatch>, String> {
+) -> std::result::Result<Vec<SearchMatch>, String> {
     let re = Regex::new(pattern).map_err(|e| format!("Invalid regex: {}", e))?;
 
     let matches = re
@@ -353,10 +408,9 @@ fn find_regex_matches(
         .map(|m| {
             let start = m.start().saturating_sub(CONTEXT_PADDING);
             let end = (m.end() + CONTEXT_PADDING).min(content.len());
-            // Snap to char boundaries to avoid panics on multi-byte UTF-8
             let start = content.floor_char_boundary(start);
             let end = content.ceil_char_boundary(end);
-            RegexMatch {
+            SearchMatch {
                 snippet: content[start..end].to_string(),
                 offset: m.start(),
             }
@@ -427,5 +481,51 @@ mod tests {
         let pattern = r"hello";
         let matches = find_regex_matches(content, pattern).unwrap();
         assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn test_literal_simple_match() {
+        let content = "hello world foo bar";
+        let matches = find_literal_matches(content, "world");
+        assert_eq!(matches.len(), 1);
+        assert!(matches[0].snippet.contains("world"));
+    }
+
+    #[test]
+    fn test_literal_no_match() {
+        let content = "hello world";
+        let matches = find_literal_matches(content, "xyz");
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_literal_multiple_matches() {
+        let content = "foo bar foo baz foo";
+        let matches = find_literal_matches(content, "foo");
+        assert_eq!(matches.len(), 3);
+    }
+
+    #[test]
+    fn test_literal_empty_pattern() {
+        let content = "hello world";
+        let matches = find_literal_matches(content, "");
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_literal_with_brackets() {
+        let content = r#"{"index": "[3352] Summer 2025 checkbox"}"#;
+        let matches = find_literal_matches(content, "[3352]");
+        assert_eq!(matches.len(), 1);
+        assert!(matches[0].snippet.contains("[3352]"));
+    }
+
+    #[test]
+    fn test_literal_context_padding() {
+        let content = "aaaaaaaaaa_PREFIX_match_here_SUFFIX_bbbbbbbbbb";
+        let matches = find_literal_matches(content, "match_here");
+        assert_eq!(matches.len(), 1);
+        assert!(matches[0].snippet.contains("PREFIX"));
+        assert!(matches[0].snippet.contains("SUFFIX"));
     }
 }

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -27,6 +27,28 @@ pub fn request_to_span_input(request: &ProviderRequest) -> Value {
     serde_json::json!(contents)
 }
 
+/// Convert ProviderRequest tools into the `ai.prompt.tools` attribute format.
+pub fn request_to_tools_attr(request: &ProviderRequest) -> Option<Value> {
+    let tools = request.tools.as_ref()?;
+    let tool_array: Vec<Value> = tools
+        .iter()
+        .flat_map(|t| &t.function_declarations)
+        .map(|f| {
+            serde_json::json!({
+                "type": "function",
+                "name": f.name,
+                "description": f.description,
+                "parameters": f.parameters,
+            })
+        })
+        .collect();
+    if tool_array.is_empty() {
+        None
+    } else {
+        Some(Value::Array(tool_array))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct InternalSpan {
     pub name: String,
@@ -49,6 +71,7 @@ pub struct InternalSpan {
     pub error: Option<String>,
     pub provider_batch_id: Option<String>,
     pub metadata: Option<HashMap<String, Value>>,
+    pub tools: Option<Value>,
 }
 
 /// Try to parse JSON string, return the parsed value or the original string
@@ -197,6 +220,10 @@ pub async fn emit_internal_span(queue: Arc<MessageQueue>, span: InternalSpan) ->
                 value,
             );
         }
+    }
+
+    if let Some(tools) = span.tools {
+        attrs.insert("ai.prompt.tools".to_string(), tools);
     }
 
     attrs.insert(

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use chrono::Utc;
 use regex::Regex;
 use serde_json::Value;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, sync::LazyLock};
 use uuid::Uuid;
 
 use crate::{
@@ -15,6 +15,22 @@ use crate::{
     signals::provider::models::ProviderRequest,
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
 };
+
+static BASE64_IMAGE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?:/9j/|iVBORw0KGgo|R0lGODlh|UklGR|PHN2Zz)[A-Za-z0-9+/=_-]{64,}"#).unwrap()
+});
+
+static SIGNATURE_FIELD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"("(?:signature|thought_signature)")\s*:\s*"[^"]*""#).unwrap());
+
+/// Strip base64 images and signature/thought_signature values from raw
+/// ClickHouse span content using regex
+pub fn strip_noise(raw: &str) -> String {
+    let without_images = BASE64_IMAGE_RE.replace_all(raw, "[base64 image omitted]");
+    SIGNATURE_FIELD_RE
+        .replace_all(&without_images, r#"$1:"[signature omitted]""#)
+        .into_owned()
+}
 
 /// Build the span input value from a ProviderRequest by combining contents
 /// with the system instruction (relabeled as role "system") prepended.
@@ -305,4 +321,69 @@ pub async fn emit_internal_span(queue: Arc<MessageQueue>, span: InternalSpan) ->
     }
 
     span_id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_noise_png_base64() {
+        let raw = r#"{{"text":"hello","random_key":"iVBORw0KGgoAAAANSUhEUgAAB4AAAAPhCAIAAACXJyV9AAAQAElEQVR4nOzdBUAU2x7H8WMQiohdYHd3XLs777W7sLtbr93Y3d3dnddALBRQMVFETEBs8B3Y-_Yuu7Dswg4Cfj-P5505zM7uzs7Msr9z9j_x_f3fCQAAAAAAAAAADGBhkdjwheMLAAAAAAAAAAAUQAANAAAAAAAAAFAEAT","next":"world"}}"#;
+        let result = strip_noise(&raw);
+        assert!(result.contains("[base64 image omitted]"));
+        assert!(!result.contains("iVBORw0KGgo"));
+        assert!(result.contains("hello"));
+        assert!(result.contains("world"));
+    }
+
+    #[test]
+    fn test_strip_noise_url_safe_base64() {
+        let raw = r#"{"data":"/9j/4AAQSkZJRgABAQ-_Yuu7Dswg4Cfj-P5505zM7uzs7Msr9z9j_x_f3fCQAAAAAAAAAADGBhkdjwheMLAAAAAAAAAAAUQAANAAAAAAAAAFAE"}"#;
+        let result = strip_noise(raw);
+        assert!(result.contains("[base64 image omitted]"));
+        assert!(!result.contains("Yuu7Dswg4Cfj"));
+    }
+
+    #[test]
+    fn test_strip_noise_raw_base64_with_trailing_url_safe_chars() {
+        let prefix = "/9j/".to_string();
+        let standard = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let url_safe_tail = "-_Yuu7Dswg4Cfj-P5505zM7uzs";
+        let raw = format!(r#"{{"img":"{}{}{}"}}"#, prefix, standard, url_safe_tail);
+        let result = strip_noise(&raw);
+        assert!(result.contains("[base64 image omitted]"));
+        assert!(!result.contains(url_safe_tail));
+    }
+
+    #[test]
+    fn test_strip_noise_signature_fields() {
+        let raw = r#"{"content":"hi","signature":"abc123longHashValue","thought_signature":"def456anotherHash"}"#;
+        let result = strip_noise(raw);
+        assert!(result.contains(r#""signature":"[signature omitted]""#));
+        assert!(result.contains(r#""thought_signature":"[signature omitted]""#));
+        assert!(result.contains("hi"));
+        assert!(!result.contains("abc123longHashValue"));
+        assert!(!result.contains("def456anotherHash"));
+    }
+
+    #[test]
+    fn test_strip_noise_no_false_positives() {
+        let raw = r#"{"message":"hello world","count":42}"#;
+        let result = strip_noise(raw);
+        assert_eq!(result, raw);
+    }
+
+    #[test]
+    fn test_strip_noise_multimodal_content() {
+        let long_b64 = "A".repeat(200);
+        let raw = format!(
+            r#"{{"text":"Current screenshot:"}},{{"inline_data":{{"data":"/9j/{}"}}}}"#,
+            long_b64
+        );
+        let result = strip_noise(&raw);
+        assert!(result.contains("[base64 image omitted]"));
+        assert!(result.contains("Current screenshot:"));
+        assert!(!result.contains(&long_b64));
+    }
 }

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -103,51 +103,54 @@ pub fn extract_batch_id_from_operation(operation_name: &str) -> Result<String> {
         .ok_or_else(|| anyhow::anyhow!("Invalid operation name format: {}", operation_name))
 }
 
-/// Replaces `<span>` XML tags with markdown URLs in a JSON value.
-/// Converts short span IDs (last 4 hex chars of UUID) to full UUIDs using span_ids_map.
+/// Replaces span references with markdown URLs in a JSON value.
+/// Handles both proper `<span>` XML tags and informal `span abc123` references.
 ///
-/// Format: `<span id='a1b2' name='openai.chat' reference_text='...' />`
-/// Becomes: `[openai.chat](https://www.laminar.sh/project/{project_id}/traces/{trace_id}?spanId={uuid})`
+/// Converts short span IDs (last 6 hex chars of UUID) to full UUIDs using span_ids_map.
 ///
-/// # Arguments
-/// * `attributes` - JSON value that may contain span tags in its string values
-/// * `span_ids_map` - Maps short IDs (4-char hex suffixes) to full span UUIDs
-/// * `project_id` - Project UUID
-/// * `trace_id` - Trace UUID
-///
-/// # Returns
-/// JSON value with span tags replaced by markdown links
+/// Formats handled:
+/// - `<span id='a1b2c3' name='openai.chat' />` → `[openai.chat](...?spanId=...)`
+/// - `span a1b2c3` or `(span a1b2c3)` → `[span a1b2c3](...?spanId=...)`
 pub fn replace_span_tags_with_links(
     attributes: Value,
     span_ids_map: &HashMap<String, Uuid>,
     project_id: Uuid,
     trace_id: Uuid,
 ) -> Result<Value> {
-    // Convert to JSON string
     let json_str = serde_json::to_string(&attributes)?;
 
-    // Pattern to match <span id='...' name='...' ... />
-    let pattern = Regex::new(r#"<span\s+id=['"]([^'"]+)['"]\s+name=['"]([^'"]+)['"][^>]*/?\s*>"#)?;
+    // 1. Replace proper <span id='...' name='...' /> XML tags
+    let xml_pattern =
+        Regex::new(r#"<span\s+id=['"]([^'"]+)['"]\s+name=['"]([^'"]+)['"][^>]*/?\s*>"#)?;
 
-    // Replace all span tags
-    let replaced_str = pattern.replace_all(&json_str, |caps: &regex::Captures| {
+    let after_xml = xml_pattern.replace_all(&json_str, |caps: &regex::Captures| {
         let short_id = &caps[1];
         let span_name = &caps[2];
-
-        // Look up the full UUID from the short ID
         let real_span_id = span_ids_map
             .get(short_id)
             .map(|uuid| uuid.to_string())
             .unwrap_or_else(|| short_id.to_string());
-
         format!(
             "[{}](https://www.laminar.sh/project/{}/traces/{}?spanId={})",
             span_name, project_id, trace_id, real_span_id
         )
     });
 
-    // Parse back to Value
-    let result: Value = serde_json::from_str(&replaced_str)?;
+    // 2. Replace informal "span <hex_id>" references (only for known span IDs)
+    let informal_pattern = Regex::new(r"\bspan\s+([0-9a-fA-F]{6})\b")?;
+
+    let after_informal = informal_pattern.replace_all(&after_xml, |caps: &regex::Captures| {
+        let short_id = caps[1].to_lowercase();
+        match span_ids_map.get(&short_id) {
+            Some(uuid) => format!(
+                "[span {}](https://www.laminar.sh/project/{}/traces/{}?spanId={})",
+                short_id, project_id, trace_id, uuid
+            ),
+            None => caps[0].to_string(),
+        }
+    });
+
+    let result: Value = serde_json::from_str(&after_informal)?;
     Ok(result)
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the signal identification toolchain and trace serialization format (new `search_in_spans`, different span truncation/omission semantics), which could affect signal extraction behavior and LLM/tool-call loops. Also alters internal observability spans to include tool metadata, impacting downstream consumers of span attributes.
> 
> **Overview**
> **Signal processing now supports a new tool, `search_in_spans`, to retrieve targeted snippets from truncated span input/output instead of fetching full spans.** The tool is exposed in tool definitions and prompts, executed in `response_processor`, and includes literal+optional-regex matching with bounded results.
> 
> **Trace data fed to the LLM is reformatted and re-scoped.** The trace “structure” output no longer uses YAML/skeleton views or `serde_yaml`; spans are emitted as a structured text list with explicit `input`/`output` strings, `<empty>/<omitted>` markers, and `input_truncated`/`output_truncated` flags, with base64 images and signature fields stripped via regex.
> 
> **Internal observability spans now capture tool definitions.** `InternalSpan` gains a `tools` field and both realtime and batch submission paths attach `ai.prompt.tools`; `process_run` is simplified by dropping unused parameters, and `get_full_spans` span-id parsing is hardened to accept malformed ID strings via regex extraction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 713797db5f25e071c6571a928f74ae2e7e5401ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->