### PR TITLE
[WIP] feat: Home page with banner, notifications, and dashboards

### DIFF
--- a/frontend/app/project/[projectId]/home/page.tsx
+++ b/frontend/app/project/[projectId]/home/page.tsx
@@ -1,0 +1,11 @@
+import { type Metadata } from "next";
+
+import Home from "@/components/home";
+
+export const metadata: Metadata = {
+  title: "Home",
+};
+
+export default async function HomePage() {
+  return <Home />;
+}

--- a/frontend/components/home/feature-banner/banner-data.ts
+++ b/frontend/components/home/feature-banner/banner-data.ts
@@ -1,0 +1,50 @@
+export interface FeatureItem {
+  label: string;
+  title: string;
+  description: string;
+  docsUrl: string;
+  tryItUrl: string;
+}
+
+export const features: FeatureItem[] = [
+  {
+    label: "New in Laminar",
+    title: "Revamped Signals for Automatic Insights",
+    description:
+      "Laminar proactively detects patterns in your traces and creates signals from them. Automatic event clustering gives you instant insights from your traces.",
+    docsUrl: "https://docs.laminar.sh/signals/overview",
+    tryItUrl: "signals",
+  },
+  {
+    label: "New in Laminar",
+    title: "Usage Limits & Billing Controls",
+    description:
+      "Set spending caps and usage limits for your projects. Get alerts before you hit thresholds and maintain full control over your observability costs.",
+    docsUrl: "https://docs.laminar.sh/overview",
+    tryItUrl: "settings",
+  },
+  {
+    label: "New in Laminar",
+    title: "Agent Search Across Traces",
+    description:
+      "Search through your agent traces with natural language queries. Quickly find specific conversations, errors, or patterns across all your trace data.",
+    docsUrl: "https://docs.laminar.sh/traces/introduction",
+    tryItUrl: "traces",
+  },
+  {
+    label: "New in Laminar",
+    title: "Slack Reports & Email Alerts",
+    description:
+      "Receive automated reports in Slack and alert emails when important events are detected. Stay informed without constantly checking the dashboard.",
+    docsUrl: "https://docs.laminar.sh/overview",
+    tryItUrl: "settings",
+  },
+  {
+    label: "New in Laminar",
+    title: "Per-Signal Sampling Configuration",
+    description:
+      "Fine-tune sampling rates for individual signals. Reduce noise on high-volume signals while keeping full fidelity on critical ones.",
+    docsUrl: "https://docs.laminar.sh/signals/overview",
+    tryItUrl: "signals",
+  },
+];

