### PR TITLE
use new signal messages table with ttl

### DIFF
--- a/app-server/src/ch/signal_run_messages.rs
+++ b/app-server/src/ch/signal_run_messages.rs
@@ -50,18 +50,48 @@ pub async fn insert_signal_run_messages(
 
             let ch_insert_end_res = ch_insert.end().await;
             match ch_insert_end_res {
-                Ok(_) => Ok(()),
-                Err(e) => Err(anyhow::anyhow!(
-                    "Clickhouse signal_run_messages batch insertion failed: {:?}",
-                    e
-                )),
+                Ok(_) => {}
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Clickhouse signal_run_messages batch insertion failed: {:?}",
+                        e
+                    ));
+                }
             }
         }
-        Err(e) => Err(anyhow::anyhow!(
-            "Failed to insert signal_run_messages batch into Clickhouse: {:?}",
-            e
-        )),
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "Failed to insert signal_run_messages batch into Clickhouse: {:?}",
+                e
+            ));
+        }
     }
+
+    // Dual-write to new TTL-based table. Best-effort — don't fail the operation if this errors.
+    match clickhouse
+        .insert::<CHSignalRunMessage>("new_signal_run_messages")
+        .await
+    {
+        Ok(mut ch_insert) => {
+            for message in messages {
+                if let Err(e) = ch_insert.write(message).await {
+                    log::err!("Failed to write to new_signal_run_messages: {:?}", e);
+                    return Ok(());
+                }
+            }
+            if let Err(e) = ch_insert.end().await {
+                log::err!("Failed to flush new_signal_run_messages batch: {:?}", e);
+            }
+        }
+        Err(e) => {
+            log::err!(
+                "Failed to start insert into new_signal_run_messages: {:?}",
+                e
+            );
+        }
+    }
+
+    Ok(())
 }
 
 #[instrument(skip(clickhouse))]

