### PR TITLE
feat: add support for vercel/mastra sdks

### DIFF
--- a/app-server/src/traces/provider/mod.rs
+++ b/app-server/src/traces/provider/mod.rs
@@ -29,5 +29,10 @@ fn is_ai_sdk_llm_span(span: &Span) -> bool {
                 .attributes
                 .raw_attributes
                 .get("ai.model.provider")
+                .is_some()
+            || span
+                .attributes
+                .raw_attributes
+                .get("aisdk.model.provider")
                 .is_some())
 }

--- a/app-server/src/traces/span_attributes.rs
+++ b/app-server/src/traces/span_attributes.rs
@@ -49,3 +49,7 @@ pub const OPENAI_RESPONSE_SERVICE_TIER: &str = "openai.response.service_tier";
 pub const OPENAI_REQUEST_SERVICE_TIER: &str = "openai.request.service_tier";
 pub const ANTHROPIC_RESPONSE_SERVICE_TIER: &str = "anthropic.response.service_tier";
 pub const ANTHROPIC_REQUEST_SERVICE_TIER: &str = "anthropic.request.service_tier";
+
+// Newer Vercel AI SDK / Mastra attributes
+pub const AISDK_MODEL_ID: &str = "aisdk.model.id";
+pub const AISDK_MODEL_PROVIDER: &str = "aisdk.model.provider";

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -9,6 +9,7 @@ use indexmap::IndexMap;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::{
@@ -32,13 +33,22 @@ use crate::{
 
 use super::{
     span_attributes::{
-        ASSOCIATION_PROPERTIES_PREFIX, GEN_AI_COMPLETION_TOKENS, GEN_AI_INPUT_COST,
-        GEN_AI_INPUT_TOKENS, GEN_AI_OUTPUT_COST, GEN_AI_OUTPUT_TOKENS, GEN_AI_PROMPT_TOKENS,
-        GEN_AI_REQUEST_MODEL, GEN_AI_RESPONSE_MODEL, GEN_AI_SYSTEM, GEN_AI_TOTAL_COST,
-        SPAN_IDS_PATH, SPAN_PATH, SPAN_TYPE,
+        AISDK_MODEL_ID, AISDK_MODEL_PROVIDER, ASSOCIATION_PROPERTIES_PREFIX,
+        GEN_AI_COMPLETION_TOKENS, GEN_AI_INPUT_COST, GEN_AI_INPUT_TOKENS, GEN_AI_OUTPUT_COST,
+        GEN_AI_OUTPUT_TOKENS, GEN_AI_PROMPT_TOKENS, GEN_AI_REQUEST_MODEL, GEN_AI_RESPONSE_MODEL,
+        GEN_AI_SYSTEM, GEN_AI_TOTAL_COST, SPAN_IDS_PATH, SPAN_PATH, SPAN_TYPE,
     },
     utils::skip_span_name,
 };
+
+/// Known operation prefixes used to namespace AI SDK span attributes.
+const AISDK_OPERATION_PREFIXES: &[&str] = &[
+    "stream",
+    "generateText",
+    "streamText",
+    "generateObject",
+    "streamObject",
+];
 
 const INPUT_ATTRIBUTE_NAME: &str = "lmnr.span.input";
 const OUTPUT_ATTRIBUTE_NAME: &str = "lmnr.span.output";
@@ -170,6 +180,94 @@ impl SpanAttributes {
             .and_then(|s| serde_json::from_value(s.clone()).ok())
     }
 
+    /// Normalize newer operation-prefixed attributes to standard `gen_ai.*` and `ai.*` keys so the existing extraction pipeline picks them up.
+    pub fn normalize_aisdk_attributes(&mut self) {
+        if let Some(model_id) = self.raw_attributes.get(AISDK_MODEL_ID).cloned() {
+            self.insert_if_absent(GEN_AI_REQUEST_MODEL, model_id.clone());
+            self.insert_if_absent("ai.model.id", model_id);
+        }
+
+        if let Some(provider) = self.raw_attributes.get(AISDK_MODEL_PROVIDER).cloned() {
+            self.insert_if_absent("ai.model.provider", provider.clone());
+            if !self.raw_attributes.contains_key(GEN_AI_SYSTEM) {
+                let normalized = match &provider {
+                    Value::String(s) => Value::String(
+                        s.split('.')
+                            .next()
+                            .unwrap_or(s)
+                            .to_lowercase()
+                            .trim()
+                            .to_string(),
+                    ),
+                    other => other.clone(),
+                };
+                self.raw_attributes
+                    .insert(GEN_AI_SYSTEM.to_string(), normalized);
+            }
+        }
+
+        let Some(prefix) = self.detect_aisdk_operation_prefix() else {
+            return;
+        };
+
+        // Usage attributes
+        self.normalize_if_absent(&format!("{prefix}.usage.inputTokens"), GEN_AI_INPUT_TOKENS);
+        self.normalize_if_absent(
+            &format!("{prefix}.usage.outputTokens"),
+            GEN_AI_OUTPUT_TOKENS,
+        );
+        self.normalize_if_absent(
+            &format!("{prefix}.usage.cachedInputTokens"),
+            GEN_AI_CACHE_READ_INPUT_TOKENS,
+        );
+
+        self.normalize_if_absent(&format!("{prefix}.prompt.messages"), "ai.prompt.messages");
+        self.normalize_if_absent(&format!("{prefix}.response.text"), "ai.response.text");
+        self.normalize_if_absent(
+            &format!("{prefix}.response.toolCalls"),
+            "ai.response.toolCalls",
+        );
+        self.normalize_if_absent(&format!("{prefix}.response.object"), "ai.response.object");
+    }
+
+    fn detect_aisdk_operation_prefix(&self) -> Option<&'static str> {
+        for prefix in AISDK_OPERATION_PREFIXES {
+            if self
+                .raw_attributes
+                .contains_key(&format!("{prefix}.usage.inputTokens"))
+                || self
+                    .raw_attributes
+                    .contains_key(&format!("{prefix}.usage.outputTokens"))
+                || self
+                    .raw_attributes
+                    .contains_key(&format!("{prefix}.prompt.messages"))
+                || self
+                    .raw_attributes
+                    .contains_key(&format!("{prefix}.response.text"))
+            {
+                return Some(prefix);
+            }
+        }
+        None
+    }
+
+    /// Copy a value from `source_key` to `target_key` if source exists and target does not.
+    fn normalize_if_absent(&mut self, source_key: &str, target_key: &str) {
+        if !self.raw_attributes.contains_key(target_key) {
+            if let Some(value) = self.raw_attributes.get(source_key).cloned() {
+                self.raw_attributes
+                    .insert(target_key.to_string(), value);
+            }
+        }
+    }
+
+    /// Insert a value only if the key does not already exist.
+    fn insert_if_absent(&mut self, key: &str, value: Value) {
+        if !self.raw_attributes.contains_key(key) {
+            self.raw_attributes.insert(key.to_string(), value);
+        }
+    }
+
     pub fn input_tokens(&mut self) -> InputTokens {
         let total_input_tokens =
             if let Some(Value::Number(n)) = self.raw_attributes.get(GEN_AI_INPUT_TOKENS) {
@@ -195,8 +293,19 @@ impl SpanAttributes {
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
 
-        let regular_input_tokens =
-            (total_input_tokens - (cache_write_tokens + cache_read_tokens)).max(0);
+        let cache_total = cache_write_tokens + cache_read_tokens;
+        if cache_total > total_input_tokens && total_input_tokens > 0 {
+            warn!(
+                total_input_tokens,
+                cache_write_tokens,
+                cache_read_tokens,
+                "Cache tokens ({}) exceed total input tokens ({}). Token breakdown may be inaccurate.",
+                cache_total,
+                total_input_tokens
+            );
+        }
+
+        let regular_input_tokens = (total_input_tokens - cache_total).max(0);
 
         InputTokens {
             regular_input_tokens,
@@ -307,10 +416,9 @@ impl SpanAttributes {
         } else {
             // quick hack until we figure how to set span type on auto-instrumentation
             if self.raw_attributes.contains_key(GEN_AI_SYSTEM)
-                || self
-                    .raw_attributes
-                    .iter()
-                    .any(|(k, _)| k.starts_with("gen_ai.") || k.starts_with("llm."))
+                || self.raw_attributes.iter().any(|(k, _)| {
+                    k.starts_with("gen_ai.") || k.starts_with("llm.") || k.starts_with("aisdk.")
+                })
             {
                 SpanType::LLM
             } else {
@@ -579,6 +687,13 @@ impl Span {
         // Get the raw attributes map for parsing
         if self.attributes.raw_attributes.is_empty() {
             return;
+        }
+
+        self.attributes.normalize_aisdk_attributes();
+
+        // Re-evaluate span type after normalization — gen_ai.system may now be present
+        if self.span_type == SpanType::Default {
+            self.span_type = self.attributes.span_type();
         }
 
         if self.is_llm_span() {
@@ -927,6 +1042,15 @@ pub fn should_keep_attribute(attribute: &str) -> bool {
     // AI SDK
     // remove ai.prompt.messages as it is stored in AI SDK span inputs
     if attribute == "ai.prompt.messages" || attribute == "ai.prompt" {
+        return false;
+    }
+
+    // Newer AI SDK operation-prefixed prompt attributes (normalized to ai.prompt.messages)
+    if attribute.ends_with(".prompt.messages")
+        && AISDK_OPERATION_PREFIXES
+            .iter()
+            .any(|p| attribute.starts_with(p))
+    {
         return false;
     }
 
@@ -3238,5 +3362,289 @@ mod tests {
             span.attributes.raw_attributes.get("llm.usage.total_tokens"),
             Some(&json!(105))
         );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_stream_attributes() {
+        // Simulates a span with newer AI SDK stream.* / aisdk.* attributes.
+        // Verifies that tokens, model, provider, and input/output are all extracted correctly.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("glm-4.5-flash")),
+            ("aisdk.model.provider".to_string(), json!("openai.chat")),
+            ("stream.usage.inputTokens".to_string(), json!(14)),
+            ("stream.usage.outputTokens".to_string(), json!(87)),
+            ("stream.usage.cachedInputTokens".to_string(), json!(12)),
+            (
+                "stream.prompt.messages".to_string(),
+                json!("[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}]"),
+            ),
+            (
+                "stream.response.text".to_string(),
+                json!("Hi there!"),
+            ),
+            (
+                "stream.response.toolCalls".to_string(),
+                json!("[]"),
+            ),
+        ]);
+
+        let mut span = Span {
+            span_id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            trace_id: Uuid::new_v4(),
+            parent_span_id: None,
+            name: "mastra.stream".to_string(),
+            attributes: SpanAttributes::new(attributes),
+            start_time: Utc::now(),
+            end_time: Utc::now(),
+            span_type: SpanType::Default,
+            input: None,
+            output: None,
+            events: vec![],
+            status: None,
+            tags: None,
+            input_url: None,
+            output_url: None,
+            size_bytes: 0,
+        };
+
+        span.parse_and_enrich_attributes();
+
+        // Span type should be re-evaluated to LLM after normalization
+        assert_eq!(span.span_type, SpanType::LLM);
+
+        // Token counts should be extracted via gen_ai.usage.* normalization
+        let input_tokens = span.attributes.input_tokens();
+        assert_eq!(input_tokens.total(), 14);
+        assert_eq!(input_tokens.cache_read_tokens, 12);
+        assert_eq!(input_tokens.regular_input_tokens, 2);
+        assert_eq!(span.attributes.output_tokens(), 87);
+
+        // Model from aisdk.model.id
+        assert_eq!(
+            span.attributes.request_model(),
+            Some("glm-4.5-flash".to_string())
+        );
+
+        // Provider from aisdk.model.provider, normalized
+        assert_eq!(
+            span.attributes.provider_name(&span.name),
+            Some("openai".to_string())
+        );
+
+        assert!(span.input.is_some(), "span input should be parsed");
+
+        assert!(span.output.is_some(), "span output should be parsed");
+
+        assert_eq!(
+            span.attributes
+                .raw_attributes
+                .get("stream.usage.inputTokens"),
+            Some(&json!(14))
+        );
+        assert_eq!(
+            span.attributes
+                .raw_attributes
+                .get("aisdk.model.provider"),
+            Some(&json!("openai.chat"))
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_generate_text_attributes() {
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("openai")),
+            ("generateText.usage.inputTokens".to_string(), json!(50)),
+            ("generateText.usage.outputTokens".to_string(), json!(100)),
+        ]);
+
+        let mut span = Span {
+            span_id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            trace_id: Uuid::new_v4(),
+            parent_span_id: None,
+            name: "ai.generateText".to_string(),
+            attributes: SpanAttributes::new(attributes),
+            start_time: Utc::now(),
+            end_time: Utc::now(),
+            span_type: SpanType::Default,
+            input: None,
+            output: None,
+            events: vec![],
+            status: None,
+            tags: None,
+            input_url: None,
+            output_url: None,
+            size_bytes: 0,
+        };
+
+        span.parse_and_enrich_attributes();
+
+        assert_eq!(span.span_type, SpanType::LLM);
+        assert_eq!(span.attributes.input_tokens().total(), 50);
+        assert_eq!(span.attributes.output_tokens(), 100);
+        assert_eq!(
+            span.attributes.request_model(),
+            Some("gpt-4o".to_string())
+        );
+        assert_eq!(
+            span.attributes.provider_name(&span.name),
+            Some("openai".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_does_not_overwrite_existing() {
+        // If standard gen_ai.* keys already exist, normalization should NOT overwrite them.
+        let attributes = HashMap::from([
+            ("gen_ai.usage.input_tokens".to_string(), json!(50)),
+            ("gen_ai.usage.output_tokens".to_string(), json!(200)),
+            ("gen_ai.request.model".to_string(), json!("existing-model")),
+            ("gen_ai.system".to_string(), json!("existing-provider")),
+            // These should be ignored since standard keys already exist
+            ("aisdk.model.id".to_string(), json!("overwrite-model")),
+            ("aisdk.model.provider".to_string(), json!("overwrite.provider")),
+            ("stream.usage.inputTokens".to_string(), json!(999)),
+            ("stream.usage.outputTokens".to_string(), json!(888)),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_INPUT_TOKENS),
+            Some(&json!(50))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_OUTPUT_TOKENS),
+            Some(&json!(200))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_REQUEST_MODEL),
+            Some(&json!("existing-model"))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_SYSTEM),
+            Some(&json!("existing-provider"))
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_no_op_without_aisdk_attributes() {
+        // Normalization should be a no-op for spans without any aisdk/stream attributes.
+        let attributes = HashMap::from([
+            ("gen_ai.system".to_string(), json!("openai")),
+            ("gen_ai.usage.input_tokens".to_string(), json!(10)),
+            ("gen_ai.usage.output_tokens".to_string(), json!(20)),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes.clone());
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(attrs.raw_attributes.len(), attributes.len());
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_INPUT_TOKENS),
+            Some(&json!(10))
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_provider_lowercased() {
+        // Provider should be lowercased and trimmed, even if the SDK sends mixed case.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("OpenAI.Chat")),
+            ("stream.usage.inputTokens".to_string(), json!(10)),
+            ("stream.usage.outputTokens".to_string(), json!(20)),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_SYSTEM),
+            Some(&json!("openai"))
+        );
+
+        assert_eq!(
+            attrs.raw_attributes.get("ai.model.provider"),
+            Some(&json!("OpenAI.Chat"))
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_stream_object_prefix() {
+        // Verify that streamObject prefix is also detected and normalized.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("openai")),
+            ("streamObject.usage.inputTokens".to_string(), json!(30)),
+            ("streamObject.usage.outputTokens".to_string(), json!(60)),
+            (
+                "streamObject.prompt.messages".to_string(),
+                json!("[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"extract data\"}]}]"),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_INPUT_TOKENS),
+            Some(&json!(30))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_OUTPUT_TOKENS),
+            Some(&json!(60))
+        );
+        assert!(attrs.raw_attributes.contains_key("ai.prompt.messages"));
+    }
+
+    #[test]
+    fn test_cache_tokens_exceed_total_clips_to_zero() {
+        // When cache tokens > total (inconsistent instrumentation), regular_input_tokens
+        // should clip to 0 rather than go negative.
+        let attributes = HashMap::from([
+            ("gen_ai.usage.input_tokens".to_string(), json!(100)),
+            (
+                "gen_ai.usage.cache_read_input_tokens".to_string(),
+                json!(150),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        let input_tokens = attrs.input_tokens();
+
+        assert_eq!(input_tokens.regular_input_tokens, 0);
+        assert_eq!(input_tokens.cache_read_tokens, 150);
+        assert_eq!(input_tokens.total(), 150);
+    }
+
+    #[test]
+    fn test_normalize_aisdk_only_model_no_prefix() {
+        // Span has aisdk.model.* but no operation-prefixed attributes.
+        // Model/provider should still be normalized.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("claude-3-opus")),
+            (
+                "aisdk.model.provider".to_string(),
+                json!("anthropic.messages"),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_REQUEST_MODEL),
+            Some(&json!("claude-3-opus"))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_SYSTEM),
+            Some(&json!("anthropic"))
+        );
+        assert!(!attrs.raw_attributes.contains_key(GEN_AI_INPUT_TOKENS));
+        assert!(!attrs.raw_attributes.contains_key(GEN_AI_OUTPUT_TOKENS));
     }
 }

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, LazyLock};
 use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::{Value, json};
-use tracing::instrument;
+use tracing::{instrument, warn};
 use uuid::Uuid;
 
 use crate::opentelemetry_proto::opentelemetry_proto_common_v1;
@@ -19,8 +19,9 @@ use crate::{
 
 use super::span_attributes::{
     ANTHROPIC_REQUEST_SERVICE_TIER, ANTHROPIC_RESPONSE_SERVICE_TIER, GEN_AI_REQUEST_BATCH,
-    GEN_AI_REQUEST_SERVICE_TIER, GEN_AI_RESPONSE_SERVICE_TIER, GEN_AI_USAGE_AUDIO_INPUT_TOKENS,
-    GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS, GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_1H_TOKENS,
+    GEN_AI_REQUEST_SERVICE_TIER, GEN_AI_RESPONSE_SERVICE_TIER, GEN_AI_SYSTEM,
+    GEN_AI_USAGE_AUDIO_INPUT_TOKENS, GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS,
+    GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_1H_TOKENS,
     GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_5M_TOKENS, GEN_AI_USAGE_REASONING_TOKENS,
     OPENAI_REQUEST_SERVICE_TIER, OPENAI_RESPONSE_SERVICE_TIER,
 };
@@ -98,7 +99,25 @@ pub async fn get_llm_usage_for_span(
             input_cost = cost_entry.input_cost;
             output_cost = cost_entry.output_cost;
             total_cost = input_cost + output_cost;
+        } else if total_tokens > 0 {
+            warn!(
+                span_name,
+                model,
+                provider = provider_name.as_deref().unwrap_or("unknown"),
+                "No pricing found for model. Cost will be reported as 0."
+            );
         }
+    } else if attributes.raw_attributes.contains_key(GEN_AI_SYSTEM) && total_tokens > 0 {
+        // Span has gen_ai.system but no model name.
+        warn!(
+            span_name,
+            provider = attributes
+                .raw_attributes
+                .get(GEN_AI_SYSTEM)
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown"),
+            "LLM span has tokens but no model name. Cost cannot be calculated."
+        );
     }
 
     SpanUsage {


### PR DESCRIPTION
Fixes: #838 
Add support for Vercel/ Mastra SDKs via normalisation of raw attributes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LLM span attribute normalization and span-type detection, which can change how usage/cost and inputs/outputs are extracted for incoming traces. Risk is moderate because it’s additive and guarded (no overwrites), but it affects core telemetry parsing paths.
> 
> **Overview**
> Adds support for newer Vercel AI SDK/Mastra telemetry by **normalizing `aisdk.*` and operation-prefixed keys** (e.g. `stream.*`, `generateText.*`) into the existing `gen_ai.*`/`ai.*` attributes during `Span::parse_and_enrich_attributes`, including model/provider, token usage, and prompt/response fields.
> 
> Updates LLM span classification to recognize `aisdk.*`, filters out operation-prefixed prompt attributes from persisted raw attributes, and adds warning logs for inconsistent token breakdowns (cache tokens > total) and for spans where token usage exists but pricing/model info is missing. Includes a comprehensive new test suite covering normalization behavior and non-overwrite guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b85baa87bca4e5a2375b62b2308dc7e24687d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->