### PR TITLE
fix: persist dataset id, dont re-render iframe

### DIFF
--- a/frontend/components/queue/queue-store.tsx
+++ b/frontend/components/queue/queue-store.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, type PropsWithChildren, useContext, useState } from "react";
 import { createStore, useStore } from "zustand";
+import { persist } from "zustand/middleware";
 
 import { type LabelingQueue, type LabelingQueueItem } from "@/lib/queue/types";
 
@@ -120,154 +121,161 @@ const getDefaultQueueItem = (queueId: string): QueueState["currentItem"] => ({
 });
 
 const createQueueStore = (queue: LabelingQueue) =>
-  createStore<QueueStore>()((set, get) => ({
-    queue,
-    currentItem: getDefaultQueueItem(queue.id),
-    isLoading: "first-load" as const,
-    isValid: true,
-    dataset: undefined,
+  createStore<QueueStore>()(
+    persist(
+      (set, get) => ({
+        queue,
+        currentItem: getDefaultQueueItem(queue.id),
+        isLoading: "first-load" as const,
+        isValid: true,
+        dataset: undefined,
 
-    globalTargetSelections: {},
-    annotationSchema: (queue.annotationSchema as Record<string, unknown>) || null,
-    fields: parseAnnotationSchema((queue.annotationSchema as Record<string, unknown>) || null),
-    focusedFieldIndex:
-      parseAnnotationSchema((queue.annotationSchema as Record<string, unknown>) || null).length > 0 ? 0 : -1,
+        globalTargetSelections: {},
+        annotationSchema: (queue.annotationSchema as Record<string, unknown>) || null,
+        fields: parseAnnotationSchema((queue.annotationSchema as Record<string, unknown>) || null),
+        focusedFieldIndex:
+          parseAnnotationSchema((queue.annotationSchema as Record<string, unknown>) || null).length > 0 ? 0 : -1,
 
-    setQueue: (queue) => set({ queue }),
+        setQueue: (queue) => set({ queue }),
 
-    setCurrentItem: (currentItem) => {
-      const { globalTargetSelections } = get();
-      if (currentItem) {
-        // Merge global selections with existing target data, prioritizing item-specific data
-        currentItem = {
-          ...currentItem,
-          payload: {
-            ...currentItem.payload,
-            target: {
-              ...globalTargetSelections,
-              ...currentItem.payload.target,
-            },
-          },
-        };
-      }
-      set({ currentItem });
-    },
-
-    setCurrentItemTarget: (target) => {
-      set((state) => {
-        if (!state.currentItem) return state;
-        return {
-          ...state,
-          currentItem: {
-            ...state.currentItem,
-            payload: {
-              ...state.currentItem.payload,
-              target,
-            },
-          },
-        };
-      });
-    },
-
-    clearGlobalSelections: () => {
-      set({ globalTargetSelections: {} });
-    },
-
-    setIsLoading: (isLoading) => set({ isLoading }),
-    setIsValid: (isValid) => set({ isValid }),
-    setDataset: (dataset) => set({ dataset }),
-
-    setAnnotationSchema: (annotationSchema: Record<string, unknown> | null) => {
-      const fields = parseAnnotationSchema(annotationSchema);
-      set({
-        annotationSchema,
-        fields,
-        focusedFieldIndex: fields.length > 0 ? 0 : -1,
-      });
-    },
-
-    getTarget: () => {
-      const { currentItem } = get();
-      return currentItem?.payload.target || {};
-    },
-
-    updateTargetField: (key, value) => {
-      set((state) => {
-        if (!state.currentItem) return state;
-
-        const newGlobalSelections = {
-          ...state.globalTargetSelections,
-          [key]: value,
-        };
-
-        return {
-          ...state,
-          globalTargetSelections: newGlobalSelections,
-          currentItem: {
-            ...state.currentItem,
-            payload: {
-              ...state.currentItem.payload,
-              target: {
-                ...state.currentItem.payload.target,
-                [key]: value,
+        setCurrentItem: (currentItem) => {
+          const { globalTargetSelections } = get();
+          if (currentItem) {
+            currentItem = {
+              ...currentItem,
+              payload: {
+                ...currentItem.payload,
+                target: {
+                  ...globalTargetSelections,
+                  ...currentItem.payload.target,
+                },
               },
-            },
-          },
-        };
-      });
-    },
+            };
+          }
+          set({ currentItem });
+        },
 
-    setFocusedField: (index) => {
-      const { fields } = get();
-      if (index >= 0 && index < fields.length) {
-        set({ focusedFieldIndex: index });
+        setCurrentItemTarget: (target) => {
+          set((state) => {
+            if (!state.currentItem) return state;
+            return {
+              ...state,
+              currentItem: {
+                ...state.currentItem,
+                payload: {
+                  ...state.currentItem.payload,
+                  target,
+                },
+              },
+            };
+          });
+        },
+
+        clearGlobalSelections: () => {
+          set({ globalTargetSelections: {} });
+        },
+
+        setIsLoading: (isLoading) => set({ isLoading }),
+        setIsValid: (isValid) => set({ isValid }),
+        setDataset: (dataset) => set({ dataset }),
+
+        setAnnotationSchema: (annotationSchema: Record<string, unknown> | null) => {
+          const fields = parseAnnotationSchema(annotationSchema);
+          set({
+            annotationSchema,
+            fields,
+            focusedFieldIndex: fields.length > 0 ? 0 : -1,
+          });
+        },
+
+        getTarget: () => {
+          const { currentItem } = get();
+          return currentItem?.payload.target || {};
+        },
+
+        updateTargetField: (key, value) => {
+          set((state) => {
+            if (!state.currentItem) return state;
+
+            const newGlobalSelections = {
+              ...state.globalTargetSelections,
+              [key]: value,
+            };
+
+            return {
+              ...state,
+              globalTargetSelections: newGlobalSelections,
+              currentItem: {
+                ...state.currentItem,
+                payload: {
+                  ...state.currentItem.payload,
+                  target: {
+                    ...state.currentItem.payload.target,
+                    [key]: value,
+                  },
+                },
+              },
+            };
+          });
+        },
+
+        setFocusedField: (index) => {
+          const { fields } = get();
+          if (index >= 0 && index < fields.length) {
+            set({ focusedFieldIndex: index });
+          }
+        },
+
+        focusField: (direction: "next" | "prev" | "first") => {
+          const { fields, focusedFieldIndex } = get();
+          if (fields.length === 0) return;
+
+          let newIndex: number;
+          switch (direction) {
+            case "next":
+              newIndex = (focusedFieldIndex + 1) % fields.length;
+              break;
+            case "prev":
+              newIndex = (focusedFieldIndex - 1 + fields.length) % fields.length;
+              break;
+            case "first":
+              newIndex = 0;
+              break;
+          }
+          set({ focusedFieldIndex: newIndex });
+        },
+
+        selectOptionInFocusedField: (optionNumber: number) => {
+          const { fields, focusedFieldIndex, updateTargetField } = get();
+          const field = fields[focusedFieldIndex];
+          if (!field) return;
+
+          const options = field.options;
+          if (field.type === "number" && options && "min" in options) {
+            const { min = 1, max = 5 } = options;
+            if (optionNumber >= min && optionNumber <= max) {
+              updateTargetField(field.key, optionNumber);
+            }
+          } else if (field.type === "enum" && Array.isArray(field.options)) {
+            const optionIndex = optionNumber - 1;
+            if (optionIndex >= 0 && optionIndex < field.options.length) {
+              updateTargetField(field.key, field.options[optionIndex]);
+            }
+          } else if (field.type === "boolean") {
+            if (optionNumber === 1) {
+              updateTargetField(field.key, false);
+            } else if (optionNumber === 2) {
+              updateTargetField(field.key, true);
+            }
+          }
+        },
+      }),
+      {
+        name: `queue-store-${queue.id}`,
+        partialize: (state) => ({ dataset: state.dataset }),
       }
-    },
-
-    focusField: (direction: "next" | "prev" | "first") => {
-      const { fields, focusedFieldIndex } = get();
-      if (fields.length === 0) return;
-
-      let newIndex: number;
-      switch (direction) {
-        case "next":
-          newIndex = (focusedFieldIndex + 1) % fields.length;
-          break;
-        case "prev":
-          newIndex = (focusedFieldIndex - 1 + fields.length) % fields.length;
-          break;
-        case "first":
-          newIndex = 0;
-          break;
-      }
-      set({ focusedFieldIndex: newIndex });
-    },
-
-    selectOptionInFocusedField: (optionNumber: number) => {
-      const { fields, focusedFieldIndex, updateTargetField } = get();
-      const field = fields[focusedFieldIndex];
-      if (!field) return;
-
-      const options = field.options;
-      if (field.type === "number" && options && "min" in options) {
-        const { min = 1, max = 5 } = options;
-        if (optionNumber >= min && optionNumber <= max) {
-          updateTargetField(field.key, optionNumber);
-        }
-      } else if (field.type === "enum" && Array.isArray(field.options)) {
-        const optionIndex = optionNumber - 1;
-        if (optionIndex >= 0 && optionIndex < field.options.length) {
-          updateTargetField(field.key, field.options[optionIndex]);
-        }
-      } else if (field.type === "boolean") {
-        if (optionNumber === 1) {
-          updateTargetField(field.key, false);
-        } else if (optionNumber === 2) {
-          updateTargetField(field.key, true);
-        }
-      }
-    },
-  }));
+    )
+  );
 
 type QueueStoreApi = ReturnType<typeof createQueueStore>;
 

--- a/frontend/components/ui/content-renderer/index.tsx
+++ b/frontend/components/ui/content-renderer/index.tsx
@@ -259,7 +259,7 @@ const PureContentRenderer = ({
         {renderHeaderContent()}
       </div>
       {mode === "custom" ? (
-        <div className="flex-1 flex bg-muted/50 overflow-auto w-full min-h-0">
+        <div className="flex-1 flex bg-muted/50 overflow-auto w-full min-h-0 border-t">
           <TemplateRenderer data={renderedValue} presetKey={presetKey} />
         </div>
       ) : mode === "messages" ? (

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -211,6 +211,7 @@ const JsxRenderer = ({ code, data, className }: { code: string; data: any; class
     iframeReadyRef.current = false;
 
     const handleReady = (event: MessageEvent) => {
+      if (event.source !== iframe.contentWindow) return;
       if (event.data?.type !== `${MESSAGE_TYPE}_READY`) return;
       iframeReadyRef.current = true;
 

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -102,9 +102,9 @@ const createIframeContent = (templateCode: string): string => {
         return result.code;
       }
       
-      renderWithData(data) {
-        const { preact, preactHooks, twindObserve, tw } = this.deps;
-        const { render, h, Fragment } = preact;
+      buildTemplateFn() {
+        const { preact, preactHooks } = this.deps;
+        const { h, Fragment } = preact;
         const { useState, useEffect, useMemo, useRef, useCallback, useContext } = preactHooks;
         
         const templateFunction = new Function(
@@ -116,7 +116,14 @@ const createIframeContent = (templateCode: string): string => {
           throw new Error('Template must be a function');
         }
         
-        const element = h(templateFunction, { data });
+        return templateFunction;
+      }
+
+      renderWithData(data) {
+        const { preact, twindObserve, tw } = this.deps;
+        const { render, h } = preact;
+        
+        const element = h(this.templateFn, { data });
         if (!element) {
           throw new Error('Template function must return a valid element');
         }
@@ -129,6 +136,7 @@ const createIframeContent = (templateCode: string): string => {
         try {
           this.deps = await this.loadDependencies();
           this.compiledCode = this.compileTemplate(this.deps.babel);
+          this.templateFn = this.buildTemplateFn();
           this.ready = true;
 
           window.addEventListener('message', (event) => {

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -2,14 +2,14 @@ import { useEffect, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 
-const createIframeContent = (templateCode: string, data: any): string => {
-  const serializedData = JSON.stringify(data);
-  // Escape characters that would break the template literal embedding
+const MESSAGE_TYPE = "__TEMPLATE_DATA_UPDATE__";
+
+const createIframeContent = (templateCode: string): string => {
   const escapedTemplateCode = templateCode
-    .replace(/\\/g, "\\\\") // preserve backslashes (so '\n' stays two chars)
-    .replace(/`/g, "\\`") // avoid closing the template literal
-    .replace(/\$/g, "\\$") // avoid accidental interpolation
-    .replace(/<\\\/script>/gi, "<\\\\/script>"); // prevent breaking out of the script tag
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\$/g, "\\$")
+    .replace(/<\\\/script>/gi, "<\\\\/script>");
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -32,15 +32,8 @@ const createIframeContent = (templateCode: string, data: any): string => {
   </script>
   
   <style>
-       
-    * { 
-      box-sizing: border-box; 
-    }
-    
-    html, body, #root {
-      height: 100%;
-    }
-    
+    * { box-sizing: border-box; }
+    html, body, #root { height: 100%; }
     body { 
       margin: 0; 
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -48,10 +41,7 @@ const createIframeContent = (templateCode: string, data: any): string => {
       background: #0A0A0A;
       color: #FAFAFA;
     }
-    
-    .error {
-      color: #CC3333;
-    }
+    .error { color: #CC3333; }
     .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
   </style>
 </head>
@@ -59,11 +49,15 @@ const createIframeContent = (templateCode: string, data: any): string => {
   <div id="root" />
   
   <script type="module">
+    const parentOrigin = window.origin;
+
     class TemplateRenderer {
       constructor() {
         this.root = document.getElementById('root');
-        this.data = ${serializedData};
         this.templateCode = \`${escapedTemplateCode}\`;
+        this.compiledCode = null;
+        this.deps = null;
+        this.ready = false;
       }
       
       showError(message, details = '') {
@@ -77,109 +71,88 @@ const createIframeContent = (templateCode: string, data: any): string => {
       }
       
       async loadDependencies() {
-        try {
-          const [preactModule, preactHooksModule, babelModule, twindCore, presetTailwind, presetAutoprefix] = await Promise.all([
-            import('preact'),
-            import('preact/hooks'),
-            import('@babel/standalone'),
-            import('@twind/core'),
-            import('@twind/preset-tailwind'),
-            import('@twind/preset-autoprefix')
-          ]);
-          
-          // Initialize Twind with Tailwind-compatible presets
-          const core = twindCore.default || twindCore;
-          const tailwind = presetTailwind.default || presetTailwind;
-          const autoprefix = presetAutoprefix.default || presetAutoprefix;
-          const { install, observe } = core;
-          const tw = install({ presets: [tailwind(), autoprefix()] });
+        const [preactModule, preactHooksModule, babelModule, twindCore, presetTailwind, presetAutoprefix] = await Promise.all([
+          import('preact'),
+          import('preact/hooks'),
+          import('@babel/standalone'),
+          import('@twind/core'),
+          import('@twind/preset-tailwind'),
+          import('@twind/preset-autoprefix')
+        ]);
+        
+        const core = twindCore.default || twindCore;
+        const tailwind = presetTailwind.default || presetTailwind;
+        const autoprefix = presetAutoprefix.default || presetAutoprefix;
+        const { install, observe } = core;
+        const tw = install({ presets: [tailwind(), autoprefix()] });
 
-          return {
-            preact: preactModule,
-            preactHooks: preactHooksModule,
-            babel: babelModule.default || babelModule,
-            twindObserve: observe,
-            tw
-          };
-        } catch (error) {
-          throw new Error(\`Failed to load dependencies: \${error.message}\`);
-        }
+        return {
+          preact: preactModule,
+          preactHooks: preactHooksModule,
+          babel: babelModule.default || babelModule,
+          twindObserve: observe,
+          tw
+        };
       }
       
       compileTemplate(babel) {
-        try {
-          const result = babel.transform(this.templateCode, {
-            presets: [
-              ['react', {
-                pragma: 'h',
-                pragmaFrag: 'Fragment'
-              }]
-            ]
-          });
-          
-          return result.code;
-        } catch (error) {
-          throw new Error(\`Template compilation failed: \${error.message}\`);
-        }
+        const result = babel.transform(this.templateCode, {
+          presets: [['react', { pragma: 'h', pragmaFrag: 'Fragment' }]]
+        });
+        return result.code;
       }
       
-      executeTemplate(compiledCode, preact, preactHooks, twindObserve, tw) {
+      renderWithData(data) {
+        const { preact, preactHooks, twindObserve, tw } = this.deps;
+        const { render, h, Fragment } = preact;
+        const { useState, useEffect, useMemo, useRef, useCallback, useContext } = preactHooks;
+        
+        const templateFunction = new Function(
+          'h', 'Fragment', 'useState', 'useEffect', 'useMemo', 'useRef', 'useCallback', 'useContext',
+          'return ' + this.compiledCode
+        )(h, Fragment, useState, useEffect, useMemo, useRef, useCallback, useContext);
+        
+        if (typeof templateFunction !== 'function') {
+          throw new Error('Template must be a function');
+        }
+        
+        const element = h(templateFunction, { data });
+        if (!element) {
+          throw new Error('Template function must return a valid element');
+        }
+        
+        try { twindObserve(tw, this.root); } catch {}
+        render(element, this.root);
+      }
+      
+      async init() {
         try {
-          const { render, h, Fragment } = preact;
-          const { useState, useEffect, useMemo, useRef, useCallback, useContext } = preactHooks;
-          
-          const templateFunction = new Function(
-            'h',
-            'Fragment',
-            'useState',
-            'useEffect',
-            'useMemo',
-            'useRef',
-            'useCallback',
-            'useContext',
-            'return ' + compiledCode
-          )(h, Fragment, useState, useEffect, useMemo, useRef, useCallback, useContext);
-          
-          if (typeof templateFunction !== 'function') {
-            throw new Error('Template must be a function');
-          }
-          
-          const element = h(templateFunction, { data: this.data });
-          
-          if (!element) {
-            throw new Error('Template function must return a valid element');
-          }
-          
-          this.root.innerHTML = '';
-          
-          try {
-            twindObserve(tw, this.root);
-          } catch {}
+          this.deps = await this.loadDependencies();
+          this.compiledCode = this.compileTemplate(this.deps.babel);
+          this.ready = true;
 
-          render(element, this.root);
-          
+          window.addEventListener('message', (event) => {
+            if (event.origin !== parentOrigin) return;
+            if (!event.data || event.data.type !== '${MESSAGE_TYPE}') return;
+
+            if (this.ready) {
+              try {
+                this.renderWithData(event.data.payload);
+              } catch (error) {
+                this.showError(error.message || 'Render error', error.stack);
+              }
+            }
+          });
+
+          window.parent.postMessage({ type: '${MESSAGE_TYPE}_READY' }, parentOrigin);
         } catch (error) {
-          throw new Error(\`Template execution failed: \${error.message}\`);
-        }
-      }
-      
-      async render() {
-        try {
-          const { preact, preactHooks, babel, twindObserve, tw } = await this.loadDependencies();
-          const compiledCode = this.compileTemplate(babel);
-          this.executeTemplate(compiledCode, preact, preactHooks, twindObserve, tw);
-          
-        } catch (error) {
-          this.showError(
-            error.message || 'Unknown error occurred',
-            error.stack
-          );
+          this.showError(error.message || 'Unknown error occurred', error.stack);
         }
       }
     }
     
     const renderer = new TemplateRenderer();
-    renderer.render();
+    renderer.init();
   </script>
 </body>
 </html>`;
@@ -191,19 +164,8 @@ const createErrorContent = (message: string): string => `
 <head>
   <meta charset="utf-8">
   <style>
-    body { 
-      margin: 0; 
-      padding: 1rem; 
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; 
-      background: #FAFAFA;
-    }
-    .error { 
-      color: #dc2626; 
-      background: #fef2f2; 
-      padding: 1rem; 
-      border-radius: 0.375rem; 
-      border: 1px solid #fecaca; 
-    }
+    body { margin: 0; padding: 1rem; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #FAFAFA; }
+    .error { color: #dc2626; background: #fef2f2; padding: 1rem; border-radius: 0.375rem; border: 1px solid #fecaca; }
   </style>
 </head>
 <body>
@@ -239,30 +201,54 @@ const parseData = (data: any): any => {
 
 const JsxRenderer = ({ code, data, className }: { code: string; data: any; className?: string }) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const pendingDataRef = useRef<any>(null);
+  const iframeReadyRef = useRef(false);
 
   useEffect(() => {
     const iframe = iframeRef.current;
     if (!iframe) return;
 
-    try {
-      const parsedData = parseData(data);
-      const normalizedCode = normalizeTemplateCode(code);
-      iframe.srcdoc = createIframeContent(normalizedCode, parsedData);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Failed to initialize template renderer";
+    iframeReadyRef.current = false;
 
-      iframe.srcdoc = createErrorContent(errorMessage);
+    const handleReady = (event: MessageEvent) => {
+      if (event.data?.type !== `${MESSAGE_TYPE}_READY`) return;
+      iframeReadyRef.current = true;
+
+      if (pendingDataRef.current !== null) {
+        iframe.contentWindow?.postMessage({ type: MESSAGE_TYPE, payload: pendingDataRef.current }, window.origin);
+      }
+    };
+
+    window.addEventListener("message", handleReady);
+
+    try {
+      iframe.srcdoc = createIframeContent(normalizeTemplateCode(code));
+    } catch (error) {
+      iframe.srcdoc = createErrorContent(
+        error instanceof Error ? error.message : "Failed to initialize template renderer"
+      );
     }
-  }, [code, data]);
+
+    return () => window.removeEventListener("message", handleReady);
+  }, [code]);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    const parsedData = parseData(data);
+    pendingDataRef.current = parsedData;
+
+    if (iframeReadyRef.current) {
+      iframe.contentWindow?.postMessage({ type: MESSAGE_TYPE, payload: parsedData }, window.origin);
+    }
+  }, [data]);
 
   return (
     <iframe
       ref={iframeRef}
-      className={cn("w-full h-full border", className)}
-      style={{
-        contain: "layout style",
-        isolation: "isolate",
-      }}
+      className={cn("w-full h-full", className)}
+      style={{ contain: "layout style", isolation: "isolate" }}
       sandbox="allow-scripts allow-same-origin"
       title="Template Preview"
       referrerPolicy="no-referrer"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches client-side state persistence and introduces a cross-window messaging flow for the template iframe; regressions could show up as stale dataset selection or missed/incorrect template updates.
> 
> **Overview**
> Persists `QueueStore.dataset` to storage using Zustand `persist`, keyed per queue (`queue-store-${queue.id}`) and saving only the dataset field.
> 
> Refactors the JSX `TemplateRenderer` iframe so it initializes once per `code` change and receives subsequent `data` updates via a READY handshake + `postMessage`, instead of regenerating `srcdoc` on every data change (plus minor styling tweaks like adding a top border in `ContentRenderer`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8276d720d0b01c1b755633534e1940a205e029c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->