### PR TITLE
add an info comment about enabling events manually

### DIFF
--- a/frontend/app/api/webhook/stripe/route.ts
+++ b/frontend/app/api/webhook/stripe/route.ts
@@ -180,9 +180,8 @@ export async function POST(req: NextRequest): Promise<Response> {
     case "customer.subscription.updated":
       await handleSubscriptionChange(event);
       break;
+    // NOTE: if adding new events here, don't forget to enable them via Stripe Workbench
     default:
-      // Unexpected event type
-      // console.log(`Stripe Webhook. Unhandled event type ${event.type}.`);
       break;
   }
   return new Response("Webhook received.", { status: 200 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adds a code comment and removes dead commented-out logging in the webhook default case, with no runtime behavior change.
> 
> **Overview**
> Adds an inline note in `frontend/app/api/webhook/stripe/route.ts` reminding developers that when new Stripe webhook `event.type`s are handled, they must also be enabled manually via Stripe Workbench.
> 
> Also removes the previously commented-out “Unhandled event type” log from the `default` branch, keeping behavior unchanged (still no-op on unknown events).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fce3613b1d5576b7fb8e2677d8cd24e04c216a15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->