### PR TITLE
feat: deep parse output, don't persist on db

### DIFF
--- a/frontend/lib/actions/spans/previews/index.ts
+++ b/frontend/lib/actions/spans/previews/index.ts
@@ -8,7 +8,13 @@ import { spanRenderingKeys } from "@/lib/db/migrations/schema";
 
 import { generatePreviewKeys } from "./prompts.ts";
 import { matchProviderKey } from "./provider-keys.ts";
-import { classifyPayload, generateFingerprint, validateMustacheKey } from "./utils.ts";
+import {
+  classifyPayload,
+  detectOutputStructure,
+  generateFingerprint,
+  type ProviderHint,
+  validateMustacheKey,
+} from "./utils.ts";
 
 export const GetSpanPreviewsSchema = TimeRangeSchema.omit({ pastHours: true }).extend({
   projectId: z.string(),
@@ -20,8 +26,6 @@ export const GetSpanPreviewsSchema = TimeRangeSchema.omit({ pastHours: true }).e
 export type SpanPreviewResult = Record<string, string | null>;
 
 export const PREVIEW_SPAN_TYPES = new Set(["LLM", "CACHED", "TOOL", "EXECUTOR", "EVALUATOR"]);
-
-export const PROVIDER_SPAN_TYPES = new Set(["LLM", "CACHED"]);
 
 /** Span types that go through the full preview generation pipeline (provider matching + LLM key generation). */
 const GENERATION_SPAN_TYPES = new Set(["LLM", "CACHED"]);
@@ -67,6 +71,7 @@ interface ParsedSpan {
   name: string;
   parsedData: Record<string, unknown> | unknown[];
   fingerprint: string;
+  provider: ProviderHint;
 }
 
 interface GetSpanPreviewsOptions {
@@ -75,11 +80,12 @@ interface GetSpanPreviewsOptions {
 
 const tryProviderMatch = (
   parsedData: Record<string, unknown> | unknown[],
-  spanType: string
+  spanType: string,
+  providerHint?: ProviderHint
 ): { rendered: string; key: string } | null => {
-  if (!PROVIDER_SPAN_TYPES.has(spanType)) return null;
+  if (!GENERATION_SPAN_TYPES.has(spanType)) return null;
 
-  const match = matchProviderKey(parsedData);
+  const match = matchProviderKey(parsedData, providerHint);
   if (!match) return null;
 
   const rendered = validateMustacheKey(match.key, match.data ?? parsedData);
@@ -95,13 +101,10 @@ const toJsonPreview = (data: unknown): string => JSON.stringify(data).slice(0, 2
  *
  * Only LLM/CACHED spans are candidates for the generation pipeline.
  * All other span types resolve immediately with their raw output.
- * When `skipGeneration` is true (e.g. shared traces), even LLM/CACHED spans
- * resolve immediately with a JSON preview.
  */
 const classifyRawSpans = (
   rawSpans: Array<{ spanId: string; data: string; name: string }>,
-  spanTypes: Record<string, string>,
-  skipGeneration: boolean
+  spanTypes: Record<string, string>
 ): { resolved: SpanPreviewResult; needsProcessing: ParsedSpan[] } => {
   const resolved: SpanPreviewResult = {};
   const needsProcessing: ParsedSpan[] = [];
@@ -109,7 +112,7 @@ const classifyRawSpans = (
   rawSpans.forEach((raw) => {
     const spanType = spanTypes[raw.spanId] ?? "";
 
-    if (!GENERATION_SPAN_TYPES.has(spanType) || skipGeneration) {
+    if (!GENERATION_SPAN_TYPES.has(spanType)) {
       const rawStr = typeof raw.data === "string" ? raw.data : JSON.stringify(raw.data);
       resolved[raw.spanId] = rawStr.length > 1000 ? rawStr.slice(0, 1000) : rawStr;
       return;
@@ -131,6 +134,7 @@ const classifyRawSpans = (
           name: raw.name,
           parsedData: classification.data,
           fingerprint: generateFingerprint(raw.name, classification.data),
+          provider: detectOutputStructure(classification.data),
         });
         return;
       }
@@ -178,8 +182,8 @@ const applyCachedKeys = async (
   parsedSpans.forEach((span) => {
     const cachedKey = fingerprintToKey.get(span.fingerprint);
     if (cachedKey) {
-      const isProviderType = PROVIDER_SPAN_TYPES.has(spanTypes[span.spanId] ?? "");
-      const match = isProviderType ? matchProviderKey(span.parsedData) : null;
+      const isProviderType = GENERATION_SPAN_TYPES.has(spanTypes[span.spanId] ?? "");
+      const match = isProviderType ? matchProviderKey(span.parsedData, span.provider) : null;
       const rendered = validateMustacheKey(cachedKey, match?.data ?? span.parsedData);
       if (rendered) {
         resolved[span.spanId] = rendered;
@@ -202,24 +206,21 @@ const applyProviderMatching = (
   spanTypes: Record<string, string>
 ): {
   resolved: SpanPreviewResult;
-  keysToSave: Array<{ fingerprint: string; key: string }>;
   needsLlm: ParsedSpan[];
 } => {
   const resolved: SpanPreviewResult = {};
-  const keysToSave: Array<{ fingerprint: string; key: string }> = [];
   const needsLlm: ParsedSpan[] = [];
 
   uncachedSpans.forEach((span) => {
-    const providerMatch = tryProviderMatch(span.parsedData, spanTypes[span.spanId] ?? "");
+    const providerMatch = tryProviderMatch(span.parsedData, spanTypes[span.spanId] ?? "", span.provider);
     if (providerMatch) {
       resolved[span.spanId] = providerMatch.rendered;
-      keysToSave.push({ fingerprint: span.fingerprint, key: providerMatch.key });
     } else {
       needsLlm.push(span);
     }
   });
 
-  return { resolved, keysToSave, needsLlm };
+  return { resolved, needsLlm };
 };
 
 const deduplicateByFingerprint = (
@@ -285,7 +286,6 @@ const generateAndApplyKeys = async (
       continue;
     }
 
-    // Only cache the key if it renders successfully for at least one span
     let keyProducedValidRender = false;
 
     for (const span of spans) {
@@ -344,9 +344,9 @@ export async function getSpanPreviews(
 
   const rawSpans = await fetchSpanData(projectId, traceId, spanIds, spanTypes, startDate, endDate);
 
-  const { resolved: classifiedPreviews, needsProcessing } = classifyRawSpans(rawSpans, spanTypes, skipGeneration);
+  const { resolved: classifiedPreviews, needsProcessing } = classifyRawSpans(rawSpans, spanTypes);
 
-  if (needsProcessing.length === 0 || skipGeneration) {
+  if (needsProcessing.length === 0) {
     return fillMissing(classifiedPreviews, spanIds);
   }
 
@@ -358,11 +358,21 @@ export async function getSpanPreviews(
     return fillMissing(cachedResult, spanIds);
   }
 
-  const { resolved: providerPreviews, keysToSave: providerKeys, needsLlm } = applyProviderMatching(uncached, spanTypes);
+  const { resolved: providerPreviews, needsLlm } = applyProviderMatching(uncached, spanTypes);
+
+  const providerResult = { ...cachedResult, ...providerPreviews };
+
+  if (skipGeneration || needsLlm.length === 0) {
+    // Shared traces: resolve remaining spans with JSON fallback, no LLM calls
+    for (const span of needsLlm) {
+      providerResult[span.spanId] = toJsonPreview(span.parsedData);
+    }
+    return fillMissing(providerResult, spanIds);
+  }
 
   const { resolved: llmPreviews, keysToSave: llmKeys } = await generateAndApplyKeys(needsLlm);
 
-  await saveRenderingKeys(projectId, [...providerKeys, ...llmKeys]);
+  await saveRenderingKeys(projectId, llmKeys);
 
-  return fillMissing({ ...cachedResult, ...providerPreviews, ...llmPreviews }, spanIds);
+  return fillMissing({ ...providerResult, ...llmPreviews }, spanIds);
 }

--- a/frontend/lib/actions/spans/previews/provider-keys.ts
+++ b/frontend/lib/actions/spans/previews/provider-keys.ts
@@ -1,3 +1,7 @@
+import { get, has, isPlainObject } from "lodash";
+
+import { type ProviderHint } from "./utils.ts";
+
 export type ProviderKeyMatch = {
   key: string;
   /** When set, use this instead of the original data for Mustache rendering. */
@@ -6,73 +10,59 @@ export type ProviderKeyMatch = {
 
 type Obj = Record<string, unknown>;
 
-const isObj = (val: unknown): val is Obj => val !== null && typeof val === "object" && !Array.isArray(val);
-
-const has = (obj: Obj, key: string): boolean => key in obj;
-
 const unwrapSingle = (data: unknown): unknown => (Array.isArray(data) && data.length === 1 ? data[0] : data);
 
-const nested = (obj: Obj, ...path: string[]): Obj | null => {
-  let cur: unknown = obj;
-  for (const key of path) {
-    if (!isObj(cur) || !has(cur, key)) return null;
-    cur = cur[key];
+const peekInner = (data: unknown, wrapperKey?: string): Obj | null => {
+  if (wrapperKey && isPlainObject(data)) {
+    const first = get(data, [wrapperKey, 0]);
+    return isPlainObject(first) ? (first as Obj) : null;
   }
-  return isObj(cur) ? cur : null;
+  const item = Array.isArray(data) ? data[0] : data;
+  return isPlainObject(item) ? (item as Obj) : null;
 };
 
-const firstItem = (obj: Obj, key: string): unknown | null => {
-  if (!has(obj, key) || !Array.isArray(obj[key])) return null;
-  const arr = obj[key] as unknown[];
-  return arr.length > 0 ? arr[0] : null;
+const hasOpenAIToolCalls = (choice: Obj): boolean => {
+  const tcs = get(choice, "message.tool_calls");
+  return Array.isArray(tcs) && tcs.some((tc) => isPlainObject(get(tc, "function")));
 };
 
-const hasOpenAIToolCalls = (obj: Obj): boolean => {
-  const msg = nested(obj, "message");
-  if (!msg || !Array.isArray(msg.tool_calls)) return false;
-  return (msg.tool_calls as unknown[]).some((tc) => isObj(tc) && isObj(tc.function as unknown));
+const hasMessageContent = (choice: Obj): boolean => {
+  const content = get(choice, "message.content");
+  return content === null || typeof content === "string";
 };
 
-const hasMessageContent = (obj: Obj): boolean => {
-  const msg = nested(obj, "message");
-  return msg !== null && has(msg, "content");
+const hasGeminiFunctionCall = (candidate: Obj): boolean => {
+  const parts = get(candidate, "content.parts");
+  return Array.isArray(parts) && parts.some((p) => isPlainObject(get(p, "function_call")));
 };
 
-const hasGeminiFunctionCall = (obj: Obj): boolean => {
-  const content = nested(obj, "content");
-  if (!content || !Array.isArray(content.parts)) return false;
-  return (content.parts as unknown[]).some(
-    (p) => isObj(p) && has(p, "function_call") && isObj(p.function_call as unknown)
-  );
-};
+const hasGeminiText = (candidate: Obj): boolean =>
+  !hasGeminiFunctionCall(candidate) && typeof get(candidate, "content.parts.0.text") === "string";
 
-const hasGeminiText = (obj: Obj): boolean => {
-  const content = nested(obj, "content");
-  if (!content || !Array.isArray(content.parts) || (content.parts as unknown[]).length === 0) return false;
-  return !hasGeminiFunctionCall(obj);
-};
-
-const hasAnthropicTextContent = (obj: Obj): boolean => {
-  if (!has(obj, "content")) return false;
-  const content = obj.content;
-  if (Array.isArray(content) && content.length > 0) {
-    const first = content[0];
-    return isObj(first) && first.type === "text" && has(first, "text");
-  }
-  return typeof content === "string" && has(obj, "role");
-};
-
-const isLangChainAssistant = (obj: Obj): boolean => {
-  const role = obj.role;
-  return (role === "assistant" || role === "ai") && has(obj, "content");
+const hasAnthropicTextContent = (msg: Obj): boolean => {
+  const content = msg.content;
+  if (Array.isArray(content)) return typeof get(content, "0.text") === "string" && get(content, "0.type") === "text";
+  return typeof content === "string" && has(msg, "role");
 };
 
 const hasMixedToolContent = (msg: Obj): boolean => {
-  if (!has(msg, "content") || !Array.isArray(msg.content)) return false;
-  return (msg.content as unknown[]).some(
-    (item) => isObj(item) && (item.type === "tool_call" || item.type === "tool_use")
+  const content = msg.content;
+  return (
+    Array.isArray(content) && content.some((i) => isPlainObject(i) && (i.type === "tool_call" || i.type === "tool_use"))
   );
 };
+
+const isLangChainAssistant = (msg: Obj): boolean => {
+  if (msg.role !== "assistant" && msg.role !== "ai") return false;
+  const content = msg.content;
+  if (typeof content === "string") return true;
+  if (Array.isArray(content)) return get(content, "0.type") === "text" && typeof get(content, "0.text") === "string";
+  return false;
+};
+
+// ---------------------------------------------------------------------------
+// Transform helpers — truncate tool-call arguments for compact display
+// ---------------------------------------------------------------------------
 
 const MAX_ARGS_LENGTH = 80;
 const truncate = (str: string, max: number): string => (str.length > max ? str.slice(0, max) + "…" : str);
@@ -81,10 +71,11 @@ const toStr = (val: unknown): string => truncate(typeof val === "string" ? val :
 const stringifyMixedArgs = (data: Obj): Obj => ({
   ...data,
   content: (data.content as unknown[]).map((item) => {
-    if (!isObj(item)) return item;
-    if (item.type === "tool_call" && has(item, "arguments")) return { ...item, arguments: toStr(item.arguments) };
-    if (item.type === "tool_use" && has(item, "input")) return { ...item, input: toStr(item.input) };
-    return item;
+    if (!isPlainObject(item)) return item;
+    const obj = item as Obj;
+    if (obj.type === "tool_call" && has(obj, "arguments")) return { ...obj, arguments: toStr(obj.arguments) };
+    if (obj.type === "tool_use" && has(obj, "input")) return { ...obj, input: toStr(obj.input) };
+    return obj;
   }),
 });
 
@@ -95,44 +86,35 @@ const stringifyOpenAIToolCalls = (choice: Obj): Obj => {
     message: {
       ...msg,
       tool_calls: (msg.tool_calls as unknown[]).map((tc) => {
-        if (!isObj(tc) || !isObj(tc.function as unknown)) return tc;
-        const fn = tc.function as Obj;
-        return { ...tc, function: { ...fn, arguments: toStr(fn.arguments) } };
+        const fn = get(tc, "function") as Obj | undefined;
+        if (!fn) return tc;
+        return { ...(tc as Obj), function: { ...fn, arguments: toStr(fn.arguments) } };
       }),
     },
   };
 };
 
-const stringifyGeminiToolCalls = (item: Obj): Obj => {
-  const content = item.content as Obj;
+const stringifyGeminiToolCalls = (candidate: Obj): Obj => {
+  const content = candidate.content as Obj;
   return {
-    ...item,
+    ...candidate,
     content: {
       ...content,
       parts: (content.parts as unknown[]).map((p) => {
-        if (!isObj(p) || !isObj(p.function_call as unknown)) return p;
-        const fc = p.function_call as Obj;
-        return { ...p, function_call: { ...fc, args: toStr(fc.args) } };
+        const fc = get(p, "function_call") as Obj | undefined;
+        if (!fc) return p;
+        return { ...(p as Obj), function_call: { ...fc, args: toStr(fc.args) } };
       }),
     },
   };
 };
 
 const mapItems = (data: unknown, fn: (obj: Obj) => Obj): unknown =>
-  Array.isArray(data) ? data.map((c) => (isObj(c) ? fn(c) : c)) : isObj(data) ? fn(data) : data;
-
-// ---------------------------------------------------------------------------
-// Helpers to peek at first inner item (bare obj, root array, or outer wrapper)
-// ---------------------------------------------------------------------------
-
-const peekInner = (data: unknown, wrapperKey?: string): Obj | null => {
-  if (wrapperKey && isObj(data) && has(data, wrapperKey)) {
-    const first = firstItem(data, wrapperKey);
-    return isObj(first) ? first : null;
-  }
-  const item = Array.isArray(data) ? data[0] : data;
-  return isObj(item) ? item : null;
-};
+  Array.isArray(data)
+    ? data.map((c) => (isPlainObject(c) ? fn(c as Obj) : c))
+    : isPlainObject(data)
+      ? fn(data as Obj)
+      : data;
 
 // ---------------------------------------------------------------------------
 // Mustache key templates
@@ -153,6 +135,7 @@ const MIXED_TOOL_USE_KEY =
 // ---------------------------------------------------------------------------
 
 interface ProviderPattern {
+  provider: ProviderHint;
   test: (data: unknown) => boolean;
   resolve: (data: unknown) => ProviderKeyMatch;
 }
@@ -160,14 +143,18 @@ interface ProviderPattern {
 const patterns: ProviderPattern[] = [
   // --- OpenAI tool calls ---
   {
+    provider: "openai",
     test: (data) => {
       const inner = peekInner(data, "choices") ?? peekInner(data);
       return inner !== null && hasOpenAIToolCalls(inner);
     },
     resolve: (data) => {
-      const transformed = mapItems(isObj(data) && has(data, "choices") ? data.choices : data, stringifyOpenAIToolCalls);
-      if (isObj(data) && has(data, "choices"))
-        return { key: `{{#choices}}${OAI_TC_INNER}{{/choices}}`, data: { ...data, choices: transformed } };
+      const transformed = mapItems(
+        isPlainObject(data) && has(data, "choices") ? (data as Obj).choices : data,
+        stringifyOpenAIToolCalls
+      );
+      if (isPlainObject(data) && has(data, "choices"))
+        return { key: `{{#choices}}${OAI_TC_INNER}{{/choices}}`, data: { ...(data as Obj), choices: transformed } };
       if (Array.isArray(data)) return { key: `{{#.}}${OAI_TC_INNER}{{/.}}`, data: transformed };
       return { key: OAI_TC_INNER, data: transformed };
     },
@@ -175,19 +162,20 @@ const patterns: ProviderPattern[] = [
 
   // --- Gemini tool calls ---
   {
+    provider: "gemini",
     test: (data) => {
       const inner = peekInner(data, "candidates") ?? peekInner(data);
       return inner !== null && hasGeminiFunctionCall(inner);
     },
     resolve: (data) => {
       const transformed = mapItems(
-        isObj(data) && has(data, "candidates") ? data.candidates : data,
+        isPlainObject(data) && has(data, "candidates") ? (data as Obj).candidates : data,
         stringifyGeminiToolCalls
       );
-      if (isObj(data) && has(data, "candidates"))
+      if (isPlainObject(data) && has(data, "candidates"))
         return {
           key: `{{#candidates.0.content.parts}}{{#function_call}}\n- \`{{{name}}}({{{args}}})\`{{/function_call}}{{/candidates.0.content.parts}}`,
-          data: { ...data, candidates: transformed },
+          data: { ...(data as Obj), candidates: transformed },
         };
       if (Array.isArray(data)) return { key: `{{#.}}${GEMINI_TC_INNER}{{/.}}`, data: transformed };
       return { key: GEMINI_TC_INNER, data: transformed };
@@ -196,12 +184,13 @@ const patterns: ProviderPattern[] = [
 
   // --- OpenAI/Azure text ---
   {
+    provider: "openai",
     test: (data) => {
       const inner = peekInner(data, "choices") ?? peekInner(data);
       return inner !== null && hasMessageContent(inner);
     },
     resolve: (data) => {
-      if (isObj(data) && has(data, "choices")) return { key: "{{choices.0.message.content}}" };
+      if (isPlainObject(data) && has(data, "choices")) return { key: "{{choices.0.message.content}}" };
       if (Array.isArray(data)) return { key: "{{#.}}{{message.content}}{{/.}}" };
       return { key: "{{message.content}}" };
     },
@@ -209,13 +198,14 @@ const patterns: ProviderPattern[] = [
 
   // --- Mixed content (text + tool_call / tool_use in content array) ---
   {
+    provider: "anthropic",
     test: (data) => {
       const msg = unwrapSingle(data);
-      return isObj(msg) && hasMixedToolContent(msg);
+      return isPlainObject(msg) && hasMixedToolContent(msg as Obj);
     },
     resolve: (data) => {
       const msg = unwrapSingle(data) as Obj;
-      const hasToolCall = (msg.content as unknown[]).some((i) => isObj(i) && i.type === "tool_call");
+      const hasToolCall = (msg.content as unknown[]).some((i) => isPlainObject(i) && (i as Obj).type === "tool_call");
       return {
         key: hasToolCall ? MIXED_TOOL_CALL_KEY : MIXED_TOOL_USE_KEY,
         data: stringifyMixedArgs(msg),
@@ -223,11 +213,12 @@ const patterns: ProviderPattern[] = [
     },
   },
 
-  // --- Anthropic ---
+  // --- Anthropic text ---
   {
+    provider: "anthropic",
     test: (data) => {
       const inner = Array.isArray(data) ? data[0] : data;
-      return isObj(inner) && hasAnthropicTextContent(inner);
+      return isPlainObject(inner) && hasAnthropicTextContent(inner as Obj);
     },
     resolve: (data) => {
       if (Array.isArray(data)) {
@@ -244,12 +235,13 @@ const patterns: ProviderPattern[] = [
 
   // --- Gemini text ---
   {
+    provider: "gemini",
     test: (data) => {
       const inner = peekInner(data, "candidates") ?? peekInner(data);
       return inner !== null && hasGeminiText(inner);
     },
     resolve: (data) => {
-      if (isObj(data) && has(data, "candidates")) return { key: "{{candidates.0.content.parts.0.text}}" };
+      if (isPlainObject(data) && has(data, "candidates")) return { key: "{{candidates.0.content.parts.0.text}}" };
       if (Array.isArray(data)) return { key: "{{#.}}{{content.parts.0.text}}{{/.}}" };
       return { key: "{{content.parts.0.text}}" };
     },
@@ -257,22 +249,31 @@ const patterns: ProviderPattern[] = [
 
   // --- LangChain ---
   {
+    provider: "langchain",
     test: (data) => {
       const inner = unwrapSingle(data);
-      return isObj(inner) && isLangChainAssistant(inner);
+      return isPlainObject(inner) && isLangChainAssistant(inner as Obj);
     },
     resolve: (data) => {
       const inner = unwrapSingle(data) as Obj;
       if (Array.isArray(inner.content)) {
         const first = (inner.content as unknown[])[0];
-        if (isObj(first) && first.type === "text") return { key: "{{content.0.text}}" };
+        if (isPlainObject(first) && (first as Obj).type === "text") return { key: "{{content.0.text}}" };
       }
       return { key: "{{content}}" };
     },
   },
 ];
 
-export const matchProviderKey = (data: unknown): ProviderKeyMatch | null => {
+export const matchProviderKey = (data: unknown, providerHint?: ProviderHint): ProviderKeyMatch | null => {
+  if (providerHint && providerHint !== "unknown") {
+    for (const pattern of patterns) {
+      if (pattern.provider === providerHint && pattern.test(data)) {
+        return pattern.resolve(data);
+      }
+    }
+  }
+
   for (const pattern of patterns) {
     if (pattern.test(data)) {
       return pattern.resolve(data);

--- a/frontend/lib/actions/spans/previews/utils.ts
+++ b/frontend/lib/actions/spans/previews/utils.ts
@@ -2,6 +2,10 @@ import { isEmpty, isNil, isPlainObject, isString, last, mapValues } from "lodash
 import Mustache from "mustache";
 
 import { deepParseJson } from "@/lib/actions/common/utils.ts";
+import { AnthropicOutputMessageSchema, AnthropicOutputMessagesSchema } from "@/lib/spans/types/anthropic";
+import { GeminiOutputSchema } from "@/lib/spans/types/gemini";
+import { LangChainAssistantMessageSchema, LangChainMessagesSchema } from "@/lib/spans/types/langchain";
+import { OpenAIOutputSchema } from "@/lib/spans/types/openai";
 
 export const deepParseValue = (value: unknown): unknown => {
   if (!isString(value)) return value;
@@ -40,6 +44,21 @@ export const classifyPayload = (raw: unknown): PayloadClassification => {
   }
 
   return { kind: "raw", preview: String(deepParsed) };
+};
+
+export type ProviderHint = "openai" | "anthropic" | "gemini" | "langchain" | "unknown";
+
+export const detectOutputStructure = (data: unknown): ProviderHint => {
+  if (OpenAIOutputSchema.safeParse(data).success) return "openai";
+  if (GeminiOutputSchema.safeParse(data).success) return "gemini";
+  if (AnthropicOutputMessageSchema.safeParse(data).success) return "anthropic";
+  if (AnthropicOutputMessagesSchema.safeParse(data).success) return "anthropic";
+
+  // LangChain has no dedicated output schema — check for assistant message(s)
+  if (LangChainAssistantMessageSchema.safeParse(data).success) return "langchain";
+  if (Array.isArray(data) && LangChainMessagesSchema.safeParse(data).success) return "langchain";
+
+  return "unknown";
 };
 
 const describeShape = (value: unknown): string => {
@@ -172,13 +191,5 @@ export const validateMustacheKey = (key: string, data: unknown): string | null =
     return rendered;
   } catch {
     return null;
-  }
-};
-
-export const renderMustachePreview = (key: string, data: unknown): string => {
-  try {
-    return unescapeHtml(Mustache.render(key, prepareRenderTarget(data)));
-  } catch {
-    return "";
   }
 };


### PR DESCRIPTION
- Don't save to db on successful parse
- Deep parse outputs to properly detect structure
- Properly parse formats

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span preview generation and caching/persistence behavior (including when LLM generation is skipped), which could alter displayed previews and reduce reuse of cached keys. Moderate risk due to updated provider-detection heuristics and DB write-path changes.
> 
> **Overview**
> Span preview generation now **deep-parses span outputs** and attaches a detected `ProviderHint` (OpenAI/Anthropic/Gemini/LangChain) to drive more accurate provider-specific mustache key matching.
> 
> Provider key matching was refactored to be more robust (using `lodash` helpers and optional provider-hinted pattern selection) and `skipGeneration` was changed to *still apply provider matching/cached keys* while skipping only the LLM key-generation step (falling back to JSON previews for remaining spans).
> 
> Rendering key persistence was tightened so only **LLM-generated keys** are saved; provider-derived matches are no longer written to `spanRenderingKeys`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d106a2602bd9a27c1832507813ecc434c0b9a058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->