### PR TITLE
better slack formatting of alerts

### DIFF
--- a/app-server/src/notifications/slack.rs
+++ b/app-server/src/notifications/slack.rs
@@ -146,7 +146,8 @@ fn format_event_identification_blocks(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": format!("*Event*: `{}`", event_name)                }
+                    "text": format!("*Event*: `{}`", event_name)
+                }
             }),
             json!({
                 "type": "section",

--- a/app-server/src/notifications/slack.rs
+++ b/app-server/src/notifications/slack.rs
@@ -119,7 +119,7 @@ fn format_event_identification_blocks(
                         serde_json::Value::Null => String::new(),
                         _ => serde_json::to_string_pretty(value).unwrap_or_default(),
                     };
-                    format!("_{}_\n{}", key, formatted_value)
+                    format!("• *{}*: {}", key, formatted_value)
                 })
                 .collect()
         } else {
@@ -146,7 +146,7 @@ fn format_event_identification_blocks(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": format!("*Event*: `{}`", event_name)
+                    "text": format!(":small_blue_diamond: *Event*: `{}`", event_name)
                 }
             }),
             json!({
@@ -169,6 +169,7 @@ fn format_event_identification_blocks(
                 }
             ]
         }));
+        blocks.push(json!({"type": "divider"}));
         return json!(blocks);
     }
 
@@ -194,7 +195,8 @@ fn format_event_identification_blocks(
                     "action_id": "view_trace"
                 }
             ]
-        }
+        },
+        {"type": "divider"}
     ])
 }
 

--- a/app-server/src/notifications/slack.rs
+++ b/app-server/src/notifications/slack.rs
@@ -119,7 +119,7 @@ fn format_event_identification_blocks(
                         serde_json::Value::Null => String::new(),
                         _ => serde_json::to_string_pretty(value).unwrap_or_default(),
                     };
-                    format!("_{}_\n{}", key, formatted_value)
+                    format!("_{}_:\n{}", key, formatted_value)
                 })
                 .collect()
         } else {

--- a/app-server/src/notifications/slack.rs
+++ b/app-server/src/notifications/slack.rs
@@ -119,7 +119,7 @@ fn format_event_identification_blocks(
                         serde_json::Value::Null => String::new(),
                         _ => serde_json::to_string_pretty(value).unwrap_or_default(),
                     };
-                    format!("• *{}*: {}", key, formatted_value)
+                    format!("_{}_\n{}", key, formatted_value)
                 })
                 .collect()
         } else {
@@ -146,8 +146,7 @@ fn format_event_identification_blocks(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": format!(":small_blue_diamond: *Event*: `{}`", event_name)
-                }
+                    "text": format!("*Event*: `{}`", event_name)                }
             }),
             json!({
                 "type": "section",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust Slack message presentation (mrkdwn labels and dividers) without altering notification routing, auth, or data handling.
> 
> **Overview**
> Improves Slack alert readability by formatting extracted-information keys as italic labels with a trailing colon (e.g., `_key_:`) before values.
> 
> Adds a `divider` block after event-identification notifications (both with and without extracted info) to visually separate alerts in Slack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59b4436bda81d41880abe6b9c82fc630877e4ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->