### PR TITLE
remove instrumentation from non-critical functions

### DIFF
--- a/app-server/src/quickwit/client.rs
+++ b/app-server/src/quickwit/client.rs
@@ -155,10 +155,7 @@ impl QuickwitClient {
         index_id: &str,
         query_body: serde_json::Value,
     ) -> anyhow::Result<serde_json::Value> {
-        let url = format!(
-            "{}/api/v1/{}/search",
-            self.inner.search_endpoint, index_id
-        );
+        let url = format!("{}/api/v1/{}/search", self.inner.search_endpoint, index_id);
 
         let response = self
             .inner
@@ -185,7 +182,6 @@ impl QuickwitClient {
     }
 }
 
-#[instrument(skip(docs))]
 pub fn build_doc_batch<T: serde::Serialize>(
     index_id: &str,
     docs: &[T],

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, LazyLock};
 use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::{Value, json};
-use tracing::instrument;
 use uuid::Uuid;
 
 use crate::opentelemetry_proto::opentelemetry_proto_common_v1;
@@ -30,7 +29,6 @@ static SKIP_SPAN_NAME_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^Runnable[A-Z][A-Za-z]*(?:<[A-Za-z_,]+>)*\.task$").unwrap());
 
 /// Calculate usage for both default and LLM spans
-#[instrument(skip(attributes, db, cache, span_name))]
 pub async fn get_llm_usage_for_span(
     // mut because input and output tokens are updated to new convention
     attributes: &mut SpanAttributes,

--- a/app-server/src/utils/limits.rs
+++ b/app-server/src/utils/limits.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use chrono::{DateTime, Months, Utc};
-use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -185,7 +184,6 @@ pub async fn get_workspace_signal_runs_limit_exceeded(
     Ok(signal_runs >= effective_limit)
 }
 
-#[instrument(skip(db, clickhouse, cache, queue, project_id, bytes))]
 pub async fn update_workspace_bytes_ingested(
     db: Arc<DB>,
     clickhouse: clickhouse::Client,
@@ -277,7 +275,6 @@ pub async fn update_workspace_bytes_ingested(
     Ok(())
 }
 
-#[instrument(skip(db, clickhouse, cache, queue, project_id, runs))]
 pub async fn update_workspace_signal_runs_used(
     db: Arc<DB>,
     clickhouse: clickhouse::Client,
@@ -521,9 +518,7 @@ async fn send_soft_limit_notification(
             );
             // Message is now durably queued. Eagerly update DB and evict the warnings
             // cache so ingestion workers don't re-enqueue for the same billing cycle.
-            if let Err(e) =
-                usage_warnings::mark_warning_as_notified(&db.pool, warning_id).await
-            {
+            if let Err(e) = usage_warnings::mark_warning_as_notified(&db.pool, warning_id).await {
                 log::error!(
                     "Failed to update last_notified_at for warning [{}]: {:?}",
                     warning_id,
@@ -642,7 +637,6 @@ fn render_usage_warning_email(
         meter_description = meter_description,
     )
 }
-
 
 /// Fetch usage warnings for a workspace, using a short-lived cache to avoid
 /// hitting the database on every ingestion batch.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Removes `tracing::instrument` annotations and related imports from a few utility/ingestion paths; behavior should be unchanged aside from reduced tracing spans.
> 
> **Overview**
> Removes `tracing::instrument` usage from several non-critical functions (e.g., Quickwit doc batch building, LLM span usage calculation, and workspace usage limit update helpers) and drops now-unused `instrument` imports.
> 
> Includes a few no-op formatting cleanups (e.g., `format!`/`if let Err` layout), with no intended functional changes beyond reduced tracing overhead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e71cdd7ee98443c9fe61916de3235cba7fdc49df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->