### PR TITLE
llm client

### DIFF
--- a/app-server/src/features/mod.rs
+++ b/app-server/src/features/mod.rs
@@ -50,6 +50,9 @@ pub fn is_feature_enabled(feature: Feature) -> bool {
         }
         Feature::Signals => {
             env::var("GOOGLE_GENERATIVE_AI_API_KEY").is_ok_and(|s| !s.is_empty())
+                || (env::var("AWS_ACCESS_KEY_ID").is_ok_and(|s| !s.is_empty())
+                    && env::var("AWS_SECRET_ACCESS_KEY").is_ok_and(|s| !s.is_empty())
+                    && env::var("AWS_REGION").is_ok_and(|s| !s.is_empty()))
         }
         Feature::Reports => {
             env::var("ENABLE_REPORTS").is_ok_and(|s| s == "true")

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -918,22 +918,22 @@ fn main() -> anyhow::Result<()> {
         let worker_pool = Arc::new(WorkerPool::new(queue.clone()));
         let batch_worker_pool = Arc::new(BatchWorkerPool::new(queue.clone()));
 
-        // == LLM Provider client ==
-        let llm_provider_client: Option<Arc<signals::provider::ProviderClient>> =
+        // == LLM Client ==
+        let llm_provider_client: Option<Arc<signals::provider::LlmClient>> =
             if is_feature_enabled(Feature::Signals) {
-                log::info!("Initializing LLM provider client for signals");
-                match runtime_handle.block_on(signals::provider::create_provider_client()) {
+                log::info!("Initializing LLM client for signals");
+                match runtime_handle.block_on(signals::provider::LlmClient::new()) {
                     Ok(client) => Some(Arc::new(client)),
                     Err(e) => {
                         log::warn!(
-                            "Failed to create LLM provider client (signals will be disabled): {:?}",
+                            "Failed to create LLM client (signals will be disabled): {:?}",
                             e
                         );
                         None
                     }
                 }
             } else {
-                log::info!("Signals feature disabled - skipping LLM provider initialization");
+                log::info!("Signals feature disabled - skipping LLM client initialization");
                 None
             };
 

--- a/app-server/src/reports/generator.rs
+++ b/app-server/src/reports/generator.rs
@@ -27,7 +27,10 @@ use crate::notifications::{
 use crate::signals::provider::models::{
     ProviderFunctionDeclaration, ProviderGenerationConfig, ProviderTool,
 };
-use crate::signals::provider::{LlmClient, ProviderContent, ProviderPart, ProviderRequest};
+use crate::signals::provider::{
+    LlmClient, ProviderContent, ProviderPart, ProviderRequest, ProviderThinkingConfig,
+    ProviderThinkingLevel,
+};
 use crate::worker::{HandlerError, MessageHandler};
 
 const MAX_EVENTS_FOR_SUMMARY: u64 = 128;
@@ -481,7 +484,11 @@ async fn generate_project_summary(
         system_instruction: Some(system_instruction),
         tools: Some(vec![tool]),
         generation_config: Some(ProviderGenerationConfig {
-            temperature: Some(0.2),
+            temperature: Some(1.0),
+            thinking_config: Some(ProviderThinkingConfig {
+                thinking_level: Some(ProviderThinkingLevel::Medium),
+                ..Default::default()
+            }),
             ..Default::default()
         }),
         provider: None,

--- a/app-server/src/reports/generator.rs
+++ b/app-server/src/reports/generator.rs
@@ -24,13 +24,10 @@ use crate::notifications::{
     EmailPayload, NotificationDefinitionType, NotificationMessage, ReportPayload, TargetType,
     push_to_notification_queue,
 };
-use crate::signals::llm_model;
 use crate::signals::provider::models::{
     ProviderFunctionDeclaration, ProviderGenerationConfig, ProviderTool,
 };
-use crate::signals::provider::{
-    LanguageModelClient, ProviderClient, ProviderContent, ProviderPart, ProviderRequest,
-};
+use crate::signals::provider::{LlmClient, ProviderContent, ProviderPart, ProviderRequest};
 use crate::worker::{HandlerError, MessageHandler};
 
 const MAX_EVENTS_FOR_SUMMARY: u64 = 128;
@@ -48,7 +45,7 @@ pub struct ReportsGenerator {
     pub db: Arc<DB>,
     pub clickhouse: clickhouse::Client,
     pub queue: Arc<MessageQueue>,
-    pub llm_client: Option<Arc<ProviderClient>>,
+    pub llm_client: Option<Arc<LlmClient>>,
 }
 
 #[async_trait]
@@ -73,7 +70,7 @@ async fn process_report_trigger(
     db: Arc<DB>,
     clickhouse: clickhouse::Client,
     queue: Arc<MessageQueue>,
-    llm_client: Option<Arc<ProviderClient>>,
+    llm_client: Option<Arc<LlmClient>>,
 ) -> Result<(), HandlerError> {
     let workspace_id = message.workspace_id;
     let report_id = message.id;
@@ -439,7 +436,7 @@ fn build_summary_context(
 /// Generate a per-project AI summary using the LLM with tool calling.
 /// Returns (summary_text, noteworthy_signal_event_ids).
 async fn generate_project_summary(
-    llm_client: &ProviderClient,
+    llm_client: &LlmClient,
     project_name: &str,
     signal_name_map: &HashMap<Uuid, String>,
     signal_event_counts: &BTreeMap<String, u64>,
@@ -487,11 +484,12 @@ async fn generate_project_summary(
             temperature: Some(0.2),
             ..Default::default()
         }),
+        provider: None,
+        model_size: None,
     };
 
-    let model = llm_model();
     let response = llm_client
-        .generate_content(&model, &request)
+        .generate_content(&request)
         .await
         .map_err(|e| anyhow::anyhow!("LLM generate_content failed: {:?}", e))?;
 

--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -10,10 +10,10 @@ use crate::{
     },
     db::{DB, signal_jobs::update_signal_job_stats},
     signals::{
-        SignalRun, llm_model,
+        SignalRun,
         prompts::{IDENTIFICATION_PROMPT, SYSTEM_PROMPT},
         provider::{
-            ProviderClient, ProviderThinkingConfig, ProviderThinkingLevel,
+            LlmClient, ProviderThinkingConfig, ProviderThinkingLevel,
             models::{
                 ProviderContent as Content, ProviderGenerationConfig, ProviderPart as Part,
                 ProviderRequest, ProviderRequestItem,
@@ -70,7 +70,7 @@ pub async fn process_run(
     structured_output_schema: &serde_json::Value,
     clickhouse: clickhouse::Client,
     cache: Arc<Cache>,
-    llm_client: Arc<ProviderClient>,
+    llm_client: Arc<LlmClient>,
 ) -> Result<ProcessRunResult, HandlerError> {
     let processing_start_time = Utc::now();
 
@@ -104,11 +104,9 @@ pub async fn process_run(
                 .collect();
 
             if !uncached.is_empty() {
-                let model = llm_model();
                 let generated = generate_and_cache_summaries(
                     &cache,
                     &llm_client,
-                    &model,
                     project_id,
                     signal_id,
                     prompt,
@@ -229,6 +227,8 @@ pub async fn process_run(
                 }),
                 ..Default::default()
             }),
+            provider: None,
+            model_size: None,
         },
         metadata: Some(serde_json::json!({
             "run_id": run_id,

--- a/app-server/src/signals/pendings_consumer.rs
+++ b/app-server/src/signals/pendings_consumer.rs
@@ -13,7 +13,7 @@ use crate::{
     signals::SignalRun,
     signals::{
         SignalWorkerConfig,
-        provider::{LanguageModelClient, ProviderClient, models::ProviderBatchOutput},
+        provider::{LlmClient, models::ProviderBatchOutput},
         push_to_signals_queue,
         queue::{SignalJobPendingBatchMessage, SignalMessage, push_to_realtime_queue, push_to_waiting_queue},
         response_processor::{FailureMetadata, finalize_runs, process_provider_responses},
@@ -28,7 +28,7 @@ pub struct SignalJobPendingBatchHandler {
     pub cache: Arc<crate::cache::Cache>,
     pub queue: Arc<MessageQueue>,
     pub clickhouse: clickhouse::Client,
-    pub llm_client: Arc<ProviderClient>,
+    pub llm_client: Arc<LlmClient>,
     pub config: Arc<SignalWorkerConfig>,
 }
 
@@ -38,7 +38,7 @@ impl SignalJobPendingBatchHandler {
         cache: Arc<crate::cache::Cache>,
         queue: Arc<MessageQueue>,
         clickhouse: clickhouse::Client,
-        llm_client: Arc<ProviderClient>,
+        llm_client: Arc<LlmClient>,
         config: Arc<SignalWorkerConfig>,
     ) -> Self {
         Self {
@@ -75,7 +75,7 @@ async fn process(
     db: Arc<DB>,
     clickhouse: clickhouse::Client,
     queue: Arc<MessageQueue>,
-    llm_client: Arc<ProviderClient>,
+    llm_client: Arc<LlmClient>,
     config: Arc<SignalWorkerConfig>,
     cache: Arc<crate::cache::Cache>,
 ) -> Result<(), HandlerError> {

--- a/app-server/src/signals/provider/mod.rs
+++ b/app-server/src/signals/provider/mod.rs
@@ -137,9 +137,9 @@ pub(crate) fn default_model_for_provider(provider: &str) -> String {
 /// Map a (provider, model size) pair to a concrete model ID.
 pub fn model_for_size(provider: &str, size: ModelSize) -> String {
     match (provider, size) {
-        ("gemini", ModelSize::Small) => "gemini-2.0-flash-lite".to_string(),
+        ("gemini", ModelSize::Small) => "gemini-3-flash-preview".to_string(),
         ("gemini", ModelSize::Medium) => "gemini-3-flash-preview".to_string(),
-        ("gemini", ModelSize::Large) => "gemini-2.5-pro-preview".to_string(),
+        ("gemini", ModelSize::Large) => "gemini-3-pro-preview".to_string(),
         ("bedrock", ModelSize::Small) => {
             "global.anthropic.claude-haiku-4-5-20251001-v1:0".to_string()
         }
@@ -281,22 +281,8 @@ impl LlmClient {
     }
 
     pub async fn get_batch(&self, batch_name: &str) -> ProviderResult<ProviderBatchOperation> {
+        // TODO: Implement batch retrieval for all providers
         let client = self.providers.get(&self.default_provider).unwrap();
         client.get_batch(batch_name).await
-    }
-
-    pub fn supports_batch(&self) -> bool {
-        self.providers
-            .get(&self.default_provider)
-            .map(|c| c.supports_batch())
-            .unwrap_or(false)
-    }
-
-    pub fn default_provider_name(&self) -> &str {
-        &self.default_provider
-    }
-
-    pub fn default_model_name(&self) -> &str {
-        &self.default_model
     }
 }

--- a/app-server/src/signals/provider/mod.rs
+++ b/app-server/src/signals/provider/mod.rs
@@ -9,6 +9,7 @@ pub use mock::MockProviderClient;
 pub use models::*;
 
 use enum_dispatch::enum_dispatch;
+use std::collections::HashMap;
 use std::env;
 use std::sync::OnceLock;
 use thiserror::Error;
@@ -54,7 +55,7 @@ impl ProviderError {
 pub type ProviderResult<T> = Result<T, ProviderError>;
 
 #[enum_dispatch]
-pub trait LanguageModelClient: Send + Sync {
+pub(crate) trait LanguageModelClient: Send + Sync {
     fn supports_batch(&self) -> bool {
         false
     }
@@ -85,7 +86,7 @@ pub trait LanguageModelClient: Send + Sync {
 
 #[derive(Clone)]
 #[enum_dispatch(LanguageModelClient)]
-pub enum ProviderClient {
+pub(crate) enum ProviderClient {
     Gemini(GeminiClient),
     Bedrock(BedrockClient),
     Mock(MockProviderClient),
@@ -98,25 +99,19 @@ pub fn always_use_realtime() -> bool {
 }
 
 /// Checks whether the required environment variables are set for the Gemini provider.
-pub fn has_gemini_credentials() -> bool {
+fn has_gemini_credentials() -> bool {
     env::var("GOOGLE_GENERATIVE_AI_API_KEY").is_ok_and(|v| !v.is_empty())
 }
 
 /// Checks whether the required environment variables are set for the Bedrock provider.
-pub fn has_bedrock_credentials() -> bool {
+fn has_bedrock_credentials() -> bool {
     env::var("AWS_ACCESS_KEY_ID").is_ok_and(|v| !v.is_empty())
         && env::var("AWS_SECRET_ACCESS_KEY").is_ok_and(|v| !v.is_empty())
         && env::var("AWS_REGION").is_ok_and(|v| !v.is_empty())
 }
 
 /// Resolve the provider name from env var or credential auto-detection.
-///
-/// Resolution order:
-/// 1. If `SIGNALS_LLM_PROVIDER` is set (case-insensitive, whitespace-tolerant), use it.
-/// 2. Otherwise, return the first provider whose credentials are available
-///    (Gemini first, then Bedrock).
-/// 3. Falls back to "gemini" if no credentials are found.
-pub fn resolve_provider_name() -> String {
+pub(crate) fn resolve_provider_name() -> String {
     env::var("SIGNALS_LLM_PROVIDER")
         .ok()
         .map(|v| v.trim().to_lowercase())
@@ -131,15 +126,30 @@ pub fn resolve_provider_name() -> String {
 }
 
 /// Return the default model ID for a given provider name.
-pub fn default_model_for_provider(provider: &str) -> String {
+pub(crate) fn default_model_for_provider(provider: &str) -> String {
     match provider {
-        "mock" => "".to_string(), // keep empty so that span name is shown instead of model name
+        "mock" => "".to_string(),
         "bedrock" => "global.anthropic.claude-haiku-4-5-20251001-v1:0".to_string(),
         _ => "gemini-3-flash-preview".to_string(),
     }
 }
 
-fn finalize_client<C: LanguageModelClient>(client: &C) -> Result<(), ProviderError> {
+/// Map a (provider, model size) pair to a concrete model ID.
+pub fn model_for_size(provider: &str, size: ModelSize) -> String {
+    match (provider, size) {
+        ("gemini", ModelSize::Small) => "gemini-2.0-flash-lite".to_string(),
+        ("gemini", ModelSize::Medium) => "gemini-3-flash-preview".to_string(),
+        ("gemini", ModelSize::Large) => "gemini-2.5-pro-preview".to_string(),
+        ("bedrock", ModelSize::Small) => {
+            "global.anthropic.claude-haiku-4-5-20251001-v1:0".to_string()
+        }
+        ("bedrock", ModelSize::Medium) => "global.anthropic.claude-sonnet-4-6".to_string(),
+        ("bedrock", ModelSize::Large) => "global.anthropic.claude-opus-4-6".to_string(),
+        _ => default_model_for_provider(provider),
+    }
+}
+
+fn finalize_client(client: &ProviderClient) -> Result<(), ProviderError> {
     let always_realtime_env = std::env::var("SIGNALS_ALWAYS_USE_REALTIME")
         .is_ok_and(|v| v.trim().to_lowercase() == "true");
     ALWAYS_USE_REALTIME
@@ -151,47 +161,142 @@ fn finalize_client<C: LanguageModelClient>(client: &C) -> Result<(), ProviderErr
         })
 }
 
-/// Initialize a provider client based on configuration and available credentials.
-///
-/// Uses [`resolve_provider_name`] for provider selection, then validates credentials
-/// and constructs the appropriate client.
-pub async fn create_provider_client() -> Result<ProviderClient, ProviderError> {
-    let provider_name = resolve_provider_name();
+/// LLM client that holds all available provider clients and multiplexes
+/// requests based on optional `provider` and `model_size` fields on
+/// [`ProviderRequest`]. Callers never deal with provider resolution --
+/// they just call `generate_content(&request)`.
+#[derive(Clone)]
+pub struct LlmClient {
+    providers: HashMap<String, ProviderClient>,
+    default_provider: String,
+    default_model: String,
+}
 
-    match provider_name.as_str() {
-        "gemini" => {
-            if !has_gemini_credentials() {
-                return Err(ProviderError::ConfigError(
-                    "Provider resolved to 'gemini' but GOOGLE_GENERATIVE_AI_API_KEY is not set"
-                        .to_string(),
-                ));
-            }
+impl LlmClient {
+    pub async fn new() -> Result<Self, ProviderError> {
+        let default_provider = resolve_provider_name();
+        let default_model = env::var("SIGNALS_LLM_MODEL")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| default_model_for_provider(&default_provider));
+
+        let mut providers = HashMap::new();
+
+        if has_gemini_credentials() {
             let client = GeminiClient::new().map_err(|e| {
                 ProviderError::ConfigError(format!("Failed to create Gemini client: {e}"))
             })?;
             log::info!("Initialized Gemini provider");
-            finalize_client(&client)?;
-            Ok(ProviderClient::Gemini(client))
+            providers.insert("gemini".to_string(), ProviderClient::Gemini(client));
         }
-        "bedrock" => {
-            if !has_bedrock_credentials() {
-                return Err(ProviderError::ConfigError(
-                    "Provider resolved to 'bedrock' but one or more required AWS env vars are missing (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION)".to_string(),
-                ));
-            }
+
+        if has_bedrock_credentials() {
             let client = BedrockClient::new().await?;
             log::info!("Initialized Bedrock provider");
-            finalize_client(&client)?;
-            Ok(ProviderClient::Bedrock(client))
+            providers.insert("bedrock".to_string(), ProviderClient::Bedrock(client));
         }
-        "mock" => {
+
+        if default_provider == "mock" {
             let client = MockProviderClient::new();
             log::info!("Initialized Mock provider");
-            finalize_client(&client)?;
-            Ok(ProviderClient::Mock(client))
+            providers.insert("mock".to_string(), ProviderClient::Mock(client));
         }
-        other => Err(ProviderError::ConfigError(format!(
-            "Unknown provider: '{other}'. Supported providers: gemini, bedrock, mock",
-        ))),
+
+        if !providers.contains_key(&default_provider) {
+            return Err(ProviderError::ConfigError(format!(
+                "Default provider '{}' could not be initialized (missing credentials?)",
+                default_provider
+            )));
+        }
+
+        finalize_client(providers.get(&default_provider).unwrap())?;
+
+        Ok(Self {
+            providers,
+            default_provider,
+            default_model,
+        })
+    }
+
+    /// Build an `LlmClient` directly from a `ProviderClient` for tests.
+    #[cfg(test)]
+    pub fn from_provider(name: &str, client: ProviderClient) -> Self {
+        let default_model = default_model_for_provider(name);
+        let mut providers = HashMap::new();
+        providers.insert(name.to_string(), client);
+        Self {
+            providers,
+            default_provider: name.to_string(),
+            default_model,
+        }
+    }
+
+    fn resolve(
+        &self,
+        request: &ProviderRequest,
+    ) -> Result<(&ProviderClient, String), ProviderError> {
+        let provider_name = request
+            .provider
+            .as_deref()
+            .unwrap_or(&self.default_provider);
+        let client = self.providers.get(provider_name).ok_or_else(|| {
+            ProviderError::ConfigError(format!(
+                "Provider '{}' not available. Available: {:?}",
+                provider_name,
+                self.providers.keys().collect::<Vec<_>>()
+            ))
+        })?;
+        let model = match request.model_size {
+            Some(size) => model_for_size(provider_name, size),
+            None => self.default_model.clone(),
+        };
+        Ok((client, model))
+    }
+
+    pub async fn generate_content(
+        &self,
+        request: &ProviderRequest,
+    ) -> ProviderResult<ProviderResponse> {
+        let (client, model) = self.resolve(request)?;
+        client.generate_content(&model, request).await
+    }
+
+    pub async fn create_batch(
+        &self,
+        requests: Vec<ProviderRequestItem>,
+        display_name: Option<String>,
+    ) -> ProviderResult<ProviderBatchOperation> {
+        let (client, model) = requests
+            .first()
+            .map(|r| self.resolve(&r.request))
+            .transpose()?
+            .unwrap_or_else(|| {
+                (
+                    self.providers.get(&self.default_provider).unwrap(),
+                    self.default_model.clone(),
+                )
+            });
+        client.create_batch(&model, requests, display_name).await
+    }
+
+    pub async fn get_batch(&self, batch_name: &str) -> ProviderResult<ProviderBatchOperation> {
+        let client = self.providers.get(&self.default_provider).unwrap();
+        client.get_batch(batch_name).await
+    }
+
+    pub fn supports_batch(&self) -> bool {
+        self.providers
+            .get(&self.default_provider)
+            .map(|c| c.supports_batch())
+            .unwrap_or(false)
+    }
+
+    pub fn default_provider_name(&self) -> &str {
+        &self.default_provider
+    }
+
+    pub fn default_model_name(&self) -> &str {
+        &self.default_model
     }
 }

--- a/app-server/src/signals/provider/models.rs
+++ b/app-server/src/signals/provider/models.rs
@@ -1,5 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum ModelSize {
+    Small,
+    Medium,
+    Large,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderRequestItem {
@@ -18,6 +26,10 @@ pub struct ProviderRequest {
     pub tools: Option<Vec<ProviderTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generation_config: Option<ProviderGenerationConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_size: Option<ModelSize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -12,7 +12,7 @@ use crate::{
         common::{ProcessRunResult, handle_failed_runs, process_run},
         llm_model, llm_provider,
         provider::{
-            LanguageModelClient, ProviderClient,
+            LlmClient,
             models::{ProviderBatchOutput, ProviderInlineResponse},
         },
         queue::{SignalMessage, push_to_realtime_queue},
@@ -36,7 +36,7 @@ pub struct SignalJobRealtimeHandler {
     pub cache: Arc<Cache>,
     pub queue: Arc<MessageQueue>,
     pub clickhouse: clickhouse::Client,
-    pub llm_client: Arc<ProviderClient>,
+    pub llm_client: Arc<LlmClient>,
     pub config: Arc<SignalWorkerConfig>,
 }
 
@@ -46,7 +46,7 @@ impl SignalJobRealtimeHandler {
         cache: Arc<Cache>,
         queue: Arc<MessageQueue>,
         clickhouse: clickhouse::Client,
-        llm_client: Arc<ProviderClient>,
+        llm_client: Arc<LlmClient>,
         config: Arc<SignalWorkerConfig>,
     ) -> Self {
         Self {
@@ -166,13 +166,12 @@ impl SignalJobRealtimeHandler {
         let span_input = request_to_span_input(&request);
         let span_tools = request_to_tools_attr(&request);
 
-        let model_str = llm_model();
         let llm_client = self.llm_client.clone();
         let req_clone = request.clone();
 
         let generate_fn = || async {
             llm_client
-                .generate_content(&model_str, &req_clone)
+                .generate_content(&req_clone)
                 .await
                 .map_err(|e| {
                     if e.is_retryable() {
@@ -359,6 +358,7 @@ mod tests {
         MessageQueue, MessageQueueDeliveryTrait, MessageQueueReceiverTrait, MessageQueueTrait,
     };
     use crate::signals::provider::mock::{GenerateFailureMode, MockProviderClient};
+    use crate::signals::provider::ProviderClient;
     use crate::signals::provider::models::ProviderRequest;
     use crate::signals::queue::{SIGNALS_REALTIME_EXCHANGE, SIGNALS_REALTIME_ROUTING_KEY};
     use std::time::Duration;
@@ -370,6 +370,8 @@ mod tests {
             system_instruction: None,
             tools: None,
             generation_config: None,
+            provider: None,
+            model_size: None,
         }
     }
 
@@ -428,9 +430,12 @@ mod tests {
             internal_project_id: None,
             waiting_queue_ttl_ms: 300_000,
         });
-        let provider_client = Arc::new(ProviderClient::Mock(llm_client));
+        let client = Arc::new(LlmClient::from_provider(
+            "mock",
+            ProviderClient::Mock(llm_client),
+        ));
 
-        SignalJobRealtimeHandler::new(db, cache, queue, clickhouse, provider_client, config)
+        SignalJobRealtimeHandler::new(db, cache, queue, clickhouse, client, config)
     }
 
     /// When generate_content always returns a retryable 429 error, after backoff is exhausted

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -16,7 +16,7 @@ use crate::{
     mq::MessageQueue,
     signals::{
         SignalRun, SignalWorkerConfig, llm_model, llm_provider,
-        provider::{LanguageModelClient, ProviderClient, models::ProviderRequestItem},
+        provider::{LlmClient, models::ProviderRequestItem},
         queue::{
             SignalJobPendingBatchMessage, SignalJobSubmissionBatchMessage, SignalMessage,
             push_to_pending_queue, push_to_realtime_queue, push_to_signals_queue,
@@ -41,7 +41,7 @@ pub struct SignalJobSubmissionBatchHandler {
     pub cache: Arc<crate::cache::Cache>,
     pub queue: Arc<MessageQueue>,
     pub clickhouse: clickhouse::Client,
-    pub llm_client: Arc<ProviderClient>,
+    pub llm_client: Arc<LlmClient>,
     pub config: Arc<SignalWorkerConfig>,
 }
 
@@ -51,7 +51,7 @@ impl SignalJobSubmissionBatchHandler {
         cache: Arc<crate::cache::Cache>,
         queue: Arc<MessageQueue>,
         clickhouse: clickhouse::Client,
-        llm_client: Arc<ProviderClient>,
+        llm_client: Arc<LlmClient>,
         config: Arc<SignalWorkerConfig>,
     ) -> Self {
         Self {
@@ -98,7 +98,7 @@ async fn process(
     cache: Arc<crate::cache::Cache>,
     clickhouse: clickhouse::Client,
     queue: Arc<MessageQueue>,
-    llm_client: Arc<ProviderClient>,
+    llm_client: Arc<LlmClient>,
     config: Arc<SignalWorkerConfig>,
 ) -> Result<(), HandlerError> {
     let batch_message_id = msg.id;
@@ -177,7 +177,7 @@ async fn process_batch(
     cache: Arc<crate::cache::Cache>,
     clickhouse: clickhouse::Client,
     queue: Arc<MessageQueue>,
-    llm_client: Arc<ProviderClient>,
+    llm_client: Arc<LlmClient>,
     config: Arc<SignalWorkerConfig>,
 ) -> Result<(), HandlerError> {
     let mut requests: Vec<ProviderRequestItem> = Vec::with_capacity(msg.messages.len());
@@ -243,7 +243,6 @@ async fn process_batch(
     }
 
     let batch_result = submit_batch_to_llm(
-        &llm_model(),
         llm_client,
         requests,
         successful_messages.clone(),
@@ -310,8 +309,7 @@ async fn emit_submit_spans(
 /// Submit batch to LLM API and push to pending queue on success.
 /// On failure, returns the failed runs and the handler error.
 async fn submit_batch_to_llm(
-    model: &str,
-    llm_client: Arc<ProviderClient>,
+    llm_client: Arc<LlmClient>,
     requests: Vec<ProviderRequestItem>,
     messages: Vec<SignalMessage>,
     queue: Arc<MessageQueue>,
@@ -320,7 +318,6 @@ async fn submit_batch_to_llm(
     let span_requests = requests.clone();
     match llm_client
         .create_batch(
-            model,
             requests,
             Some(format!("signal_batch_{}", Uuid::new_v4())),
         )

--- a/app-server/src/signals/summarize.rs
+++ b/app-server/src/signals/summarize.rs
@@ -9,7 +9,7 @@ use crate::cache::{Cache, CacheTrait};
 use crate::signals::provider::models::{
     ProviderContent, ProviderGenerationConfig, ProviderPart, ProviderRequest,
 };
-use crate::signals::provider::{LanguageModelClient, ProviderClient};
+use crate::signals::provider::LlmClient;
 use crate::signals::provider::{ProviderThinkingConfig, ProviderThinkingLevel};
 
 const SUMMARY_CACHE_TTL_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days
@@ -76,17 +76,16 @@ pub async fn lookup_cached_summaries(
 /// Returns the generated summaries as `hash -> summary`.
 pub async fn generate_and_cache_summaries(
     cache: &Arc<Cache>,
-    llm_client: &Arc<ProviderClient>,
-    model: &str,
+    llm_client: &Arc<LlmClient>,
     project_id: Uuid,
     signal_id: Uuid,
     signal_prompt: &str,
-    uncached: &HashMap<String, String>, // hash -> full system prompt text
+    uncached: &HashMap<String, String>,
 ) -> HashMap<String, String> {
     let sig_hash = hash_signal_prompt(signal_prompt);
     let mut result = HashMap::new();
     for (hash, sys_prompt_text) in uncached {
-        match generate_summary(llm_client, model, signal_prompt, sys_prompt_text).await {
+        match generate_summary(llm_client, signal_prompt, sys_prompt_text).await {
             Ok(summary) => {
                 let key = cache_key(project_id, signal_id, &sig_hash, hash);
                 if let Err(e) = cache
@@ -110,8 +109,7 @@ pub async fn generate_and_cache_summaries(
 }
 
 async fn generate_summary(
-    llm_client: &Arc<ProviderClient>,
-    model: &str,
+    llm_client: &Arc<LlmClient>,
     signal_prompt: &str,
     system_prompt_text: &str,
 ) -> anyhow::Result<String> {
@@ -138,10 +136,12 @@ async fn generate_summary(
             }),
             ..Default::default()
         }),
+        provider: None,
+        model_size: None,
     };
 
     let response = llm_client
-        .generate_content(model, &request)
+        .generate_content(&request)
         .await
         .map_err(|e| anyhow::anyhow!("LLM call failed for system prompt summary: {}", e))?;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Refactors core Signals/Reports LLM integration to route requests through a new multiplexing client and changes model selection/config behavior, which could impact batch/realtime processing and summary generation if provider resolution or defaults are misconfigured.
> 
> **Overview**
> This PR replaces the single `ProviderClient` + explicit model-string flow with a new `LlmClient` that initializes available providers (Gemini/Bedrock/Mock), selects a provider/model per request via new `ProviderRequest.provider` and `ProviderRequest.model_size` fields, and centralizes default provider/model resolution.
> 
> Signals batch, realtime, summarization, and reports generation are updated to call `LlmClient::generate_content`/`create_batch` without passing a model, and the Signals feature flag now enables when either Gemini or AWS Bedrock credentials are present. Report summary generation also adjusts LLM generation config (adds thinking config and increases temperature).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43291df1bcffa77abd9f66281c47bbd5fbabba58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->