### PR TITLE
fix playground

### DIFF
--- a/frontend/components/playground/messages/reasoning-field.tsx
+++ b/frontend/components/playground/messages/reasoning-field.tsx
@@ -48,6 +48,32 @@ const ReasoningField = () => {
   if (anthropicThinkingModels.find((a) => a === model)) {
     const config = anthropicProviderOptionsSettings[model as (typeof anthropicThinkingModels)[number]].thinking;
 
+    if (config.type === "effort") {
+      return (
+        <div className="flex justify-between items-center">
+          <span className="text-sm font-medium">Effort</span>
+          <Controller
+            render={({ field: { value, onChange } }) => (
+              <Select value={value} onValueChange={onChange}>
+                <SelectTrigger className="w-fit">
+                  <SelectValue placeholder="Select effort" />
+                </SelectTrigger>
+                <SelectContent>
+                  {config.levels.map((level) => (
+                    <SelectItem key={level} value={level}>
+                      {capitalize(level)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            name="providerOptions.anthropic.effort"
+            control={control}
+          />
+        </div>
+      );
+    }
+
     return (
       <div className="flex flex-col gap-4">
         <Controller

--- a/frontend/components/playground/messages/reasoning-field.tsx
+++ b/frontend/components/playground/messages/reasoning-field.tsx
@@ -103,6 +103,45 @@ const ReasoningField = () => {
 
   if (googleThinkingModels.find((g) => g === model)) {
     const config = googleProviderOptionsSettings[model as (typeof googleThinkingModels)[number]].thinkingConfig;
+
+    if (config.type === "level") {
+      return (
+        <div className="flex flex-col gap-4">
+          <div className="flex justify-between items-center">
+            <span className="text-sm font-medium">Thinking Level</span>
+            <Controller
+              render={({ field: { value, onChange } }) => (
+                <Select value={value} onValueChange={onChange}>
+                  <SelectTrigger className="w-fit">
+                    <SelectValue placeholder="Select level" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {config.levels.map((level) => (
+                      <SelectItem key={level} value={level}>
+                        {capitalize(level)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+              name="providerOptions.google.thinkingConfig.thinkingLevel"
+              control={control}
+            />
+          </div>
+          <Controller
+            render={({ field: { onChange, value } }) => (
+              <div className="flex flex-col gap-2">
+                <span className="text-sm font-medium">Include Thoughts</span>
+                <Switch checked={value || undefined} onCheckedChange={onChange} />
+              </div>
+            )}
+            name="providerOptions.google.thinkingConfig.includeThoughts"
+            control={control}
+          />
+        </div>
+      );
+    }
+
     return (
       <div className="flex flex-col gap-4">
         <Controller

--- a/frontend/components/playground/messages/reasoning-field.tsx
+++ b/frontend/components/playground/messages/reasoning-field.tsx
@@ -77,26 +77,29 @@ const ReasoningField = () => {
     return (
       <div className="flex flex-col gap-4">
         <Controller
-          render={({ field: { value, onChange } }) => (
-            <>
-              <div className="flex justify-between">
-                <span className="text-sm font-medium">Thinking Tokens</span>
-                <Input
-                  onChange={(e) => onChange(Number(e.target.value))}
-                  value={Number(value)}
-                  type="number"
-                  className="text-sm font-medium w-16 text-right hide-arrow px-1 py-0 h-fit"
+          render={({ field: { value, onChange } }) => {
+            const tokens = value != null ? Number(value) : config.min;
+            return (
+              <>
+                <div className="flex justify-between">
+                  <span className="text-sm font-medium">Thinking Tokens</span>
+                  <Input
+                    onChange={(e) => onChange(Number(e.target.value))}
+                    value={tokens}
+                    type="number"
+                    className="text-sm font-medium w-16 text-right hide-arrow px-1 py-0 h-fit"
+                  />
+                </div>
+                <Slider
+                  value={[tokens]}
+                  min={config.min}
+                  max={watch("maxTokens")}
+                  step={1}
+                  onValueChange={(v) => onChange(v?.[0])}
                 />
-              </div>
-              <Slider
-                value={[Number(value)]}
-                min={config.min}
-                max={watch("maxTokens")}
-                step={1}
-                onValueChange={(v) => onChange(v?.[0])}
-              />
-            </>
-          )}
+              </>
+            );
+          }}
           name="providerOptions.anthropic.thinking.budgetTokens"
           control={control}
         />

--- a/frontend/components/playground/types.ts
+++ b/frontend/components/playground/types.ts
@@ -161,6 +161,16 @@ export const providers: { provider: Provider; models: LanguageModel[] }[] = [
         name: "claude-sonnet-4-5-20250929",
         label: "Claude 4.5 Sonnet",
       },
+      {
+        id: "anthropic:claude-sonnet-4-6",
+        name: "claude-sonnet-4-6",
+        label: "Claude 4.6 Sonnet",
+      },
+      {
+        id: "anthropic:claude-opus-4-6",
+        name: "claude-opus-4-6",
+        label: "Claude 4.6 Opus",
+      },
     ],
   },
   {

--- a/frontend/components/playground/utils.tsx
+++ b/frontend/components/playground/utils.tsx
@@ -81,8 +81,7 @@ export const getDefaultThinkingModelProviderOptions = <P extends Provider, K ext
         return {
           anthropic: {
             thinking: {
-              type: "enabled",
-              budgetTokens: anthropicConfig.min,
+              type: "disabled",
             },
           },
         };

--- a/frontend/components/playground/utils.tsx
+++ b/frontend/components/playground/utils.tsx
@@ -14,7 +14,7 @@ import {
   IconOpenAI,
 } from "@/components/ui/icons";
 import { EnvVars } from "@/lib/env/utils";
-import { anthropicThinkingModels } from "@/lib/playground/providers/anthropic";
+import { anthropicProviderOptionsSettings, anthropicThinkingModels } from "@/lib/playground/providers/anthropic";
 import { googleProviderOptionsSettings, googleThinkingModels } from "@/lib/playground/providers/google";
 import { openAIThinkingModels } from "@/lib/playground/providers/openai";
 import { type ProviderOptions } from "@/lib/playground/types";
@@ -67,15 +67,26 @@ export const getDefaultThinkingModelProviderOptions = <P extends Provider, K ext
     [...anthropicThinkingModels, ...googleThinkingModels, ...openAIThinkingModels].find((m) => m === (value as string))
   ) {
     switch (provider) {
-      case "anthropic":
+      case "anthropic": {
+        const anthropicConfig =
+          anthropicProviderOptionsSettings[value as (typeof anthropicThinkingModels)[number]].thinking;
+        if (anthropicConfig.type === "effort") {
+          return {
+            anthropic: {
+              thinking: { type: "adaptive" },
+              effort: "medium",
+            },
+          };
+        }
         return {
           anthropic: {
             thinking: {
-              type: "disabled",
-              budgetTokens: 1024,
+              type: "enabled",
+              budgetTokens: anthropicConfig.min,
             },
           },
         };
+      }
       case "gemini": {
         const config = googleProviderOptionsSettings[value as (typeof googleThinkingModels)[number]].thinkingConfig;
         if (config.type === "level") {

--- a/frontend/components/playground/utils.tsx
+++ b/frontend/components/playground/utils.tsx
@@ -78,11 +78,22 @@ export const getDefaultThinkingModelProviderOptions = <P extends Provider, K ext
         };
       case "gemini": {
         const config = googleProviderOptionsSettings[value as (typeof googleThinkingModels)[number]].thinkingConfig;
+        if (config.type === "level") {
+          const defaultLevel = config.levels.includes("medium") ? "medium" : config.levels[0];
+          return {
+            google: {
+              thinkingConfig: {
+                includeThoughts: false,
+                thinkingLevel: defaultLevel,
+              },
+            },
+          };
+        }
         return {
           google: {
             thinkingConfig: {
               includeThoughts: false,
-              thinkingBudget: config?.min,
+              thinkingBudget: config.min,
             },
           },
         };

--- a/frontend/lib/actions/chat/index.ts
+++ b/frontend/lib/actions/chat/index.ts
@@ -101,6 +101,15 @@ export async function generateChatResponse(
   const provider = model.split(":")[0] as Provider;
   const decodedKey = await getProviderApiKey(projectId, provider);
 
+  if (providerOptions?.google?.thinkingConfig) {
+    const tc = providerOptions.google.thinkingConfig as Record<string, unknown>;
+    if (tc.thinkingLevel != null) {
+      delete tc.thinkingBudget;
+    } else if (tc.thinkingBudget != null) {
+      delete tc.thinkingLevel;
+    }
+  }
+
   const startTime = new Date();
 
   let result: any;

--- a/frontend/lib/playground/providers/anthropic.ts
+++ b/frontend/lib/playground/providers/anthropic.ts
@@ -1,4 +1,16 @@
-import { type AnthropicProviderOptions } from "@ai-sdk/anthropic";
+type EffortLevel = "low" | "medium" | "high" | "max";
+
+export interface AnthropicBudgetConfig {
+  type: "budget";
+  min: number;
+}
+
+export interface AnthropicEffortConfig {
+  type: "effort";
+  levels: EffortLevel[];
+}
+
+export type AnthropicThinkingConfig = AnthropicBudgetConfig | AnthropicEffortConfig;
 
 export const anthropicThinkingModels = [
   "anthropic:claude-3-7-sonnet-20250219",
@@ -13,46 +25,30 @@ export const anthropicThinkingModels = [
 
 export const anthropicProviderOptionsSettings: Record<
   (typeof anthropicThinkingModels)[number],
-  Record<keyof Pick<AnthropicProviderOptions, "thinking">, { min: number }>
+  { thinking: AnthropicThinkingConfig }
 > = {
   "anthropic:claude-3-7-sonnet-20250219": {
-    thinking: {
-      min: 1024,
-    },
+    thinking: { type: "budget", min: 1024 },
   },
   "anthropic:claude-sonnet-4-20250514": {
-    thinking: {
-      min: 1024,
-    },
+    thinking: { type: "budget", min: 1024 },
   },
   "anthropic:claude-opus-4-20250514": {
-    thinking: {
-      min: 1024,
-    },
+    thinking: { type: "budget", min: 1024 },
   },
   "anthropic:claude-opus-4-1-20250805": {
-    thinking: {
-      min: 1024,
-    },
+    thinking: { type: "budget", min: 1024 },
   },
   "anthropic:claude-haiku-4-5-20251001": {
-    thinking: {
-      min: 1024,
-    },
+    thinking: { type: "budget", min: 1024 },
   },
   "anthropic:claude-sonnet-4-5-20250929": {
-    thinking: {
-      min: 1024,
-    },
+    thinking: { type: "budget", min: 1024 },
   },
   "anthropic:claude-sonnet-4-6": {
-    thinking: {
-      min: 1024,
-    },
+    thinking: { type: "effort", levels: ["low", "medium", "high"] },
   },
   "anthropic:claude-opus-4-6": {
-    thinking: {
-      min: 1024,
-    },
+    thinking: { type: "effort", levels: ["low", "medium", "high", "max"] },
   },
 };

--- a/frontend/lib/playground/providers/anthropic.ts
+++ b/frontend/lib/playground/providers/anthropic.ts
@@ -4,6 +4,11 @@ export const anthropicThinkingModels = [
   "anthropic:claude-3-7-sonnet-20250219",
   "anthropic:claude-sonnet-4-20250514",
   "anthropic:claude-opus-4-20250514",
+  "anthropic:claude-opus-4-1-20250805",
+  "anthropic:claude-haiku-4-5-20251001",
+  "anthropic:claude-sonnet-4-5-20250929",
+  "anthropic:claude-sonnet-4-6",
+  "anthropic:claude-opus-4-6",
 ] as const;
 
 export const anthropicProviderOptionsSettings: Record<
@@ -21,6 +26,31 @@ export const anthropicProviderOptionsSettings: Record<
     },
   },
   "anthropic:claude-opus-4-20250514": {
+    thinking: {
+      min: 1024,
+    },
+  },
+  "anthropic:claude-opus-4-1-20250805": {
+    thinking: {
+      min: 1024,
+    },
+  },
+  "anthropic:claude-haiku-4-5-20251001": {
+    thinking: {
+      min: 1024,
+    },
+  },
+  "anthropic:claude-sonnet-4-5-20250929": {
+    thinking: {
+      min: 1024,
+    },
+  },
+  "anthropic:claude-sonnet-4-6": {
+    thinking: {
+      min: 1024,
+    },
+  },
+  "anthropic:claude-opus-4-6": {
     thinking: {
       min: 1024,
     },

--- a/frontend/lib/playground/providers/google.ts
+++ b/frontend/lib/playground/providers/google.ts
@@ -1,5 +1,20 @@
 import { type GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
 
+type ThinkingLevel = NonNullable<NonNullable<GoogleGenerativeAIProviderOptions["thinkingConfig"]>["thinkingLevel"]>;
+
+export interface GoogleBudgetConfig {
+  type: "budget";
+  min: number;
+  max: number;
+}
+
+export interface GoogleLevelConfig {
+  type: "level";
+  levels: ThinkingLevel[];
+}
+
+export type GoogleThinkingConfig = GoogleBudgetConfig | GoogleLevelConfig;
+
 export const googleThinkingModels = [
   "gemini:gemini-2.5-pro",
   "gemini:gemini-2.5-flash",
@@ -12,49 +27,51 @@ export const googleThinkingModels = [
 
 export const googleProviderOptionsSettings: Record<
   (typeof googleThinkingModels)[number],
-  Record<keyof Pick<GoogleGenerativeAIProviderOptions, "thinkingConfig">, { min: number; max: number }>
+  { thinkingConfig: GoogleThinkingConfig }
 > = {
   "gemini:gemini-2.5-pro": {
     thinkingConfig: {
+      type: "budget",
       min: 128,
       max: 32768,
     },
   },
   "gemini:gemini-2.5-flash": {
     thinkingConfig: {
+      type: "budget",
       min: 0,
       max: 24576,
     },
   },
   "gemini:gemini-2.5-flash-lite": {
     thinkingConfig: {
+      type: "budget",
       min: 512,
       max: 24576,
     },
   },
   "gemini:gemini-3-flash-preview": {
     thinkingConfig: {
-      min: 0,
-      max: 24576,
+      type: "level",
+      levels: ["minimal", "low", "medium", "high"],
     },
   },
   "gemini:gemini-3-pro-preview": {
     thinkingConfig: {
-      min: 1024,
-      max: 24576,
+      type: "level",
+      levels: ["low", "high"],
     },
   },
   "gemini:gemini-3.1-pro-preview": {
     thinkingConfig: {
-      min: 1024,
-      max: 24576,
+      type: "level",
+      levels: ["low", "medium", "high"],
     },
   },
-
   "gemini:gemini-3.1-flash-lite-preview": {
     thinkingConfig: {
-      min: 512,
-      max: 24576,
+      type: "level",
+      levels: ["minimal", "low", "medium", "high"],
     },
   },
 };

--- a/frontend/lib/playground/types.ts
+++ b/frontend/lib/playground/types.ts
@@ -85,7 +85,11 @@ export type OpenAIProviderOptions = {
 };
 
 export type ProviderOptions =
-  | { anthropic: AnthropicProviderOptions }
+  | {
+      anthropic: AnthropicProviderOptions & {
+        effort?: "low" | "medium" | "high" | "max";
+      };
+    }
   | OpenAIProviderOptions
   | { google: GoogleGenerativeAIProviderOptions }
   | Record<string, never>;

--- a/frontend/lib/playground/types.ts
+++ b/frontend/lib/playground/types.ts
@@ -21,6 +21,7 @@ export interface ImagePart {
 export interface TextPart {
   type: "text";
   text: string;
+  providerOptions?: Record<string, Record<string, unknown>>;
 }
 
 export interface ToolResultPart {
@@ -69,6 +70,7 @@ export interface ToolCallPart {
   toolCallId: string;
   toolName: string;
   input: unknown;
+  providerOptions?: Record<string, Record<string, unknown>>;
 }
 
 export interface Message {

--- a/frontend/lib/playground/types.ts
+++ b/frontend/lib/playground/types.ts
@@ -86,7 +86,8 @@ export type OpenAIProviderOptions = {
 
 export type ProviderOptions =
   | {
-      anthropic: AnthropicProviderOptions & {
+      anthropic: Omit<AnthropicProviderOptions, "thinking"> & {
+        thinking?: { type: "enabled"; budgetTokens?: number } | { type: "disabled" } | { type: "adaptive" };
         effort?: "low" | "medium" | "high" | "max";
       };
     }

--- a/frontend/lib/playground/utils.ts
+++ b/frontend/lib/playground/utils.ts
@@ -1,4 +1,4 @@
-import { type ModelMessage, type SystemModelMessage } from "ai";
+import { type ModelMessage, type SystemModelMessage, type ToolModelMessage } from "ai";
 
 import { type Message } from "@/lib/playground/types";
 
@@ -6,12 +6,23 @@ import { tryParseJson } from "../utils";
 
 export const parseSystemMessages = (messages: Message[]): ModelMessage[] =>
   messages.map((message) => {
-    // Handle system messages with text content
     if (message.role === "system" && message.content?.[0]?.type === "text") {
       return {
         role: message.role,
         content: message.content[0].text,
       } as SystemModelMessage;
+    }
+
+    if (
+      message.role === "user" &&
+      Array.isArray(message.content) &&
+      message.content.length > 0 &&
+      message.content.every((part) => part.type === "tool-result")
+    ) {
+      return {
+        role: "tool",
+        content: message.content,
+      } as unknown as ToolModelMessage;
     }
 
     return message as ModelMessage;

--- a/frontend/lib/spans/types/gemini.ts
+++ b/frontend/lib/spans/types/gemini.ts
@@ -182,8 +182,13 @@ export const convertGeminiToPlaygroundMessages = async (
       // Gemini parts use field-presence discrimination (no "type" key).
       // Unrecognised variants are skipped.
       for (const part of message.parts) {
+        const thoughtSig =
+          "thoughtSignature" in part && part.thoughtSignature
+            ? { google: { thoughtSignature: part.thoughtSignature } }
+            : undefined;
+
         if ("text" in part) {
-          content.push({ type: "text", text: part.text });
+          content.push({ type: "text", text: part.text, ...(thoughtSig && { providerOptions: thoughtSig }) });
         } else if ("inlineData" in part) {
           if (part.inlineData.mimeType.startsWith("image/")) {
             let imageData = part.inlineData.data;
@@ -224,6 +229,7 @@ export const convertGeminiToPlaygroundMessages = async (
             toolCallId: part.functionCall.id ?? part.functionCall.name,
             toolName: part.functionCall.name,
             input: { type: "json", value: JSON.stringify(part.functionCall.args ?? {}) },
+            ...(thoughtSig && { providerOptions: thoughtSig }),
           });
         } else if ("functionResponse" in part) {
           content.push({

--- a/frontend/lib/spans/types/gemini.ts
+++ b/frontend/lib/spans/types/gemini.ts
@@ -228,7 +228,7 @@ export const convertGeminiToPlaygroundMessages = async (
             type: "tool-call",
             toolCallId: part.functionCall.id ?? part.functionCall.name,
             toolName: part.functionCall.name,
-            input: { type: "json", value: JSON.stringify(part.functionCall.args ?? {}) },
+            input: part.functionCall.args ?? {},
             ...(thoughtSig && { providerOptions: thoughtSig }),
           });
         } else if ("functionResponse" in part) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^3.0.17",
-    "@ai-sdk/anthropic": "^2.0.13",
+    "@ai-sdk/anthropic": "^2.0.71",
     "@ai-sdk/azure": "^2.0.26",
     "@ai-sdk/google": "^2.0.64",
     "@ai-sdk/groq": "^2.0.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "@ai-sdk/amazon-bedrock": "^3.0.17",
     "@ai-sdk/anthropic": "^2.0.13",
     "@ai-sdk/azure": "^2.0.26",
-    "@ai-sdk/google": "^2.0.24",
+    "@ai-sdk/google": "^2.0.64",
     "@ai-sdk/groq": "^2.0.17",
     "@ai-sdk/mistral": "^2.0.13",
     "@ai-sdk/openai": "^2.0.23",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.0.26
         version: 2.0.28(zod@4.3.6)
       '@ai-sdk/google':
-        specifier: ^2.0.24
-        version: 2.0.24(zod@4.3.6)
+        specifier: ^2.0.64
+        version: 2.0.64(zod@4.3.6)
       '@ai-sdk/groq':
         specifier: ^2.0.17
         version: 2.0.18(zod@4.3.6)
@@ -489,8 +489,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@2.0.24':
-    resolution: {integrity: sha512-GUNj1fo+q/JHDB2d1zIEULPt/EvwhGs8MIDo7PEEsuMcNyFwXzc80IUlTvFRUNy0tiZ6kBRw40dRU/hJRx5zQg==}
+  '@ai-sdk/google@2.0.64':
+    resolution: {integrity: sha512-FUVSkdpC+j2o3anRHabJ5UXXPfnqs8uRkv5zh5x4u8p1e7C4y+YtTxeTD2aSSMGV+8ef+VNEAp5gponXpwKk0g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -525,6 +525,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@3.0.22':
+    resolution: {integrity: sha512-fFT1KfUUKktfAFm5mClJhS1oux9tP2qgzmEZVl5UdwltQ1LO/s8hd7znVrgKzivwv1s1FIPza0s9OpJaNB/vHw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@3.0.8':
     resolution: {integrity: sha512-cDj1iigu7MW2tgAQeBzOiLhjHOUM9vENsgh4oAVitek0d//WdgfPCsKO3euP7m7LyO/j9a1vr/So+BGNdpFXYw==}
     engines: {node: '>=18'}
@@ -533,6 +539,10 @@ packages:
 
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@2.0.1':
+    resolution: {integrity: sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@2.0.117':
@@ -1483,183 +1493,155 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1881,35 +1863,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.95':
     resolution: {integrity: sha512-PXy0UT1J/8MPG8UAkWp6Fd51ZtIZINFzIjGH909JjQrtCuJf3X6nanHYdz1A+Wq9o4aoPAw1YEUpFS1lelsVlg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.95':
     resolution: {integrity: sha512-2IzCkW2RHRdcgF9W5/plHvYFpc6uikyjMb5SxjqmNxfyDFz9/HB89yhi8YQo0SNqrGRI7yBVDec7Pt+uMyRWsg==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.95':
     resolution: {integrity: sha512-OV/ol/OtcUr4qDhQg8G7SdViZX8XyQeKpPsVv/j3+7U178FGoU4M+yIocdVo1ih/A8GQ63+LjF4jDoEjaVU8Pw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.95':
     resolution: {integrity: sha512-Z5KzqBK/XzPz5+SFHKz7yKqClEQ8pOiEDdgk5SlphBLVNb8JFIJkxhtJKSvnJyHh2rjVgiFmvtJzMF0gNwwKyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.95':
     resolution: {integrity: sha512-aj0YbRpe8qVJ4OzMsK7NfNQePgcf9zkGFzNZ9mSuaxXzhpLHmlF2GivNdCdNOg8WzA/NxV6IU4c5XkXadUMLeA==}
@@ -1950,28 +1927,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.0':
     resolution: {integrity: sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.0':
     resolution: {integrity: sha512-FmbDcZQ8yJRq93EJSL6xaE0KK/Rslraf8fj1uViGxg7K4CKBCRYSubILJPEhjSgZurpcPQq12QNOJQ0DRJl6Hg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.0':
     resolution: {integrity: sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.0':
     resolution: {integrity: sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA==}
@@ -3306,79 +3279,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -3818,6 +3778,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -3862,28 +3825,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.15':
     resolution: {integrity: sha512-AbvmEiteEj1nf42nE8skdHv73NoR+EwXVSgPY6l39X12Ex8pzOwwfi3Kc8GAmjsnsaDEbk+aj9NyL3UeyHcTLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.15':
     resolution: {integrity: sha512-+rzMVlvVgrXtFiS+ES78yWgKqpThgV19ISKD58Ck+YO5pO5KjyxLt7AWKsWMbY0R9yBDC82w6QVGz837AKQcHg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.15':
     resolution: {integrity: sha512-fPdEy7a8eQN9qOIK3Em9D3TO1z41JScJn8yxl/76mp4sAXFDfV4YXxsiptJcOwy6bGR+70ZSwFIZhTXzQeqwQg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.15':
     resolution: {integrity: sha512-sJ4yd6iXXdlgIMfIBXuVGp/NvmviEoMVWMOAGxtxhzLPp9LOj5k0pMEMZdjeMCl4C6Up+RM8T3Zgk+BMQ0bGcQ==}
@@ -5510,28 +5469,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -7128,10 +7083,10 @@ snapshots:
       '@vercel/oidc': 3.0.5
       zod: 4.3.6
 
-  '@ai-sdk/google@2.0.24(zod@4.3.6)':
+  '@ai-sdk/google@2.0.64(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.13(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.22(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/groq@2.0.18(zod@4.3.6)':
@@ -7166,6 +7121,13 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@3.0.22(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@3.0.8(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -7174,6 +7136,10 @@ snapshots:
       zod: 4.3.6
 
   '@ai-sdk/provider@2.0.0':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@2.0.1':
     dependencies:
       json-schema: 0.4.0
 
@@ -10873,6 +10839,8 @@ snapshots:
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.0.17
         version: 3.0.19(zod@4.3.6)
       '@ai-sdk/anthropic':
-        specifier: ^2.0.13
-        version: 2.0.38(zod@4.3.6)
+        specifier: ^2.0.71
+        version: 2.0.71(zod@4.3.6)
       '@ai-sdk/azure':
         specifier: ^2.0.26
         version: 2.0.28(zod@4.3.6)
@@ -465,8 +465,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
-  '@ai-sdk/anthropic@2.0.38':
-    resolution: {integrity: sha512-NjU1ftHbu90OfRCgBwfFelmdEXwGFwLEcfyOyyfjRDm8QHaJUlPNnXhdhPTYuUU386yhj29Vibemiaq6jQv3lA==}
+  '@ai-sdk/anthropic@2.0.71':
+    resolution: {integrity: sha512-JXTtAwlyxGzzRtpiAXk/O93aOTgdfoVX28EoUuRNVqZRgtkoniLQTtqeb8uZ4oXljNJlXzaJLNasS/U90w/wjw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -7056,10 +7056,10 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.8(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/anthropic@2.0.38(zod@4.3.6)':
+  '@ai-sdk/anthropic@2.0.71(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.13(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.22(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/azure@2.0.28(zod@4.3.6)':


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches playground generation parameters and provider option shaping (including mutating `providerOptions` before calling the AI SDK), which can affect runtime behavior across models but is scoped to thinking/reasoning configuration.
> 
> **Overview**
> Updates the Playground to handle **provider-specific “thinking” configurations** that vary by model.
> 
> For **Anthropic**, model settings now discriminate between token-budget vs effort-based thinking; the UI renders either a budget slider/input or an effort level selector, defaults are generated accordingly, and new Claude 4.6 models are added.
> 
> For **Gemini**, thinking settings now support either budget-based or level-based configs; the UI and default provider options adapt to each mode, and chat generation normalizes `thinkingConfig` by ensuring only one of `thinkingLevel` or `thinkingBudget` is sent.
> 
> Separately, Gemini span-to-playground conversion now preserves `thoughtSignature` into per-part `providerOptions` and stops wrapping tool-call args as JSON strings, and `@ai-sdk/anthropic`/`@ai-sdk/google` dependencies are bumped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecca09154e1a92a44a40a983dff1b2452e2d7e01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->