### PR TITLE
fix context

### DIFF
--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -209,8 +209,14 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
             let is_tool = ch_span.span_type == 6;
             let is_default = !is_llm && !is_tool;
 
-            // Exclude default spans with empty input and output
-            if is_default && is_empty_raw(&ch_span.input) && is_empty_raw(&ch_span.output) {
+            let has_exception = extract_exception_from_events(&ch_span.events).is_some();
+
+            // Exclude default spans with empty input and output, unless they have an exception
+            if is_default
+                && is_empty_raw(&ch_span.input)
+                && is_empty_raw(&ch_span.output)
+                && !has_exception
+            {
                 return None;
             }
 
@@ -636,6 +642,28 @@ mod tests {
         let result = compress_span_content(&spans);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "agent");
+    }
+
+    #[test]
+    fn test_empty_default_span_with_exception_kept() {
+        let parent_id = Uuid::new_v4();
+        let span_id = Uuid::new_v4();
+        let mut span = make_span(span_id, parent_id, "failing_step", 0, 2000, "", "");
+        span.events = vec![(
+            2_500_000_000,
+            "exception".to_string(),
+            r#"{"exception.message":"connection timeout"}"#.to_string(),
+        )];
+
+        let spans = vec![
+            make_span(parent_id, Uuid::nil(), "agent", 0, 1000, "\"run\"", "\"ok\""),
+            span,
+        ];
+
+        let result = compress_span_content(&spans);
+        assert_eq!(result.len(), 2);
+        let kept = result.iter().find(|s| s.name == "failing_step").unwrap();
+        assert!(kept.exception.is_some());
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small change to span filtering logic to preserve exception-bearing spans, plus a focused unit test. Main risk is slightly increased span output volume for traces that previously dropped these spans.
> 
> **Overview**
> Updates `compress_span_content` to **stop dropping default spans with empty input/output when they contain an `exception` event**, ensuring error context is preserved in compressed trace output.
> 
> Adds a regression test covering an empty default span with an exception to verify it is kept and that `exception` is populated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a17cf824a5af7a46f416fbfe8cfd8303393dc892. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->