### PR TITLE
fix: add z index, fix opacity, gradient

### DIFF
--- a/frontend/components/traces/span-view/common.tsx
+++ b/frontend/components/traces/span-view/common.tsx
@@ -287,7 +287,6 @@ export const MessageWrapper = ({
     return () => resizeObserver.disconnect();
   }, [checkOverflow]);
 
-  const isCapped = !isExpanded && isOverflowing;
   const showToggle = isOverflowing || isExpanded;
 
   return (

--- a/frontend/components/traces/span-view/common.tsx
+++ b/frontend/components/traces/span-view/common.tsx
@@ -297,19 +297,17 @@ export const MessageWrapper = ({
       </div>
       {showToggle && (
         <div className="sticky bottom-0 z-30 flex flex-col items-center">
-          {!isExpanded && (
-            <div
-              className="w-full pointer-events-none"
-              style={{
-                height: 36,
-                marginTop: -36,
-                background: "linear-gradient(to bottom, transparent, hsl(var(--background) / 0.75))",
-              }}
-            />
-          )}
+          <div
+            className="w-full pointer-events-none"
+            style={{
+              height: 36,
+              marginTop: -42,
+              background: "linear-gradient(to bottom, transparent, hsl(var(--background) / 1))",
+            }}
+          />
           <button
             onClick={() => setIsExpanded((prev) => !prev)}
-            className="py-1 bg-background/75 w-full flex items-center justify-center gap-1 text-xs text-secondary-foreground cursor-pointer rounded-b border-b transition-colors"
+            className="py-1 bg-background w-full flex items-center justify-center gap-1 text-xs text-secondary-foreground cursor-pointer rounded-b border-b transition-colors"
           >
             {isExpanded ? <ChevronUp className="size-3.5" /> : <ChevronDown className="size-3.5" />}
           </button>

--- a/frontend/components/traces/span-view/common.tsx
+++ b/frontend/components/traces/span-view/common.tsx
@@ -291,26 +291,26 @@ export const MessageWrapper = ({
   const showToggle = isOverflowing || isExpanded;
 
   return (
-    <div className="relative border rounded">
+    <div className={cn("relative border rounded", { "border-b-0": showToggle })}>
       <RoleHeader role={role} className={stickyHeader ? "sticky top-0 z-10" : undefined} />
       <div ref={containerRef} className="overflow-hidden" style={!isExpanded ? { maxHeight } : undefined}>
         <div className="flex flex-col divide-y">{children}</div>
       </div>
       {showToggle && (
-        <div className="sticky bottom-0 z-30 flex flex-col items-center rounded-b">
+        <div className="sticky bottom-0 z-30 flex flex-col items-center">
           {!isExpanded && (
             <div
               className="w-full pointer-events-none"
               style={{
-                height: isCapped ? 48 : 24,
-                marginTop: isCapped ? -48 : 0,
-                background: "linear-gradient(to bottom, transparent, hsl(var(--secondary)))",
+                height: 36,
+                marginTop: -36,
+                background: "linear-gradient(to bottom, transparent, hsl(var(--background) / 0.75))",
               }}
             />
           )}
           <button
             onClick={() => setIsExpanded((prev) => !prev)}
-            className="py-1.5 bg-secondary w-full flex items-center justify-center gap-1 text-xs text-secondary-foreground cursor-pointer rounded-b transition-colors -mt-2"
+            className="py-1 bg-background/75 w-full flex items-center justify-center gap-1 text-xs text-secondary-foreground cursor-pointer rounded-b border-b transition-colors"
           >
             {isExpanded ? <ChevronUp className="size-3.5" /> : <ChevronDown className="size-3.5" />}
           </button>

--- a/frontend/components/traces/span-view/messages.tsx
+++ b/frontend/components/traces/span-view/messages.tsx
@@ -351,7 +351,7 @@ function PureMessages({ messages, presetKey, hideScrollToBottom = false, maxHeig
         <Button
           aria-label="Scroll to bottom"
           size="icon"
-          className="absolute bottom-3 right-3 rounded-full"
+          className="absolute bottom-3 right-3 rounded-full z-40"
           onClick={scrollToBottom}
         >
           <ChevronDown className="w-4 h-4" />

--- a/frontend/components/traces/span-view/span-overview.tsx
+++ b/frontend/components/traces/span-view/span-overview.tsx
@@ -153,7 +153,7 @@ const PureSpanOverview = ({ span }: { span: Span }) => {
         <Button
           aria-label="Scroll to bottom"
           size="icon"
-          className="absolute bottom-3 right-3 rounded-full"
+          className="absolute bottom-3 right-3 rounded-full z-40"
           onClick={scrollToBottom}
         >
           <ChevronDown className="w-4 h-4" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only styling changes to span-view message wrappers and scroll controls; main risk is minor visual regressions across themes/screens.
> 
> **Overview**
> Improves span-view message card collapsing UI by reworking the bottom fade/gradient and toggle styling: the wrapper now conditionally removes the outer bottom border when the toggle is shown, uses a consistent gradient overlay (background-based) and updated toggle button padding/background/border.
> 
> Raises the `Scroll to bottom` floating button with `z-40` in both `messages` and `span-overview` to prevent it from being covered by overlays/sticky elements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eab4c42555f2f4ca701110afc40d45cc4d58b597. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->