### PR TITLE
compress system prompts

### DIFF
--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -22,3 +22,4 @@ pub const SIGNAL_BATCH_SUBMITTED_CACHE_KEY: &str = "signal_batch_submitted";
 pub const SAMPLING_FACTORS_CACHE_KEY: &str = "sampling_factors";
 pub const WORKSPACE_USAGE_WARNINGS_CACHE_KEY: &str = "workspace_usage_warnings";
 pub const USAGE_WARNING_SEND_LOCK_KEY: &str = "usage_warning_send_lock";
+pub const SYS_PROMPT_SUMMARY_CACHE_KEY: &str = "sys_prompt_summary";

--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
 use crate::{
+    cache::Cache,
     ch::{
         signal_run_messages::{
             CHSignalRunMessage, delete_signal_run_messages, get_signal_run_messages,
@@ -11,16 +12,17 @@ use crate::{
     },
     db::{DB, signal_jobs::update_signal_job_stats},
     signals::{
-        SignalRun,
+        SignalRun, llm_model,
         prompts::{IDENTIFICATION_PROMPT, SYSTEM_PROMPT},
         provider::{
-            ProviderThinkingConfig, ProviderThinkingLevel,
+            ProviderClient, ProviderThinkingConfig, ProviderThinkingLevel,
             models::{
                 ProviderContent as Content, ProviderGenerationConfig, ProviderPart as Part,
                 ProviderRequest, ProviderRequestItem,
             },
         },
-        spans::get_trace_structure_as_string,
+        spans::{build_trace_structure_string, extract_system_prompts, get_trace_ch_spans},
+        summarize::{generate_and_cache_summaries, lookup_cached_summaries},
         tools::build_tool_definitions,
     },
     worker::HandlerError,
@@ -78,9 +80,12 @@ pub async fn process_run(
     project_id: Uuid,
     trace_id: Uuid,
     run_id: Uuid,
+    signal_id: Uuid,
     prompt: &str,
     structured_output_schema: &serde_json::Value,
     clickhouse: clickhouse::Client,
+    cache: Arc<Cache>,
+    llm_client: Arc<ProviderClient>,
 ) -> Result<ProcessRunResult, HandlerError> {
     let processing_start_time = Utc::now();
 
@@ -92,13 +97,47 @@ pub async fn process_run(
         })?;
 
     let (contents, system_instruction, new_messages) = if existing_messages.is_empty() {
-        // No messages exist - build initial prompts
+        // Fetch spans and build compressed trace with system prompt summarization
+        let ch_spans = get_trace_ch_spans(clickhouse.clone(), project_id, trace_id)
+            .await
+            .map_err(|e| {
+                HandlerError::Transient(anyhow::anyhow!("Failed to get trace spans: {}", e))
+            })?;
+
+        let extracted = extract_system_prompts(&ch_spans);
+        let system_prompt_summaries = if extracted.is_empty() {
+            HashMap::new()
+        } else {
+            let hashes: Vec<String> = extracted.keys().cloned().collect();
+            let mut summaries =
+                lookup_cached_summaries(&cache, project_id, signal_id, &hashes).await;
+
+            let uncached: HashMap<String, String> = extracted
+                .iter()
+                .filter(|(h, _)| !summaries.contains_key(*h))
+                .map(|(h, t)| (h.clone(), t.clone()))
+                .collect();
+
+            if !uncached.is_empty() {
+                let model = llm_model();
+                let generated = generate_and_cache_summaries(
+                    &cache,
+                    &llm_client,
+                    &model,
+                    project_id,
+                    signal_id,
+                    prompt,
+                    &uncached,
+                )
+                .await;
+                summaries.extend(generated);
+            }
+
+            summaries
+        };
+
         let trace_structure =
-            get_trace_structure_as_string(clickhouse.clone(), project_id, trace_id)
-                .await
-                .map_err(|e| {
-                    HandlerError::Transient(anyhow::anyhow!("Failed to get trace structure: {}", e))
-                })?;
+            build_trace_structure_string(&ch_spans, trace_id, &system_prompt_summaries);
 
         let system_prompt = SYSTEM_PROMPT.replace("{{fullTraceData}}", &trace_structure);
 
@@ -198,10 +237,10 @@ pub async fn process_run(
             system_instruction: system_instruction.clone(),
             tools: Some(tools),
             generation_config: Some(ProviderGenerationConfig {
-                temperature: Some(0.85),
+                temperature: Some(0.95),
                 thinking_config: Some(ProviderThinkingConfig {
                     include_thoughts: Some(true),
-                    thinking_level: Some(ProviderThinkingLevel::Medium),
+                    thinking_level: Some(ProviderThinkingLevel::Low),
                 }),
                 ..Default::default()
             }),

--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -110,7 +110,7 @@ pub async fn process_run(
         } else {
             let hashes: Vec<String> = extracted.keys().cloned().collect();
             let mut summaries =
-                lookup_cached_summaries(&cache, project_id, signal_id, &hashes).await;
+                lookup_cached_summaries(&cache, project_id, signal_id, prompt, &hashes).await;
 
             let uncached: HashMap<String, String> = extracted
                 .iter()

--- a/app-server/src/signals/mod.rs
+++ b/app-server/src/signals/mod.rs
@@ -16,6 +16,7 @@ pub mod response_processor;
 pub mod search;
 pub mod spans;
 pub mod submissions_consumer;
+pub mod summarize;
 pub mod tools;
 pub mod utils;
 

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -1,10 +1,10 @@
 pub const SYSTEM_PROMPT: &str = r#"You are an expert in analyzing traces of LLM powered applications, such as chatbots, AI agents, etc.
 
-<trace>
 <data_conventions>
 - Each span's `path` is the concatenated names of all ancestor spans and the current span (e.g. `agent.run.llm_call`). Use it to understand the span's position in the call hierarchy, especially when a `parent` span ID is not present in the output.
 - Default spans with empty input and output are excluded entirely. Their children still appear with the original `parent` ID; use the `path` field to infer the hierarchy.
 - For LLM spans, only the first occurrence at each path includes the full prompt. Subsequent LLM spans at the same path have `input: '<omitted>'`. Input LLM messages longer than 3000 characters are truncated per-message.
+- System prompts (role: "system") in LLM span inputs are extracted and replaced with a `system_prompt: sp_XXXX` reference. Compressed summaries of each unique system prompt appear in the `system_prompts:` section at the top of the spans output. Use `search_in_spans` on the original span if you need specific details from the full system prompt.
 - Tool span inputs that originated from a preceding LLM span's tool call output are replaced with `<from_llm_output span_id='...'>` to avoid duplication. The tool call arguments can be found in the referenced LLM span's output. Do NOT call retrieval tools on `<from_llm_output>` inputs.
 - Tool span outputs longer than 1024 characters are truncated.
 - LLM span outputs longer than 1024 characters are truncated.
@@ -66,6 +66,7 @@ For example:
 NEVER reference a span solely by its id, always use the <span> xml tag with the above format.
 </span_reference_format>
 
+<trace>
 {{fullTraceData}}
 </trace>"#;
 

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -73,9 +73,12 @@ impl MessageHandler for SignalJobRealtimeHandler {
             project_id,
             trace_id,
             message.run_id,
+            signal.id,
             &signal.prompt,
             &signal.structured_output_schema,
             self.clickhouse.clone(),
+            self.cache.clone(),
+            self.llm_client.clone(),
         )
         .await
         {

--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use chrono::DateTime;
 use serde::Deserialize;
 use serde_json::Value;
+use sha3::{Digest, Sha3_256};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use uuid::Uuid;
@@ -37,6 +38,7 @@ pub struct CompressedSpan {
     pub status: String,
     pub parent: Option<String>,
     pub exception: Option<String>,
+    pub system_prompt_ref: Option<String>,
 }
 
 const SPAN_SHORT_ID_LEN: usize = 6;
@@ -181,15 +183,88 @@ fn content_overlap_score(needle_words: &HashSet<String>, haystack_words: &HashSe
     matched as f64 / needle_words.len() as f64
 }
 
+/// Hash a system prompt text to a stable short hex identifier.
+/// Normalizes whitespace and lowercases before hashing so minor formatting
+/// variations produce the same hash.
+fn hash_system_prompt(text: &str) -> String {
+    let normalized = text
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+    let digest = Sha3_256::digest(normalized.as_bytes());
+    format!("{:x}", digest)[..8].to_string()
+}
+
+/// Extract the system message from a parsed LLM input message array.
+/// Returns `(system_text, remaining_messages)` if a `role: "system"` message is found.
+fn extract_system_message(parsed: &Value) -> Option<(String, Value)> {
+    let messages = parsed.as_array()?;
+    let sys_idx = messages.iter().position(|m| {
+        m.get("role")
+            .and_then(|r| r.as_str())
+            .is_some_and(|r| r == "system")
+    })?;
+    let sys_msg = &messages[sys_idx];
+    let sys_text = sys_msg
+        .get("content")
+        .and_then(|c| c.as_str())
+        .or_else(|| {
+            sys_msg
+                .get("parts")
+                .and_then(|p| p.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|p| p.get("text"))
+                .and_then(|t| t.as_str())
+        })
+        .unwrap_or("")
+        .to_string();
+    if sys_text.is_empty() {
+        return None;
+    }
+    let remaining: Vec<Value> = messages
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != sys_idx)
+        .map(|(_, m)| m.clone())
+        .collect();
+    Some((sys_text, Value::Array(remaining)))
+}
+
+/// Scan all LLM spans and extract unique system prompts.
+/// Returns a map of `hash -> full_system_prompt_text` for all unique system prompts found.
+pub fn extract_system_prompts(ch_spans: &[CHSpan]) -> HashMap<String, String> {
+    let mut result: HashMap<String, String> = HashMap::new();
+    for span in ch_spans {
+        if span.span_type != 1 {
+            continue;
+        }
+        let parsed = try_parse_json(&strip_noise(&span.input));
+        if let Some((sys_text, _)) = extract_system_message(&parsed) {
+            let hash = hash_system_prompt(&sys_text);
+            result.entry(hash).or_insert(sys_text);
+        }
+    }
+    result
+}
+
 /// Compress span content based on type and occurrence.
 /// Spans are identified by the last 6 hex chars of their UUID, which is stable
 /// across iterations regardless of span arrival order.
+///
+/// `system_prompt_summaries` maps system prompt hash -> compressed summary.
+/// When provided, system messages are extracted from LLM inputs and replaced
+/// with a `system_prompt: sp_XXXX` reference. Summaries appear in the preamble.
 ///
 /// Optimizations applied:
 /// - Default spans with empty input AND output are fully excluded.
 /// - Tool span inputs that duplicate a preceding LLM sibling's output are
 ///   replaced with a `<from_llm_output span_id='...'>` reference.
-pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
+/// - System prompts in LLM inputs are extracted and replaced with references.
+pub fn compress_span_content(
+    ch_spans: &[CHSpan],
+    system_prompt_summaries: &HashMap<String, String>,
+) -> Vec<CompressedSpan> {
     let span_uuid_to_short: HashMap<Uuid, String> = ch_spans
         .iter()
         .map(|span| (span.span_id, span_short_id(&span.span_id)))
@@ -235,6 +310,8 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
             let mut input_truncated = false;
             let mut output_truncated = false;
 
+            let mut sys_prompt_ref: Option<String> = None;
+
             let (input, output) = if is_llm {
                 let cleaned_output = clean_whitespace(&strip_noise(&ch_span.output));
                 let output_words = extract_words(&cleaned_output);
@@ -254,7 +331,21 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
                 } else {
                     seen_llm_paths.insert(path.clone());
                     let parsed = try_parse_json(&strip_noise(&ch_span.input));
-                    let llm_str = truncate_llm_input(&parsed, &mut input_truncated);
+
+                    let input_to_process =
+                        if let Some((sys_text, remaining)) = extract_system_message(&parsed) {
+                            let hash = hash_system_prompt(&sys_text);
+                            if system_prompt_summaries.contains_key(&hash) {
+                                sys_prompt_ref = Some(format!("sp_{}", hash));
+                                remaining
+                            } else {
+                                parsed
+                            }
+                        } else {
+                            parsed
+                        };
+
+                    let llm_str = truncate_llm_input(&input_to_process, &mut input_truncated);
                     let input_str = clean_whitespace(&llm_str);
                     let input_str =
                         truncate_str(input_str, LLM_INPUT_TOTAL_MAX_CHARS, &mut input_truncated);
@@ -335,13 +426,34 @@ pub fn compress_span_content(ch_spans: &[CHSpan]) -> Vec<CompressedSpan> {
                 },
                 parent,
                 exception,
+                system_prompt_ref: sys_prompt_ref,
             })
         })
         .collect()
 }
 
-fn spans_to_string(spans: &[CompressedSpan]) -> String {
+fn spans_to_string(
+    spans: &[CompressedSpan],
+    system_prompt_summaries: &HashMap<String, String>,
+) -> String {
     let mut out = String::new();
+
+    // Emit system prompts preamble if any were extracted
+    let used_refs: HashSet<&str> = spans
+        .iter()
+        .filter_map(|s| s.system_prompt_ref.as_deref())
+        .collect();
+    if !used_refs.is_empty() {
+        let _ = writeln!(out, "system_prompts:");
+        for ref_id in &used_refs {
+            let hash = ref_id.strip_prefix("sp_").unwrap_or(ref_id);
+            if let Some(summary) = system_prompt_summaries.get(hash) {
+                let _ = writeln!(out, "  {}: {}", ref_id, summary);
+            }
+        }
+        let _ = writeln!(out);
+    }
+
     for span in spans {
         let is_llm = span.span_type == "llm";
         let _ = writeln!(out, "- id: {}", span.id);
@@ -361,6 +473,9 @@ fn spans_to_string(spans: &[CompressedSpan]) -> String {
         }
         if !span.status.is_empty() {
             let _ = writeln!(out, "  status: {}", span.status);
+        }
+        if let Some(ref_id) = &span.system_prompt_ref {
+            let _ = writeln!(out, "  system_prompt: {}", ref_id);
         }
         if span.input_truncated {
             let _ = writeln!(out, "  input_truncated: true");
@@ -459,27 +574,50 @@ pub async fn get_trace_span_ids_and_end_time(
     Ok(spans)
 }
 
-/// Get trace structure as YAML of all compressed spans
+/// Query trace spans from ClickHouse (public for use in process_run).
+pub async fn get_trace_ch_spans(
+    clickhouse: clickhouse::Client,
+    project_id: Uuid,
+    trace_id: Uuid,
+) -> Result<Vec<CHSpan>> {
+    get_trace_spans(clickhouse, project_id, trace_id).await
+}
+
+/// Build the trace structure string from pre-fetched spans and system prompt summaries.
+pub fn build_trace_structure_string(
+    ch_spans: &[CHSpan],
+    trace_id: Uuid,
+    system_prompt_summaries: &HashMap<String, String>,
+) -> String {
+    if ch_spans.is_empty() {
+        return format!(
+            "No spans found for trace {}. Either the trace does not exist in this project or there are no spans in the trace.",
+            trace_id
+        );
+    }
+
+    let compressed_spans = compress_span_content(ch_spans, system_prompt_summaries);
+    let trace_str = spans_to_string(&compressed_spans, system_prompt_summaries);
+
+    format!(
+        "Here are all spans of the trace:\n<spans>\n{}</spans>\n",
+        trace_str
+    )
+}
+
+/// Get trace structure as YAML of all compressed spans.
+/// This is the simple path without system prompt summarization (used by MCP, trace chat).
 pub async fn get_trace_structure_as_string(
     clickhouse: clickhouse::Client,
     project_id: Uuid,
     trace_id: Uuid,
 ) -> Result<String> {
     let ch_spans = get_trace_spans(clickhouse, project_id, trace_id).await?;
-
-    if ch_spans.is_empty() {
-        return Ok(format!(
-            "No spans found for trace {}. Either the trace does not exist in this project or there are no spans in the trace.",
-            trace_id
-        ));
-    }
-
-    let compressed_spans = compress_span_content(&ch_spans);
-    let trace_str = spans_to_string(&compressed_spans);
-
-    Ok(format!(
-        "Here are all spans of the trace:\n<spans>\n{}</spans>\n",
-        trace_str
+    let empty_summaries = HashMap::new();
+    Ok(build_trace_structure_string(
+        &ch_spans,
+        trace_id,
+        &empty_summaries,
     ))
 }
 
@@ -639,7 +777,8 @@ mod tests {
             ),
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "agent");
     }
@@ -656,11 +795,20 @@ mod tests {
         )];
 
         let spans = vec![
-            make_span(parent_id, Uuid::nil(), "agent", 0, 1000, "\"run\"", "\"ok\""),
+            make_span(
+                parent_id,
+                Uuid::nil(),
+                "agent",
+                0,
+                1000,
+                "\"run\"",
+                "\"ok\"",
+            ),
             span,
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         assert_eq!(result.len(), 2);
         let kept = result.iter().find(|s| s.name == "failing_step").unwrap();
         assert!(kept.exception.is_some());
@@ -689,7 +837,8 @@ mod tests {
             ),
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         assert_eq!(result.len(), 2);
     }
 
@@ -719,7 +868,8 @@ mod tests {
             make_span(Uuid::new_v4(), parent_id, "done", 6, 2000, tool_input, "{}"),
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         let tool_span = result.iter().find(|s| s.name == "done").unwrap();
 
         assert!(
@@ -760,7 +910,8 @@ mod tests {
             ),
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         let tool_span = result.iter().find(|s| s.name == "go_back").unwrap();
 
         assert!(
@@ -801,7 +952,8 @@ mod tests {
             ),
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         let tool_span = result.iter().find(|s| s.name == "db_query").unwrap();
 
         assert!(
@@ -836,7 +988,8 @@ mod tests {
             ),
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         let tool_span = result.iter().find(|s| s.name == "navigate").unwrap();
 
         assert!(
@@ -877,7 +1030,8 @@ mod tests {
             ),
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         let tool_span = result.iter().find(|s| s.name == "click").unwrap();
 
         assert!(
@@ -938,7 +1092,8 @@ mod tests {
             ),
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         let search_tool = result.iter().find(|s| s.name == "search_db").unwrap();
         let email_tool = result.iter().find(|s| s.name == "send_mail").unwrap();
 
@@ -1002,11 +1157,240 @@ mod tests {
             ),
         ];
 
-        let result = compress_span_content(&spans);
+        let no_summaries = HashMap::new();
+        let result = compress_span_content(&spans, &no_summaries);
         let outer_tool = result.iter().find(|s| s.name == "outer_tool").unwrap();
         let inner_tool = result.iter().find(|s| s.name == "inner_tool").unwrap();
 
         assert!(outer_tool.input.contains(&span_short_id(&outer_llm)));
         assert!(inner_tool.input.contains(&span_short_id(&inner_llm)));
+    }
+
+    // ===================================================================
+    // extract_system_message
+    // ===================================================================
+
+    #[test]
+    fn test_extract_system_message_openai_format() {
+        let input = serde_json::json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"}
+        ]);
+        let (sys_text, remaining) = extract_system_message(&input).unwrap();
+        assert_eq!(sys_text, "You are a helpful assistant.");
+        assert_eq!(remaining.as_array().unwrap().len(), 1);
+        assert_eq!(remaining[0]["role"], "user");
+    }
+
+    #[test]
+    fn test_extract_system_message_gemini_parts_format() {
+        let input = serde_json::json!([
+            {"role": "system", "parts": [{"text": "You are a safety-focused agent."}]},
+            {"role": "user", "parts": [{"text": "Do something"}]}
+        ]);
+        let (sys_text, remaining) = extract_system_message(&input).unwrap();
+        assert_eq!(sys_text, "You are a safety-focused agent.");
+        assert_eq!(remaining.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_extract_system_message_none_when_absent() {
+        let input = serde_json::json!([
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"}
+        ]);
+        assert!(extract_system_message(&input).is_none());
+    }
+
+    #[test]
+    fn test_extract_system_message_none_for_non_array() {
+        let input = serde_json::json!({"role": "system", "content": "test"});
+        assert!(extract_system_message(&input).is_none());
+    }
+
+    // ===================================================================
+    // hash_system_prompt
+    // ===================================================================
+
+    #[test]
+    fn test_hash_stability() {
+        let hash1 = hash_system_prompt("You are a helpful assistant.");
+        let hash2 = hash_system_prompt("You are a helpful assistant.");
+        assert_eq!(hash1, hash2);
+        assert_eq!(hash1.len(), 8);
+    }
+
+    #[test]
+    fn test_hash_whitespace_normalization() {
+        let hash1 = hash_system_prompt("You  are\n a   helpful\tassistant.");
+        let hash2 = hash_system_prompt("You are a helpful assistant.");
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_hash_case_normalization() {
+        let hash1 = hash_system_prompt("You Are A Helpful Assistant.");
+        let hash2 = hash_system_prompt("you are a helpful assistant.");
+        assert_eq!(hash1, hash2);
+    }
+
+    // ===================================================================
+    // extract_system_prompts (full scan)
+    // ===================================================================
+
+    #[test]
+    fn test_extract_system_prompts_from_trace() {
+        let sys_prompt = "You are a customer support agent. Always be polite.";
+        let input = format!(
+            r#"[{{"role":"system","content":"{}"}},{{"role":"user","content":"Help me"}}]"#,
+            sys_prompt
+        );
+        let spans = vec![
+            make_span(
+                Uuid::new_v4(),
+                Uuid::nil(),
+                "llm_call",
+                1,
+                1000,
+                &input,
+                "ok",
+            ),
+            make_span(
+                Uuid::new_v4(),
+                Uuid::nil(),
+                "tool_call",
+                6,
+                2000,
+                "{}",
+                "ok",
+            ),
+        ];
+
+        let extracted = extract_system_prompts(&spans);
+        assert_eq!(extracted.len(), 1);
+        let (_, text) = extracted.iter().next().unwrap();
+        assert_eq!(text, sys_prompt);
+    }
+
+    #[test]
+    fn test_extract_system_prompts_deduplicates() {
+        let sys_prompt = "You are a helpful agent.";
+        let input = format!(
+            r#"[{{"role":"system","content":"{}"}},{{"role":"user","content":"Hi"}}]"#,
+            sys_prompt
+        );
+        let spans = vec![
+            make_span(Uuid::new_v4(), Uuid::nil(), "llm_a", 1, 1000, &input, "a"),
+            make_span(Uuid::new_v4(), Uuid::nil(), "llm_b", 1, 2000, &input, "b"),
+        ];
+
+        let extracted = extract_system_prompts(&spans);
+        assert_eq!(extracted.len(), 1);
+    }
+
+    // ===================================================================
+    // compress_span_content — system prompt extraction
+    // ===================================================================
+
+    #[test]
+    fn test_system_prompt_extracted_and_referenced() {
+        let sys_prompt = "You are a customer support agent. Always be polite and helpful.";
+        let input = format!(
+            r#"[{{"role":"system","content":"{}"}},{{"role":"user","content":"Help me"}}]"#,
+            sys_prompt
+        );
+        let hash = hash_system_prompt(sys_prompt);
+        let summaries: HashMap<String, String> = [(
+            hash.clone(),
+            "Customer support agent. Be polite.".to_string(),
+        )]
+        .into_iter()
+        .collect();
+
+        let spans = vec![make_span(
+            Uuid::new_v4(),
+            Uuid::nil(),
+            "openai.chat",
+            1,
+            1000,
+            &input,
+            "Sure, I can help!",
+        )];
+
+        let result = compress_span_content(&spans, &summaries);
+        assert_eq!(result.len(), 1);
+        let span = &result[0];
+        assert_eq!(span.system_prompt_ref, Some(format!("sp_{}", hash)));
+        assert!(
+            !span.input.contains("customer support"),
+            "system message should be stripped from input, got: {}",
+            span.input
+        );
+        assert!(span.input.contains("Help me"));
+    }
+
+    #[test]
+    fn test_system_prompt_kept_when_no_summary() {
+        let sys_prompt = "You are a customer support agent.";
+        let input = format!(
+            r#"[{{"role":"system","content":"{}"}},{{"role":"user","content":"Help me"}}]"#,
+            sys_prompt
+        );
+
+        let no_summaries = HashMap::new();
+        let spans = vec![make_span(
+            Uuid::new_v4(),
+            Uuid::nil(),
+            "openai.chat",
+            1,
+            1000,
+            &input,
+            "Sure!",
+        )];
+
+        let result = compress_span_content(&spans, &no_summaries);
+        assert_eq!(result.len(), 1);
+        let span = &result[0];
+        assert!(span.system_prompt_ref.is_none());
+        assert!(span.input.contains("customer support"));
+    }
+
+    #[test]
+    fn test_system_prompt_preamble_in_output() {
+        let sys_prompt = "You are a safety-focused AI agent with strict rules.";
+        let input = format!(
+            r#"[{{"role":"system","content":"{}"}},{{"role":"user","content":"Do X"}}]"#,
+            sys_prompt
+        );
+        let hash = hash_system_prompt(sys_prompt);
+        let summary = "Safety-focused AI agent with strict rules.".to_string();
+        let summaries: HashMap<String, String> =
+            [(hash.clone(), summary.clone())].into_iter().collect();
+
+        let spans = vec![make_span(
+            Uuid::new_v4(),
+            Uuid::nil(),
+            "llm",
+            1,
+            1000,
+            &input,
+            "ok",
+        )];
+
+        let compressed = compress_span_content(&spans, &summaries);
+        let output = spans_to_string(&compressed, &summaries);
+        assert!(
+            output.contains("system_prompts:"),
+            "output should contain system_prompts section, got:\n{}",
+            output
+        );
+        assert!(
+            output.contains(&format!("sp_{}", hash)),
+            "output should contain the ref id"
+        );
+        assert!(
+            output.contains(&summary),
+            "output should contain the summary"
+        );
     }
 }

--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -3,7 +3,7 @@ use chrono::DateTime;
 use serde::Deserialize;
 use serde_json::Value;
 use sha3::{Digest, Sha3_256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Write;
 use uuid::Uuid;
 
@@ -439,7 +439,7 @@ fn spans_to_string(
     let mut out = String::new();
 
     // Emit system prompts preamble if any were extracted
-    let used_refs: HashSet<&str> = spans
+    let used_refs: BTreeSet<&str> = spans
         .iter()
         .filter_map(|s| s.system_prompt_ref.as_deref())
         .collect();

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -144,7 +144,8 @@ async fn process(
         }
     }
 
-    let result = process_batch(msg, db, clickhouse, queue, llm_client, config).await;
+    let result =
+        process_batch(msg, db, cache.clone(), clickhouse, queue, llm_client, config).await;
 
     if result.is_ok() {
         if let Err(e) = cache
@@ -173,6 +174,7 @@ async fn process(
 async fn process_batch(
     msg: SignalJobSubmissionBatchMessage,
     db: Arc<DB>,
+    cache: Arc<crate::cache::Cache>,
     clickhouse: clickhouse::Client,
     queue: Arc<MessageQueue>,
     llm_client: Arc<ProviderClient>,
@@ -192,9 +194,12 @@ async fn process_batch(
             project_id,
             trace_id,
             message.run_id,
+            signal.id,
             &signal.prompt,
             &signal.structured_output_schema,
             clickhouse.clone(),
+            cache.clone(),
+            llm_client.clone(),
         )
         .await
         {

--- a/app-server/src/signals/summarize.rs
+++ b/app-server/src/signals/summarize.rs
@@ -1,0 +1,148 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::cache::keys::SYS_PROMPT_SUMMARY_CACHE_KEY;
+use crate::cache::{Cache, CacheTrait};
+use crate::signals::provider::models::{
+    ProviderContent, ProviderGenerationConfig, ProviderPart, ProviderRequest,
+};
+use crate::signals::provider::{LanguageModelClient, ProviderClient};
+use crate::signals::provider::{ProviderThinkingConfig, ProviderThinkingLevel};
+
+const SUMMARY_CACHE_TTL_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days
+
+const SUMMARIZATION_PROMPT: &str = r#"Given this signal description that a developer wants to detect in traces:
+<signal_description>
+{{signal_prompt}}
+</signal_description>
+
+Compress the following system prompt from an LLM application. Retain only information relevant to detecting the above signal. Keep essential rules, constraints, and behavioral instructions that relate to the signal. Remove boilerplate, examples, formatting, and irrelevant details. Every sentence must be complete — never cut off mid-sentence or mid-word. Output ONLY the compressed text, nothing else.
+
+<system_prompt>
+{{system_prompt}}
+</system_prompt>"#;
+
+fn cache_key(project_id: Uuid, signal_id: Uuid, prompt_hash: &str) -> String {
+    format!("{SYS_PROMPT_SUMMARY_CACHE_KEY}:{project_id}:{signal_id}:{prompt_hash}")
+}
+
+/// Look up cached summaries for a set of system prompt hashes.
+/// Returns a map of `hash -> summary` for all hits.
+pub async fn lookup_cached_summaries(
+    cache: &Arc<Cache>,
+    project_id: Uuid,
+    signal_id: Uuid,
+    hashes: &[String],
+) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+    for hash in hashes {
+        let key = cache_key(project_id, signal_id, hash);
+        match cache.get::<String>(&key).await {
+            Ok(Some(summary)) => {
+                result.insert(hash.clone(), summary);
+            }
+            Ok(None) => {}
+            Err(e) => {
+                log::warn!(
+                    "Cache read error for system prompt summary {}: {:?}",
+                    hash,
+                    e
+                );
+            }
+        }
+    }
+    log::info!("Lookup cached summaries: {:?}", result);
+    result
+}
+
+/// Generate summaries for uncached system prompts and store them in cache.
+/// Returns the generated summaries as `hash -> summary`.
+pub async fn generate_and_cache_summaries(
+    cache: &Arc<Cache>,
+    llm_client: &Arc<ProviderClient>,
+    model: &str,
+    project_id: Uuid,
+    signal_id: Uuid,
+    signal_prompt: &str,
+    uncached: &HashMap<String, String>, // hash -> full system prompt text
+) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+    for (hash, sys_prompt_text) in uncached {
+        match generate_summary(llm_client, model, signal_prompt, sys_prompt_text).await {
+            Ok(summary) => {
+                let key = cache_key(project_id, signal_id, hash);
+                if let Err(e) = cache
+                    .insert_with_ttl(&key, summary.clone(), SUMMARY_CACHE_TTL_SECONDS)
+                    .await
+                {
+                    log::warn!("Failed to cache system prompt summary {}: {:?}", hash, e);
+                }
+                result.insert(hash.clone(), summary);
+            }
+            Err(e) => {
+                log::error!(
+                    "Failed to generate system prompt summary for {}: {:?}",
+                    hash,
+                    e
+                );
+            }
+        }
+    }
+    result
+}
+
+async fn generate_summary(
+    llm_client: &Arc<ProviderClient>,
+    model: &str,
+    signal_prompt: &str,
+    system_prompt_text: &str,
+) -> anyhow::Result<String> {
+    let user_prompt = SUMMARIZATION_PROMPT
+        .replace("{{signal_prompt}}", signal_prompt)
+        .replace("{{system_prompt}}", system_prompt_text);
+
+    let request = ProviderRequest {
+        contents: vec![ProviderContent {
+            role: Some("user".to_string()),
+            parts: Some(vec![ProviderPart {
+                text: Some(user_prompt),
+                ..Default::default()
+            }]),
+        }],
+        system_instruction: None,
+        tools: None,
+        generation_config: Some(ProviderGenerationConfig {
+            temperature: Some(0.0),
+            max_output_tokens: Some(2048),
+            thinking_config: Some(ProviderThinkingConfig {
+                include_thoughts: Some(false),
+                thinking_level: Some(ProviderThinkingLevel::Minimal),
+            }),
+            ..Default::default()
+        }),
+    };
+
+    let response = llm_client
+        .generate_content(model, &request)
+        .await
+        .map_err(|e| anyhow::anyhow!("LLM call failed for system prompt summary: {}", e))?;
+
+    let text = response
+        .candidates
+        .as_ref()
+        .and_then(|c| c.first())
+        .and_then(|c| c.content.as_ref())
+        .and_then(|c| c.parts.as_ref())
+        .and_then(|p| p.iter().find_map(|part| part.text.as_deref()))
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    if text.is_empty() {
+        anyhow::bail!("LLM returned empty summary");
+    }
+
+    Ok(text)
+}

--- a/app-server/src/signals/summarize.rs
+++ b/app-server/src/signals/summarize.rs
@@ -12,6 +12,8 @@ use crate::signals::provider::models::{
 use crate::signals::provider::{LanguageModelClient, ProviderClient};
 use crate::signals::provider::{ProviderThinkingConfig, ProviderThinkingLevel};
 
+const SUMMARY_CACHE_TTL_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days
+
 const SUMMARIZATION_PROMPT: &str = r#"Given this signal description that a developer wants to detect in traces:
 <signal_description>
 {{signal_prompt}}
@@ -85,7 +87,10 @@ pub async fn generate_and_cache_summaries(
         match generate_summary(llm_client, model, signal_prompt, sys_prompt_text).await {
             Ok(summary) => {
                 let key = cache_key(project_id, signal_id, &sig_hash, hash);
-                if let Err(e) = cache.insert(&key, summary.clone()).await {
+                if let Err(e) = cache
+                    .insert_with_ttl(&key, summary.clone(), SUMMARY_CACHE_TTL_SECONDS)
+                    .await
+                {
                     log::warn!("Failed to cache system prompt summary {}: {:?}", hash, e);
                 }
                 result.insert(hash.clone(), summary);

--- a/app-server/src/signals/summarize.rs
+++ b/app-server/src/signals/summarize.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use sha3::{Digest, Sha3_256};
 use uuid::Uuid;
 
 use crate::cache::keys::SYS_PROMPT_SUMMARY_CACHE_KEY;
@@ -10,8 +11,6 @@ use crate::signals::provider::models::{
 };
 use crate::signals::provider::{LanguageModelClient, ProviderClient};
 use crate::signals::provider::{ProviderThinkingConfig, ProviderThinkingLevel};
-
-const SUMMARY_CACHE_TTL_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days
 
 const SUMMARIZATION_PROMPT: &str = r#"Given this signal description that a developer wants to detect in traces:
 <signal_description>
@@ -24,8 +23,18 @@ Compress the following system prompt from an LLM application. Retain only inform
 {{system_prompt}}
 </system_prompt>"#;
 
-fn cache_key(project_id: Uuid, signal_id: Uuid, prompt_hash: &str) -> String {
-    format!("{SYS_PROMPT_SUMMARY_CACHE_KEY}:{project_id}:{signal_id}:{prompt_hash}")
+fn hash_signal_prompt(signal_prompt: &str) -> String {
+    let digest = Sha3_256::digest(signal_prompt.as_bytes());
+    format!("{:x}", digest)[..8].to_string()
+}
+
+fn cache_key(
+    project_id: Uuid,
+    signal_id: Uuid,
+    signal_prompt_hash: &str,
+    sys_prompt_hash: &str,
+) -> String {
+    format!("{SYS_PROMPT_SUMMARY_CACHE_KEY}:{project_id}:{signal_id}:{signal_prompt_hash}:{sys_prompt_hash}")
 }
 
 /// Look up cached summaries for a set of system prompt hashes.
@@ -34,11 +43,13 @@ pub async fn lookup_cached_summaries(
     cache: &Arc<Cache>,
     project_id: Uuid,
     signal_id: Uuid,
+    signal_prompt: &str,
     hashes: &[String],
 ) -> HashMap<String, String> {
+    let sig_hash = hash_signal_prompt(signal_prompt);
     let mut result = HashMap::new();
     for hash in hashes {
-        let key = cache_key(project_id, signal_id, hash);
+        let key = cache_key(project_id, signal_id, &sig_hash, hash);
         match cache.get::<String>(&key).await {
             Ok(Some(summary)) => {
                 result.insert(hash.clone(), summary);
@@ -53,7 +64,7 @@ pub async fn lookup_cached_summaries(
             }
         }
     }
-    log::info!("Lookup cached summaries: {:?}", result);
+
     result
 }
 
@@ -68,15 +79,13 @@ pub async fn generate_and_cache_summaries(
     signal_prompt: &str,
     uncached: &HashMap<String, String>, // hash -> full system prompt text
 ) -> HashMap<String, String> {
+    let sig_hash = hash_signal_prompt(signal_prompt);
     let mut result = HashMap::new();
     for (hash, sys_prompt_text) in uncached {
         match generate_summary(llm_client, model, signal_prompt, sys_prompt_text).await {
             Ok(summary) => {
-                let key = cache_key(project_id, signal_id, hash);
-                if let Err(e) = cache
-                    .insert_with_ttl(&key, summary.clone(), SUMMARY_CACHE_TTL_SECONDS)
-                    .await
-                {
+                let key = cache_key(project_id, signal_id, &sig_hash, hash);
+                if let Err(e) = cache.insert(&key, summary.clone()).await {
                     log::warn!("Failed to cache system prompt summary {}: {:?}", hash, e);
                 }
                 result.insert(hash.clone(), summary);

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -184,7 +184,7 @@ pub fn replace_span_tags_with_links(
             .map(|uuid| uuid.to_string())
             .unwrap_or_else(|| short_id.to_string());
         format!(
-            "[{}](https://www.laminar.sh/project/{}/traces/{}?spanId={}&chat=true)",
+            "[{}](https://laminar.sh/project/{}/traces/{}?spanId={}&chat=true)",
             span_name, project_id, trace_id, real_span_id
         )
     });
@@ -196,7 +196,7 @@ pub fn replace_span_tags_with_links(
         let short_id = caps[1].to_lowercase();
         match span_ids_map.get(&short_id) {
             Some(uuid) => format!(
-                "[span {}](https://www.laminar.sh/project/{}/traces/{}?spanId={}&chat=true)",
+                "[span {}](https://laminar.sh/project/{}/traces/{}?spanId={}&chat=true)",
                 short_id, project_id, trace_id, uuid
             ),
             None => caps[0].to_string(),
@@ -429,10 +429,7 @@ mod tests {
 
     #[test]
     fn test_clean_whitespace_actual_whitespace() {
-        assert_eq!(
-            clean_whitespace("hello\n\t\tworld\nfoo"),
-            "hello world foo"
-        );
+        assert_eq!(clean_whitespace("hello\n\t\tworld\nfoo"), "hello world foo");
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new LLM-driven summarization and caching logic into the signal-run prompt construction path, which can affect runtime cost/latency and the fidelity of trace context used for identification.
> 
> **Overview**
> **Reduces prompt size for signal identification by extracting system prompts from LLM spans and replacing them with stable `sp_XXXXXXXX` references plus a `system_prompts:` summary preamble.**
> 
> `process_run` now fetches trace spans directly, generates (or reuses cached) signal-specific system-prompt summaries via a new `signals/summarize.rs` module, and uses them when building the trace structure string.
> 
> Also tweaks signal generation settings (higher temperature, lower thinking level), threads `cache`/`llm_client` and `signal_id` through realtime and batch processing, and updates span-link URLs to `https://laminar.sh/...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d702074861a60639fa2cda16da9d8a19437db87d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->