### PR TITLE
remove exclude-newer on lock level

### DIFF
--- a/query-engine/uv.lock
+++ b/query-engine/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 
-[options]
-exclude-newer = "2026-03-30T13:03:03.819936Z"
-exclude-newer-span = "P2D"
-
 [[package]]
 name = "colorama"
 version = "0.4.6"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since it only edits `query-engine/uv.lock`, but future lock refreshes may resolve to newer package builds due to the removed time-based cutoff.
> 
> **Overview**
> Removes the `[options]` section from `query-engine/uv.lock`, dropping `exclude-newer` and `exclude-newer-span` so the lockfile is no longer constrained by a timestamp-based cutoff during resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28206d5aa8e79a05eba4bc6f10677f697e697df4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->