### PR TITLE
feat: add trace to span search

### DIFF
--- a/frontend/components/traces/span-view/index.tsx
+++ b/frontend/components/traces/span-view/index.tsx
@@ -21,6 +21,7 @@ import { SpanViewSkeleton } from "./skeleton";
 interface SpanViewProps {
   spanId: string;
   traceId: string;
+  initialSearchTerm?: string;
 }
 
 const swrFetcher = async (url: string) => {
@@ -114,9 +115,9 @@ const SpanViewTabs = ({
   );
 };
 
-export function SpanView({ spanId, traceId }: SpanViewProps) {
+export function SpanView({ spanId, traceId, initialSearchTerm }: SpanViewProps) {
   const { projectId } = useParams();
-  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(!!initialSearchTerm);
   const {
     data: span,
     isLoading,
@@ -172,7 +173,7 @@ export function SpanView({ spanId, traceId }: SpanViewProps) {
 
   if (span) {
     return (
-      <SpanSearchProvider>
+      <SpanSearchProvider initialSearchTerm={initialSearchTerm}>
         <SpanControls span={span}>
           <SpanViewTabs span={span} searchRef={searchRef} searchOpen={searchOpen} setSearchOpen={setSearchOpen} />
         </SpanControls>

--- a/frontend/components/traces/span-view/search-bar.tsx
+++ b/frontend/components/traces/span-view/search-bar.tsx
@@ -16,7 +16,7 @@ interface SpanViewSearchBarProps {
 const SpanViewSearchBar = ({ open, setOpen, ref }: SpanViewSearchBarProps) => {
   const searchState = useSpanSearchState();
 
-  const [inputValue, setInputValue] = useState("");
+  const [inputValue, setInputValue] = useState(searchState?.searchTerm ?? "");
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const searchTerm = searchState?.searchTerm ?? "";

--- a/frontend/components/traces/span-view/span-search-context.tsx
+++ b/frontend/components/traces/span-view/span-search-context.tsx
@@ -112,10 +112,10 @@ function navigateToMatch(view: EditorView, searchTerm: string, localIndex: numbe
   });
 }
 
-export function SpanSearchProvider({ children }: PropsWithChildren) {
+export function SpanSearchProvider({ children, initialSearchTerm }: PropsWithChildren<{ initialSearchTerm?: string }>) {
   const editors = useRef<Map<string, EditorInstance>>(new Map());
-  const searchTermRef = useRef("");
-  const [searchTerm, setSearchTermState] = useState("");
+  const searchTermRef = useRef(initialSearchTerm ?? "");
+  const [searchTerm, setSearchTermState] = useState(initialSearchTerm ?? "");
   const [totalMatches, setTotalMatches] = useState(0);
   const [currentGlobalIndex, setCurrentGlobalIndex] = useState(0);
 

--- a/frontend/components/traces/trace-view/trace-view-content.tsx
+++ b/frontend/components/traces/trace-view/trace-view-content.tsx
@@ -1,6 +1,6 @@
 import { get, isNil } from "lodash";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { shallow } from "zustand/shallow";
 
 import Chat from "@/components/traces/trace-view/chat";
@@ -74,9 +74,7 @@ export default function TraceViewContent({
     isTraceLoading,
     setIsTraceLoading,
     setIsSpansLoading,
-    traceError,
     setTraceError,
-    spansError,
     setSpansError,
   } = useTraceViewStore(
     (state) => ({
@@ -90,9 +88,7 @@ export default function TraceViewContent({
       isSpansLoading: state.isSpansLoading,
       setIsSpansLoading: state.setIsSpansLoading,
       setIsTraceLoading: state.setIsTraceLoading,
-      traceError: state.traceError,
       setTraceError: state.setTraceError,
-      spansError: state.spansError,
       setSpansError: state.setSpansError,
     }),
     shallow
@@ -180,11 +176,14 @@ export default function TraceViewContent({
     [setSelectedSpan, searchParams, setSpanPath, router, pathName]
   );
 
+  const [traceSearchTerm, setTraceSearchTerm] = useState("");
+
   const fetchSpans = useCallback(
     async (search: string, filters: Filter[]) => {
       try {
         setIsSpansLoading(true);
         setSpansError(undefined);
+        setTraceSearchTerm(search);
 
         const params = new URLSearchParams();
         if (search) {
@@ -335,7 +334,12 @@ export default function TraceViewContent({
       ) : selectedSpan.spanType === SpanType.HUMAN_EVALUATOR ? (
         <HumanEvaluatorSpanView traceId={selectedSpan.traceId} spanId={selectedSpan.spanId} key={selectedSpan.spanId} />
       ) : (
-        <SpanView key={selectedSpan.spanId} spanId={selectedSpan.spanId} traceId={traceId} />
+        <SpanView
+          key={selectedSpan.spanId}
+          spanId={selectedSpan.spanId}
+          traceId={traceId}
+          initialSearchTerm={traceSearchTerm}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/state wiring change that pre-populates and auto-opens span search based on the trace-level search term; main risk is minor UX regressions (stale term, focus/visibility) rather than data or security impact.
> 
> **Overview**
> Adds support for carrying a trace-level `search` term into the span details panel, so opening a span can start with the same search context.
> 
> `TraceViewContent` now tracks the last spans query string and passes it to `SpanView` as `initialSearchTerm`, which initializes `SpanSearchProvider` and the search bar input and auto-expands the search UI when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab7466ea046586f15c73b237ee8fab1e3747d08f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->