--- a/app-server/src/ch/signal_run_messages.rs
+++ b/app-server/src/ch/signal_run_messages.rs
@@ -39,7 +39,7 @@ pub async fn insert_signal_run_messages(
     messages: &[CHSignalRunMessage],
 ) -> Result<()> {
     let mut ch_insert = clickhouse
-        .insert::<CHSignalRunMessage>("signal_run_messages_v2")
+        .insert::<CHSignalRunMessage>("signal_run_messages")
         .await?;
 
     for message in messages {
@@ -58,7 +58,7 @@ pub async fn get_signal_run_messages(
     run_id: Uuid,
 ) -> Result<Vec<CHSignalRunMessage>> {
     let messages = clickhouse
-        .query("SELECT project_id, run_id, time, message FROM signal_run_messages_v2 WHERE project_id = ? AND run_id = ? ORDER BY time ASC")
+        .query("SELECT project_id, run_id, time, message FROM signal_run_messages WHERE project_id = ? AND run_id = ? ORDER BY time ASC")
         .bind(project_id)
         .bind(run_id)
         .fetch_all::<CHSignalRunMessage>()

--- a/app-server/src/ch/signal_run_messages.rs
+++ b/app-server/src/ch/signal_run_messages.rs
@@ -69,23 +69,23 @@ pub async fn insert_signal_run_messages(
 
     // Dual-write to new TTL-based table. Best-effort — don't fail the operation if this errors.
     match clickhouse
-        .insert::<CHSignalRunMessage>("new_signal_run_messages")
+        .insert::<CHSignalRunMessage>("signal_run_messages_v2")
         .await
     {
         Ok(mut ch_insert) => {
             for message in messages {
                 if let Err(e) = ch_insert.write(message).await {
-                    log::err!("Failed to write to new_signal_run_messages: {:?}", e);
+                    log::err!("Failed to write to signal_run_messages_v2: {:?}", e);
                     return Ok(());
                 }
             }
             if let Err(e) = ch_insert.end().await {
-                log::err!("Failed to flush new_signal_run_messages batch: {:?}", e);
+                log::err!("Failed to flush signal_run_messages_v2 batch: {:?}", e);
             }
         }
         Err(e) => {
             log::err!(
-                "Failed to start insert into new_signal_run_messages: {:?}",
+                "Failed to start insert into signal_run_messages_v2: {:?}",
                 e
             );
         }

--- a/app-server/src/ch/signal_run_messages.rs
+++ b/app-server/src/ch/signal_run_messages.rs
@@ -38,58 +38,15 @@ pub async fn insert_signal_run_messages(
     clickhouse: clickhouse::Client,
     messages: &[CHSignalRunMessage],
 ) -> Result<()> {
-    let ch_insert = clickhouse
-        .insert::<CHSignalRunMessage>("signal_run_messages")
-        .await;
-
-    match ch_insert {
-        Ok(mut ch_insert) => {
-            for message in messages {
-                ch_insert.write(message).await?;
-            }
-
-            let ch_insert_end_res = ch_insert.end().await;
-            match ch_insert_end_res {
-                Ok(_) => {}
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "Clickhouse signal_run_messages batch insertion failed: {:?}",
-                        e
-                    ));
-                }
-            }
-        }
-        Err(e) => {
-            return Err(anyhow::anyhow!(
-                "Failed to insert signal_run_messages batch into Clickhouse: {:?}",
-                e
-            ));
-        }
-    }
-
-    // Dual-write to new TTL-based table. Best-effort — don't fail the operation if this errors.
-    match clickhouse
+    let mut ch_insert = clickhouse
         .insert::<CHSignalRunMessage>("signal_run_messages_v2")
-        .await
-    {
-        Ok(mut ch_insert) => {
-            for message in messages {
-                if let Err(e) = ch_insert.write(message).await {
-                    log::err!("Failed to write to signal_run_messages_v2: {:?}", e);
-                    return Ok(());
-                }
-            }
-            if let Err(e) = ch_insert.end().await {
-                log::err!("Failed to flush signal_run_messages_v2 batch: {:?}", e);
-            }
-        }
-        Err(e) => {
-            log::err!(
-                "Failed to start insert into signal_run_messages_v2: {:?}",
-                e
-            );
-        }
+        .await?;
+
+    for message in messages {
+        ch_insert.write(message).await?;
     }
+
+    ch_insert.end().await?;
 
     Ok(())
 }
@@ -101,52 +58,11 @@ pub async fn get_signal_run_messages(
     run_id: Uuid,
 ) -> Result<Vec<CHSignalRunMessage>> {
     let messages = clickhouse
-        .query("SELECT project_id, run_id, time, message FROM signal_run_messages WHERE project_id = ? AND run_id = ? ORDER BY time ASC")
+        .query("SELECT project_id, run_id, time, message FROM signal_run_messages_v2 WHERE project_id = ? AND run_id = ? ORDER BY time ASC")
         .bind(project_id)
         .bind(run_id)
         .fetch_all::<CHSignalRunMessage>()
         .await?;
 
     Ok(messages)
-}
-
-#[instrument(skip(clickhouse, project_run_pairs))]
-pub async fn delete_signal_run_messages(
-    clickhouse: clickhouse::Client,
-    project_run_pairs: &[(Uuid, Uuid)],
-) -> Result<()> {
-    use std::collections::HashMap;
-
-    if project_run_pairs.is_empty() {
-        return Ok(());
-    }
-
-    // Group run_ids by project_id
-    let mut runs_by_project: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
-    for (project_id, run_id) in project_run_pairs {
-        runs_by_project
-            .entry(*project_id)
-            .or_insert_with(Vec::new)
-            .push(*run_id);
-    }
-
-    // Execute DELETE queries in parallel for each project
-    let delete_futures: Vec<_> = runs_by_project
-        .into_iter()
-        .map(|(project_id, run_ids)| {
-            let ch = clickhouse.clone();
-            async move {
-                let query = "DELETE FROM signal_run_messages WHERE project_id = ? AND run_id IN ?";
-                ch.query(query)
-                    .bind(project_id)
-                    .bind(run_ids)
-                    .execute()
-                    .await
-            }
-        })
-        .collect();
-
-    futures_util::future::try_join_all(delete_futures).await?;
-
-    Ok(())
 }

--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -4,9 +4,7 @@ use uuid::Uuid;
 
 use crate::{
     ch::{
-        signal_run_messages::{
-            CHSignalRunMessage, delete_signal_run_messages, get_signal_run_messages,
-        },
+        signal_run_messages::{CHSignalRunMessage, get_signal_run_messages},
         signal_runs::{CHSignalRun, insert_signal_runs},
     },
     db::{DB, signal_jobs::update_signal_job_stats},
@@ -45,19 +43,6 @@ pub async fn handle_failed_runs(
     let failed_runs_ch: Vec<CHSignalRun> = failed_runs.iter().map(CHSignalRun::from).collect();
     if let Err(e) = insert_signal_runs(clickhouse.clone(), &failed_runs_ch).await {
         log::error!("[SIGNAL JOB] Failed to insert failed runs: {:?}", e);
-    }
-
-    // Delete messages for failed runs since they won't be processed further
-    let project_run_pairs: Vec<(Uuid, Uuid)> = failed_runs
-        .iter()
-        .map(|run| (run.project_id, run.run_id))
-        .collect();
-
-    if let Err(e) = delete_signal_run_messages(clickhouse.clone(), &project_run_pairs).await {
-        log::error!(
-            "[SIGNAL JOB] Failed to delete messages for failed runs: {:?}",
-            e
-        );
     }
 
     // Update job statistics - group by job_id since runs may belong to different jobs

--- a/app-server/src/signals/pendings_consumer.rs
+++ b/app-server/src/signals/pendings_consumer.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use crate::{
     cache::Cache,
     ch::{
-        signal_run_messages::{delete_signal_run_messages, insert_signal_run_messages},
+        signal_run_messages::insert_signal_run_messages,
         signal_runs::{CHSignalRun, insert_signal_runs},
     },
     db::DB,
@@ -260,18 +260,6 @@ async fn process_failed_batch(
             .collect();
         if let Err(e) = insert_signal_runs(clickhouse.clone(), &failed_runs_ch).await {
             log::error!("[SIGNAL JOB] Failed to insert failed runs: {:?}", e);
-        }
-
-        let project_run_pairs: Vec<(Uuid, Uuid)> = permanently_failed_runs
-            .iter()
-            .map(|run| (run.project_id, run.run_id))
-            .collect();
-
-        if let Err(e) = delete_signal_run_messages(clickhouse.clone(), &project_run_pairs).await {
-            log::error!(
-                "[SIGNAL JOB] Failed to delete messages for failed runs: {:?}",
-                e
-            );
         }
 
         let mut failed_by_job: HashMap<Uuid, i32> = HashMap::new();

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use crate::{
     cache::Cache,
     ch::signal_events::{CHSignalEvent, insert_signal_events},
-    ch::signal_run_messages::{CHSignalRunMessage, delete_signal_run_messages},
+    ch::signal_run_messages::CHSignalRunMessage,
     ch::signal_runs::{CHSignalRun, insert_signal_runs},
     db::DB,
     db::spans::SpanType,
@@ -207,7 +207,7 @@ pub async fn process_provider_responses(
     })
 }
 
-/// Insert results into ClickHouse, clean up messages, and update job stats.
+/// Insert results into ClickHouse and update job stats.
 /// Callers must insert `new_messages` into ClickHouse **before** routing pending/failed runs to
 /// any queue, to avoid a race where a consumer picks up a run before its conversation history
 /// (e.g. tool results or retry guidance) has been persisted.
@@ -256,24 +256,6 @@ pub async fn finalize_runs(
             "[SIGNAL JOB] Failed to insert permanently failed runs: {:?}",
             e
         );
-    }
-
-    // Delete messages for completed and permanently failed runs
-    let final_runs: Vec<&SignalRun> = succeeded_runs
-        .iter()
-        .chain(permanently_failed_runs.iter())
-        .collect();
-    if !final_runs.is_empty() {
-        let project_run_pairs: Vec<(Uuid, Uuid)> = final_runs
-            .iter()
-            .map(|run| (run.project_id, run.run_id))
-            .collect();
-        if let Err(e) = delete_signal_run_messages(clickhouse.clone(), &project_run_pairs).await {
-            log::error!(
-                "[SIGNAL JOB] Failed to delete messages for final runs: {:?}",
-                e
-            );
-        }
     }
 
     // Update job stats for succeeded runs

--- a/frontend/lib/clickhouse/migrations/35_signal_messages_ttl.sql
+++ b/frontend/lib/clickhouse/migrations/35_signal_messages_ttl.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS signal_run_messages_v2
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(time)
 ORDER BY (project_id, run_id, time)
-TTL time + INTERVAL 7 DAY;
+TTL time + INTERVAL 7 DAY
 SETTINGS index_granularity = 8192;
 
 INSERT INTO signal_run_messages_v2(

--- a/frontend/lib/clickhouse/migrations/35_signal_messages_ttl.sql
+++ b/frontend/lib/clickhouse/migrations/35_signal_messages_ttl.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS signal_run_messages_v2
+(
+    project_id UUID,
+    run_id UUID,
+    time DateTime64(9, 'UTC'),
+    message String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(time)
+ORDER BY (project_id, run_id, time)
+TTL time + INTERVAL 7 DAY;
+SETTINGS index_granularity = 8192;
+
+INSERT INTO signal_run_messages_v2(
+    project_id,
+    run_id,
+    time,
+    message
+)
+SELECT project_id, run_id, time, message
+FROM signal_run_messages
+WHERE time >= now() - INTERVAL 7 DAY;
+
+DROP TABLE IF EXISTS signal_run_messages;

--- a/frontend/lib/clickhouse/migrations/35_signal_messages_ttl.sql
+++ b/frontend/lib/clickhouse/migrations/35_signal_messages_ttl.sql
@@ -21,4 +21,6 @@ SELECT project_id, run_id, time, message
 FROM signal_run_messages
 WHERE time >= now() - INTERVAL 7 DAY;
 
-DROP TABLE IF EXISTS signal_run_messages;
+EXCHANGE TABLES signal_run_messages AND signal_run_messages_v2;
+
+DROP TABLE IF EXISTS signal_run_messages_v2;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes ClickHouse schema and retention for `signal_run_messages` via a table swap and removes explicit message deletion logic, which could impact message availability and storage if the migration/TTL behaves unexpectedly.
> 
> **Overview**
> Moves `signal_run_messages` to a TTL-managed ClickHouse table by adding migration `35_signal_messages_ttl.sql`, which backfills 7 days of data, exchanges tables, and drops the temporary table.
> 
> On the server side, removes the previous dual-write to `signal_run_messages_v2` and deletes the `delete_signal_run_messages` API; signal workers no longer delete messages for failed/completed runs and `insert_signal_run_messages` is simplified to a single-table insert with standard error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2382444110a3ee5a42b708a3c3e1d5160bf87bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->