### PR TITLE
rate limiter

### DIFF
--- a/app-server/Cargo.lock
+++ b/app-server/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "flate2",
  "foldhash 0.1.5",
@@ -56,6 +56,21 @@ dependencies = [
  "tokio-util",
  "tracing",
  "zstd",
+]
+
+[[package]]
+name = "actix-limitation"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf9d4ce7fd50ab56efde47127bd5a2e5e27ae1dc3edbcb85be16672f477ff0a"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "chrono",
+ "derive_more 0.99.20",
+ "log",
+ "redis 0.23.3",
+ "time",
 ]
 
 [[package]]
@@ -149,7 +164,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "foldhash 0.1.5",
  "futures-core",
@@ -327,6 +342,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 name = "app-server"
 version = "0.1.0"
 dependencies = [
+ "actix-limitation",
  "actix-web",
  "actix-web-httpauth",
  "anyhow",
@@ -359,7 +375,7 @@ dependencies = [
  "prost",
  "rand 0.9.2",
  "rayon",
- "redis",
+ "redis 0.32.7",
  "regex",
  "reqwest 0.12.28",
  "resend-rs",
@@ -1471,6 +1487,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -1782,6 +1804,19 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -1795,7 +1830,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -4163,6 +4198,25 @@ dependencies = [
  "flume",
  "futures-core",
  "futures-io",
+]
+
+[[package]]
+name = "redis"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f49cdc0bb3f412bf8e7d1bd90fe1d9eb10bc5c399ba90973c14662a27b3f8ba"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]

--- a/app-server/Cargo.toml
+++ b/app-server/Cargo.toml
@@ -4,7 +4,7 @@ name = "app-server"
 version = "0.1.0"
 
 [dependencies]
-actix-limitation = {version = "0.5", default-features = false}
+actix-limitation = {version = "0.5.1", default-features = false}
 actix-web = "4.13"
 actix-web-httpauth = "0.8.2"
 anyhow = "1"

--- a/app-server/Cargo.toml
+++ b/app-server/Cargo.toml
@@ -4,6 +4,7 @@ name = "app-server"
 version = "0.1.0"
 
 [dependencies]
+actix-limitation = {version = "0.5", default-features = false}
 actix-web = "4.13"
 actix-web-httpauth = "0.8.2"
 anyhow = "1"

--- a/app-server/src/api/v1/sql.rs
+++ b/app-server/src/api/v1/sql.rs
@@ -30,7 +30,7 @@ pub struct SqlQueryResponse {
     pub data: Vec<serde_json::Value>,
 }
 
-#[post("sql/query")]
+#[post("query")]
 pub async fn execute_sql_query(
     req: web::Json<SqlQueryRequest>,
     project_api_key: ProjectApiKey,

--- a/app-server/src/features/mod.rs
+++ b/app-server/src/features/mod.rs
@@ -20,6 +20,7 @@ pub enum Feature {
     Clustering,
     Signals,
     Reports,
+    RateLimiter,
 }
 
 pub fn is_feature_enabled(feature: Feature) -> bool {
@@ -53,6 +54,11 @@ pub fn is_feature_enabled(feature: Feature) -> bool {
         Feature::Reports => {
             env::var("ENABLE_REPORTS").is_ok_and(|s| s == "true")
                 && env::var("RESEND_API_KEY").is_ok_and(|s| !s.is_empty())
+        }
+        Feature::RateLimiter => {
+            env::var("REDIS_URL").is_ok()
+                && env::var("RATE_LIMIT").is_ok()
+                && env::var("RATE_LIMIT_PERIOD_SECS").is_ok()
         }
     }
 }

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1445,9 +1445,10 @@ fn main() -> anyhow::Result<()> {
         log::info!("Enabling producer mode, spinning up full HTTP and gRPC servers");
 
         // === Rate limiter ===
-        let rate_limiter = if let Ok(redis_url) = env::var("REDIS_URL") {
-            let limit = get_unsigned_env_with_default("RATE_LIMIT", 100);
-            let period_secs = get_unsigned_env_with_default("RATE_LIMIT_PERIOD_SECS", 60);
+        let rate_limiter = if is_feature_enabled(Feature::RateLimiter) {
+            let redis_url = env::var("REDIS_URL").unwrap();
+            let limit: usize = env::var("RATE_LIMIT").unwrap().parse().unwrap();
+            let period_secs: u64 = env::var("RATE_LIMIT_PERIOD_SECS").unwrap().parse().unwrap();
             // project_auth middleware populates ProjectApiKey in request extensions
             match Limiter::builder(&redis_url)
                 .key_by(|req: &dev::ServiceRequest| {
@@ -1456,7 +1457,7 @@ fn main() -> anyhow::Result<()> {
                         .map(|k| format!("ratelimit:{}", k.project_id))
                 })
                 .limit(limit)
-                .period(Duration::from_secs(period_secs as u64))
+                .period(Duration::from_secs(period_secs))
                 .build()
             {
                 Ok(limiter) => {
@@ -1473,6 +1474,7 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         } else {
+            log::info!("Rate limiter is disabled");
             None
         };
 

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1575,7 +1575,7 @@ fn main() -> anyhow::Result<()> {
                             )
                             .service({
                                 // rate limited endpoints, currently enabled only for v1/sql/query
-                                let mut scope = web::scope("/v1")
+                                let mut scope = web::scope("/v1/sql")
                                     .wrap(Condition::new(
                                         rate_limiter.is_some(),
                                         RateLimiter::default(),

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1501,7 +1501,7 @@ fn main() -> anyhow::Result<()> {
                         let project_ingestion_auth =
                             HttpAuthentication::bearer(auth::project_ingestion_validator);
 
-                        App::new()
+                        let mut app = App::new()
                             .wrap(ErrorHandlers::new().handler(
                                 StatusCode::BAD_REQUEST,
                                 |res: dev::ServiceResponse| {
@@ -1524,7 +1524,13 @@ fn main() -> anyhow::Result<()> {
                             .app_data(web::Data::new(sse_connections_for_http.clone()))
                             .app_data(web::Data::new(quickwit_client.clone()))
                             .app_data(web::Data::new(pubsub.clone()))
-                            .app_data(web::Data::new(http_client_for_http.clone()))
+                            .app_data(web::Data::new(http_client_for_http.clone()));
+
+                        if let Some(ref limiter) = rate_limiter {
+                            app = app.app_data(web::Data::new(limiter.clone()));
+                        }
+
+                        app
                             // Ingestion endpoints allow both default and ingest-only keys
                             .service(
                                 web::scope("/v1/browser-sessions").service(
@@ -1575,19 +1581,15 @@ fn main() -> anyhow::Result<()> {
                                         web::route().to(api::v1::mcp::method_not_allowed),
                                     ),
                             )
-                            .service({
-                                // rate limited endpoints, currently enabled only for v1/sql/query
-                                let mut scope = web::scope("/v1/sql")
+                            .service(
+                                web::scope("/v1/sql")
                                     .wrap(Condition::new(
                                         rate_limiter.is_some(),
                                         RateLimiter::default(),
                                     ))
-                                    .wrap(project_auth.clone());
-                                if let Some(ref limiter) = rate_limiter {
-                                    scope = scope.app_data(web::Data::new(limiter.clone()));
-                                }
-                                scope.service(api::v1::sql::execute_sql_query)
-                            })
+                                    .wrap(project_auth.clone())
+                                    .service(api::v1::sql::execute_sql_query),
+                            )
                             .service(
                                 web::scope("/v1")
                                     .wrap(project_auth.clone())

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -5,10 +5,11 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
+use actix_limitation::{Limiter, RateLimiter};
 use actix_web::{
-    App, HttpServer, dev,
+    App, HttpMessage, HttpServer, dev,
     http::StatusCode,
-    middleware::{ErrorHandlerResponse, ErrorHandlers, Logger, NormalizePath},
+    middleware::{Condition, ErrorHandlerResponse, ErrorHandlers, Logger, NormalizePath},
     web::{self, JsonConfig, PayloadConfig},
 };
 use actix_web_httpauth::middleware::HttpAuthentication;
@@ -1442,6 +1443,39 @@ fn main() -> anyhow::Result<()> {
 
     if enable_producer() {
         log::info!("Enabling producer mode, spinning up full HTTP and gRPC servers");
+
+        // === Rate limiter ===
+        let rate_limiter = if let Ok(redis_url) = env::var("REDIS_URL") {
+            let limit = get_unsigned_env_with_default("RATE_LIMIT", 100);
+            let period_secs = get_unsigned_env_with_default("RATE_LIMIT_PERIOD_SECS", 60);
+            // project_auth middleware populates ProjectApiKey in request extensions
+            match Limiter::builder(&redis_url)
+                .key_by(|req: &dev::ServiceRequest| {
+                    req.extensions()
+                        .get::<db::project_api_keys::ProjectApiKey>()
+                        .map(|k| format!("ratelimit:{}", k.project_id))
+                })
+                .limit(limit)
+                .period(Duration::from_secs(period_secs as u64))
+                .build()
+            {
+                Ok(limiter) => {
+                    log::info!(
+                        "Rate limiter initialized ({} req/{} s per project)",
+                        limit,
+                        period_secs
+                    );
+                    Some(limiter)
+                }
+                Err(e) => {
+                    log::warn!("Failed to initialize rate limiter: {:?}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         // == HTTP server and listener workers ==
         let http_server_handle = thread::Builder::new()
             .name("http".to_string())
@@ -1539,6 +1573,19 @@ fn main() -> anyhow::Result<()> {
                                         web::route().to(api::v1::mcp::method_not_allowed),
                                     ),
                             )
+                            .service({
+                                // rate limited endpoints, currently enabled only for v1/sql/query
+                                let mut scope = web::scope("/v1")
+                                    .wrap(Condition::new(
+                                        rate_limiter.is_some(),
+                                        RateLimiter::default(),
+                                    ))
+                                    .wrap(project_auth.clone());
+                                if let Some(ref limiter) = rate_limiter {
+                                    scope = scope.app_data(web::Data::new(limiter.clone()));
+                                }
+                                scope.service(api::v1::sql::execute_sql_query)
+                            })
                             .service(
                                 web::scope("/v1")
                                     .wrap(project_auth.clone())
@@ -1549,7 +1596,6 @@ fn main() -> anyhow::Result<()> {
                                     .service(api::v1::evals::init_eval)
                                     .service(api::v1::evals::save_eval_datapoints)
                                     .service(api::v1::evals::update_eval_datapoint)
-                                    .service(api::v1::sql::execute_sql_query)
                                     .service(api::v1::rollouts::stream)
                                     .service(api::v1::rollouts::update_status)
                                     .service(api::v1::rollouts::send_span_update)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces Redis-backed request rate limiting in the HTTP server and changes the `v1/sql` query route, which can affect production traffic patterns and client compatibility. Misconfiguration or Redis issues could disable limiting or impact SQL query availability/performance.
> 
> **Overview**
> Adds an optional Redis-backed **per-project rate limiter** (via `actix-limitation`) gated by a new `Feature::RateLimiter` requiring `REDIS_URL`, `RATE_LIMIT`, and `RATE_LIMIT_PERIOD_SECS`.
> 
> Moves the SQL query handler to `POST /v1/sql/query` (from `POST /v1/sql/sql/query`) and applies the rate-limiting middleware only to the `/v1/sql` scope when enabled.
> 
> Updates dependencies/lockfile to include `actix-limitation` and introduces additional locked versions for `redis`/`derive_more` needed by the new crate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 319bb80d1aff98be06dca369712ac92613cc15ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->