### PR TITLE
feat: search improvements

### DIFF
--- a/frontend/components/common/advanced-search/components/search-input.tsx
+++ b/frontend/components/common/advanced-search/components/search-input.tsx
@@ -2,7 +2,7 @@
 
 import { Search, X } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import React, { type ChangeEvent, type FocusEvent, type KeyboardEvent, memo, useCallback } from "react";
+import React, { type ChangeEvent, type FocusEvent, type KeyboardEvent, memo, useCallback, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { getSuggestionAtIndex, getSuggestionsCount } from "@/components/common/advanced-search/utils.ts";
@@ -61,6 +61,8 @@ const FilterSearchInput = ({
     submit,
     clearAll,
     setTags,
+    undo,
+    redo,
   } = useAdvancedSearchContext((state) => ({
     setInputValue: state.setInputValue,
     setIsOpen: state.setIsOpen,
@@ -75,10 +77,13 @@ const FilterSearchInput = ({
     submit: state.submit,
     clearAll: state.clearAll,
     setTags: state.setTags,
+    undo: state.undo,
+    redo: state.redo,
   }));
 
   const { mainInputRef } = useAdvancedSearchRefsContext();
   const { navigateToTag, registerTagHandle } = useAdvancedSearchNavigation();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleInputChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -89,6 +94,16 @@ const FilterSearchInput = ({
       setIsOpen(true);
     },
     [setInputValue, setIsOpen, selectedTagIds.size, removeSelectedTags, router, pathname, searchParams]
+  );
+
+  const handleInputFocus = useCallback(
+    (e: FocusEvent<HTMLInputElement>) => {
+      const cameFromInside = containerRef.current?.contains(e.relatedTarget as Node);
+      if (!cameFromInside) {
+        setIsOpen(true);
+      }
+    },
+    [setIsOpen]
   );
 
   const handleInputBlur = useCallback(() => {
@@ -131,6 +146,22 @@ const FilterSearchInput = ({
       const input = mainInputRef.current;
       const count = getSuggestionsCount(filters, inputValue, autocompleteData);
       const showRecent = !inputValue.trim() && tags.length === 0 && recentSearches.length > 0;
+
+      if ((e.metaKey || e.ctrlKey) && e.key === "z") {
+        e.preventDefault();
+        if (e.shiftKey) {
+          redo(router, pathname, searchParams);
+        } else {
+          undo(router, pathname, searchParams);
+        }
+        return;
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key === "y") {
+        e.preventDefault();
+        redo(router, pathname, searchParams);
+        return;
+      }
 
       if ((e.metaKey || e.ctrlKey) && e.key === "a") {
         if (tags.length > 0) {
@@ -296,7 +327,8 @@ const FilterSearchInput = ({
       removeTag,
       addTag,
       addCompleteTag,
-      setTags,
+      undo,
+      redo,
       submit,
       handleRecentSelect,
       navigateToTag,
@@ -328,6 +360,7 @@ const FilterSearchInput = ({
 
   return (
     <div
+      ref={containerRef}
       className={cn(
         "flex items-start gap-2 px-1 rounded-md border border-input relative",
         "bg-muted/80 transition duration-250 py-0.75",
@@ -356,7 +389,8 @@ const FilterSearchInput = ({
           type="text"
           value={inputValue}
           onChange={handleInputChange}
-          onFocus={() => setIsOpen(true)}
+          onFocus={handleInputFocus}
+          onClick={() => setIsOpen(true)}
           onBlur={handleInputBlur}
           onKeyDown={handleKeyDown}
           disabled={disabled}

--- a/frontend/components/common/advanced-search/components/search-input.tsx
+++ b/frontend/components/common/advanced-search/components/search-input.tsx
@@ -12,7 +12,6 @@ import { Operator } from "@/lib/actions/common/operators";
 import { cn } from "@/lib/utils";
 
 import { useAdvancedSearchContext, useAdvancedSearchNavigation, useAdvancedSearchRefsContext } from "../store";
-import { createTagFromFilter } from "../types";
 import FilterSuggestions from "./suggestions";
 import FilterTag from "./tag";
 
@@ -60,7 +59,7 @@ const FilterSearchInput = ({
     removeSelectedTags,
     submit,
     clearAll,
-    setTags,
+    applyRecentSearch,
     undo,
     redo,
   } = useAdvancedSearchContext((state) => ({
@@ -76,7 +75,7 @@ const FilterSearchInput = ({
     removeSelectedTags: state.removeSelectedTags,
     submit: state.submit,
     clearAll: state.clearAll,
-    setTags: state.setTags,
+    applyRecentSearch: state.applyRecentSearch,
     undo: state.undo,
     redo: state.redo,
   }));
@@ -117,28 +116,9 @@ const FilterSearchInput = ({
     (index: number) => {
       const rs = recentSearches[index];
       if (!rs) return;
-      const recentTags = rs.filters.map(createTagFromFilter);
-      setTags(recentTags);
-      setInputValue(rs.search);
-      setIsOpen(false);
-      setActiveIndex(-1);
-      setActiveRecentIndex(-1);
-      queueMicrotask(() => {
-        submit(router, pathname, searchParams);
-      });
+      applyRecentSearch(rs, router, pathname, searchParams);
     },
-    [
-      recentSearches,
-      setTags,
-      setInputValue,
-      setIsOpen,
-      setActiveIndex,
-      setActiveRecentIndex,
-      submit,
-      router,
-      pathname,
-      searchParams,
-    ]
+    [recentSearches, applyRecentSearch, router, pathname, searchParams]
   );
 
   const handleKeyDown = useCallback(

--- a/frontend/components/common/advanced-search/components/search-input.tsx
+++ b/frontend/components/common/advanced-search/components/search-input.tsx
@@ -12,6 +12,7 @@ import { Operator } from "@/lib/actions/common/operators";
 import { cn } from "@/lib/utils";
 
 import { useAdvancedSearchContext, useAdvancedSearchNavigation, useAdvancedSearchRefsContext } from "../store";
+import { createTagFromFilter } from "../types";
 import FilterSuggestions from "./suggestions";
 import FilterTag from "./tag";
 
@@ -38,16 +39,19 @@ const FilterSearchInput = ({
   const inputValue = useAdvancedSearchContext((state) => state.inputValue);
   const isOpen = useAdvancedSearchContext((state) => state.isOpen);
   const activeIndex = useAdvancedSearchContext((state) => state.activeIndex);
+  const activeRecentIndex = useAdvancedSearchContext((state) => state.activeRecentIndex);
   const selectedTagIds = useAdvancedSearchContext((state) => state.selectedTagIds);
   const openSelectId = useAdvancedSearchContext((state) => state.openSelectId);
   const filters = useAdvancedSearchContext((state) => state.filters);
   const autocompleteData = useAdvancedSearchContext((state) => state.autocompleteData);
   const activeTagId = useAdvancedSearchContext((state) => state.getActiveTagId());
+  const recentSearches = useAdvancedSearchContext((state) => state.recentSearches);
 
   const {
     setInputValue,
     setIsOpen,
     setActiveIndex,
+    setActiveRecentIndex,
     addTag,
     addCompleteTag,
     removeTag,
@@ -56,10 +60,12 @@ const FilterSearchInput = ({
     removeSelectedTags,
     submit,
     clearAll,
+    setTags,
   } = useAdvancedSearchContext((state) => ({
     setInputValue: state.setInputValue,
     setIsOpen: state.setIsOpen,
     setActiveIndex: state.setActiveIndex,
+    setActiveRecentIndex: state.setActiveRecentIndex,
     addTag: state.addTag,
     addCompleteTag: state.addCompleteTag,
     removeTag: state.removeTag,
@@ -68,6 +74,7 @@ const FilterSearchInput = ({
     removeSelectedTags: state.removeSelectedTags,
     submit: state.submit,
     clearAll: state.clearAll,
+    setTags: state.setTags,
   }));
 
   const { mainInputRef } = useAdvancedSearchRefsContext();
@@ -85,17 +92,45 @@ const FilterSearchInput = ({
   );
 
   const handleInputBlur = useCallback(() => {
-    // Don't close if there's an active tag (focus is transferring to it)
     if (activeTagId) return;
     if (openSelectId) return;
     setIsOpen(false);
     submit(router, pathname, searchParams);
   }, [activeTagId, openSelectId, setIsOpen, submit, router, pathname, searchParams]);
 
+  const handleRecentSelect = useCallback(
+    (index: number) => {
+      const rs = recentSearches[index];
+      if (!rs) return;
+      const recentTags = rs.filters.map(createTagFromFilter);
+      setTags(recentTags);
+      setInputValue(rs.search);
+      setIsOpen(false);
+      setActiveIndex(-1);
+      setActiveRecentIndex(-1);
+      queueMicrotask(() => {
+        submit(router, pathname, searchParams);
+      });
+    },
+    [
+      recentSearches,
+      setTags,
+      setInputValue,
+      setIsOpen,
+      setActiveIndex,
+      setActiveRecentIndex,
+      submit,
+      router,
+      pathname,
+      searchParams,
+    ]
+  );
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       const input = mainInputRef.current;
       const count = getSuggestionsCount(filters, inputValue, autocompleteData);
+      const showRecent = !inputValue.trim() && tags.length === 0 && recentSearches.length > 0;
 
       if ((e.metaKey || e.ctrlKey) && e.key === "a") {
         if (tags.length > 0) {
@@ -120,20 +155,67 @@ const FilterSearchInput = ({
         }
       }
 
+      // In recent row: left/right navigates chips, enter selects, down goes to suggestions, up goes to input
+      if (activeRecentIndex >= 0 && showRecent) {
+        if (e.key === "ArrowRight") {
+          e.preventDefault();
+          setActiveRecentIndex(Math.min(activeRecentIndex + 1, recentSearches.length - 1));
+          return;
+        }
+        if (e.key === "ArrowLeft") {
+          e.preventDefault();
+          setActiveRecentIndex(Math.max(activeRecentIndex - 1, 0));
+          return;
+        }
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          if (count > 0) {
+            setActiveIndex(0);
+          }
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setActiveRecentIndex(-1);
+          return;
+        }
+        if (e.key === "Enter") {
+          e.preventDefault();
+          handleRecentSelect(activeRecentIndex);
+          return;
+        }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          setActiveRecentIndex(-1);
+          setIsOpen(false);
+          input?.blur();
+          return;
+        }
+        return;
+      }
+
       // Arrow down
       if (e.key === "ArrowDown") {
-        if (isOpen && count > 0) {
+        if (isOpen) {
           e.preventDefault();
-          setActiveIndex(Math.min(activeIndex + 1, count - 1));
+          if (activeIndex === -1 && showRecent) {
+            setActiveRecentIndex(0);
+          } else if (count > 0) {
+            setActiveIndex(Math.min(activeIndex + 1, count - 1));
+          }
         }
         return;
       }
 
       // Arrow up
       if (e.key === "ArrowUp") {
-        if (isOpen && count > 0) {
+        if (isOpen) {
           e.preventDefault();
-          setActiveIndex(Math.max(activeIndex - 1, 0));
+          if (activeIndex === 0 && showRecent) {
+            setActiveRecentIndex(0);
+          } else if (activeIndex > 0) {
+            setActiveIndex(activeIndex - 1);
+          }
         }
         return;
       }
@@ -147,7 +229,6 @@ const FilterSearchInput = ({
             if (suggestion.type === "field") {
               addTag(suggestion.filter.key);
             } else if (suggestion.type === "value") {
-              // Get the default operator for this field's dataType
               const columnFilter = filters.find((f) => f.key === suggestion.field);
               const defaultOperator = columnFilter
                 ? (dataTypeOperationsMap[columnFilter.dataType]?.[0]?.key ?? Operator.Eq)
@@ -202,17 +283,22 @@ const FilterSearchInput = ({
       selectedTagIds.size,
       isOpen,
       activeIndex,
+      activeRecentIndex,
       autocompleteData,
+      recentSearches,
       setInputValue,
       setIsOpen,
       setActiveIndex,
+      setActiveRecentIndex,
       selectAllTags,
       clearSelection,
       removeSelectedTags,
       removeTag,
       addTag,
       addCompleteTag,
+      setTags,
       submit,
+      handleRecentSelect,
       navigateToTag,
       router,
       pathname,

--- a/frontend/components/common/advanced-search/components/suggestions.tsx
+++ b/frontend/components/common/advanced-search/components/suggestions.tsx
@@ -74,7 +74,7 @@ const RecentSearchChip = ({
   return (
     <div
       className={cn(
-        "inline-flex items-center rounded-md border h-6 text-xs gap-0.5 px-0.5 cursor-pointer shrink-0 transition-colors",
+        "inline-flex items-center rounded-md border h-6 text-xs divide-x px-0.5 cursor-pointer shrink-0 transition-colors",
         isActive ? "bg-accent border-primary/40" : "bg-background hover:bg-accent"
       )}
       onMouseDown={(e) => {
@@ -90,9 +90,9 @@ const RecentSearchChip = ({
         const displayValue = Array.isArray(tag.value) ? tag.value.join(", ") : String(tag.value);
 
         return (
-          <span key={tag.id} className="inline-flex items-center gap-0.5 rounded bg-muted/80 px-1.5 h-[18px]">
+          <span key={tag.id} className="inline-flex items-center gap-1 px-1.5 h-4">
             <span className="text-secondary-foreground font-medium">{displayName}</span>
-            <span className="text-muted-foreground">{operatorLabel}</span>
+            <span className="text-secondary-foreground/80">{operatorLabel}</span>
             <span className="text-primary">{displayValue}</span>
           </span>
         );
@@ -198,6 +198,7 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
         "absolute top-full left-0 right-0 z-50 mt-1 bg-secondary border rounded-md shadow-md overflow-hidden",
         className
       )}
+      onMouseDown={(e) => e.preventDefault()}
     >
       {showRecent && (
         <div className="border-b">

--- a/frontend/components/common/advanced-search/components/suggestions.tsx
+++ b/frontend/components/common/advanced-search/components/suggestions.tsx
@@ -4,13 +4,13 @@ import { Search } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 
-import { dataTypeOperationsMap } from "@/components/ui/infinite-datatable/ui/datatable-filter/utils";
+import { dataTypeOperationsMap, OperatorLabelMap } from "@/components/ui/infinite-datatable/ui/datatable-filter/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Operator } from "@/lib/actions/common/operators";
 import { cn } from "@/lib/utils";
 
-import { useAdvancedSearchContext, useAdvancedSearchRefsContext } from "../store";
-import { type ColumnFilter } from "../types";
+import { type RecentSearch, useAdvancedSearchContext, useAdvancedSearchRefsContext } from "../store";
+import { type ColumnFilter, createTagFromFilter } from "../types";
 import { buildValueSuggestions } from "../utils";
 
 interface FieldSuggestion {
@@ -58,6 +58,52 @@ export const buildSuggestions = (
   return [...fieldSuggestions, ...valueSuggestions, { type: "raw_search" as const, value: inputValue.trim() }];
 };
 
+const RecentSearchChip = ({
+  recentSearch,
+  columnFilters,
+  isActive,
+  onSelect,
+}: {
+  recentSearch: RecentSearch;
+  columnFilters: ColumnFilter[];
+  isActive: boolean;
+  onSelect: () => void;
+}) => {
+  const tags = recentSearch.filters.map(createTagFromFilter);
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-md border h-6 text-xs gap-0.5 px-0.5 cursor-pointer shrink-0 transition-colors",
+        isActive ? "bg-accent border-primary/40" : "bg-background hover:bg-accent"
+      )}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      onClick={onSelect}
+    >
+      {tags.map((tag) => {
+        const colFilter = columnFilters.find((f) => f.key === tag.field);
+        const displayName = colFilter?.name ?? tag.field;
+        const operatorLabel = OperatorLabelMap[tag.operator] ?? tag.operator;
+        const displayValue = Array.isArray(tag.value) ? tag.value.join(", ") : String(tag.value);
+
+        return (
+          <span key={tag.id} className="inline-flex items-center gap-0.5 rounded bg-muted/80 px-1.5 h-[18px]">
+            <span className="text-secondary-foreground font-medium">{displayName}</span>
+            <span className="text-muted-foreground">{operatorLabel}</span>
+            <span className="text-primary">{displayValue}</span>
+          </span>
+        );
+      })}
+      {recentSearch.search && (
+        <span className="px-1 text-secondary-foreground truncate">&quot;{recentSearch.search}&quot;</span>
+      )}
+    </div>
+  );
+};
+
 interface FilterSuggestionsProps {
   className?: string;
 }
@@ -70,16 +116,23 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
   const inputValue = useAdvancedSearchContext((state) => state.inputValue);
   const isOpen = useAdvancedSearchContext((state) => state.isOpen);
   const activeIndex = useAdvancedSearchContext((state) => state.activeIndex);
+  const activeRecentIndex = useAdvancedSearchContext((state) => state.activeRecentIndex);
   const filters = useAdvancedSearchContext((state) => state.filters);
   const autocompleteData = useAdvancedSearchContext((state) => state.autocompleteData);
+  const tags = useAdvancedSearchContext((state) => state.tags);
+  const recentSearches = useAdvancedSearchContext((state) => state.recentSearches);
 
-  const { addTag, addCompleteTag, setInputValue, setIsOpen, submit } = useAdvancedSearchContext((state) => ({
-    addTag: state.addTag,
-    addCompleteTag: state.addCompleteTag,
-    setInputValue: state.setInputValue,
-    setIsOpen: state.setIsOpen,
-    submit: state.submit,
-  }));
+  const { addTag, addCompleteTag, setInputValue, setIsOpen, setTags, submit, setActiveIndex, setActiveRecentIndex } =
+    useAdvancedSearchContext((state) => ({
+      addTag: state.addTag,
+      addCompleteTag: state.addCompleteTag,
+      setInputValue: state.setInputValue,
+      setIsOpen: state.setIsOpen,
+      setTags: state.setTags,
+      submit: state.submit,
+      setActiveIndex: state.setActiveIndex,
+      setActiveRecentIndex: state.setActiveRecentIndex,
+    }));
 
   const { mainInputRef } = useAdvancedSearchRefsContext();
 
@@ -90,6 +143,8 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
     [inputValue, filters, autocompleteData]
   );
 
+  const showRecent = !inputValue.trim() && tags.length === 0 && recentSearches.length > 0;
+
   useEffect(() => {
     const activeElement = suggestionRefs.current.get(activeIndex);
     if (activeElement) {
@@ -99,15 +154,12 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
 
   const handleValueSelect = useCallback(
     (field: string, value: string) => {
-      // Find the filter to get the proper field key and default operator
       const columnFilter = filters.find((f) => f.key === field);
       if (!columnFilter) return;
 
-      // Get the default operator for this field's dataType
       const defaultOperator = dataTypeOperationsMap[columnFilter.dataType]?.[0]?.key ?? Operator.Eq;
       addCompleteTag(field, defaultOperator, value, router, pathname, searchParams);
 
-      // Keep focus on main input
       mainInputRef.current?.focus();
     },
     [filters, addCompleteTag, router, pathname, searchParams, mainInputRef]
@@ -122,7 +174,23 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
     [setInputValue, setIsOpen, submit, router, pathname, searchParams]
   );
 
-  if (!isOpen || suggestions.length === 0) return null;
+  const handleRecentSearchSelect = useCallback(
+    (recentSearch: RecentSearch) => {
+      const recentTags = recentSearch.filters.map(createTagFromFilter);
+      setTags(recentTags);
+      setInputValue(recentSearch.search);
+      setIsOpen(false);
+      setActiveIndex(-1);
+      setActiveRecentIndex(-1);
+
+      queueMicrotask(() => {
+        submit(router, pathname, searchParams);
+      });
+    },
+    [setTags, setInputValue, setIsOpen, setActiveIndex, setActiveRecentIndex, submit, router, pathname, searchParams]
+  );
+
+  if (!isOpen || (suggestions.length === 0 && !showRecent)) return null;
 
   return (
     <div
@@ -131,88 +199,106 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
         className
       )}
     >
-      <div className="px-3 pt-2 pb-1 text-[10px] text-muted-foreground font-medium uppercase tracking-wide">
-        {inputValue.trim() ? "Suggestions" : "Filter by"}
-      </div>
-      <ScrollArea className="max-h-64 [&>div]:max-h-64">
-        <div className="pb-1">
-          {suggestions.map((suggestion, idx) => {
-            const isActive = idx === activeIndex;
-
-            if (suggestion.type === "field") {
-              return (
-                <div
-                  key={`field-${suggestion.filter.key}`}
-                  ref={(el) => {
-                    if (el) suggestionRefs.current.set(idx, el);
-                  }}
-                  className={cn(
-                    "px-3 py-1.5 text-xs cursor-pointer font-medium text-secondary-foreground",
-                    isActive ? "bg-accent" : "hover:bg-accent"
-                  )}
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  onClick={() => addTag(suggestion.filter.key)}
-                >
-                  {suggestion.filter.name}
-                </div>
-              );
-            }
-
-            if (suggestion.type === "value") {
-              // Find the filter name for display
-              const filterForField = filters.find((f) => f.key === suggestion.field);
-              const displayName = filterForField?.name || suggestion.field;
-
-              return (
-                <div
-                  key={`value-${suggestion.field}-${suggestion.value}-${idx}`}
-                  ref={(el) => {
-                    if (el) suggestionRefs.current.set(idx, el);
-                  }}
-                  className={cn(
-                    "px-3 py-1.5 text-xs cursor-pointer text-secondary-foreground",
-                    isActive ? "bg-accent" : "hover:bg-accent"
-                  )}
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  onClick={() => handleValueSelect(suggestion.field, suggestion.value)}
-                >
-                  <span className="text-muted-foreground">{displayName}:</span>{" "}
-                  <span className="font-medium">{suggestion.value}</span>
-                </div>
-              );
-            }
-
-            // Raw search suggestion
-            return (
-              <div
-                key="raw-search"
-                ref={(el) => {
-                  if (el) suggestionRefs.current.set(idx, el);
-                }}
-                className={cn(
-                  "flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer text-secondary-foreground border-t mt-1 pt-2",
-                  isActive ? "bg-accent" : "hover:bg-accent"
-                )}
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                }}
-                onClick={() => handleRawSearchSelect(suggestion.value)}
-              >
-                <Search className="w-3 h-3" />
-                <span className="text-muted-foreground">Full text search:</span>
-                <span className="font-medium">&quot;{suggestion.value}&quot;</span>
-              </div>
-            );
-          })}
+      {showRecent && (
+        <div className="border-b">
+          <div className="px-3 pt-2 pb-1 text-xs text-muted-foreground font-medium tracking-wide">Recent searches</div>
+          <div className="flex items-center gap-1.5 px-3 pb-2 pt-1 overflow-x-auto no-scrollbar">
+            {recentSearches.map((rs, idx) => (
+              <RecentSearchChip
+                key={rs.timestamp}
+                recentSearch={rs}
+                columnFilters={filters}
+                isActive={activeRecentIndex === idx}
+                onSelect={() => handleRecentSearchSelect(rs)}
+              />
+            ))}
+          </div>
         </div>
-      </ScrollArea>
+      )}
+      {suggestions.length > 0 && (
+        <>
+          <div className="px-3 pt-2 pb-1 text-xs text-muted-foreground font-medium tracking-wide">
+            {inputValue.trim() ? "Suggestions" : "Filter by"}
+          </div>
+          <ScrollArea className="max-h-64 [&>div]:max-h-64">
+            <div className="pb-1">
+              {suggestions.map((suggestion, idx) => {
+                const isActive = idx === activeIndex;
+
+                if (suggestion.type === "field") {
+                  return (
+                    <div
+                      key={`field-${suggestion.filter.key}`}
+                      ref={(el) => {
+                        if (el) suggestionRefs.current.set(idx, el);
+                      }}
+                      className={cn(
+                        "px-3 py-1.5 text-xs cursor-pointer font-medium text-secondary-foreground",
+                        isActive ? "bg-accent" : "hover:bg-accent"
+                      )}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onClick={() => addTag(suggestion.filter.key)}
+                    >
+                      {suggestion.filter.name}
+                    </div>
+                  );
+                }
+
+                if (suggestion.type === "value") {
+                  const filterForField = filters.find((f) => f.key === suggestion.field);
+                  const displayName = filterForField?.name || suggestion.field;
+
+                  return (
+                    <div
+                      key={`value-${suggestion.field}-${suggestion.value}-${idx}`}
+                      ref={(el) => {
+                        if (el) suggestionRefs.current.set(idx, el);
+                      }}
+                      className={cn(
+                        "px-3 py-1.5 text-xs cursor-pointer text-secondary-foreground",
+                        isActive ? "bg-accent" : "hover:bg-accent"
+                      )}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onClick={() => handleValueSelect(suggestion.field, suggestion.value)}
+                    >
+                      <span className="text-muted-foreground">{displayName}:</span>{" "}
+                      <span className="font-medium">{suggestion.value}</span>
+                    </div>
+                  );
+                }
+
+                return (
+                  <div
+                    key="raw-search"
+                    ref={(el) => {
+                      if (el) suggestionRefs.current.set(idx, el);
+                    }}
+                    className={cn(
+                      "flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer text-secondary-foreground border-t mt-1 pt-2",
+                      isActive ? "bg-accent" : "hover:bg-accent"
+                    )}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }}
+                    onClick={() => handleRawSearchSelect(suggestion.value)}
+                  >
+                    <Search className="w-3 h-3" />
+                    <span className="text-muted-foreground">Full text search:</span>
+                    <span className="font-medium">&quot;{suggestion.value}&quot;</span>
+                  </div>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/components/common/advanced-search/components/suggestions.tsx
+++ b/frontend/components/common/advanced-search/components/suggestions.tsx
@@ -2,7 +2,7 @@
 
 import { Search } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { dataTypeOperationsMap, OperatorLabelMap } from "@/components/ui/infinite-datatable/ui/datatable-filter/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -63,16 +63,19 @@ const RecentSearchChip = ({
   columnFilters,
   isActive,
   onSelect,
+  ref,
 }: {
   recentSearch: RecentSearch;
   columnFilters: ColumnFilter[];
   isActive: boolean;
   onSelect: () => void;
+  ref?: React.Ref<HTMLDivElement>;
 }) => {
   const tags = recentSearch.filters.map(createTagFromFilter);
 
   return (
     <div
+      ref={ref}
       className={cn(
         "inline-flex items-center rounded-md border h-6 text-xs divide-x px-0.5 cursor-pointer shrink-0 transition-colors",
         isActive ? "bg-accent border-primary/40" : "bg-background hover:bg-accent"
@@ -122,21 +125,22 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
   const tags = useAdvancedSearchContext((state) => state.tags);
   const recentSearches = useAdvancedSearchContext((state) => state.recentSearches);
 
-  const { addTag, addCompleteTag, setInputValue, setIsOpen, setTags, submit, setActiveIndex, setActiveRecentIndex } =
-    useAdvancedSearchContext((state) => ({
+  const { addTag, addCompleteTag, setInputValue, setIsOpen, submit, applyRecentSearch } = useAdvancedSearchContext(
+    (state) => ({
       addTag: state.addTag,
       addCompleteTag: state.addCompleteTag,
       setInputValue: state.setInputValue,
       setIsOpen: state.setIsOpen,
-      setTags: state.setTags,
       submit: state.submit,
-      setActiveIndex: state.setActiveIndex,
-      setActiveRecentIndex: state.setActiveRecentIndex,
-    }));
+      applyRecentSearch: state.applyRecentSearch,
+    })
+  );
 
   const { mainInputRef } = useAdvancedSearchRefsContext();
 
   const suggestionRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  const recentChipRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  const recentContainerRef = useRef<HTMLDivElement>(null);
 
   const suggestions = useMemo(
     () => buildSuggestions(inputValue, filters, autocompleteData),
@@ -151,6 +155,23 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
       activeElement.scrollIntoView({ block: "nearest" });
     }
   }, [activeIndex]);
+
+  useEffect(() => {
+    const chip = recentChipRefs.current.get(activeRecentIndex);
+    const container = recentContainerRef.current;
+    if (!chip || !container) return;
+
+    const chipLeft = chip.offsetLeft;
+    const chipRight = chipLeft + chip.offsetWidth;
+    const scrollLeft = container.scrollLeft;
+    const visibleRight = scrollLeft + container.clientWidth;
+
+    if (chipLeft < scrollLeft) {
+      container.scrollTo({ left: chipLeft - 12, behavior: "smooth" });
+    } else if (chipRight > visibleRight) {
+      container.scrollTo({ left: chipRight - container.clientWidth + 12, behavior: "smooth" });
+    }
+  }, [activeRecentIndex]);
 
   const handleValueSelect = useCallback(
     (field: string, value: string) => {
@@ -176,18 +197,9 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
 
   const handleRecentSearchSelect = useCallback(
     (recentSearch: RecentSearch) => {
-      const recentTags = recentSearch.filters.map(createTagFromFilter);
-      setTags(recentTags);
-      setInputValue(recentSearch.search);
-      setIsOpen(false);
-      setActiveIndex(-1);
-      setActiveRecentIndex(-1);
-
-      queueMicrotask(() => {
-        submit(router, pathname, searchParams);
-      });
+      applyRecentSearch(recentSearch, router, pathname, searchParams);
     },
-    [setTags, setInputValue, setIsOpen, setActiveIndex, setActiveRecentIndex, submit, router, pathname, searchParams]
+    [applyRecentSearch, router, pathname, searchParams]
   );
 
   if (!isOpen || (suggestions.length === 0 && !showRecent)) return null;
@@ -203,10 +215,16 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
       {showRecent && (
         <div className="border-b">
           <div className="px-3 pt-2 pb-1 text-xs text-muted-foreground font-medium tracking-wide">Recent searches</div>
-          <div className="flex items-center gap-1.5 px-3 pb-2 pt-1 overflow-x-auto no-scrollbar">
+          <div
+            ref={recentContainerRef}
+            className="flex items-center gap-1.5 px-3 pb-2 pt-1 overflow-x-auto no-scrollbar"
+          >
             {recentSearches.map((rs, idx) => (
               <RecentSearchChip
                 key={rs.timestamp}
+                ref={(el) => {
+                  if (el) recentChipRefs.current.set(idx, el);
+                }}
                 recentSearch={rs}
                 columnFilters={filters}
                 isActive={activeRecentIndex === idx}

--- a/frontend/components/common/advanced-search/index.tsx
+++ b/frontend/components/common/advanced-search/index.tsx
@@ -153,6 +153,7 @@ interface AdvancedSearchProps {
   mode?: AdvancedSearchMode;
   value?: { filters: Filter[]; search: string };
   onSubmit?: (filters: Filter[], search: string) => void;
+  storageKey?: string;
   options?: {
     // If provided autocomplete won't fetch suggestions
     suggestions?: Map<string, string[]>;
@@ -169,6 +170,7 @@ const AdvancedSearch = ({
   mode = "url",
   value,
   onSubmit,
+  storageKey,
   options: { suggestions, disableHotKey } = { disableHotKey: false },
 }: AdvancedSearchProps) => (
   <AdvancedSearchStoreProvider
@@ -178,6 +180,7 @@ const AdvancedSearch = ({
     initialSearch={value?.search}
     onSubmit={onSubmit}
     suggestions={suggestions}
+    storageKey={storageKey}
   >
     <AdvancedSearchInner
       filters={filters}

--- a/frontend/components/common/advanced-search/store.tsx
+++ b/frontend/components/common/advanced-search/store.tsx
@@ -5,6 +5,7 @@ import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.
 import { type ReadonlyURLSearchParams, useSearchParams } from "next/navigation";
 import { createContext, type PropsWithChildren, type RefObject, useContext, useMemo, useRef, useState } from "react";
 import { createStore, type StoreApi, useStore } from "zustand";
+import { persist } from "zustand/middleware";
 
 import { dataTypeOperationsMap } from "@/components/ui/infinite-datatable/ui/datatable-filter/utils";
 import { type Filter, type FilterDataType, FilterSchema } from "@/lib/actions/common/filters";
@@ -28,6 +29,20 @@ function toFilterDataType(uiDataType: ColumnFilter["dataType"]): FilterDataType 
   return uiDataType === "enum" ? "string" : uiDataType;
 }
 
+export interface RecentSearch {
+  filters: Filter[];
+  search: string;
+  timestamp: number;
+}
+
+const MAX_RECENT_SEARCHES = 5;
+
+function areSearchesEqual(a: RecentSearch, b: RecentSearch): boolean {
+  if (a.search !== b.search) return false;
+  if (a.filters.length !== b.filters.length) return false;
+  return JSON.stringify(a.filters) === JSON.stringify(b.filters);
+}
+
 interface AdvancedSearchStore {
   // State
   autocompleteData: AutocompleteCache;
@@ -35,9 +50,11 @@ interface AdvancedSearchStore {
   inputValue: string;
   isOpen: boolean;
   activeIndex: number;
+  activeRecentIndex: number;
   selectedTagIds: Set<string>;
   openSelectId: string | null;
   tagFocusStates: Map<string, FilterTagFocusState>;
+  recentSearches: RecentSearch[];
 
   // Config (from props)
   filters: ColumnFilter[];
@@ -54,6 +71,7 @@ interface AdvancedSearchStore {
   setInputValue: (value: string) => void;
   setIsOpen: (isOpen: boolean) => void;
   setActiveIndex: (index: number) => void;
+  setActiveRecentIndex: (index: number) => void;
   setOpenSelectId: (id: string | null) => void;
 
   // Actions - tag operations
@@ -90,6 +108,9 @@ interface AdvancedSearchStore {
   submit: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
   clearAll: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
   updateLastSubmitted: (filters: Filter[], search: string) => void;
+
+  // Actions - recent searches
+  addRecentSearch: (filters: Filter[], search: string) => void;
 }
 
 const createAdvancedSearchStore = (
@@ -98,31 +119,34 @@ const createAdvancedSearchStore = (
   initialSearch: string,
   mode: AdvancedSearchMode,
   onSubmit?: (filters: Filter[], search: string) => void,
-  suggestions?: Map<string, string[]>
+  suggestions?: Map<string, string[]>,
+  storageKey?: string
 ) => {
-  // Track last submitted state to avoid redundant submits
   let lastSubmitted = {
     filters: initialTags.map(createFilterFromTag),
     search: initialSearch.trim(),
   };
 
-  return createStore<AdvancedSearchStore>()((set, get) => ({
-    // Initial state
+  type Set = StoreApi<AdvancedSearchStore>["setState"] &
+    ((fn: (state: AdvancedSearchStore) => Partial<AdvancedSearchStore>) => void);
+  type Get = StoreApi<AdvancedSearchStore>["getState"];
+
+  const storeConfig = (set: Set, get: Get): AdvancedSearchStore => ({
     autocompleteData: suggestions || new Map(),
     tags: initialTags,
     inputValue: initialSearch,
     isOpen: false,
     activeIndex: -1,
+    activeRecentIndex: -1,
     selectedTagIds: new Set<string>(),
     openSelectId: null,
     tagFocusStates: new Map<string, FilterTagFocusState>(),
+    recentSearches: [],
 
-    // Config
     filters,
     mode,
     onSubmit,
 
-    // Computed selectors
     getActiveTagId: () => {
       const { tagFocusStates } = get();
       for (const [tagId, focusState] of tagFocusStates) {
@@ -131,16 +155,14 @@ const createAdvancedSearchStore = (
       return null;
     },
 
-    // Autocomplete actions
     setAutocompleteData: (data) => set({ autocompleteData: data }),
 
-    // UI state actions
-    setInputValue: (value) => set({ inputValue: value, activeIndex: -1 }),
-    setIsOpen: (isOpen) => set({ isOpen, activeIndex: -1 }),
-    setActiveIndex: (activeIndex) => set({ activeIndex }),
+    setInputValue: (value) => set({ inputValue: value, activeIndex: -1, activeRecentIndex: -1 }),
+    setIsOpen: (isOpen) => set({ isOpen, activeIndex: -1, activeRecentIndex: -1 }),
+    setActiveIndex: (activeIndex) => set({ activeIndex, activeRecentIndex: -1 }),
+    setActiveRecentIndex: (activeRecentIndex) => set({ activeRecentIndex, activeIndex: -1 }),
     setOpenSelectId: (openSelectId) => set({ openSelectId }),
 
-    // Tag operations
     setTags: (tags) => {
       set({ tags });
     },
@@ -149,11 +171,9 @@ const createAdvancedSearchStore = (
       const columnFilter = filters.find((f) => f.key === field);
       if (!columnFilter) return;
 
-      // Get the default operator for this dataType (first available operator)
       const operations = dataTypeOperationsMap[columnFilter.dataType];
       const defaultOperator = operations?.[0]?.key ?? Operator.Eq;
 
-      // Array filters need empty array as default value
       const defaultValue = columnFilter.dataType === "array" ? [] : "";
 
       const newTag: FilterTag = {
@@ -173,6 +193,7 @@ const createAdvancedSearchStore = (
           inputValue: "",
           isOpen: false,
           activeIndex: -1,
+          activeRecentIndex: -1,
           tagFocusStates: newFocusStates,
         };
       });
@@ -183,7 +204,6 @@ const createAdvancedSearchStore = (
       const columnFilter = filters.find((f) => f.key === field);
       if (!columnFilter) return;
 
-      // Array filters need value wrapped in array
       const tagValue = columnFilter.dataType === "array" && !Array.isArray(value) ? [value] : value;
 
       const newTag: FilterTag = {
@@ -205,7 +225,10 @@ const createAdvancedSearchStore = (
         inputValue: "",
         isOpen: false,
         activeIndex: -1,
+        activeRecentIndex: -1,
       });
+
+      get().addRecentSearch(filterObjects, searchValue);
 
       queueMicrotask(() => {
         if (mode === "url") {
@@ -269,7 +292,6 @@ const createAdvancedSearchStore = (
       }));
     },
 
-    // Selection actions
     selectAllTags: () => {
       set((state) => ({
         selectedTagIds: new Set(state.tags.map((t) => t.id)),
@@ -297,7 +319,6 @@ const createAdvancedSearchStore = (
       });
     },
 
-    // Focus actions
     setTagFocusState: (tagId, focusState) => {
       set((state) => {
         const newFocusStates = new Map(state.tagFocusStates);
@@ -308,7 +329,6 @@ const createAdvancedSearchStore = (
 
     getTagFocusState: (tagId) => get().tagFocusStates.get(tagId) || { type: "idle" },
 
-    // Submit/clear actions
     submit: (router, pathname, searchParams) => {
       const { tags, inputValue, onSubmit, mode } = get();
       const filterObjects = tags.map(createFilterFromTag);
@@ -338,6 +358,8 @@ const createAdvancedSearchStore = (
       }
 
       lastSubmitted = { filters: filterObjects, search: searchValue };
+
+      get().addRecentSearch(filterObjects, searchValue);
 
       onSubmit?.(filterObjects, searchValue);
     },
@@ -369,7 +391,37 @@ const createAdvancedSearchStore = (
     updateLastSubmitted: (filters, search) => {
       lastSubmitted = { filters, search };
     },
-  }));
+
+    addRecentSearch: (filters, search) => {
+      if (!storageKey) return;
+      if (filters.length === 0 && !search.trim()) return;
+
+      const entry: RecentSearch = {
+        filters,
+        search: search.trim(),
+        timestamp: Date.now(),
+      };
+
+      const { recentSearches } = get();
+      const deduplicated = recentSearches.filter((s) => !areSearchesEqual(s, entry));
+      set({ recentSearches: [entry, ...deduplicated].slice(0, MAX_RECENT_SEARCHES) });
+    },
+  });
+
+  if (storageKey) {
+    return createStore<AdvancedSearchStore>()(
+      persist(storeConfig, {
+        name: `advanced-search-${storageKey}`,
+        partialize: (state) => ({ recentSearches: state.recentSearches }),
+        merge: (persisted, current) => ({
+          ...current,
+          ...(persisted as Partial<AdvancedSearchStore>),
+        }),
+      })
+    );
+  }
+
+  return createStore<AdvancedSearchStore>()(storeConfig);
 };
 
 const AdvancedSearchStoreContext = createContext<StoreApi<AdvancedSearchStore> | undefined>(undefined);
@@ -405,6 +457,7 @@ interface AdvancedSearchStoreProviderProps {
   initialSearch?: string;
   onSubmit?: (filters: Filter[], search: string) => void;
   suggestions?: Map<string, string[]>;
+  storageKey?: string;
 }
 
 export const AdvancedSearchStoreProvider = ({
@@ -415,6 +468,7 @@ export const AdvancedSearchStoreProvider = ({
   initialSearch = "",
   onSubmit,
   suggestions,
+  storageKey,
 }: PropsWithChildren<AdvancedSearchStoreProviderProps>) => {
   const searchParams = useSearchParams();
 
@@ -455,7 +509,9 @@ export const AdvancedSearchStoreProvider = ({
     };
   }, [searchParams, filters, mode, initialFilters, initialSearch]);
 
-  const [storeState] = useState(() => createAdvancedSearchStore(filters, tags, search, mode, onSubmit, suggestions));
+  const [storeState] = useState(() =>
+    createAdvancedSearchStore(filters, tags, search, mode, onSubmit, suggestions, storageKey)
+  );
   const mainInputRef = useRef<HTMLInputElement>(null);
   const tagHandlesRef = useRef<Map<string, FilterTagRef>>(new Map());
 

--- a/frontend/components/common/advanced-search/store/index.tsx
+++ b/frontend/components/common/advanced-search/store/index.tsx
@@ -320,6 +320,20 @@ function createCoreSlice(
     updateLastSubmitted: (filters, search) => {
       context.setLastSubmitted({ filters, search });
     },
+
+    applyRecentSearch: (recentSearch, router, pathname, searchParams) => {
+      const recentTags = recentSearch.filters.map(createTagFromFilter);
+      set({
+        tags: recentTags,
+        inputValue: recentSearch.search,
+        isOpen: false,
+        activeIndex: -1,
+        activeRecentIndex: -1,
+      });
+      queueMicrotask(() => {
+        get().submit(router, pathname, searchParams);
+      });
+    },
   };
 }
 

--- a/frontend/components/common/advanced-search/store/index.tsx
+++ b/frontend/components/common/advanced-search/store/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { isEqual, uniqueId } from "lodash";
-import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
-import { type ReadonlyURLSearchParams, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { createContext, type PropsWithChildren, type RefObject, useContext, useMemo, useRef, useState } from "react";
 import { createStore, type StoreApi, useStore } from "zustand";
 import { persist } from "zustand/middleware";
@@ -13,7 +12,6 @@ import { Operator } from "@/lib/actions/common/operators";
 
 import {
   type AdvancedSearchMode,
-  type AutocompleteCache,
   type ColumnFilter,
   createFilterFromTag,
   createTagFromFilter,
@@ -21,127 +19,38 @@ import {
   type FilterTagFocusState,
   type FilterTagRef,
   type TagFocusPosition,
-} from "./types";
-import { getNextField, getPreviousField } from "./utils";
+} from "../types";
+import { getNextField, getPreviousField } from "../utils";
+import { createRecentsSlice, type RecentsSlice } from "./recents-slice";
+import type { AdvancedSearchStore, SliceContext, StoreGet, StoreSet } from "./types";
+import { createUndoRedoSlice, type UndoRedoSlice, type UndoSnapshot } from "./undo-redo-slice";
 
-/** Map UI column dataType (which includes "enum") to the Filter schema's FilterDataType */
+export type { RecentSearch } from "./recents-slice";
+export type { AdvancedSearchStore } from "./types";
+
 function toFilterDataType(uiDataType: ColumnFilter["dataType"]): FilterDataType {
   return uiDataType === "enum" ? "string" : uiDataType;
 }
 
-export interface RecentSearch {
-  filters: Filter[];
-  search: string;
-  timestamp: number;
-}
-
-const MAX_RECENT_SEARCHES = 5;
-
-function areSearchesEqual(a: RecentSearch, b: RecentSearch): boolean {
-  if (a.search !== b.search) return false;
-  if (a.filters.length !== b.filters.length) return false;
-  return JSON.stringify(a.filters) === JSON.stringify(b.filters);
-}
-
-interface AdvancedSearchStore {
-  // State
-  autocompleteData: AutocompleteCache;
-  tags: FilterTag[];
-  inputValue: string;
-  isOpen: boolean;
-  activeIndex: number;
-  activeRecentIndex: number;
-  selectedTagIds: Set<string>;
-  openSelectId: string | null;
-  tagFocusStates: Map<string, FilterTagFocusState>;
-  recentSearches: RecentSearch[];
-
-  // Config (from props)
-  filters: ColumnFilter[];
-  mode: AdvancedSearchMode;
-  onSubmit?: (filters: Filter[], search: string) => void;
-
-  // Computed selectors
-  getActiveTagId: () => string | null;
-
-  // Actions - autocomplete
-  setAutocompleteData: (data: AutocompleteCache) => void;
-
-  // Actions - UI state
-  setInputValue: (value: string) => void;
-  setIsOpen: (isOpen: boolean) => void;
-  setActiveIndex: (index: number) => void;
-  setActiveRecentIndex: (index: number) => void;
-  setOpenSelectId: (id: string | null) => void;
-
-  // Actions - tag operations
-  setTags: (tags: FilterTag[]) => void;
-  addTag: (field: string) => void;
-  addCompleteTag: (
-    field: string,
-    operator: Operator,
-    value: string,
-    router: AppRouterInstance,
-    pathname: string,
-    searchParams: ReadonlyURLSearchParams
-  ) => FilterTag | undefined;
-  removeTag: (
-    tagId: string,
-    router: AppRouterInstance,
-    pathname: string,
-    searchParams: ReadonlyURLSearchParams
-  ) => void;
-  updateTagField: (tagId: string, field: string) => void;
-  updateTagOperator: (tagId: string, operator: Operator) => void;
-  updateTagValue: (tagId: string, value: string | string[]) => void;
-
-  // Actions - selection
-  selectAllTags: () => void;
-  clearSelection: () => void;
-  removeSelectedTags: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
-
-  // Actions - focus
-  setTagFocusState: (tagId: string, state: FilterTagFocusState) => void;
-  getTagFocusState: (tagId: string) => FilterTagFocusState;
-
-  // Actions - submit/clear
-  submit: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
-  clearAll: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
-  updateLastSubmitted: (filters: Filter[], search: string) => void;
-
-  // Actions - recent searches
-  addRecentSearch: (filters: Filter[], search: string) => void;
-}
-
-const createAdvancedSearchStore = (
+function createCoreSlice(
+  set: StoreSet,
+  get: StoreGet,
+  context: SliceContext,
   filters: ColumnFilter[],
-  initialTags: FilterTag[],
-  initialSearch: string,
   mode: AdvancedSearchMode,
   onSubmit?: (filters: Filter[], search: string) => void,
-  suggestions?: Map<string, string[]>,
-  storageKey?: string
-) => {
-  let lastSubmitted = {
-    filters: initialTags.map(createFilterFromTag),
-    search: initialSearch.trim(),
-  };
-
-  type Set = StoreApi<AdvancedSearchStore>["setState"] &
-    ((fn: (state: AdvancedSearchStore) => Partial<AdvancedSearchStore>) => void);
-  type Get = StoreApi<AdvancedSearchStore>["getState"];
-
-  const storeConfig = (set: Set, get: Get): AdvancedSearchStore => ({
+  suggestions?: Map<string, string[]>
+): Omit<AdvancedSearchStore, keyof RecentsSlice | keyof UndoRedoSlice> {
+  return {
     autocompleteData: suggestions || new Map(),
-    tags: initialTags,
-    inputValue: initialSearch,
+    tags: context.initialTags,
+    inputValue: context.initialSearch,
     isOpen: false,
     activeIndex: -1,
     activeRecentIndex: -1,
     selectedTagIds: new Set<string>(),
     openSelectId: null,
     tagFocusStates: new Map<string, FilterTagFocusState>(),
-    recentSearches: [],
 
     filters,
     mode,
@@ -166,6 +75,7 @@ const createAdvancedSearchStore = (
     setTags: (tags) => {
       set({ tags });
     },
+
     addTag: (field) => {
       const { filters } = get();
       const columnFilter = filters.find((f) => f.key === field);
@@ -173,7 +83,6 @@ const createAdvancedSearchStore = (
 
       const operations = dataTypeOperationsMap[columnFilter.dataType];
       const defaultOperator = operations?.[0]?.key ?? Operator.Eq;
-
       const defaultValue = columnFilter.dataType === "array" ? [] : "";
 
       const newTag: FilterTag = {
@@ -204,6 +113,8 @@ const createAdvancedSearchStore = (
       const columnFilter = filters.find((f) => f.key === field);
       if (!columnFilter) return;
 
+      get().pushUndoSnapshot();
+
       const tagValue = columnFilter.dataType === "array" && !Array.isArray(value) ? [value] : value;
 
       const newTag: FilterTag = {
@@ -218,7 +129,7 @@ const createAdvancedSearchStore = (
       const filterObjects = updatedTags.map(createFilterFromTag);
       const searchValue = "";
 
-      lastSubmitted = { filters: filterObjects, search: searchValue };
+      context.setLastSubmitted({ filters: filterObjects, search: searchValue });
 
       set({
         tags: updatedTags,
@@ -226,6 +137,11 @@ const createAdvancedSearchStore = (
         isOpen: false,
         activeIndex: -1,
         activeRecentIndex: -1,
+      });
+
+      context.setLastCommittedSnapshot({
+        tags: updatedTags.map((t) => ({ ...t, value: Array.isArray(t.value) ? [...t.value] : t.value })),
+        inputValue: "",
       });
 
       get().addRecentSearch(filterObjects, searchValue);
@@ -334,9 +250,15 @@ const createAdvancedSearchStore = (
       const filterObjects = tags.map(createFilterFromTag);
       const searchValue = inputValue.trim();
 
-      if (isEqual(lastSubmitted.filters, filterObjects) && lastSubmitted.search === searchValue) {
+      set({ isOpen: false, activeIndex: -1, activeRecentIndex: -1 });
+
+      if (
+        isEqual(context.getLastSubmitted().filters, filterObjects) &&
+        context.getLastSubmitted().search === searchValue
+      ) {
         return;
       }
+      get().pushUndoSnapshot();
 
       if (mode === "url") {
         const params = new URLSearchParams(searchParams.toString());
@@ -357,7 +279,11 @@ const createAdvancedSearchStore = (
         router.push(`${pathname}?${params.toString()}`);
       }
 
-      lastSubmitted = { filters: filterObjects, search: searchValue };
+      context.setLastSubmitted({ filters: filterObjects, search: searchValue });
+      context.setLastCommittedSnapshot({
+        tags: tags.map((t) => ({ ...t, value: Array.isArray(t.value) ? [...t.value] : t.value })),
+        inputValue,
+      });
 
       get().addRecentSearch(filterObjects, searchValue);
 
@@ -365,6 +291,7 @@ const createAdvancedSearchStore = (
     },
 
     clearAll: (router, pathname, searchParams) => {
+      get().pushUndoSnapshot();
       const { mode, onSubmit } = get();
 
       set({
@@ -384,28 +311,55 @@ const createAdvancedSearchStore = (
         router.push(`${pathname}?${params.toString()}`);
       }
 
-      lastSubmitted = { filters: [], search: "" };
+      context.setLastSubmitted({ filters: [], search: "" });
+      context.setLastCommittedSnapshot({ tags: [], inputValue: "" });
 
       onSubmit?.([], "");
     },
+
     updateLastSubmitted: (filters, search) => {
-      lastSubmitted = { filters, search };
+      context.setLastSubmitted({ filters, search });
     },
+  };
+}
 
-    addRecentSearch: (filters, search) => {
-      if (!storageKey) return;
-      if (filters.length === 0 && !search.trim()) return;
+const createAdvancedSearchStore = (
+  filters: ColumnFilter[],
+  initialTags: FilterTag[],
+  initialSearch: string,
+  mode: AdvancedSearchMode,
+  onSubmit?: (filters: Filter[], search: string) => void,
+  suggestions?: Map<string, string[]>,
+  storageKey?: string
+) => {
+  let lastSubmitted = {
+    filters: initialTags.map(createFilterFromTag),
+    search: initialSearch.trim(),
+  };
 
-      const entry: RecentSearch = {
-        filters,
-        search: search.trim(),
-        timestamp: Date.now(),
-      };
+  let lastCommittedSnapshot: UndoSnapshot = {
+    tags: initialTags.map((t) => ({ ...t, value: Array.isArray(t.value) ? [...t.value] : t.value })),
+    inputValue: initialSearch,
+  };
 
-      const { recentSearches } = get();
-      const deduplicated = recentSearches.filter((s) => !areSearchesEqual(s, entry));
-      set({ recentSearches: [entry, ...deduplicated].slice(0, MAX_RECENT_SEARCHES) });
+  const context: SliceContext = {
+    storageKey,
+    initialTags,
+    initialSearch,
+    getLastCommittedSnapshot: () => lastCommittedSnapshot,
+    setLastCommittedSnapshot: (snapshot) => {
+      lastCommittedSnapshot = snapshot;
     },
+    getLastSubmitted: () => lastSubmitted,
+    setLastSubmitted: (value) => {
+      lastSubmitted = value;
+    },
+  };
+
+  const storeConfig = (set: StoreSet, get: StoreGet): AdvancedSearchStore => ({
+    ...createCoreSlice(set, get, context, filters, mode, onSubmit, suggestions),
+    ...createRecentsSlice(set, get, context),
+    ...createUndoRedoSlice(set, get, context),
   });
 
   if (storageKey) {
@@ -423,6 +377,8 @@ const createAdvancedSearchStore = (
 
   return createStore<AdvancedSearchStore>()(storeConfig);
 };
+
+// Context & hooks
 
 const AdvancedSearchStoreContext = createContext<StoreApi<AdvancedSearchStore> | undefined>(undefined);
 
@@ -450,6 +406,7 @@ export const useAdvancedSearchRefsContext = () => {
 };
 
 // Provider
+
 interface AdvancedSearchStoreProviderProps {
   filters: ColumnFilter[];
   mode?: AdvancedSearchMode;

--- a/frontend/components/common/advanced-search/store/recents-slice.ts
+++ b/frontend/components/common/advanced-search/store/recents-slice.ts
@@ -1,0 +1,43 @@
+import { type Filter, FilterSchema } from "@/lib/actions/common/filters";
+
+import type { SliceCreator } from "./types";
+
+export interface RecentSearch {
+  filters: Filter[];
+  search: string;
+  timestamp: number;
+}
+
+const MAX_RECENT_SEARCHES = 5;
+
+function areSearchesEqual(a: RecentSearch, b: RecentSearch): boolean {
+  if (a.search !== b.search) return false;
+  if (a.filters.length !== b.filters.length) return false;
+  return JSON.stringify(a.filters) === JSON.stringify(b.filters);
+}
+
+export interface RecentsSlice {
+  recentSearches: RecentSearch[];
+  addRecentSearch: (filters: Filter[], search: string) => void;
+}
+
+export const createRecentsSlice: SliceCreator<RecentsSlice> = (set, get, { storageKey }) => ({
+  recentSearches: [],
+
+  addRecentSearch: (filters, search) => {
+    if (!storageKey) return;
+
+    const validFilters = filters.filter((f) => FilterSchema.safeParse(f).success);
+    if (validFilters.length === 0 && !search.trim()) return;
+
+    const entry: RecentSearch = {
+      filters: validFilters,
+      search: search.trim(),
+      timestamp: Date.now(),
+    };
+
+    const { recentSearches } = get();
+    const deduplicated = recentSearches.filter((s) => !areSearchesEqual(s, entry));
+    set({ recentSearches: [entry, ...deduplicated].slice(0, MAX_RECENT_SEARCHES) });
+  },
+});

--- a/frontend/components/common/advanced-search/store/types.ts
+++ b/frontend/components/common/advanced-search/store/types.ts
@@ -1,0 +1,78 @@
+import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+import type { Filter } from "@/lib/actions/common/filters";
+import type { Operator } from "@/lib/actions/common/operators";
+
+import type { AdvancedSearchMode, AutocompleteCache, ColumnFilter, FilterTag, FilterTagFocusState } from "../types";
+import type { RecentsSlice } from "./recents-slice";
+import type { UndoRedoSlice, UndoSnapshot } from "./undo-redo-slice";
+
+export interface SliceContext {
+  storageKey?: string;
+  getLastCommittedSnapshot: () => UndoSnapshot;
+  setLastCommittedSnapshot: (snapshot: UndoSnapshot) => void;
+  getLastSubmitted: () => { filters: Filter[]; search: string };
+  setLastSubmitted: (value: { filters: Filter[]; search: string }) => void;
+  initialTags: FilterTag[];
+  initialSearch: string;
+}
+
+export interface AdvancedSearchStore extends RecentsSlice, UndoRedoSlice {
+  autocompleteData: AutocompleteCache;
+  tags: FilterTag[];
+  inputValue: string;
+  isOpen: boolean;
+  activeIndex: number;
+  activeRecentIndex: number;
+  selectedTagIds: Set<string>;
+  openSelectId: string | null;
+  tagFocusStates: Map<string, FilterTagFocusState>;
+  filters: ColumnFilter[];
+  mode: AdvancedSearchMode;
+  onSubmit?: (filters: Filter[], search: string) => void;
+
+  getActiveTagId: () => string | null;
+  setAutocompleteData: (data: AutocompleteCache) => void;
+  setInputValue: (value: string) => void;
+  setIsOpen: (isOpen: boolean) => void;
+  setActiveIndex: (index: number) => void;
+  setActiveRecentIndex: (index: number) => void;
+  setOpenSelectId: (id: string | null) => void;
+  setTags: (tags: FilterTag[]) => void;
+  addTag: (field: string) => void;
+  addCompleteTag: (
+    field: string,
+    operator: Operator,
+    value: string,
+    router: AppRouterInstance,
+    pathname: string,
+    searchParams: ReadonlyURLSearchParams
+  ) => FilterTag | undefined;
+  removeTag: (
+    tagId: string,
+    router: AppRouterInstance,
+    pathname: string,
+    searchParams: ReadonlyURLSearchParams
+  ) => void;
+  updateTagField: (tagId: string, field: string) => void;
+  updateTagOperator: (tagId: string, operator: Operator) => void;
+  updateTagValue: (tagId: string, value: string | string[]) => void;
+  selectAllTags: () => void;
+  clearSelection: () => void;
+  removeSelectedTags: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
+  setTagFocusState: (tagId: string, state: FilterTagFocusState) => void;
+  getTagFocusState: (tagId: string) => FilterTagFocusState;
+  submit: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
+  clearAll: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
+  updateLastSubmitted: (filters: Filter[], search: string) => void;
+  pushUndoSnapshot: () => void;
+}
+
+export type StoreSet = {
+  (partial: Partial<AdvancedSearchStore>): void;
+  (fn: (state: AdvancedSearchStore) => Partial<AdvancedSearchStore>): void;
+};
+export type StoreGet = () => AdvancedSearchStore;
+
+export type SliceCreator<T> = (set: StoreSet, get: StoreGet, context: SliceContext) => T;

--- a/frontend/components/common/advanced-search/store/types.ts
+++ b/frontend/components/common/advanced-search/store/types.ts
@@ -5,7 +5,7 @@ import type { Filter } from "@/lib/actions/common/filters";
 import type { Operator } from "@/lib/actions/common/operators";
 
 import type { AdvancedSearchMode, AutocompleteCache, ColumnFilter, FilterTag, FilterTagFocusState } from "../types";
-import type { RecentsSlice } from "./recents-slice";
+import type { RecentSearch, RecentsSlice } from "./recents-slice";
 import type { UndoRedoSlice, UndoSnapshot } from "./undo-redo-slice";
 
 export interface SliceContext {
@@ -67,6 +67,12 @@ export interface AdvancedSearchStore extends RecentsSlice, UndoRedoSlice {
   clearAll: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
   updateLastSubmitted: (filters: Filter[], search: string) => void;
   pushUndoSnapshot: () => void;
+  applyRecentSearch: (
+    recentSearch: RecentSearch,
+    router: AppRouterInstance,
+    pathname: string,
+    searchParams: ReadonlyURLSearchParams
+  ) => void;
 }
 
 export type StoreSet = {

--- a/frontend/components/common/advanced-search/store/undo-redo-slice.ts
+++ b/frontend/components/common/advanced-search/store/undo-redo-slice.ts
@@ -1,0 +1,120 @@
+import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+import { createFilterFromTag, type FilterTag, type FilterTagFocusState } from "../types";
+import type { SliceCreator } from "./types";
+
+const MAX_UNDO_STACK = 50;
+
+export interface UndoSnapshot {
+  tags: FilterTag[];
+  inputValue: string;
+}
+
+export interface UndoRedoSlice {
+  undoStack: UndoSnapshot[];
+  redoStack: UndoSnapshot[];
+  pushUndoSnapshot: () => void;
+  undo: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
+  redo: (router: AppRouterInstance, pathname: string, searchParams: ReadonlyURLSearchParams) => void;
+  canUndo: () => boolean;
+  canRedo: () => boolean;
+}
+
+export const createUndoRedoSlice: SliceCreator<UndoRedoSlice> = (
+  set,
+  get,
+  { getLastCommittedSnapshot, setLastCommittedSnapshot, setLastSubmitted }
+) => ({
+  undoStack: [],
+  redoStack: [],
+
+  pushUndoSnapshot: () => {
+    const { undoStack } = get();
+    set({
+      undoStack: [...undoStack.slice(-(MAX_UNDO_STACK - 1)), getLastCommittedSnapshot()],
+      redoStack: [],
+    });
+  },
+
+  undo: (router, pathname, searchParams) => {
+    const { undoStack } = get();
+    if (undoStack.length === 0) return;
+
+    const previous = undoStack[undoStack.length - 1];
+
+    set({
+      undoStack: undoStack.slice(0, -1),
+      redoStack: [...get().redoStack, getLastCommittedSnapshot()],
+      tags: previous.tags,
+      inputValue: previous.inputValue,
+      selectedTagIds: new Set<string>(),
+      tagFocusStates: new Map<string, FilterTagFocusState>(),
+    });
+
+    setLastCommittedSnapshot({
+      tags: previous.tags.map((t) => ({ ...t, value: Array.isArray(t.value) ? [...t.value] : t.value })),
+      inputValue: previous.inputValue,
+    });
+
+    const { onSubmit, mode } = get();
+    const filterObjects = previous.tags.map(createFilterFromTag);
+    const searchValue = previous.inputValue.trim();
+
+    if (mode === "url") {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("filter");
+      params.delete("search");
+      params.delete("pageNumber");
+      params.set("pageNumber", "0");
+      filterObjects.forEach((filter) => params.append("filter", JSON.stringify(filter)));
+      if (searchValue) params.set("search", searchValue);
+      router.push(`${pathname}?${params.toString()}`);
+    }
+
+    setLastSubmitted({ filters: filterObjects, search: searchValue });
+    onSubmit?.(filterObjects, searchValue);
+  },
+
+  redo: (router, pathname, searchParams) => {
+    const { redoStack } = get();
+    if (redoStack.length === 0) return;
+
+    const next = redoStack[redoStack.length - 1];
+
+    set({
+      redoStack: redoStack.slice(0, -1),
+      undoStack: [...get().undoStack, getLastCommittedSnapshot()],
+      tags: next.tags,
+      inputValue: next.inputValue,
+      selectedTagIds: new Set<string>(),
+      tagFocusStates: new Map<string, FilterTagFocusState>(),
+    });
+
+    setLastCommittedSnapshot({
+      tags: next.tags.map((t) => ({ ...t, value: Array.isArray(t.value) ? [...t.value] : t.value })),
+      inputValue: next.inputValue,
+    });
+
+    const { onSubmit, mode } = get();
+    const filterObjects = next.tags.map(createFilterFromTag);
+    const searchValue = next.inputValue.trim();
+
+    if (mode === "url") {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("filter");
+      params.delete("search");
+      params.delete("pageNumber");
+      params.set("pageNumber", "0");
+      filterObjects.forEach((filter) => params.append("filter", JSON.stringify(filter)));
+      if (searchValue) params.set("search", searchValue);
+      router.push(`${pathname}?${params.toString()}`);
+    }
+
+    setLastSubmitted({ filters: filterObjects, search: searchValue });
+    onSubmit?.(filterObjects, searchValue);
+  },
+
+  canUndo: () => get().undoStack.length > 0,
+  canRedo: () => get().redoStack.length > 0,
+});

--- a/frontend/components/signal/create-signal-job/index.tsx
+++ b/frontend/components/signal/create-signal-job/index.tsx
@@ -321,6 +321,7 @@ const CreateSignalJobContent = () => {
           </div>
           <div className="w-full px-px">
             <AdvancedSearch
+              storageKey="traces"
               mode="state"
               filters={tableFilters}
               resource="traces"

--- a/frontend/components/traces/spans-table/index.tsx
+++ b/frontend/components/traces/spans-table/index.tsx
@@ -172,6 +172,7 @@ function SpansTableContent() {
         </div>
         <div className="w-full px-px">
           <AdvancedSearch
+            storageKey="spans"
             filters={filters}
             resource="spans"
             placeholder="Search by span name, tokens, tags, full text and more..."

--- a/frontend/components/traces/trace-picker/trace-picker-content.tsx
+++ b/frontend/components/traces/trace-picker/trace-picker-content.tsx
@@ -129,6 +129,7 @@ const TracePickerContent = ({
             mode="state"
             filters={traceFilters}
             resource="traces"
+            storageKey="traces"
             value={filters}
             onSubmit={(f, search) => setFilters({ filters: f, search })}
             placeholder="Search traces..."

--- a/frontend/components/traces/traces-table/index.tsx
+++ b/frontend/components/traces/traces-table/index.tsx
@@ -419,6 +419,7 @@ function TracesTableContent() {
         </div>
         <div className="w-full px-px">
           <AdvancedSearch
+            storageKey="traces"
             filters={filters}
             resource="traces"
             placeholder="Search by root span name, tokens, tags, full text and more..."

--- a/frontend/lib/actions/common/filters.ts
+++ b/frontend/lib/actions/common/filters.ts
@@ -38,7 +38,7 @@ export const JsonFilterSchema = BaseFilterSchema.extend({
 export const ArrayFilterSchema = z.object({
   dataType: FilterDataTypeSchema.optional(),
   column: z.string(),
-  value: z.array(z.string().min(1)),
+  value: z.array(z.string().min(1)).min(1),
   operator: z.enum(ARRAY_OPERATORS),
 });
 


### PR DESCRIPTION
- recent searches
- undo/redo interactions (ctrl +z/y)
- interactions improvements
- refactor store into slices

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/state-management change: introduces persisted recent-search history and undo/redo stacks that can mutate URL params and submit behavior, which could affect search navigation and filtering correctness.
> 
> **Overview**
> Improves `AdvancedSearch` UX by adding **recent searches** (up to 5, optionally persisted via new `storageKey`) and **undo/redo** support (`ctrl/cmd+z`, `ctrl/cmd+shift+z`, `ctrl/cmd+y`).
> 
> Refactors the zustand store into composable slices (`core`, `recents`, `undo-redo`), tracks committed snapshots, and records recent entries on submit/tag completion/clear, with a new `applyRecentSearch` action.
> 
> Updates input/suggestions interactions: renders a recent-search chip row when the query is empty, adds keyboard navigation between recents and suggestions, and tweaks focus/blur handling to keep the dropdown open appropriately.
> 
> Tightens validation by requiring array filter values to be non-empty (`ArrayFilterSchema.value.min(1)`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9597fb3f526fb521f44e58f34fd99d0cc2abe57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->