### PR TITLE
limit spans query to the last 7 days when moving spans table

### DIFF
--- a/frontend/lib/clickhouse/migrations/33_spans_new_order_with_projection.sql
+++ b/frontend/lib/clickhouse/migrations/33_spans_new_order_with_projection.sql
@@ -132,8 +132,9 @@ INSERT INTO spans_v2 (
     trace_type,
     tags_array,
     events
-FROM spans;
+FROM spans
+WHERE start_time >= now() - interval '7 days';
 
 RENAME TABLE spans TO old_spans;
 RENAME TABLE spans_v2 TO spans;
-DROP TABLE IF EXISTS old_spans;
+-- DROP TABLE IF EXISTS old_spans;

--- a/frontend/lib/clickhouse/migrations/README.md
+++ b/frontend/lib/clickhouse/migrations/README.md
@@ -1,0 +1,21 @@
+# Clickhouse migrations
+
+Files in this folder execute using a community [package](https://www.npmjs.com/package/clickhouse-migrations) for clickhouse migrations.
+
+Files execute in numeric order for all files ending with .sql in this directory (not nested).
+
+`orig/` contains the contents of `1_squashed.sql` from the previous implementation.
+
+## Warnings
+
+- Migration 33 only moves 1 week's worth of data for the sake of execution speed. Users wishing to move more data are advised to manually move the rest of the data.
+
+## Troubleshooting
+
+If you get a blocking error from clickhouse migration saying that migration files must not be altered / removed after apply, you can use `clickhouse_client` and execute the following query:
+
+```sql
+ALTER TABLE _migrations DELETE WHERE version >= {offending_version_from_warning:UInt32};
+```
+
+This query is not recommended outside development environments and we take steps to prevent this from happening for regular users, not developers of Laminar. Take extra care with this query, as reapplying the same migration may cause unwanted side effects.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes a schema/data migration to copy only the last 7 days of `spans` into the new table and stops auto-dropping the old table, which can leave historical data unmigrated and requires manual cleanup.
> 
> **Overview**
> Migration `33_spans_new_order_with_projection.sql` now **only backfills spans from the last 7 days** when creating and swapping in the new `spans` table, instead of copying all historical rows.
> 
> It also **preserves the pre-migration table** by commenting out `DROP TABLE old_spans`, and adds a new `migrations/README.md` documenting execution order, the 7-day limitation for migration 33, and how to reset `_migrations` entries in development.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 483775f77421e879bf5aafb73c32995487b67fc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->