### PR TITLE
exclude non-default trace types from signals processing

### DIFF
--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -22,7 +22,7 @@ use crate::{
     db::{
         DB,
         spans::{Span, SpanType},
-        trace::{Trace, upsert_trace_statistics_batch},
+        trace::{Trace, TraceType, upsert_trace_statistics_batch},
         workspaces::WorkspaceDeployment,
     },
     features::{Feature, is_feature_enabled},
@@ -139,7 +139,13 @@ pub async fn process_span_messages(
     // so the signal agent can see the trace data when processing.
     if let Some(updated_traces) = &updated_traces {
         if is_feature_enabled(Feature::Signals) {
-            let traces_by_project = group_traces_by_project(updated_traces);
+            let default_trace_type: i16 = Into::<u8>::into(TraceType::DEFAULT) as i16;
+            let default_traces: Vec<Trace> = updated_traces
+                .iter()
+                .filter(|trace| trace.trace_type() == default_trace_type)
+                .cloned()
+                .collect();
+            let traces_by_project = group_traces_by_project(&default_traces);
             for (project_id, project_traces) in &traces_by_project {
                 check_and_push_signals(
                     *project_id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, localized change that only alters which traces are eligible for signals trigger evaluation by filtering out non-default `TraceType`s.
> 
> **Overview**
> Signals trigger evaluation now only considers *default* traces: `process_span_messages` filters `updated_traces` to `TraceType::DEFAULT` before grouping by project and calling `check_and_push_signals`.
> 
> This prevents signals processing from running on evaluation/event/playground (non-default) trace types while leaving span ingestion, ClickHouse writes, and realtime/Quickwit indexing unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 451dd5340221a4a5232843919932814230699a11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->