### PR TITLE
index attributes

### DIFF
--- a/app-server/src/quickwit/mod.rs
+++ b/app-server/src/quickwit/mod.rs
@@ -36,10 +36,16 @@ pub struct QuickwitIndexedSpan {
     pub start_time: DateTime<Utc>,
     pub input: Option<String>,
     pub output: Option<String>,
+    pub attributes: Option<String>,
 }
 
 impl From<&Span> for QuickwitIndexedSpan {
     fn from(span: &Span) -> Self {
+        let attributes = if span.attributes.raw_attributes.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&span.attributes.raw_attributes).ok()
+        };
         Self {
             span_id: span.span_id,
             project_id: span.project_id,
@@ -47,6 +53,7 @@ impl From<&Span> for QuickwitIndexedSpan {
             start_time: span.start_time,
             input: span.input.as_ref().map(json_value_to_string),
             output: span.output.as_ref().map(json_value_to_string),
+            attributes,
         }
     }
 }
@@ -118,6 +125,9 @@ impl PreprocessForIndexing for QuickwitIndexedSpan {
         }
         if let Some(ref output) = self.output {
             self.output = Some(preprocess_text(output));
+        }
+        if let Some(ref attributes) = self.attributes {
+            self.attributes = Some(preprocess_text(attributes));
         }
     }
 }

--- a/app-server/src/search/mod.rs
+++ b/app-server/src/search/mod.rs
@@ -28,7 +28,7 @@ const QUICKWIT_RESERVED_UNESCAPABLE_CHARACTERS: &[char] = &[
     '\u{2014}', // — em dash
 ];
 
-const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 2] = ["input", "output"];
+const QUICKWIT_SPANS_DEFAULT_SEARCH_FIELDS: [&str; 3] = ["input", "output", "attributes"];
 
 /// Escape special characters for Quickwit query syntax and wrap in quotes for phrase search.
 fn escape_quickwit_query(query: &str) -> String {
@@ -132,6 +132,7 @@ pub async fn search_spans(
             span_id: h.span_id,
             input_snippet: None,
             output_snippet: None,
+            attributes_snippet: None,
         })
         .collect();
 

