### PR TITLE
fix: create limits equal to 100% of current tier on upgrade

### DIFF
--- a/frontend/lib/actions/checkout/types.ts
+++ b/frontend/lib/actions/checkout/types.ts
@@ -1,5 +1,13 @@
 import type Stripe from "stripe";
 
+export type TierConfigEntry = {
+  lookupKey: string;
+  overageMegabytesLookupKey: string;
+  overageSignalRunsLookupKey: string;
+  includedBytes: number;
+  includedSignalRuns: number;
+};
+
 export const TIER_CONFIG = {
   hobby: {
     lookupKey: "hobby_monthly_2026_02",

--- a/frontend/lib/actions/checkout/webhook.ts
+++ b/frontend/lib/actions/checkout/webhook.ts
@@ -4,9 +4,17 @@ import { type Stripe } from "stripe";
 import { deleteAllProjectsWorkspaceInfoFromCache } from "@/lib/actions/project";
 import { cache, WORKSPACE_BYTES_USAGE_CACHE_KEY, WORKSPACE_SIGNAL_RUNS_USAGE_CACHE_KEY } from "@/lib/cache";
 import { db } from "@/lib/db/drizzle";
-import { users, userSubscriptionInfo, workspaceAddons, workspaces, workspaceUsage } from "@/lib/db/migrations/schema";
+import {
+  subscriptionTiers,
+  users,
+  userSubscriptionInfo,
+  workspaceAddons,
+  workspaces,
+  workspaceUsage,
+  workspaceUsageWarnings,
+} from "@/lib/db/migrations/schema";
 
-import { DATAPLANE_ADDON_LOOKUP_KEY } from "./types";
+import { DATAPLANE_ADDON_LOOKUP_KEY, type PaidTier, TIER_CONFIG, type TierConfigEntry } from "./types";
 
 interface ManageWorkspaceSubscriptionEventArgs {
   stripeCustomerId: string;
@@ -51,7 +59,7 @@ export const manageWorkspaceSubscriptionEvent = async ({
   });
   const currentTier = workspace?.subscriptionTier?.name.trim().toLowerCase();
 
-  await db
+  const [{ tierId: newTierId }] = await db
     .update(workspaces)
     .set({
       subscriptionId,
@@ -69,7 +77,8 @@ export const manageWorkspaceSubscriptionEvent = async ({
       // - the webhook event contains actual tier change
       ...(currentTier === "free" ? { resetTime: sql`now()` } : {}),
     })
-    .where(eq(workspaces.id, workspaceId));
+    .where(eq(workspaces.id, workspaceId))
+    .returning({ tierId: workspaces.tierId });
 
   if (workspace && currentTier === "free") {
     await db
@@ -94,6 +103,25 @@ export const manageWorkspaceSubscriptionEvent = async ({
     await db.delete(workspaceUsage).where(eq(workspaceUsage.workspaceId, workspaceId));
   }
   await updateUsageCacheForWorkspace(workspaceId, true, true);
+  try {
+    const newTier = await db.query.subscriptionTiers.findFirst({
+      where: eq(subscriptionTiers.id, newTierId),
+    });
+    const newTierName = newTier?.name?.toLowerCase()?.trim();
+    const currentTierConfig = ["hobby", "pro"].includes(currentTier ?? "")
+      ? TIER_CONFIG[currentTier as PaidTier]
+      : undefined;
+    if (["hobby", "pro"].includes(newTierName ?? "NOT_FOUND")) {
+      const newTierConfig = TIER_CONFIG[newTierName! as PaidTier];
+      insertNewTierUsageWarnings({
+        workspaceId,
+        newTierConfig,
+        currentTierConfig,
+      });
+    }
+  } catch (e) {
+    console.error(`Failed to create new usage warnings for workspace ${workspaceId}, Error: ${e}`);
+  }
 };
 
 export const getIdFromStripeObject = (stripeObject: string | { id: string } | null): string | undefined => {
@@ -252,4 +280,50 @@ export const handleInvoiceFinalized = async (
     .set({ resetTime: sql`date_trunc('day', ${resetDate})` })
     .where(eq(workspaces.id, workspaceId));
   await updateUsageCacheForWorkspace(workspaceId, hasBytes, hasSignalRuns);
+};
+
+export const insertNewTierUsageWarnings = async ({
+  workspaceId,
+  newTierConfig,
+  currentTierConfig,
+}: {
+  workspaceId: string;
+  newTierConfig: TierConfigEntry;
+  currentTierConfig?: TierConfigEntry;
+}) => {
+  if (currentTierConfig) {
+    await db
+      .delete(workspaceUsageWarnings)
+      .where(
+        and(
+          eq(workspaceUsageWarnings.workspaceId, workspaceId),
+          eq(workspaceUsageWarnings.usageItem, "bytes"),
+          eq(workspaceUsageWarnings.limitValue, currentTierConfig.includedBytes)
+        )
+      );
+    await db
+      .delete(workspaceUsageWarnings)
+      .where(
+        and(
+          eq(workspaceUsageWarnings.workspaceId, workspaceId),
+          eq(workspaceUsageWarnings.usageItem, "signal_runs"),
+          eq(workspaceUsageWarnings.limitValue, currentTierConfig.includedSignalRuns)
+        )
+      );
+  }
+  await db
+    .insert(workspaceUsageWarnings)
+    .values([
+      {
+        workspaceId,
+        usageItem: "bytes",
+        limitValue: newTierConfig.includedBytes,
+      },
+      {
+        workspaceId,
+        usageItem: "signal_runs",
+        limitValue: newTierConfig.includedSignalRuns,
+      },
+    ])
+    .onConflictDoNothing();
 };

--- a/frontend/lib/actions/checkout/webhook.ts
+++ b/frontend/lib/actions/checkout/webhook.ts
@@ -59,7 +59,7 @@ export const manageWorkspaceSubscriptionEvent = async ({
   });
   const currentTier = workspace?.subscriptionTier?.name.trim().toLowerCase();
 
-  const [{ tierId: newTierId }] = await db
+  const updatedRows = await db
     .update(workspaces)
     .set({
       subscriptionId,
@@ -103,6 +103,10 @@ export const manageWorkspaceSubscriptionEvent = async ({
     await db.delete(workspaceUsage).where(eq(workspaceUsage.workspaceId, workspaceId));
   }
   await updateUsageCacheForWorkspace(workspaceId, true, true);
+  if (updatedRows.length === 0) {
+    return;
+  }
+  const newTierId = updatedRows[0].tierId;
   try {
     const newTier = await db.query.subscriptionTiers.findFirst({
       where: eq(subscriptionTiers.id, newTierId),
@@ -113,7 +117,7 @@ export const manageWorkspaceSubscriptionEvent = async ({
       : undefined;
     if (["hobby", "pro"].includes(newTierName ?? "NOT_FOUND")) {
       const newTierConfig = TIER_CONFIG[newTierName! as PaidTier];
-      insertNewTierUsageWarnings({
+      await insertNewTierUsageWarnings({
         workspaceId,
         newTierConfig,
         currentTierConfig,

--- a/frontend/lib/actions/checkout/webhook.ts
+++ b/frontend/lib/actions/checkout/webhook.ts
@@ -2,6 +2,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { type Stripe } from "stripe";
 
 import { deleteAllProjectsWorkspaceInfoFromCache } from "@/lib/actions/project";
+import { invalidateUsageWarningsCacheForWorkspace } from "@/lib/actions/usage/utils";
 import { cache, WORKSPACE_BYTES_USAGE_CACHE_KEY, WORKSPACE_SIGNAL_RUNS_USAGE_CACHE_KEY } from "@/lib/cache";
 import { db } from "@/lib/db/drizzle";
 import {
@@ -122,6 +123,7 @@ export const manageWorkspaceSubscriptionEvent = async ({
         newTierConfig,
         currentTierConfig,
       });
+      await invalidateUsageWarningsCacheForWorkspace(workspaceId);
     }
   } catch (e) {
     console.error(`Failed to create new usage warnings for workspace ${workspaceId}, Error: ${e}`);
@@ -286,7 +288,7 @@ export const handleInvoiceFinalized = async (
   await updateUsageCacheForWorkspace(workspaceId, hasBytes, hasSignalRuns);
 };
 
-export const insertNewTierUsageWarnings = async ({
+const insertNewTierUsageWarnings = async ({
   workspaceId,
   newTierConfig,
   currentTierConfig,


### PR DESCRIPTION
- also delete such limits on switch tier
- downgrade is fine, it will have hard limits below that

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe subscription webhook handling and writes/deletes `workspaceUsageWarnings` rows based on tier changes, which could affect enforcement/notifications if tier resolution or limits are wrong. Logic is scoped to paid tier switches and includes cache invalidation, reducing blast radius but still impacts billing-adjacent flows.
> 
> **Overview**
> Updates checkout tier metadata by introducing `TierConfigEntry` and reusing `TIER_CONFIG` as the source of included usage limits.
> 
> Enhances the Stripe subscription webhook handler to detect the newly applied workspace tier (via `workspaces.update(...).returning`) and, on paid-tier changes, **create usage-warning thresholds at 100% of the new tier limits** while **removing thresholds tied to the previous tier**. The webhook now also invalidates the usage-warnings cache after these updates and logs (without failing the webhook) if warning creation fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63bcd7c0b5172fde2baa4022d5fc8d8db7f69746. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->