### PR TITLE
do not try to reparse array tool defs

### DIFF
--- a/frontend/components/playground/utils.tsx
+++ b/frontend/components/playground/utils.tsx
@@ -142,7 +142,7 @@ const parseGenAiToolsDefinitionsFromSpan = (tools?: string) => {
     if (!tools) {
       return undefined;
     }
-    const parsedTools = JSON.parse(tools) as {
+    const parsedTools = (typeof tools === "string" ? JSON.parse(tools) : tools) as {
       type: "function";
       name?: string;
       function: { name: string; description?: string; parameters: Record<string, any> };

--- a/frontend/components/traces/tool-list.tsx
+++ b/frontend/components/traces/tool-list.tsx
@@ -36,7 +36,7 @@ export const extractToolsFromAttributes = (attributes: Record<string, any>): Too
   // moving the schema parsing to provider-specific types, i.e. @/lib/spans/types
   if (genAiToolDefinitions) {
     try {
-      const parsed = JSON.parse(genAiToolDefinitions);
+      const parsed = typeof genAiToolDefinitions === "string" ? JSON.parse(genAiToolDefinitions) : genAiToolDefinitions;
       return parsed.map((tool: any) => {
         const func = tool.function ?? tool;
         return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small defensive parsing changes in UI helpers to avoid double-`JSON.parse` crashes when tool definitions are already provided as arrays/objects.
> 
> **Overview**
> Stops blindly `JSON.parse`-ing `gen_ai.tool.definitions` in both the playground config builder (`utils.tsx`) and trace tool extraction (`tool-list.tsx`); these paths now accept either a JSON string or an already-parsed value.
> 
> This prevents runtime errors when tool definitions arrive as arrays/objects while keeping the rendered/serialized tool output unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edabad695908f3f72eacff365fee0e574e93d9d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->