### PR TITLE
feat: handle null payloads

### DIFF
--- a/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
@@ -22,7 +22,11 @@ interface SignalTabProps {
 
 function parsePayload(payload: string): Record<string, unknown> {
   try {
-    return JSON.parse(payload);
+    const result = JSON.parse(payload);
+    if (result == null || typeof result !== "object" || Array.isArray(result)) {
+      return {};
+    }
+    return result;
   } catch {
     return {};
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI robustness change: `parsePayload` now treats `null` or non-object JSON payloads as empty, avoiding runtime issues when rendering structured fields.
> 
> **Overview**
> Improves resilience of the trace Signal Events panel by hardening `parsePayload` to only accept JSON objects.
> 
> If an event payload parses to `null`, a primitive, or an array, it now falls back to `{}` (same as parse failures), preventing invalid payload shapes from propagating into field rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3e5b1f7100d2d7b37c1148bf72f1c879c1399ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->