### PR TITLE
fix: remove hardcoded height, fix poisoned state, form, add preset key

### DIFF
--- a/frontend/components/queue/annotation-interface.tsx
+++ b/frontend/components/queue/annotation-interface.tsx
@@ -28,12 +28,12 @@ interface FieldOption {
 const getFieldOptions = (field: any): FieldOption[] => {
   if (field.type === "number" && isNumberOptions(field.options)) {
     const options = field.options as { min?: number; max?: number };
-    return Array.from({ length: (options.max || 5) - (options.min || 1) + 1 }, (_, i) => {
-      const value = (options.min || 1) + i;
+    return Array.from({ length: (options.max ?? 5) - (options.min ?? 1) + 1 }, (_, i) => {
+      const value = (options.min ?? 1) + i;
       return {
         value,
         label: String(value),
-        keyNumber: i + 1,
+        keyNumber: value,
       };
     });
   }
@@ -132,9 +132,9 @@ const FieldOptions = ({
 
   if (field.type === "number" && isNumberOptions(field.options)) {
     const options = field.options as { min?: number; max?: number };
-    const min = options.min || 1;
-    const max = options.max || 5;
-    const currentValue = (target[field.key] as number) || min;
+    const min = options.min ?? 1;
+    const max = options.max ?? 5;
+    const currentValue = (target[field.key] as number) ?? min;
 
     return (
       <div className="space-y-3">
@@ -206,13 +206,16 @@ export default function AnnotationInterface({ className }: AnnotationInterfacePr
     focusField("first");
   });
 
-  useHotkeys("1,2,3,4,5,6,7,8,9", (event: KeyboardEvent) => {
+  useHotkeys("0,1,2,3,4,5,6,7,8,9", (event: KeyboardEvent) => {
     if (fields.length === 0) return;
     const focusedField = fields[focusedFieldIndex];
     if (focusedField?.type === "string") return;
 
     const num = parseInt(event.key);
-    if (num >= 1 && num <= 9) {
+    if (focusedField?.type === "number") {
+      event.preventDefault();
+      selectOptionInFocusedField(num);
+    } else if (num >= 1 && num <= 9) {
       event.preventDefault();
       selectOptionInFocusedField(num);
     }
@@ -225,9 +228,9 @@ export default function AnnotationInterface({ className }: AnnotationInterfacePr
 
     event.preventDefault();
     const options = focusedField.options as { min?: number; max?: number };
-    const min = options.min || 1;
-    const max = options.max || 5;
-    const currentValue = (target[focusedField.key] as number) || min;
+    const min = options.min ?? 1;
+    const max = options.max ?? 5;
+    const currentValue = (target[focusedField.key] as number) ?? min;
 
     if (event.key === "left" && currentValue > min) {
       updateTargetField(focusedField.key, currentValue - 1);
@@ -280,7 +283,7 @@ export default function AnnotationInterface({ className }: AnnotationInterfacePr
               <kbd className="bg-muted/50 px-1.5 py-0.5 rounded text-white/70">a</kbd> to focus on the first dimension
             </div>
             <div className="mb-1">
-              <strong>Keys 1-9:</strong> Select options within the focused dimension
+              <strong>Keys 0-9:</strong> Select options within the focused dimension
             </div>
             <div>
               <strong>Arrow keys:</strong> Adjust slider values

--- a/frontend/components/queue/queue-store.tsx
+++ b/frontend/components/queue/queue-store.tsx
@@ -251,9 +251,8 @@ const createQueueStore = (queue: LabelingQueue) =>
       const options = field.options;
       if (field.type === "number" && options && "min" in options) {
         const { min = 1, max = 5 } = options;
-        const targetValue = min - 1 + optionNumber;
-        if (targetValue >= min && targetValue <= max) {
-          updateTargetField(field.key, targetValue);
+        if (optionNumber >= min && optionNumber <= max) {
+          updateTargetField(field.key, optionNumber);
         }
       } else if (field.type === "enum" && Array.isArray(field.options)) {
         const optionIndex = optionNumber - 1;

--- a/frontend/components/queue/queue.tsx
+++ b/frontend/components/queue/queue.tsx
@@ -364,6 +364,7 @@ function QueueInner() {
               <div className="flex flex-1 min-h-fit overflow-hidden">
                 <ContentRenderer
                   codeEditorClassName="rounded-b"
+                  presetKey={`labeling-queue-payload-${storeQueue?.id}`}
                   className={cn("rounded", {
                     "border border-destructive/75": !isValid,
                   })}

--- a/frontend/components/ui/template-renderer/index.tsx
+++ b/frontend/components/ui/template-renderer/index.tsx
@@ -69,21 +69,18 @@ export default function TemplateRenderer({ data, presetKey = null }: TemplateRen
     swrFetcher
   );
 
-  const {
-    isDialogOpen,
-    isDeleteDialogOpen,
-    setIsDialogOpen,
-    setIsDeleteDialogOpen,
-    setPresetTemplate,
-    getPresetTemplate,
-  } = useTemplateRenderer();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [savedFormState, setSavedFormState] = useState<ManageTemplateForm | null>(null);
+
+  const { setPresetTemplate, getPresetTemplate } = useTemplateRenderer();
 
   const methods = useForm<ManageTemplateForm>({
     resolver: zodResolver(manageTemplateSchema),
     defaultValues: defaultTemplateValues,
   });
 
-  const { reset, control } = methods;
+  const { reset, control, getValues } = methods;
 
   const template = useWatch({
     control,
@@ -171,13 +168,26 @@ export default function TemplateRenderer({ data, presetKey = null }: TemplateRen
   };
 
   const handleEditTemplate = useCallback(() => {
+    setSavedFormState(getValues());
     setIsDialogOpen(true);
-  }, [setIsDialogOpen]);
+  }, [getValues]);
 
   const handleCreateTemplate = useCallback(() => {
+    setSavedFormState(getValues());
     reset({ ...defaultTemplateValues, testData: data });
     setIsDialogOpen(true);
-  }, [data, reset, setIsDialogOpen]);
+  }, [data, reset, getValues]);
+
+  const handleDialogOpenChange = useCallback(
+    (open: boolean) => {
+      setIsDialogOpen(open);
+      if (!open && savedFormState) {
+        reset(savedFormState);
+        setSavedFormState(null);
+      }
+    },
+    [savedFormState, reset]
+  );
 
   const currentTemplateCode = template?.code ?? defaultTemplateValues.code;
 
@@ -187,7 +197,7 @@ export default function TemplateRenderer({ data, presetKey = null }: TemplateRen
 
   return (
     <FormProvider {...methods}>
-      <div className="flex flex-col bg-background w-full group/renderer relative">
+      <div className="flex flex-col bg-background w-full h-full group/renderer relative">
         <div className="flex items-center gap-2 p-2 absolute top-2 right-0 z-30">
           <Select value={template?.id} onValueChange={handleTemplateSelect} onOpenChange={setIsSelectOpen}>
             <SelectTrigger
@@ -245,7 +255,7 @@ export default function TemplateRenderer({ data, presetKey = null }: TemplateRen
           <JsxRenderer className="rounded-none" code={currentTemplateCode} data={data} />
         </div>
 
-        <ManageTemplateDialog testData={data} open={isDialogOpen} onOpenChange={setIsDialogOpen} />
+        <ManageTemplateDialog testData={data} open={isDialogOpen} onOpenChange={handleDialogOpenChange} />
 
         {template && (
           <ConfirmDialog

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -37,6 +37,10 @@ const createIframeContent = (templateCode: string, data: any): string => {
       box-sizing: border-box; 
     }
     
+    html, body, #root {
+      height: 100%;
+    }
+    
     body { 
       margin: 0; 
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -60,7 +64,6 @@ const createIframeContent = (templateCode: string, data: any): string => {
         this.root = document.getElementById('root');
         this.data = ${serializedData};
         this.templateCode = \`${escapedTemplateCode}\`;
-        this.unobserve = null;
       }
       
       showError(message, details = '') {
@@ -89,13 +92,14 @@ const createIframeContent = (templateCode: string, data: any): string => {
           const tailwind = presetTailwind.default || presetTailwind;
           const autoprefix = presetAutoprefix.default || presetAutoprefix;
           const { install, observe } = core;
-          install({ presets: [tailwind(), autoprefix()] });
+          const tw = install({ presets: [tailwind(), autoprefix()] });
 
           return {
             preact: preactModule,
             preactHooks: preactHooksModule,
             babel: babelModule.default || babelModule,
-            twindObserve: observe
+            twindObserve: observe,
+            tw
           };
         } catch (error) {
           throw new Error(\`Failed to load dependencies: \${error.message}\`);
@@ -119,7 +123,7 @@ const createIframeContent = (templateCode: string, data: any): string => {
         }
       }
       
-      executeTemplate(compiledCode, preact, preactHooks, twindObserve) {
+      executeTemplate(compiledCode, preact, preactHooks, twindObserve, tw) {
         try {
           const { render, h, Fragment } = preact;
           const { useState, useEffect, useMemo, useRef, useCallback, useContext } = preactHooks;
@@ -148,12 +152,8 @@ const createIframeContent = (templateCode: string, data: any): string => {
           
           this.root.innerHTML = '';
           
-          // Start or refresh Twind DOM observer to process Tailwind classes
-          if (this.unobserve) {
-            try { this.unobserve(); } catch {}
-          }
           try {
-            this.unobserve = twindObserve(this.root);
+            twindObserve(tw, this.root);
           } catch {}
 
           render(element, this.root);
@@ -165,9 +165,9 @@ const createIframeContent = (templateCode: string, data: any): string => {
       
       async render() {
         try {
-          const { preact, preactHooks, babel, twindObserve } = await this.loadDependencies();
+          const { preact, preactHooks, babel, twindObserve, tw } = await this.loadDependencies();
           const compiledCode = this.compileTemplate(babel);
-          this.executeTemplate(compiledCode, preact, preactHooks, twindObserve);
+          this.executeTemplate(compiledCode, preact, preactHooks, twindObserve, tw);
           
         } catch (error) {
           this.showError(
@@ -237,18 +237,7 @@ const parseData = (data: any): any => {
   }
 };
 
-const JsxRenderer = ({
-  code,
-  data,
-  className,
-  // height according to message in span view
-  height = 372,
-}: {
-  code: string;
-  data: any;
-  className?: string;
-  height?: number;
-}) => {
+const JsxRenderer = ({ code, data, className }: { code: string; data: any; className?: string }) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
@@ -270,15 +259,10 @@ const JsxRenderer = ({
     <iframe
       ref={iframeRef}
       className={cn("w-full h-full border", className)}
-      style={{
-        contain: "layout style",
-        isolation: "isolate",
-        height,
-      }}
       sandbox="allow-scripts allow-same-origin"
       title="Template Preview"
       referrerPolicy="no-referrer"
-      loading="lazy"
+      loading="eager"
       aria-label="Template preview"
     />
   );

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -259,10 +259,14 @@ const JsxRenderer = ({ code, data, className }: { code: string; data: any; class
     <iframe
       ref={iframeRef}
       className={cn("w-full h-full border", className)}
+      style={{
+        contain: "layout style",
+        isolation: "isolate",
+      }}
       sandbox="allow-scripts allow-same-origin"
       title="Template Preview"
       referrerPolicy="no-referrer"
-      loading="eager"
+      loading="lazy"
       aria-label="Template preview"
     />
   );

--- a/frontend/components/ui/template-renderer/manage-template-dialog.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog.tsx
@@ -124,11 +124,11 @@ const ManageTemplateDialog = ({
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit(submit)} className="flex flex-col flex-1 overflow-hidden">
-          <div className="grid grid-cols-2 gap-4 p-4 flex-1 overflow-hidden">
-            <div className="min-h-0">
+          <div className="flex gap-4 p-4 flex-1 overflow-hidden">
+            <div className="min-h-0 flex-1 min-w-0">
               <JsxRenderer code={watch("code")} data={watch("testData")} />
             </div>
-            <div className="min-h-0 flex flex-col">
+            <div className="min-h-0 flex-1 min-w-0 flex flex-col">
               <div className="mb-4">
                 <Label htmlFor="template-name">Name</Label>
                 <Controller

--- a/frontend/components/ui/template-renderer/template-renderer-store.ts
+++ b/frontend/components/ui/template-renderer/template-renderer-store.ts
@@ -2,22 +2,16 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 export type TemplateRendererState = {
-  isDialogOpen: boolean;
-  isDeleteDialogOpen: boolean;
   presetTemplates: Record<string, string>; // presetKey -> templateId mapping
 };
 
 export type TemplateRendererActions = {
-  setIsDialogOpen: (open: boolean) => void;
-  setIsDeleteDialogOpen: (open: boolean) => void;
   setPresetTemplate: (presetKey: string, templateId: string) => void;
   getPresetTemplate: (presetKey: string) => string | undefined;
   reset: () => void;
 };
 
 const initialState: TemplateRendererState = {
-  isDialogOpen: false,
-  isDeleteDialogOpen: false,
   presetTemplates: {},
 };
 
@@ -27,10 +21,6 @@ export const useTemplateRenderer = create<TemplateRendererStore>()(
   persist(
     (set, get) => ({
       ...initialState,
-
-      setIsDialogOpen: (open) => set({ isDialogOpen: open }),
-
-      setIsDeleteDialogOpen: (open) => set({ isDeleteDialogOpen: open }),
 
       setPresetTemplate: (presetKey, templateId) =>
         set((state) => ({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: changes keyboard shortcut semantics for numeric annotation fields and adjusts template renderer lifecycle/state restoration, which could affect user interactions and persistence. Frontend-only with no direct backend/security impact.
> 
> **Overview**
> **Queue annotation UX:** Numeric field option handling now uses nullish coalescing defaults and aligns hotkey selection with actual numeric values (including `0` where applicable), updating both displayed key hints and `selectOptionInFocusedField` behavior.
> 
> **Queue editor persistence:** The target JSON `ContentRenderer` now receives a queue-specific `presetKey` to keep editor settings separated per queue.
> 
> **Template renderer stability/layout:** Dialog open/delete state is removed from the persisted zustand store (now local component state), with form state snapshotted/restored on dialog close to avoid “poisoned” form state. The JSX preview iframe removes a hardcoded height, ensures full-height layout via CSS, and updates Twind observation to use the installed instance directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89288e4dbc7eb7fe244814193221ec6fd37325ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->