--- a/frontend/components/home/feature-banner/banner-nav.tsx
+++ b/frontend/components/home/feature-banner/banner-nav.tsx
@@ -1,0 +1,36 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface BannerNavProps {
+  activeIndex: number;
+  totalSlides: number;
+  onPrev: () => void;
+  onNext: () => void;
+  onSelect: (index: number) => void;
+}
+
+export default function BannerNav({ activeIndex, totalSlides, onPrev, onNext, onSelect }: BannerNavProps) {
+  return (
+    <div className="flex flex-col items-center justify-between self-stretch shrink-0 rounded-xl">
+      <button onClick={onPrev} className="text-muted-foreground hover:text-foreground transition-colors">
+        <ChevronUp size={16} />
+      </button>
+      <div className="flex flex-col gap-2 items-center">
+        {Array.from({ length: totalSlides }).map((_, index) => (
+          <button
+            key={index}
+            onClick={() => onSelect(index)}
+            className={cn(
+              "size-1.5 rounded-full transition-colors",
+              index === activeIndex ? "bg-primary" : "bg-muted-foreground/50"
+            )}
+          />
+        ))}
+      </div>
+      <button onClick={onNext} className="text-muted-foreground hover:text-foreground transition-colors">
+        <ChevronDown size={16} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/components/home/feature-banner/banner-slide.tsx
+++ b/frontend/components/home/feature-banner/banner-slide.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+import { type FeatureItem } from "./banner-data";
+
+interface BannerSlideProps {
+  feature: FeatureItem;
+}
+
+export default function BannerSlide({ feature }: BannerSlideProps) {
+  const { projectId } = useParams();
+
+  return (
+    <div
+      className="h-[164px] rounded-xl border border-primary/30 flex items-end justify-between pl-6 pr-[18px] py-[18px]"
+      style={{
+        backgroundImage:
+          "linear-gradient(90deg, rgba(208, 113, 73, 0.1) 0%, rgba(208, 113, 73, 0) 60%), linear-gradient(90deg, hsl(var(--secondary)) 0%, hsl(var(--secondary)) 100%)",
+      }}
+    >
+      <div className="flex flex-col gap-2 items-start justify-center w-[476px]">
+        <div className="flex flex-col gap-1 items-start w-full">
+          <p className="text-xs leading-4 text-primary">{feature.label}</p>
+          <p className="text-xl font-medium leading-6 text-foreground">{feature.title}</p>
+        </div>
+        <p className="text-xs leading-4 text-secondary-foreground">{feature.description}</p>
+      </div>
+      <div className="flex flex-col items-end justify-center">
+        <div className="flex gap-2 items-center">
+          <a
+            href={feature.docsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="border border-[#555] rounded px-2 py-1 text-xs leading-4 text-foreground hover:bg-muted transition-colors"
+          >
+            Docs
+          </a>
+          <Link
+            href={`/project/${projectId}/${feature.tryItUrl}`}
+            className="bg-primary border border-white/40 rounded px-2 py-1 text-xs leading-4 text-foreground hover:opacity-90 transition-opacity"
+          >
+            Try it now
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/home/feature-banner/index.tsx
+++ b/frontend/components/home/feature-banner/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { features } from "./banner-data";
@@ -48,10 +49,18 @@ export default function FeatureBanner() {
 
   return (
     <div className="flex gap-2 items-start w-full">
-      <div className="flex-1 relative">
-        <div key={activeIndex} className="animate-in fade-in duration-300">
-          <BannerSlide feature={features[activeIndex]} />
-        </div>
+      <div className="flex-1 relative overflow-hidden">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={activeIndex}
+            initial={{ scale: 0.98 }}
+            animate={{ scale: 1 }}
+            exit={{ scale: 0.98 }}
+            transition={{ duration: 0.1, ease: "easeInOut" }}
+          >
+            <BannerSlide feature={features[activeIndex]} />
+          </motion.div>
+        </AnimatePresence>
       </div>
       <BannerNav
         activeIndex={activeIndex}

--- a/frontend/components/home/feature-banner/index.tsx
+++ b/frontend/components/home/feature-banner/index.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { features } from "./banner-data";
+import BannerNav from "./banner-nav";
+import BannerSlide from "./banner-slide";
+
+export default function FeatureBanner() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const resetTimer = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    intervalRef.current = setInterval(() => {
+      setActiveIndex((prev) => (prev + 1) % features.length);
+    }, 5000);
+  }, []);
+
+  useEffect(() => {
+    resetTimer();
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [resetTimer]);
+
+  const handlePrev = useCallback(() => {
+    setActiveIndex((prev) => (prev - 1 + features.length) % features.length);
+    resetTimer();
+  }, [resetTimer]);
+
+  const handleNext = useCallback(() => {
+    setActiveIndex((prev) => (prev + 1) % features.length);
+    resetTimer();
+  }, [resetTimer]);
+
+  const handleSelect = useCallback(
+    (index: number) => {
+      setActiveIndex(index);
+      resetTimer();
+    },
+    [resetTimer]
+  );
+
+  return (
+    <div className="flex gap-2 items-start w-full">
+      <div className="flex-1 relative">
+        <div key={activeIndex} className="animate-in fade-in duration-300">
+          <BannerSlide feature={features[activeIndex]} />
+        </div>
+      </div>
+      <BannerNav
+        activeIndex={activeIndex}
+        totalSlides={features.length}
+        onPrev={handlePrev}
+        onNext={handleNext}
+        onSelect={handleSelect}
+      />
+    </div>
+  );
+}

--- a/frontend/components/home/home-dashboards/home-dashboard-card.tsx
+++ b/frontend/components/home/home-dashboards/home-dashboard-card.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Pin, PinOff } from "lucide-react";
+import Link from "next/link";
+import { useParams, useSearchParams } from "next/navigation";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+
+import { ChartRendererCore } from "@/components/chart-builder/charts";
+import { type DataRow, transformDataToColumns } from "@/components/chart-builder/utils";
+import { type DashboardChart } from "@/components/dashboard/types";
+import { Skeleton } from "@/components/ui/skeleton";
+import { type GroupByInterval } from "@/lib/clickhouse/modifiers";
+import { convertToTimeParameters } from "@/lib/time";
+
+interface HomeDashboardCardProps {
+  chart: DashboardChart;
+  isPinned: boolean;
+  onTogglePin: () => void;
+}
+
+function HomeDashboardCard({ chart, isPinned, onTogglePin }: HomeDashboardCardProps) {
+  const { projectId } = useParams();
+  const searchParams = useSearchParams();
+  const [data, setData] = useState<DataRow[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const columns = useMemo(() => transformDataToColumns(data), [data]);
+
+  const timeParameters = useMemo(() => {
+    const groupByInterval = searchParams.get("groupByInterval") as GroupByInterval | null;
+    const pastHours = searchParams.get("pastHours");
+    if (pastHours) {
+      return { pastHours, ...(groupByInterval && { groupByInterval }) };
+    }
+    const startTime = searchParams.get("startDate");
+    const endTime = searchParams.get("endDate");
+    if (startTime && endTime) {
+      return { startTime, endTime, ...(groupByInterval && { groupByInterval }) };
+    }
+    return { pastHours: 24, ...(groupByInterval && { groupByInterval }) };
+  }, [searchParams]);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const { groupByInterval, ...rest } = timeParameters;
+      const parameters = convertToTimeParameters(rest, groupByInterval);
+      setIsLoading(true);
+      setError(null);
+      const response = await fetch(`/api/projects/${projectId}/sql`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: chart.query, projectId, parameters }),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to execute SQL query");
+      }
+      const result = await response.json();
+      setData(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "An error occurred");
+      setData([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectId, chart.query, timeParameters]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return (
+    <div className="bg-secondary border border-border rounded-xl h-[269px] relative overflow-hidden flex flex-col">
+      <div className="flex items-center justify-between p-3">
+        <Link
+          href={`/project/${projectId}/dashboard`}
+          className="text-xs text-secondary-foreground truncate flex-1 hover:text-foreground transition-colors"
+        >
+          {chart.name}
+        </Link>
+        <button
+          onClick={onTogglePin}
+          className={`shrink-0 ml-2 transition-colors ${isPinned ? "text-primary" : "text-muted-foreground"} hover:text-foreground`}
+        >
+          {isPinned ? <Pin size={16} /> : <PinOff size={16} />}
+        </button>
+      </div>
+      <div className="flex-1 overflow-hidden p-2">
+        {error ? (
+          <div className="flex flex-col items-center justify-center h-full text-center">
+            <p className="text-xs text-muted-foreground">Error loading chart</p>
+          </div>
+        ) : isLoading ? (
+          <Skeleton className="h-full w-full" />
+        ) : (
+          <ChartRendererCore config={chart.settings.config} data={data} columns={columns} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default memo(HomeDashboardCard);

--- a/frontend/components/home/home-dashboards/home-dashboard-card.tsx
+++ b/frontend/components/home/home-dashboards/home-dashboard-card.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { Pin, PinOff } from "lucide-react";
-import Link from "next/link";
-import { useParams, useSearchParams } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 
 import { ChartRendererCore } from "@/components/chart-builder/charts";
@@ -20,6 +19,7 @@ interface HomeDashboardCardProps {
 
 function HomeDashboardCard({ chart, isPinned, onTogglePin }: HomeDashboardCardProps) {
   const { projectId } = useParams();
+  const router = useRouter();
   const searchParams = useSearchParams();
   const [data, setData] = useState<DataRow[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -70,16 +70,17 @@ function HomeDashboardCard({ chart, isPinned, onTogglePin }: HomeDashboardCardPr
   }, [fetchData]);
 
   return (
-    <div className="bg-secondary border border-border rounded-xl h-[269px] relative overflow-hidden flex flex-col">
+    <div
+      className="bg-secondary border border-border rounded-xl h-[269px] relative overflow-hidden flex flex-col cursor-pointer hover:border-foreground/20 transition-colors"
+      onClick={() => router.push(`/project/${projectId}/dashboard`)}
+    >
       <div className="flex items-center justify-between p-3">
-        <Link
-          href={`/project/${projectId}/dashboard`}
-          className="text-xs text-secondary-foreground truncate flex-1 hover:text-foreground transition-colors"
-        >
-          {chart.name}
-        </Link>
+        <span className="text-xs text-secondary-foreground truncate flex-1">{chart.name}</span>
         <button
-          onClick={onTogglePin}
+          onClick={(e) => {
+            e.stopPropagation();
+            onTogglePin();
+          }}
           className={`shrink-0 ml-2 transition-colors ${isPinned ? "text-primary" : "text-muted-foreground"} hover:text-foreground`}
         >
           {isPinned ? <Pin size={16} /> : <PinOff size={16} />}

--- a/frontend/components/home/home-dashboards/index.tsx
+++ b/frontend/components/home/home-dashboards/index.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import useSWR from "swr";
+
+import { type DashboardChart } from "@/components/dashboard/types";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/lib/hooks/use-toast";
+import { swrFetcher } from "@/lib/utils";
+
+import HomeDashboardCard from "./home-dashboard-card";
+
+export default function HomeDashboards() {
+  const { projectId } = useParams();
+  const { toast } = useToast();
+  const {
+    data = [],
+    isLoading,
+    error,
+  } = useSWR<DashboardChart[]>(`/api/projects/${projectId}/dashboard-charts`, swrFetcher);
+
+  // Track unpinned IDs. All dashboards are pinned by default.
+  const [unpinnedIds, setUnpinnedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (error) {
+      toast({ variant: "destructive", title: "Failed to load dashboards" });
+    }
+  }, [error, toast]);
+
+  const handleTogglePin = useCallback((id: string) => {
+    setUnpinnedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-2 items-start w-full">
+        <p className="text-xs text-secondary-foreground">Dashboards</p>
+        <div className="grid grid-cols-3 gap-4 w-full">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="w-full h-[269px] rounded-xl" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex flex-col gap-2 items-start w-full">
+        <p className="text-xs text-secondary-foreground">Dashboards</p>
+        <p className="text-sm text-muted-foreground">No dashboards yet. Create one from the Dashboards page.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 items-start w-full">
+      <p className="text-xs text-secondary-foreground">Dashboards</p>
+      <div className="grid grid-cols-3 gap-4 w-full">
+        {data.map((chart) => (
+          <HomeDashboardCard
+            key={chart.id}
+            chart={chart}
+            isPinned={!unpinnedIds.has(chart.id)}
+            onTogglePin={() => handleTogglePin(chart.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/home/index.tsx
+++ b/frontend/components/home/index.tsx
@@ -13,7 +13,7 @@ export default function Home() {
       <Header path="home" />
       <ScrollArea className="h-full">
         <div className="flex flex-col items-center">
-          <div className="max-w-[850px] w-full flex flex-col gap-[45px] pt-[65px] pb-8">
+          <div className="max-w-[1050px] w-full flex flex-col gap-[45px] pt-[65px] pb-8">
             <FeatureBanner />
             <RecentActivity />
             <HomeDashboards />

--- a/frontend/components/home/index.tsx
+++ b/frontend/components/home/index.tsx
@@ -13,7 +13,7 @@ export default function Home() {
       <Header path="home" />
       <ScrollArea className="h-full">
         <div className="flex flex-col items-center">
-          <div className="max-w-[850px] w-full flex flex-col gap-[45px] py-8">
+          <div className="max-w-[850px] w-full flex flex-col gap-[45px] pt-[65px] pb-8">
             <FeatureBanner />
             <RecentActivity />
             <HomeDashboards />

--- a/frontend/components/home/index.tsx
+++ b/frontend/components/home/index.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import Header from "@/components/ui/header";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+import FeatureBanner from "./feature-banner";
+import HomeDashboards from "./home-dashboards";
+import RecentActivity from "./recent-activity";
+
+export default function Home() {
+  return (
+    <>
+      <Header path="home" />
+      <ScrollArea className="h-full">
+        <div className="flex flex-col items-center">
+          <div className="max-w-[850px] w-full flex flex-col gap-[45px] py-8">
+            <FeatureBanner />
+            <RecentActivity />
+            <HomeDashboards />
+          </div>
+        </div>
+      </ScrollArea>
+    </>
+  );
+}

--- a/frontend/components/home/recent-activity/activity-card.tsx
+++ b/frontend/components/home/recent-activity/activity-card.tsx
@@ -26,13 +26,18 @@ export default function ActivityCard({ notification, onDismiss, isExpanded, onTo
         onClick={onToggleExpand}
       >
         <CardHeader notification={notification} onDismiss={onDismiss} />
-        <CardFooter notification={notification} projectId={projectId as string} variant="collapsed" />
+        <CardFooter
+          notification={notification}
+          projectId={projectId as string}
+          variant="collapsed"
+          onDismiss={onDismiss}
+        />
       </div>
 
       {/* Expanded overlay */}
       {isExpanded && (
         <div
-          className="absolute -left-px -bottom-px w-[calc(100%+2px)] z-10 border border-primary/30 rounded-xl flex flex-col gap-4 items-end pb-[18px] pt-[14px] px-4 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.5)] cursor-pointer"
+          className="absolute -left-px -bottom-px w-[calc(100%+2px)] h-[200px] z-10 border border-primary/30 rounded-xl flex flex-col gap-4 items-end pb-[18px] pt-[14px] px-4 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.5)] cursor-pointer"
           style={{
             backgroundImage:
               "linear-gradient(90deg, rgba(34, 34, 38, 0.75) 0%, rgba(34, 34, 38, 0.75) 100%), linear-gradient(90deg, hsl(var(--secondary)) 0%, hsl(var(--secondary)) 100%)",
@@ -50,7 +55,12 @@ export default function ActivityCard({ notification, onDismiss, isExpanded, onTo
               ))}
             </div>
           </div>
-          <CardFooter notification={notification} projectId={projectId as string} variant="expanded" />
+          <CardFooter
+            notification={notification}
+            projectId={projectId as string}
+            variant="expanded"
+            onDismiss={onDismiss}
+          />
         </div>
       )}
     </div>
@@ -104,10 +114,12 @@ function CardFooter({
   notification,
   projectId,
   variant,
+  onDismiss,
 }: {
   notification: ActivityNotification;
   projectId: string;
   variant: "collapsed" | "expanded";
+  onDismiss: (id: string) => void;
 }) {
   return (
     <div className="flex items-center justify-between w-full">
@@ -115,7 +127,10 @@ function CardFooter({
       <div className="flex gap-2 items-center">
         {notification.type === "new_signal" && variant === "collapsed" && (
           <button
-            onClick={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDismiss(notification.id);
+            }}
             className="border border-[#555] rounded px-2 py-1 text-xs leading-4 text-foreground hover:bg-muted transition-colors"
           >
             Delete

--- a/frontend/components/home/recent-activity/activity-card.tsx
+++ b/frontend/components/home/recent-activity/activity-card.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { X } from "lucide-react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+import { type ActivityNotification } from "./dummy-data";
+
+const BAR_HEIGHTS = [10, 20, 14, 10, 23, 9, 29, 10, 20, 3, 41];
+
+interface ActivityCardProps {
+  notification: ActivityNotification;
+  onDismiss: (id: string) => void;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+}
+
+export default function ActivityCard({ notification, onDismiss, isExpanded, onToggleExpand }: ActivityCardProps) {
+  const { projectId } = useParams();
+
+  return (
+    <div className="relative w-[350px] shrink-0">
+      {/* Collapsed card */}
+      <div
+        className="bg-secondary border border-primary/30 rounded-xl flex flex-col gap-3 items-end pb-[18px] pt-[14px] px-4 cursor-pointer"
+        onClick={onToggleExpand}
+      >
+        <CardHeader notification={notification} onDismiss={onDismiss} />
+        <CardFooter notification={notification} projectId={projectId as string} variant="collapsed" />
+      </div>
+
+      {/* Expanded overlay */}
+      {isExpanded && (
+        <div
+          className="absolute -left-px -bottom-px w-[calc(100%+2px)] z-10 border border-primary/30 rounded-xl flex flex-col gap-4 items-end pb-[18px] pt-[14px] px-4 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.5)] cursor-pointer"
+          style={{
+            backgroundImage:
+              "linear-gradient(90deg, rgba(34, 34, 38, 0.75) 0%, rgba(34, 34, 38, 0.75) 100%), linear-gradient(90deg, hsl(var(--secondary)) 0%, hsl(var(--secondary)) 100%)",
+          }}
+          onClick={onToggleExpand}
+        >
+          <CardHeader notification={notification} onDismiss={onDismiss} />
+          <div className="bg-muted border border-border rounded-lg p-2 flex-1 w-full relative">
+            <p className="text-base font-medium text-secondary-foreground absolute top-1 left-2">
+              {notification.eventCount} events
+            </p>
+            <div className="flex gap-1 items-end justify-center w-full h-full pt-6">
+              {BAR_HEIGHTS.map((height, i) => (
+                <div key={i} className="flex-1 rounded-sm bg-[rgba(193,122,255,0.75)]" style={{ height }} />
+              ))}
+            </div>
+          </div>
+          <CardFooter notification={notification} projectId={projectId as string} variant="expanded" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CardHeader({
+  notification,
+  onDismiss,
+}: {
+  notification: ActivityNotification;
+  onDismiss: (id: string) => void;
+}) {
+  return (
+    <div className="flex gap-0.5 items-start w-full">
+      <div className="flex-1 flex flex-col gap-0.5 items-start">
+        {notification.type === "new_signal" ? (
+          <>
+            <p className="text-xs leading-4 text-primary">New signal</p>
+            <p className="text-base font-medium leading-5 text-foreground">{notification.title}</p>
+          </>
+        ) : (
+          <>
+            <div className="flex gap-1 items-center">
+              <p className="text-xs leading-4 text-primary whitespace-nowrap">New cluster in signal</p>
+              <span className="bg-muted border border-border rounded-sm px-1 text-[10px] leading-4 text-muted-foreground whitespace-nowrap">
+                {notification.signalName}
+              </span>
+            </div>
+            <div className="flex gap-2 items-center">
+              <div className="size-3 rounded-full shrink-0" style={{ backgroundColor: notification.clusterColor }} />
+              <p className="text-base font-medium leading-5 text-foreground">{notification.title}</p>
+            </div>
+          </>
+        )}
+      </div>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onDismiss(notification.id);
+        }}
+        className="text-muted-foreground hover:text-foreground shrink-0"
+      >
+        <X size={20} />
+      </button>
+    </div>
+  );
+}
+
+function CardFooter({
+  notification,
+  projectId,
+  variant,
+}: {
+  notification: ActivityNotification;
+  projectId: string;
+  variant: "collapsed" | "expanded";
+}) {
+  return (
+    <div className="flex items-center justify-between w-full">
+      <p className="text-xs leading-[18px] text-muted-foreground">{notification.timeAgo}</p>
+      <div className="flex gap-2 items-center">
+        {notification.type === "new_signal" && variant === "collapsed" && (
+          <button
+            onClick={(e) => e.stopPropagation()}
+            className="border border-[#555] rounded px-2 py-1 text-xs leading-4 text-foreground hover:bg-muted transition-colors"
+          >
+            Delete
+          </button>
+        )}
+        <Link
+          href={`/project/${projectId}/signals`}
+          onClick={(e) => e.stopPropagation()}
+          className={`${variant === "expanded" ? "bg-primary" : "bg-muted"} rounded px-3 py-1.5 text-xs leading-4 text-foreground hover:opacity-90 transition-opacity`}
+        >
+          Open in Signals
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/home/recent-activity/activity-card.tsx
+++ b/frontend/components/home/recent-activity/activity-card.tsx
@@ -22,7 +22,7 @@ export default function ActivityCard({ notification, onDismiss, isExpanded, onTo
     <div className="relative w-[350px] shrink-0">
       {/* Collapsed card */}
       <div
-        className="bg-secondary border border-primary/30 rounded-xl flex flex-col gap-3 items-end pb-[18px] pt-[14px] px-4 cursor-pointer"
+        className="bg-secondary border rounded-xl flex flex-col gap-3 items-end pb-[18px] pt-[14px] px-4 cursor-pointer"
         onClick={onToggleExpand}
       >
         <CardHeader notification={notification} onDismiss={onDismiss} />
@@ -104,7 +104,7 @@ function CardHeader({
         }}
         className="text-muted-foreground hover:text-foreground shrink-0"
       >
-        <X size={20} />
+        <X size={16} />
       </button>
     </div>
   );

--- a/frontend/components/home/recent-activity/dummy-data.ts
+++ b/frontend/components/home/recent-activity/dummy-data.ts
@@ -1,0 +1,59 @@
+export interface ActivityNotification {
+  id: string;
+  type: "new_signal" | "new_cluster";
+  title: string;
+  signalName?: string;
+  clusterColor?: string;
+  eventCount?: number;
+  timeAgo: string;
+  createdAt: Date;
+}
+
+export const dummyNotifications: ActivityNotification[] = [
+  {
+    id: "1",
+    type: "new_signal",
+    title: "Browser Agent Errors",
+    eventCount: 42,
+    timeAgo: "4 hours ago",
+    createdAt: new Date(Date.now() - 4 * 60 * 60 * 1000),
+  },
+  {
+    id: "2",
+    type: "new_cluster",
+    title: "Inefficient Git commands",
+    signalName: "Optimization Opportunities",
+    clusterColor: "#c17aff",
+    eventCount: 84,
+    timeAgo: "8 hours ago",
+    createdAt: new Date(Date.now() - 8 * 60 * 60 * 1000),
+  },
+  {
+    id: "3",
+    type: "new_cluster",
+    title: "Slow API responses",
+    signalName: "Optimization Opportunities",
+    clusterColor: "#c17aff",
+    eventCount: 56,
+    timeAgo: "8 hours ago",
+    createdAt: new Date(Date.now() - 8 * 60 * 60 * 1000),
+  },
+  {
+    id: "4",
+    type: "new_cluster",
+    title: "Database connection timeouts",
+    signalName: "Latency Spikes",
+    clusterColor: "#ff4d4d",
+    eventCount: 31,
+    timeAgo: "12 hours ago",
+    createdAt: new Date(Date.now() - 12 * 60 * 60 * 1000),
+  },
+  {
+    id: "5",
+    type: "new_signal",
+    title: "Cost Anomalies",
+    eventCount: 17,
+    timeAgo: "1 day ago",
+    createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+  },
+];

--- a/frontend/components/home/recent-activity/index.tsx
+++ b/frontend/components/home/recent-activity/index.tsx
@@ -1,13 +1,30 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import ActivityCard from "./activity-card";
 import { type ActivityNotification, dummyNotifications } from "./dummy-data";
 
+const gradientTransition = { type: "spring" as const, stiffness: 500, damping: 20 };
+
 export default function RecentActivity() {
   const [notifications, setNotifications] = useState<ActivityNotification[]>(dummyNotifications);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [showLeftGradient, setShowLeftGradient] = useState(false);
+  const [showRightGradient, setShowRightGradient] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const updateGradients = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setShowLeftGradient(el.scrollLeft > 0);
+    setShowRightGradient(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    updateGradients();
+  }, [notifications, updateGradients]);
 
   const handleDismiss = useCallback((id: string) => {
     setNotifications((prev) => prev.filter((n) => n.id !== id));
@@ -36,7 +53,7 @@ export default function RecentActivity() {
         </button>
       </div>
       <div className="relative w-full">
-        <div className="flex gap-4 overflow-x-auto pb-2 no-scrollbar">
+        <div ref={scrollRef} onScroll={updateGradients} className="flex gap-4 overflow-x-auto pb-2 no-scrollbar">
           {notifications.map((notification) => (
             <ActivityCard
               key={notification.id}
@@ -47,7 +64,30 @@ export default function RecentActivity() {
             />
           ))}
         </div>
-        <div className="absolute right-0 top-0 bottom-0 w-[134px] bg-gradient-to-l from-background to-transparent pointer-events-none" />
+        <AnimatePresence>
+          {showLeftGradient && (
+            <motion.div
+              key="left-gradient"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={gradientTransition}
+              className="absolute left-0 top-0 bottom-0 w-[134px] bg-gradient-to-r from-background to-transparent pointer-events-none"
+            />
+          )}
+        </AnimatePresence>
+        <AnimatePresence>
+          {showRightGradient && (
+            <motion.div
+              key="right-gradient"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={gradientTransition}
+              className="absolute right-0 top-0 bottom-0 w-[134px] bg-gradient-to-l from-background to-transparent pointer-events-none"
+            />
+          )}
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/frontend/components/home/recent-activity/index.tsx
+++ b/frontend/components/home/recent-activity/index.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import ActivityCard from "./activity-card";
+import { type ActivityNotification, dummyNotifications } from "./dummy-data";
+
+export default function RecentActivity() {
+  const [notifications, setNotifications] = useState<ActivityNotification[]>(dummyNotifications);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const handleDismiss = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+    setExpandedId((prev) => (prev === id ? null : prev));
+  }, []);
+
+  const handleClearAll = useCallback(() => {
+    setNotifications([]);
+    setExpandedId(null);
+  }, []);
+
+  const handleToggleExpand = useCallback((id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id));
+  }, []);
+
+  if (notifications.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2 items-start w-full">
+      <div className="flex items-center justify-between w-full text-xs text-secondary-foreground">
+        <p>Recent Activity ({notifications.length})</p>
+        <button onClick={handleClearAll} className="hover:text-foreground transition-colors">
+          Clear all
+        </button>
+      </div>
+      <div className="relative w-full">
+        <div className="flex gap-4 overflow-x-auto pb-2 no-scrollbar">
+          {notifications.map((notification) => (
+            <ActivityCard
+              key={notification.id}
+              notification={notification}
+              onDismiss={handleDismiss}
+              isExpanded={expandedId === notification.id}
+              onToggleExpand={() => handleToggleExpand(notification.id)}
+            />
+          ))}
+        </div>
+        <div className="absolute right-0 top-0 bottom-0 w-[134px] bg-gradient-to-l from-background to-transparent pointer-events-none" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/project/utils.ts
+++ b/frontend/components/project/utils.ts
@@ -2,6 +2,7 @@ import {
   Database,
   FlaskConical,
   GitFork,
+  House,
   LayoutGrid,
   Pen,
   PlayCircle,
@@ -12,6 +13,11 @@ import {
 } from "lucide-react";
 
 export const getSidebarMenus = (projectId: string) => [
+  {
+    name: "home",
+    href: `/project/${projectId}/home`,
+    icon: House,
+  },
   {
     name: "dashboards",
     href: `/project/${projectId}/dashboard`,


### PR DESCRIPTION
## Summary
- Adds new "Home" page as the first sidebar navigation item
- Auto-animating feature banner carousel (5 slides, 5s interval, vertical dot nav)
- Recent Activity section with expandable notification cards (dummy data for now, BE doesn't exist yet)
- Dashboards section with 3-column grid and pin toggle (local state only, no BE changes)

## What's left
- [ ] Backend for notifications/signals data
- [ ] Backend for dashboard pinning persistence
- [ ] Visual QA pass against Figma designs
- [ ] Eve (QA) and Nathan (nit-pick) review passes

## Test plan
- [ ] Verify "Home" appears as first sidenav item
- [ ] Banner auto-rotates every 5s, manual nav resets timer
- [ ] Notification cards expand on click, dismiss on X, "Clear all" works
- [ ] Dashboard cards render charts, pin toggle works
- [ ] `pnpm lint` and `pnpm type-check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)