--- a/app-server/src/search/snippets.rs
+++ b/app-server/src/search/snippets.rs
@@ -18,6 +18,7 @@ pub struct SearchSpanHit {
     pub span_id: String,
     pub input_snippet: Option<SnippetInfo>,
     pub output_snippet: Option<SnippetInfo>,
+    pub attributes_snippet: Option<SnippetInfo>,
 }
 
 const RE2_META_CHARS: &[char] = &[
@@ -150,6 +151,7 @@ pub struct SpanSnippetRow {
     pub span_id: Uuid,
     pub input_snippet: String,
     pub output_snippet: String,
+    pub attributes_snippet: String,
 }
 
 #[tracing::instrument(skip_all, fields(pairs_count = pairs.len()))]
@@ -199,7 +201,8 @@ fn build_snippet_query(project_id: Uuid, context_regex: &str, key_tuples: &str) 
     format!(
         "SELECT span_id,
                 extract(input, '{context_regex}') AS input_snippet,
-                extract(output, '{context_regex}') AS output_snippet
+                extract(output, '{context_regex}') AS output_snippet,
+                extract(attributes, '{context_regex}') AS attributes_snippet
          FROM spans
          WHERE project_id = '{project_id}'
            AND (trace_id, span_id) IN ({key_tuples})
@@ -268,6 +271,10 @@ pub async fn enrich_hits_with_snippets(
 
                 hit.output_snippet =
                     post_process_snippet(&row.output_snippet, &match_re, SNIPPET_CONTEXT_CHARS)
+                        .map(|(text, highlight)| SnippetInfo { text, highlight });
+
+                hit.attributes_snippet =
+                    post_process_snippet(&row.attributes_snippet, &match_re, SNIPPET_CONTEXT_CHARS)
                         .map(|(text, highlight)| SnippetInfo { text, highlight });
             }
             hit

--- a/frontend/components/traces/snippet-preview.tsx
+++ b/frontend/components/traces/snippet-preview.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 export interface SnippetPreviewProps {
   inputSnippet?: SnippetInfo;
   outputSnippet?: SnippetInfo;
+  attributesSnippet?: SnippetInfo;
   snippetsCount?: number;
   className?: string;
   variant?: "table" | "span";
@@ -12,11 +13,12 @@ export interface SnippetPreviewProps {
 export function SnippetPreview({
   inputSnippet,
   outputSnippet,
+  attributesSnippet,
   snippetsCount,
   className,
   variant = "table",
 }: SnippetPreviewProps) {
-  const snippet = inputSnippet ?? outputSnippet;
+  const snippet = inputSnippet ?? outputSnippet ?? attributesSnippet;
   if (!snippet) {
     return <span className="text-xs text-muted-foreground">No preview</span>;
   }

--- a/frontend/components/traces/span-view/index.tsx
+++ b/frontend/components/traces/span-view/index.tsx
@@ -57,7 +57,7 @@ const SpanViewTabs = ({
   const defaultTab = initialTab ?? (isLLM ? "overview" : "span-input");
 
   return (
-    <Tabs className="flex flex-col grow overflow-hidden gap-0" defaultValue={defaultTab} tabIndex={0}>
+    <Tabs key={initialTab} className="flex flex-col grow overflow-hidden gap-0" defaultValue={defaultTab} tabIndex={0}>
       <div className="px-2 pb-2 mt-2 border-b w-full">
         <TabsList className="border-none text-xs h-7">
           {isLLM && (

--- a/frontend/components/traces/span-view/index.tsx
+++ b/frontend/components/traces/span-view/index.tsx
@@ -18,10 +18,13 @@ import { type Span, SpanType } from "@/lib/traces/types";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/tabs";
 import { SpanViewSkeleton } from "./skeleton";
 
+export type SpanViewTab = "overview" | "span-input" | "span-output" | "attributes" | "events";
+
 interface SpanViewProps {
   spanId: string;
   traceId: string;
   initialSearchTerm?: string;
+  initialTab?: SpanViewTab;
 }
 
 const swrFetcher = async (url: string) => {
@@ -42,20 +45,19 @@ const SpanViewTabs = ({
   searchRef,
   searchOpen,
   setSearchOpen,
+  initialTab,
 }: {
   span: Span;
   searchRef: React.RefObject<HTMLInputElement | null>;
   searchOpen: boolean;
   setSearchOpen: (open: boolean) => void;
+  initialTab?: SpanViewTab;
 }) => {
   const isLLM = span.spanType === SpanType.LLM;
+  const defaultTab = initialTab ?? (isLLM ? "overview" : "span-input");
 
   return (
-    <Tabs
-      className="flex flex-col grow overflow-hidden gap-0"
-      defaultValue={isLLM ? "overview" : "span-input"}
-      tabIndex={0}
-    >
+    <Tabs className="flex flex-col grow overflow-hidden gap-0" defaultValue={defaultTab} tabIndex={0}>
       <div className="px-2 pb-2 mt-2 border-b w-full">
         <TabsList className="border-none text-xs h-7">
           {isLLM && (
@@ -115,7 +117,7 @@ const SpanViewTabs = ({
   );
 };
 
-export function SpanView({ spanId, traceId, initialSearchTerm }: SpanViewProps) {
+export function SpanView({ spanId, traceId, initialSearchTerm, initialTab }: SpanViewProps) {
   const { projectId } = useParams();
   const [searchOpen, setSearchOpen] = useState(!!initialSearchTerm);
   const {
@@ -175,7 +177,13 @@ export function SpanView({ spanId, traceId, initialSearchTerm }: SpanViewProps) 
     return (
       <SpanSearchProvider initialSearchTerm={initialSearchTerm}>
         <SpanControls span={span}>
-          <SpanViewTabs span={span} searchRef={searchRef} searchOpen={searchOpen} setSearchOpen={setSearchOpen} />
+          <SpanViewTabs
+            span={span}
+            searchRef={searchRef}
+            searchOpen={searchOpen}
+            setSearchOpen={setSearchOpen}
+            initialTab={initialTab}
+          />
         </SpanControls>
       </SpanSearchProvider>
     );

--- a/frontend/components/traces/trace-view/list/list-item.tsx
+++ b/frontend/components/traces/trace-view/list/list-item.tsx
@@ -39,7 +39,7 @@ const ListItem = ({ span, output, onSpanSelect }: ListItemProps) => {
   const fullSpan = useMemo(() => spans.find((s) => s.spanId === span.spanId), [spans, span.spanId]);
   const isCached = cachingEnabled && fullSpan ? isSpanCached(fullSpan) : false;
 
-  const hasSnippet = !!(span.inputSnippet || span.outputSnippet);
+  const hasSnippet = !!(span.inputSnippet || span.outputSnippet || span.attributesSnippet);
   const isExpandableType =
     span.spanType === "LLM" ||
     span.spanType === "CACHED" ||
@@ -135,7 +135,12 @@ const ListItem = ({ span, output, onSpanSelect }: ListItemProps) => {
         {isExpanded && (
           <div className="px-2 w-full flex flex-col gap-2 h-full flex-1">
             {hasSnippet ? (
-              <SnippetPreview inputSnippet={span.inputSnippet} outputSnippet={span.outputSnippet} variant="span" />
+              <SnippetPreview
+                inputSnippet={span.inputSnippet}
+                outputSnippet={span.outputSnippet}
+                attributesSnippet={span.attributesSnippet}
+                variant="span"
+              />
             ) : isLoadingOutput ? (
               <>
                 <PreviewLoadingPlaceholder />

--- a/frontend/components/traces/trace-view/store/base.ts
+++ b/frontend/components/traces/trace-view/store/base.ts
@@ -49,6 +49,7 @@ export type TraceViewSpan = {
   };
   inputSnippet?: SnippetInfo;
   outputSnippet?: SnippetInfo;
+  attributesSnippet?: SnippetInfo;
 };
 
 export type TraceViewListSpan = {
@@ -69,6 +70,7 @@ export type TraceViewListSpan = {
   } | null;
   inputSnippet?: SnippetInfo;
   outputSnippet?: SnippetInfo;
+  attributesSnippet?: SnippetInfo;
 };
 
 export type TraceViewTrace = {
@@ -311,6 +313,7 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
         pathInfo: pathInfoMap.get(span.spanId) ?? null,
         inputSnippet: span.inputSnippet,
         outputSnippet: span.outputSnippet,
+        attributesSnippet: span.attributesSnippet,
       }));
 
       return lightweightListSpans;

--- a/frontend/components/traces/trace-view/trace-view-content.tsx
+++ b/frontend/components/traces/trace-view/trace-view-content.tsx
@@ -12,7 +12,7 @@ import { type Filter } from "@/lib/actions/common/filters";
 import { useRealtime } from "@/lib/hooks/use-realtime";
 import { SpanType } from "@/lib/traces/types";
 
-import { SpanView } from "../span-view";
+import { SpanView, type SpanViewTab } from "../span-view";
 import { SpanViewSkeleton } from "../span-view/skeleton";
 import DynamicWidthLayout from "./dynamic-width-layout";
 import FillWidthLayout from "./fill-width-layout";
@@ -327,6 +327,14 @@ export default function TraceViewContent({
     />
   );
 
+  const snippetTab: SpanViewTab | undefined = selectedSpan?.inputSnippet
+    ? "span-input"
+    : selectedSpan?.outputSnippet
+      ? "span-output"
+      : selectedSpan?.attributesSnippet
+        ? "attributes"
+        : undefined;
+
   const spanPanel = (
     <div className="flex flex-col h-full w-full overflow-hidden flex-1">
       {!selectedSpan ? (
@@ -339,6 +347,7 @@ export default function TraceViewContent({
           spanId={selectedSpan.spanId}
           traceId={traceId}
           initialSearchTerm={traceSearchTerm}
+          initialTab={snippetTab}
         />
       )}
     </div>

--- a/frontend/components/traces/trace-view/tree/span-card.tsx
+++ b/frontend/components/traces/trace-view/tree/span-card.tsx
@@ -53,7 +53,7 @@ export function SpanCard({ span, branchMask, output, onSpanSelect, depth }: Span
   const llmMetrics = getLLMMetrics(span);
   const childSpans = useMemo(() => spans.filter((s) => s.parentSpanId === span.spanId), [spans, span.spanId]);
 
-  const hasSnippet = !!(span.inputSnippet || span.outputSnippet);
+  const hasSnippet = !!(span.inputSnippet || span.outputSnippet || span.attributesSnippet);
 
   const hasChildren = childSpans && childSpans.length > 0;
   const isExpandable =
@@ -164,7 +164,12 @@ export function SpanCard({ span, branchMask, output, onSpanSelect, depth }: Span
             <div className="px-2 pt-0">
               {hasSnippet ? (
                 <div className="pb-2">
-                  <SnippetPreview inputSnippet={span.inputSnippet} outputSnippet={span.outputSnippet} variant="span" />
+                  <SnippetPreview
+                    inputSnippet={span.inputSnippet}
+                    outputSnippet={span.outputSnippet}
+                    attributesSnippet={span.attributesSnippet}
+                    variant="span"
+                  />
                 </div>
               ) : (
                 <>

--- a/frontend/components/traces/traces-table/columns.tsx
+++ b/frontend/components/traces/traces-table/columns.tsx
@@ -37,6 +37,7 @@ export const PREVIEW_COLUMN: ColumnDef<TraceRow, any> = {
     <SnippetPreview
       inputSnippet={row.row.original.inputSnippet}
       outputSnippet={row.row.original.outputSnippet}
+      attributesSnippet={row.row.original.attributesSnippet}
       snippetsCount={row.row.original.snippetsCount}
       variant="table"
     />

--- a/frontend/lib/actions/spans/index.ts
+++ b/frontend/lib/actions/spans/index.ts
@@ -339,6 +339,7 @@ export async function getTraceSpans(input: z.infer<typeof GetTraceSpansSchema>):
       if (hit) {
         span.inputSnippet = hit.input_snippet;
         span.outputSnippet = hit.output_snippet;
+        span.attributesSnippet = hit.attributes_snippet;
       }
     }
   }

--- a/frontend/lib/actions/traces/index.ts
+++ b/frontend/lib/actions/traces/index.ts
@@ -139,7 +139,7 @@ export async function getTraces(input: z.infer<typeof GetTracesSchema>): Promise
     const snippetsCountMap = new Map<string, number>();
     for (const hit of spanHits) {
       snippetsCountMap.set(hit.trace_id, (snippetsCountMap.get(hit.trace_id) ?? 0) + 1);
-      if (!snippetMap.has(hit.trace_id) && (hit.input_snippet || hit.output_snippet)) {
+      if (!snippetMap.has(hit.trace_id) && (hit.input_snippet || hit.output_snippet || hit.attributes_snippet)) {
         snippetMap.set(hit.trace_id, hit);
       }
     }
@@ -148,6 +148,7 @@ export async function getTraces(input: z.infer<typeof GetTracesSchema>): Promise
       if (hit) {
         item.inputSnippet = hit.input_snippet;
         item.outputSnippet = hit.output_snippet;
+        item.attributesSnippet = hit.attributes_snippet;
       }
       item.snippetsCount = snippetsCountMap.get(item.id) ?? 0;
     }

--- a/frontend/lib/actions/traces/search.ts
+++ b/frontend/lib/actions/traces/search.ts
@@ -12,6 +12,7 @@ export interface SpanSearchHit {
   span_id: string;
   input_snippet?: SnippetInfo;
   output_snippet?: SnippetInfo;
+  attributes_snippet?: SnippetInfo;
 }
 
 export const searchSpans = async ({

--- a/frontend/lib/quickwit/indexes/spans_v2.yaml
+++ b/frontend/lib/quickwit/indexes/spans_v2.yaml
@@ -39,11 +39,17 @@ doc_mapping:
       fast: false
       stored: false
       record: position
+    - name: attributes
+      type: text
+      tokenizer: default
+      fast: false
+      stored: false
+      record: position
   tag_fields: []
   timestamp_field: start_time
   partition_key: hash_mod(project_id, 100)
 search_settings:
-  default_search_fields: [input, output]
+  default_search_fields: [input, output, attributes]
 retention:
   period: 90 days
   schedule: daily

--- a/frontend/lib/quickwit/indexes/spans_v2.yaml
+++ b/frontend/lib/quickwit/indexes/spans_v2.yaml
@@ -39,17 +39,11 @@ doc_mapping:
       fast: false
       stored: false
       record: position
-    - name: attributes
-      type: text
-      tokenizer: default
-      fast: false
-      stored: false
-      record: position
   tag_fields: []
   timestamp_field: start_time
   partition_key: hash_mod(project_id, 100)
 search_settings:
-  default_search_fields: [input, output, attributes]
+  default_search_fields: [input, output]
 retention:
   period: 90 days
   schedule: daily

--- a/frontend/lib/traces/types.ts
+++ b/frontend/lib/traces/types.ts
@@ -145,6 +145,7 @@ export type TraceRow = {
   rootSpanOutput?: string;
   inputSnippet?: { text: string; highlight: [number, number] };
   outputSnippet?: { text: string; highlight: [number, number] };
+  attributesSnippet?: { text: string; highlight: [number, number] };
   snippetsCount?: number;
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands the search/index pipeline and snippet SQL to include a new `attributes` field, which depends on index/schema compatibility and could affect search relevance/performance if not deployed end-to-end.
> 
> **Overview**
> **Span search now includes `attributes`** in addition to `input`/`output`.
> 
> On the backend, span documents sent to Quickwit now serialize and preprocess `Span` attributes, the search API queries Quickwit across `input`, `output`, and `attributes`, and ClickHouse snippet enrichment extracts/highlights matches from `attributes` too.
> 
> On the frontend, search hit/types and trace/span preview components are extended to display an `attributes` snippet, and the span side panel can auto-open the relevant tab (`input`/`output`/`attributes`) based on where the match occurred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa50b0e47443b248ae5c1713633bbec2b94e7b9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->