### PR TITLE
remove exclude-newer on lock level (#1561)

### DIFF
--- a/query-engine/uv.lock
+++ b/query-engine/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 
-[options]
-exclude-newer = "2026-03-30T13:03:03.819936Z"
-exclude-newer-span = "P2D"
-
 [[package]]
 name = "colorama"
 version = "0.4.6"


### PR DESCRIPTION
Fixes query engine build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts lockfile metadata by removing `exclude-newer` constraints, which may change dependency resolution timing but doesn’t touch runtime code.
> 
> **Overview**
> Removes the `exclude-newer` / `exclude-newer-span` settings from `query-engine/uv.lock`, allowing `uv` to resolve dependencies without a date-based cutoff (intended to fix query-engine builds). No package versions or application code changes are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4eeae90c72e728d8bc2ed1d643d82e9c5895011. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->