### PR TITLE
Signal messages insert new table

### DIFF
--- a/app-server/src/ch/signal_run_messages.rs
+++ b/app-server/src/ch/signal_run_messages.rs
@@ -50,18 +50,48 @@ pub async fn insert_signal_run_messages(
 
             let ch_insert_end_res = ch_insert.end().await;
             match ch_insert_end_res {
-                Ok(_) => Ok(()),
-                Err(e) => Err(anyhow::anyhow!(
-                    "Clickhouse signal_run_messages batch insertion failed: {:?}",
-                    e
-                )),
+                Ok(_) => {}
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Clickhouse signal_run_messages batch insertion failed: {:?}",
+                        e
+                    ));
+                }
             }
         }
-        Err(e) => Err(anyhow::anyhow!(
-            "Failed to insert signal_run_messages batch into Clickhouse: {:?}",
-            e
-        )),
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "Failed to insert signal_run_messages batch into Clickhouse: {:?}",
+                e
+            ));
+        }
     }
+
+    // Dual-write to new TTL-based table. Best-effort — don't fail the operation if this errors.
+    match clickhouse
+        .insert::<CHSignalRunMessage>("new_signal_run_messages")
+        .await
+    {
+        Ok(mut ch_insert) => {
+            for message in messages {
+                if let Err(e) = ch_insert.write(message).await {
+                    log::err!("Failed to write to new_signal_run_messages: {:?}", e);
+                    return Ok(());
+                }
+            }
+            if let Err(e) = ch_insert.end().await {
+                log::err!("Failed to flush new_signal_run_messages batch: {:?}", e);
+            }
+        }
+        Err(e) => {
+            log::err!(
+                "Failed to start insert into new_signal_run_messages: {:?}",
+                e
+            );
+        }
+    }
+
+    Ok(())
 }
 
 #[instrument(skip(clickhouse))]

--- a/app-server/src/ch/signal_run_messages.rs
+++ b/app-server/src/ch/signal_run_messages.rs
@@ -75,16 +75,16 @@ pub async fn insert_signal_run_messages(
         Ok(mut ch_insert) => {
             for message in messages {
                 if let Err(e) = ch_insert.write(message).await {
-                    log::err!("Failed to write to signal_run_messages_v2: {:?}", e);
+                    log::error!("Failed to write to signal_run_messages_v2: {:?}", e);
                     return Ok(());
                 }
             }
             if let Err(e) = ch_insert.end().await {
-                log::err!("Failed to flush signal_run_messages_v2 batch: {:?}", e);
+                log::error!("Failed to flush signal_run_messages_v2 batch: {:?}", e);
             }
         }
         Err(e) => {
-            log::err!(
+            log::error!(
                 "Failed to start insert into signal_run_messages_v2: {:?}",
                 e
             );

--- a/app-server/src/ch/signal_run_messages.rs
+++ b/app-server/src/ch/signal_run_messages.rs
@@ -69,23 +69,23 @@ pub async fn insert_signal_run_messages(
 
     // Dual-write to new TTL-based table. Best-effort — don't fail the operation if this errors.
     match clickhouse
-        .insert::<CHSignalRunMessage>("new_signal_run_messages")
+        .insert::<CHSignalRunMessage>("signal_run_messages_v2")
         .await
     {
         Ok(mut ch_insert) => {
             for message in messages {
                 if let Err(e) = ch_insert.write(message).await {
-                    log::err!("Failed to write to new_signal_run_messages: {:?}", e);
+                    log::err!("Failed to write to signal_run_messages_v2: {:?}", e);
                     return Ok(());
                 }
             }
             if let Err(e) = ch_insert.end().await {
-                log::err!("Failed to flush new_signal_run_messages batch: {:?}", e);
+                log::err!("Failed to flush signal_run_messages_v2 batch: {:?}", e);
             }
         }
         Err(e) => {
             log::err!(
-                "Failed to start insert into new_signal_run_messages: {:?}",
+                "Failed to start insert into signal_run_messages_v2: {:?}",
                 e
             );
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches ClickHouse write-path for `signal_run_messages` by adding a second insert and changing error-handling semantics, which could affect durability/observability of message persistence if the new best-effort path misbehaves.
> 
> **Overview**
> `insert_signal_run_messages` now **dual-writes** each batch to a new ClickHouse table, `signal_run_messages_v2`, intended to be TTL-based.
> 
> The existing insert into `signal_run_messages` remains the source of truth and still fails the operation on error, while the v2 write is **best-effort**: failures are logged and do not fail the caller.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ed272c9ddc6140490b961eeb281f952523a48d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->