### PR TITLE
fix group id uuid validation

### DIFF
--- a/frontend/lib/actions/evaluations/index.ts
+++ b/frontend/lib/actions/evaluations/index.ts
@@ -15,7 +15,7 @@ import { type Evaluation } from "@/lib/evaluation/types";
 
 export const GetEvaluationsSchema = PaginationFiltersSchema.extend({
   projectId: z.guid(),
-  groupId: z.guid().nullable().optional(),
+  groupId: z.string().nullable().optional(),
   search: z.string().nullable().optional(),
 });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk schema-only change that affects request validation for `getEvaluations`; main risk is allowing malformed `groupId` values to reach the DB filter and return empty results or surface errors if unexpected types are passed.
> 
> **Overview**
> Updates `GetEvaluationsSchema` in `frontend/lib/actions/evaluations/index.ts` to validate `groupId` as a nullable optional `string` instead of requiring a UUID.
> 
> This prevents `GET /projects/:projectId/evaluations` requests with non-UUID `groupId` query params from being rejected at the Zod validation layer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f70a5a6d88432058ef8073f7fecaf235b089a01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->