### PR TITLE
add chat open url param to trace and span links in notifications

### DIFF
--- a/app-server/src/notifications/slack.rs
+++ b/app-server/src/notifications/slack.rs
@@ -93,8 +93,7 @@ pub fn decode_slack_token(
 
 /// Convert standard markdown links `[text](url)` to Slack mrkdwn `<url|text>`.
 fn md_links_to_slack(text: &str) -> String {
-    static RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap());
     RE.replace_all(text, "<$2|$1>").into_owned()
 }
 
@@ -105,7 +104,7 @@ fn format_event_identification_blocks(
     extracted_information: Option<serde_json::Value>,
 ) -> serde_json::Value {
     let trace_link = format!(
-        "https://laminar.sh/project/{}/traces/{}",
+        "https://laminar.sh/project/{}/traces/{}?chat=true",
         project_id, trace_id
     );
 
@@ -243,7 +242,7 @@ fn format_report_blocks(payload: &ReportPayload) -> serde_json::Value {
             text.push_str("\nNoteworthy Events:\n");
             for event in &project.noteworthy_events {
                 let entry = format!(
-                    "• `{}` – {} ({}) <https://laminar.sh/project/{}/traces/{}|View trace>\n",
+                    "• `{}` – {} ({}) <https://laminar.sh/project/{}/traces/{}?chat=true|View trace>\n",
                     event.signal_name,
                     event.summary,
                     event.timestamp,

--- a/app-server/src/reports/email_template.rs
+++ b/app-server/src/reports/email_template.rs
@@ -113,7 +113,7 @@ pub fn render_report_email(data: &ReportData) -> String {
                     r##"<div style="background:#f9fafb;border:1px solid #e5e7eb;border-radius:6px;padding:12px;margin-bottom:8px;">
   <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:4px;"><tr>
     <td style="font-size:12px;color:#6b7280;" align="left">{signal_name} &middot; {timestamp}</td>
-    <td style="font-size:12px;" align="right"><a href="https://lmnr.ai/project/{project_id}/traces/{trace_id}" style="color:{primary};text-decoration:none;">View trace &rarr;</a></td>
+    <td style="font-size:12px;" align="right"><a href="https://lmnr.ai/project/{project_id}/traces/{trace_id}?chat=true" style="color:{primary};text-decoration:none;">View trace &rarr;</a></td>
   </tr></table>{summary}
 </div>"##,
                     signal_name = html_escape(&event.signal_name),

--- a/app-server/src/signals/postprocess.rs
+++ b/app-server/src/signals/postprocess.rs
@@ -70,8 +70,10 @@ pub async fn process_event_notifications_and_clustering(
                 let Some(ref email) = target.email else {
                     continue;
                 };
-                let trace_link =
-                    format!("https://lmnr.ai/project/{}/traces/{}", project_id, trace_id);
+                let trace_link = format!(
+                    "https://lmnr.ai/project/{}/traces/{}?chat=true",
+                    project_id, trace_id
+                );
                 let subject = format!("Alert: {}", event_name);
                 let html = render_alert_email(&event_name, &attributes, &trace_link);
                 let payload = EmailPayload {

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -147,7 +147,7 @@ pub fn replace_span_tags_with_links(
             .map(|uuid| uuid.to_string())
             .unwrap_or_else(|| short_id.to_string());
         format!(
-            "[{}](https://www.laminar.sh/project/{}/traces/{}?spanId={})",
+            "[{}](https://www.laminar.sh/project/{}/traces/{}?spanId={}&chat=true)",
             span_name, project_id, trace_id, real_span_id
         )
     });
@@ -159,7 +159,7 @@ pub fn replace_span_tags_with_links(
         let short_id = caps[1].to_lowercase();
         match span_ids_map.get(&short_id) {
             Some(uuid) => format!(
-                "[span {}](https://www.laminar.sh/project/{}/traces/{}?spanId={})",
+                "[span {}](https://www.laminar.sh/project/{}/traces/{}?spanId={}&chat=true)",
                 short_id, project_id, trace_id, uuid
             ),
             None => caps[0].to_string(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only modifies notification/report URL formatting by appending a query parameter, with no changes to auth, data processing, or message payload structure beyond link strings.
> 
> **Overview**
> Updates Slack and email notification/report templates to append `?chat=true` to trace URLs (including Slack report “View trace” links and alert emails) so clicking a trace opens in chat mode.
> 
> Also updates `replace_span_tags_with_links` to include `chat=true` on generated `spanId` links, and makes a tiny formatting-only change to the Slack markdown-link regex definition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b60fa969a8a286a9a3a579f77b57436a416c5b6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->