### PR TITLE
feat: add support for vercel/mastra sdks (#1548)

### DIFF
--- a/app-server/src/traces/provider/mod.rs
+++ b/app-server/src/traces/provider/mod.rs
@@ -29,5 +29,10 @@ fn is_ai_sdk_llm_span(span: &Span) -> bool {
                 .attributes
                 .raw_attributes
                 .get("ai.model.provider")
+                .is_some()
+            || span
+                .attributes
+                .raw_attributes
+                .get("aisdk.model.provider")
                 .is_some())
 }

--- a/app-server/src/traces/span_attributes.rs
+++ b/app-server/src/traces/span_attributes.rs
@@ -49,3 +49,7 @@ pub const OPENAI_RESPONSE_SERVICE_TIER: &str = "openai.response.service_tier";
 pub const OPENAI_REQUEST_SERVICE_TIER: &str = "openai.request.service_tier";
 pub const ANTHROPIC_RESPONSE_SERVICE_TIER: &str = "anthropic.response.service_tier";
 pub const ANTHROPIC_REQUEST_SERVICE_TIER: &str = "anthropic.request.service_tier";
+
+// Newer Vercel AI SDK / Mastra attributes
+pub const AISDK_MODEL_ID: &str = "aisdk.model.id";
+pub const AISDK_MODEL_PROVIDER: &str = "aisdk.model.provider";

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -9,6 +9,7 @@ use indexmap::IndexMap;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::{
@@ -32,13 +33,22 @@ use crate::{
 
 use super::{
     span_attributes::{
-        ASSOCIATION_PROPERTIES_PREFIX, GEN_AI_COMPLETION_TOKENS, GEN_AI_INPUT_COST,
-        GEN_AI_INPUT_TOKENS, GEN_AI_OUTPUT_COST, GEN_AI_OUTPUT_TOKENS, GEN_AI_PROMPT_TOKENS,
-        GEN_AI_REQUEST_MODEL, GEN_AI_RESPONSE_MODEL, GEN_AI_SYSTEM, GEN_AI_TOTAL_COST,
-        SPAN_IDS_PATH, SPAN_PATH, SPAN_TYPE,
+        AISDK_MODEL_ID, AISDK_MODEL_PROVIDER, ASSOCIATION_PROPERTIES_PREFIX,
+        GEN_AI_COMPLETION_TOKENS, GEN_AI_INPUT_COST, GEN_AI_INPUT_TOKENS, GEN_AI_OUTPUT_COST,
+        GEN_AI_OUTPUT_TOKENS, GEN_AI_PROMPT_TOKENS, GEN_AI_REQUEST_MODEL, GEN_AI_RESPONSE_MODEL,
+        GEN_AI_SYSTEM, GEN_AI_TOTAL_COST, SPAN_IDS_PATH, SPAN_PATH, SPAN_TYPE,
     },
     utils::skip_span_name,
 };
+
+/// Known operation prefixes used to namespace AI SDK span attributes.
+const AISDK_OPERATION_PREFIXES: &[&str] = &[
+    "stream",
+    "generateText",
+    "streamText",
+    "generateObject",
+    "streamObject",
+];
 
 const INPUT_ATTRIBUTE_NAME: &str = "lmnr.span.input";
 const OUTPUT_ATTRIBUTE_NAME: &str = "lmnr.span.output";
@@ -170,6 +180,94 @@ impl SpanAttributes {
             .and_then(|s| serde_json::from_value(s.clone()).ok())
     }
 
+    /// Normalize newer operation-prefixed attributes to standard `gen_ai.*` and `ai.*` keys so the existing extraction pipeline picks them up.
+    pub fn normalize_aisdk_attributes(&mut self) {
+        if let Some(model_id) = self.raw_attributes.get(AISDK_MODEL_ID).cloned() {
+            self.insert_if_absent(GEN_AI_REQUEST_MODEL, model_id.clone());
+            self.insert_if_absent("ai.model.id", model_id);
+        }
+
+        if let Some(provider) = self.raw_attributes.get(AISDK_MODEL_PROVIDER).cloned() {
+            self.insert_if_absent("ai.model.provider", provider.clone());
+            if !self.raw_attributes.contains_key(GEN_AI_SYSTEM) {
+                let normalized = match &provider {
+                    Value::String(s) => Value::String(
+                        s.split('.')
+                            .next()
+                            .unwrap_or(s)
+                            .to_lowercase()
+                            .trim()
+                            .to_string(),
+                    ),
+                    other => other.clone(),
+                };
+                self.raw_attributes
+                    .insert(GEN_AI_SYSTEM.to_string(), normalized);
+            }
+        }
+
+        let Some(prefix) = self.detect_aisdk_operation_prefix() else {
+            return;
+        };
+
+        // Usage attributes
+        self.normalize_if_absent(&format!("{prefix}.usage.inputTokens"), GEN_AI_INPUT_TOKENS);
+        self.normalize_if_absent(
+            &format!("{prefix}.usage.outputTokens"),
+            GEN_AI_OUTPUT_TOKENS,
+        );
+        self.normalize_if_absent(
+            &format!("{prefix}.usage.cachedInputTokens"),
+            GEN_AI_CACHE_READ_INPUT_TOKENS,
+        );
+
+        self.normalize_if_absent(&format!("{prefix}.prompt.messages"), "ai.prompt.messages");
+        self.normalize_if_absent(&format!("{prefix}.response.text"), "ai.response.text");
+        self.normalize_if_absent(
+            &format!("{prefix}.response.toolCalls"),
+            "ai.response.toolCalls",
+        );
+        self.normalize_if_absent(&format!("{prefix}.response.object"), "ai.response.object");
+    }
+
+    fn detect_aisdk_operation_prefix(&self) -> Option<&'static str> {
+        for prefix in AISDK_OPERATION_PREFIXES {
+            if self
+                .raw_attributes
+                .contains_key(&format!("{prefix}.usage.inputTokens"))
+                || self
+                    .raw_attributes
+                    .contains_key(&format!("{prefix}.usage.outputTokens"))
+                || self
+                    .raw_attributes
+                    .contains_key(&format!("{prefix}.prompt.messages"))
+                || self
+                    .raw_attributes
+                    .contains_key(&format!("{prefix}.response.text"))
+            {
+                return Some(prefix);
+            }
+        }
+        None
+    }
+
+    /// Copy a value from `source_key` to `target_key` if source exists and target does not.
+    fn normalize_if_absent(&mut self, source_key: &str, target_key: &str) {
+        if !self.raw_attributes.contains_key(target_key) {
+            if let Some(value) = self.raw_attributes.get(source_key).cloned() {
+                self.raw_attributes
+                    .insert(target_key.to_string(), value);
+            }
+        }
+    }
+
+    /// Insert a value only if the key does not already exist.
+    fn insert_if_absent(&mut self, key: &str, value: Value) {
+        if !self.raw_attributes.contains_key(key) {
+            self.raw_attributes.insert(key.to_string(), value);
+        }
+    }
+
     pub fn input_tokens(&mut self) -> InputTokens {
         let total_input_tokens =
             if let Some(Value::Number(n)) = self.raw_attributes.get(GEN_AI_INPUT_TOKENS) {
@@ -195,8 +293,19 @@ impl SpanAttributes {
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
 
-        let regular_input_tokens =
-            (total_input_tokens - (cache_write_tokens + cache_read_tokens)).max(0);
+        let cache_total = cache_write_tokens + cache_read_tokens;
+        if cache_total > total_input_tokens && total_input_tokens > 0 {
+            warn!(
+                total_input_tokens,
+                cache_write_tokens,
+                cache_read_tokens,
+                "Cache tokens ({}) exceed total input tokens ({}). Token breakdown may be inaccurate.",
+                cache_total,
+                total_input_tokens
+            );
+        }
+
+        let regular_input_tokens = (total_input_tokens - cache_total).max(0);
 
         InputTokens {
             regular_input_tokens,
@@ -307,10 +416,9 @@ impl SpanAttributes {
         } else {
             // quick hack until we figure how to set span type on auto-instrumentation
             if self.raw_attributes.contains_key(GEN_AI_SYSTEM)
-                || self
-                    .raw_attributes
-                    .iter()
-                    .any(|(k, _)| k.starts_with("gen_ai.") || k.starts_with("llm."))
+                || self.raw_attributes.iter().any(|(k, _)| {
+                    k.starts_with("gen_ai.") || k.starts_with("llm.") || k.starts_with("aisdk.")
+                })
             {
                 SpanType::LLM
             } else {
@@ -596,6 +704,13 @@ impl Span {
         // Get the raw attributes map for parsing
         if self.attributes.raw_attributes.is_empty() {
             return;
+        }
+
+        self.attributes.normalize_aisdk_attributes();
+
+        // Re-evaluate span type after normalization — gen_ai.system may now be present
+        if self.span_type == SpanType::Default {
+            self.span_type = self.attributes.span_type();
         }
 
         if self.is_llm_span() {
@@ -1011,6 +1126,15 @@ pub fn should_keep_attribute(attribute: &str) -> bool {
     // AI SDK
     // remove ai.prompt.messages as it is stored in AI SDK span inputs
     if attribute == "ai.prompt.messages" || attribute == "ai.prompt" {
+        return false;
+    }
+
+    // Newer AI SDK operation-prefixed prompt attributes (normalized to ai.prompt.messages)
+    if attribute.ends_with(".prompt.messages")
+        && AISDK_OPERATION_PREFIXES
+            .iter()
+            .any(|p| attribute.starts_with(p))
+    {
         return false;
     }
 
@@ -3322,5 +3446,289 @@ mod tests {
             span.attributes.raw_attributes.get("llm.usage.total_tokens"),
             Some(&json!(105))
         );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_stream_attributes() {
+        // Simulates a span with newer AI SDK stream.* / aisdk.* attributes.
+        // Verifies that tokens, model, provider, and input/output are all extracted correctly.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("glm-4.5-flash")),
+            ("aisdk.model.provider".to_string(), json!("openai.chat")),
+            ("stream.usage.inputTokens".to_string(), json!(14)),
+            ("stream.usage.outputTokens".to_string(), json!(87)),
+            ("stream.usage.cachedInputTokens".to_string(), json!(12)),
+            (
+                "stream.prompt.messages".to_string(),
+                json!("[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}]"),
+            ),
+            (
+                "stream.response.text".to_string(),
+                json!("Hi there!"),
+            ),
+            (
+                "stream.response.toolCalls".to_string(),
+                json!("[]"),
+            ),
+        ]);
+
+        let mut span = Span {
+            span_id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            trace_id: Uuid::new_v4(),
+            parent_span_id: None,
+            name: "mastra.stream".to_string(),
+            attributes: SpanAttributes::new(attributes),
+            start_time: Utc::now(),
+            end_time: Utc::now(),
+            span_type: SpanType::Default,
+            input: None,
+            output: None,
+            events: vec![],
+            status: None,
+            tags: None,
+            input_url: None,
+            output_url: None,
+            size_bytes: 0,
+        };
+
+        span.parse_and_enrich_attributes();
+
+        // Span type should be re-evaluated to LLM after normalization
+        assert_eq!(span.span_type, SpanType::LLM);
+
+        // Token counts should be extracted via gen_ai.usage.* normalization
+        let input_tokens = span.attributes.input_tokens();
+        assert_eq!(input_tokens.total(), 14);
+        assert_eq!(input_tokens.cache_read_tokens, 12);
+        assert_eq!(input_tokens.regular_input_tokens, 2);
+        assert_eq!(span.attributes.output_tokens(), 87);
+
+        // Model from aisdk.model.id
+        assert_eq!(
+            span.attributes.request_model(),
+            Some("glm-4.5-flash".to_string())
+        );
+
+        // Provider from aisdk.model.provider, normalized
+        assert_eq!(
+            span.attributes.provider_name(&span.name),
+            Some("openai".to_string())
+        );
+
+        assert!(span.input.is_some(), "span input should be parsed");
+
+        assert!(span.output.is_some(), "span output should be parsed");
+
+        assert_eq!(
+            span.attributes
+                .raw_attributes
+                .get("stream.usage.inputTokens"),
+            Some(&json!(14))
+        );
+        assert_eq!(
+            span.attributes
+                .raw_attributes
+                .get("aisdk.model.provider"),
+            Some(&json!("openai.chat"))
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_generate_text_attributes() {
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("openai")),
+            ("generateText.usage.inputTokens".to_string(), json!(50)),
+            ("generateText.usage.outputTokens".to_string(), json!(100)),
+        ]);
+
+        let mut span = Span {
+            span_id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            trace_id: Uuid::new_v4(),
+            parent_span_id: None,
+            name: "ai.generateText".to_string(),
+            attributes: SpanAttributes::new(attributes),
+            start_time: Utc::now(),
+            end_time: Utc::now(),
+            span_type: SpanType::Default,
+            input: None,
+            output: None,
+            events: vec![],
+            status: None,
+            tags: None,
+            input_url: None,
+            output_url: None,
+            size_bytes: 0,
+        };
+
+        span.parse_and_enrich_attributes();
+
+        assert_eq!(span.span_type, SpanType::LLM);
+        assert_eq!(span.attributes.input_tokens().total(), 50);
+        assert_eq!(span.attributes.output_tokens(), 100);
+        assert_eq!(
+            span.attributes.request_model(),
+            Some("gpt-4o".to_string())
+        );
+        assert_eq!(
+            span.attributes.provider_name(&span.name),
+            Some("openai".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_does_not_overwrite_existing() {
+        // If standard gen_ai.* keys already exist, normalization should NOT overwrite them.
+        let attributes = HashMap::from([
+            ("gen_ai.usage.input_tokens".to_string(), json!(50)),
+            ("gen_ai.usage.output_tokens".to_string(), json!(200)),
+            ("gen_ai.request.model".to_string(), json!("existing-model")),
+            ("gen_ai.system".to_string(), json!("existing-provider")),
+            // These should be ignored since standard keys already exist
+            ("aisdk.model.id".to_string(), json!("overwrite-model")),
+            ("aisdk.model.provider".to_string(), json!("overwrite.provider")),
+            ("stream.usage.inputTokens".to_string(), json!(999)),
+            ("stream.usage.outputTokens".to_string(), json!(888)),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_INPUT_TOKENS),
+            Some(&json!(50))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_OUTPUT_TOKENS),
+            Some(&json!(200))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_REQUEST_MODEL),
+            Some(&json!("existing-model"))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_SYSTEM),
+            Some(&json!("existing-provider"))
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_no_op_without_aisdk_attributes() {
+        // Normalization should be a no-op for spans without any aisdk/stream attributes.
+        let attributes = HashMap::from([
+            ("gen_ai.system".to_string(), json!("openai")),
+            ("gen_ai.usage.input_tokens".to_string(), json!(10)),
+            ("gen_ai.usage.output_tokens".to_string(), json!(20)),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes.clone());
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(attrs.raw_attributes.len(), attributes.len());
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_INPUT_TOKENS),
+            Some(&json!(10))
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_provider_lowercased() {
+        // Provider should be lowercased and trimmed, even if the SDK sends mixed case.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("OpenAI.Chat")),
+            ("stream.usage.inputTokens".to_string(), json!(10)),
+            ("stream.usage.outputTokens".to_string(), json!(20)),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_SYSTEM),
+            Some(&json!("openai"))
+        );
+
+        assert_eq!(
+            attrs.raw_attributes.get("ai.model.provider"),
+            Some(&json!("OpenAI.Chat"))
+        );
+    }
+
+    #[test]
+    fn test_normalize_aisdk_stream_object_prefix() {
+        // Verify that streamObject prefix is also detected and normalized.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("openai")),
+            ("streamObject.usage.inputTokens".to_string(), json!(30)),
+            ("streamObject.usage.outputTokens".to_string(), json!(60)),
+            (
+                "streamObject.prompt.messages".to_string(),
+                json!("[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"extract data\"}]}]"),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_INPUT_TOKENS),
+            Some(&json!(30))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_OUTPUT_TOKENS),
+            Some(&json!(60))
+        );
+        assert!(attrs.raw_attributes.contains_key("ai.prompt.messages"));
+    }
+
+    #[test]
+    fn test_cache_tokens_exceed_total_clips_to_zero() {
+        // When cache tokens > total (inconsistent instrumentation), regular_input_tokens
+        // should clip to 0 rather than go negative.
+        let attributes = HashMap::from([
+            ("gen_ai.usage.input_tokens".to_string(), json!(100)),
+            (
+                "gen_ai.usage.cache_read_input_tokens".to_string(),
+                json!(150),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        let input_tokens = attrs.input_tokens();
+
+        assert_eq!(input_tokens.regular_input_tokens, 0);
+        assert_eq!(input_tokens.cache_read_tokens, 150);
+        assert_eq!(input_tokens.total(), 150);
+    }
+
+    #[test]
+    fn test_normalize_aisdk_only_model_no_prefix() {
+        // Span has aisdk.model.* but no operation-prefixed attributes.
+        // Model/provider should still be normalized.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("claude-3-opus")),
+            (
+                "aisdk.model.provider".to_string(),
+                json!("anthropic.messages"),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_REQUEST_MODEL),
+            Some(&json!("claude-3-opus"))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_SYSTEM),
+            Some(&json!("anthropic"))
+        );
+        assert!(!attrs.raw_attributes.contains_key(GEN_AI_INPUT_TOKENS));
+        assert!(!attrs.raw_attributes.contains_key(GEN_AI_OUTPUT_TOKENS));
     }
 }

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -1150,7 +1150,7 @@ pub fn should_keep_attribute(attribute: &str) -> bool {
     ];
     if AISDK_OPERATION_PREFIXES
         .iter()
-        .any(|p| attribute.starts_with(p))
+        .any(|p| attribute.starts_with(&format!("{p}.")))
         && AISDK_NORMALIZED_SUFFIXES
             .iter()
             .any(|s| attribute.ends_with(s))

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -1142,7 +1142,6 @@ pub fn should_keep_attribute(attribute: &str) -> bool {
     const AISDK_NORMALIZED_SUFFIXES: &[&str] = &[
         ".prompt.messages",
         ".response.text",
-        ".response.toolCalls",
         ".response.object",
         ".usage.inputTokens",
         ".usage.outputTokens",

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -3719,6 +3719,154 @@ mod tests {
     }
 
     #[test]
+    fn test_cache_write_tokens_from_input_token_details() {
+        // inputTokenDetails.cacheWriteTokens should map to gen_ai.usage.cache_creation_input_tokens
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("openai")),
+            ("stream.usage.inputTokens".to_string(), json!(100)),
+            ("stream.usage.outputTokens".to_string(), json!(50)),
+            (
+                "stream.usage.inputTokenDetails.cacheWriteTokens".to_string(),
+                json!(30),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_WRITE_INPUT_TOKENS),
+            Some(&json!(30))
+        );
+        // cache read should not be set
+        assert!(
+            !attrs
+                .raw_attributes
+                .contains_key(GEN_AI_CACHE_READ_INPUT_TOKENS)
+        );
+    }
+
+    #[test]
+    fn test_cached_input_tokens_maps_to_cache_read() {
+        // cachedInputTokens should map to gen_ai.usage.cache_read_input_tokens
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("openai")),
+            ("stream.usage.inputTokens".to_string(), json!(100)),
+            ("stream.usage.outputTokens".to_string(), json!(50)),
+            ("stream.usage.cachedInputTokens".to_string(), json!(40)),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_READ_INPUT_TOKENS),
+            Some(&json!(40))
+        );
+    }
+
+    #[test]
+    fn test_cache_read_tokens_from_input_token_details() {
+        // inputTokenDetails.cacheReadTokens should map to gen_ai.usage.cache_read_input_tokens
+        // when cachedInputTokens is absent
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("openai")),
+            ("stream.usage.inputTokens".to_string(), json!(100)),
+            ("stream.usage.outputTokens".to_string(), json!(50)),
+            (
+                "stream.usage.inputTokenDetails.cacheReadTokens".to_string(),
+                json!(25),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_READ_INPUT_TOKENS),
+            Some(&json!(25))
+        );
+    }
+
+    #[test]
+    fn test_cached_input_tokens_has_precedence_over_cache_read_token_details() {
+        // When both cachedInputTokens and inputTokenDetails.cacheReadTokens are present,
+        // cachedInputTokens should take precedence because it is normalized first.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("gpt-4o")),
+            ("aisdk.model.provider".to_string(), json!("openai")),
+            ("stream.usage.inputTokens".to_string(), json!(100)),
+            ("stream.usage.outputTokens".to_string(), json!(50)),
+            ("stream.usage.cachedInputTokens".to_string(), json!(40)),
+            (
+                "stream.usage.inputTokenDetails.cacheReadTokens".to_string(),
+                json!(25),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        // cachedInputTokens (40) wins over inputTokenDetails.cacheReadTokens (25)
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_READ_INPUT_TOKENS),
+            Some(&json!(40))
+        );
+    }
+
+    #[test]
+    fn test_all_cache_token_attributes_together() {
+        // All three cache token attributes present: cacheWriteTokens, cachedInputTokens,
+        // and cacheReadTokens. Verify they all resolve correctly with proper precedence.
+        let attributes = HashMap::from([
+            ("aisdk.model.id".to_string(), json!("claude-3-opus")),
+            (
+                "aisdk.model.provider".to_string(),
+                json!("anthropic.messages"),
+            ),
+            ("generateText.usage.inputTokens".to_string(), json!(200)),
+            ("generateText.usage.outputTokens".to_string(), json!(80)),
+            (
+                "generateText.usage.cachedInputTokens".to_string(),
+                json!(60),
+            ),
+            (
+                "generateText.usage.inputTokenDetails.cacheReadTokens".to_string(),
+                json!(45),
+            ),
+            (
+                "generateText.usage.inputTokenDetails.cacheWriteTokens".to_string(),
+                json!(30),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        // cacheWriteTokens -> gen_ai.usage.cache_creation_input_tokens
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_WRITE_INPUT_TOKENS),
+            Some(&json!(30))
+        );
+        // cachedInputTokens (60) takes precedence over inputTokenDetails.cacheReadTokens (45)
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_READ_INPUT_TOKENS),
+            Some(&json!(60))
+        );
+
+        // Verify input_tokens() computation uses the normalized values
+        let input_tokens = attrs.input_tokens();
+        assert_eq!(input_tokens.cache_write_tokens, 30);
+        assert_eq!(input_tokens.cache_read_tokens, 60);
+        // regular = total - cache_write - cache_read = 200 - 30 - 60 = 110
+        assert_eq!(input_tokens.regular_input_tokens, 110);
+        assert_eq!(input_tokens.total(), 200);
+    }
+
+    #[test]
     fn test_normalize_aisdk_only_model_no_prefix() {
         // Span has aisdk.model.* but no operation-prefixed attributes.
         // Model/provider should still be normalized.

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -232,8 +232,8 @@ impl SpanAttributes {
     fn detect_aisdk_operation_prefix(&self) -> Option<&'static str> {
         for prefix in AISDK_OPERATION_PREFIXES {
             if self
-                    .raw_attributes
-                    .contains_key(&format!("{prefix}.usage.inputTokens"))
+                .raw_attributes
+                .contains_key(&format!("{prefix}.usage.inputTokens"))
                 || self
                     .raw_attributes
                     .contains_key(&format!("{prefix}.usage.outputTokens"))
@@ -476,6 +476,10 @@ impl SpanAttributes {
             .insert(GEN_AI_INPUT_TOKENS.to_string(), json!(usage.input_tokens));
         self.raw_attributes
             .insert(GEN_AI_OUTPUT_TOKENS.to_string(), json!(usage.output_tokens));
+        self.raw_attributes.insert(
+            "llm.usage.total_tokens".to_string(),
+            json!(usage.total_tokens),
+        );
         self.raw_attributes
             .insert(GEN_AI_TOTAL_COST.to_string(), json!(usage.total_cost));
         self.raw_attributes

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -42,6 +42,9 @@ use super::{
 
 /// Known operation prefixes used to namespace AI SDK span attributes.
 const AISDK_OPERATION_PREFIXES: &[&str] = &[
+    // raw AI SDK (we convert cached token info)
+    "ai",
+    // Mastra prefixes with operation name instead of `ai`
     "stream",
     "generateText",
     "streamText",

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -232,8 +232,8 @@ impl SpanAttributes {
     fn detect_aisdk_operation_prefix(&self) -> Option<&'static str> {
         for prefix in AISDK_OPERATION_PREFIXES {
             if self
-                .raw_attributes
-                .contains_key(&format!("{prefix}.usage.inputTokens"))
+                    .raw_attributes
+                    .contains_key(&format!("{prefix}.usage.inputTokens"))
                 || self
                     .raw_attributes
                     .contains_key(&format!("{prefix}.usage.outputTokens"))
@@ -243,6 +243,12 @@ impl SpanAttributes {
                 || self
                     .raw_attributes
                     .contains_key(&format!("{prefix}.response.text"))
+                || self
+                    .raw_attributes
+                    .contains_key(&format!("{prefix}.response.toolCalls"))
+                || self
+                    .raw_attributes
+                    .contains_key(&format!("{prefix}.response.object"))
             {
                 return Some(prefix);
             }

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -219,6 +219,14 @@ impl SpanAttributes {
             &format!("{prefix}.usage.cachedInputTokens"),
             GEN_AI_CACHE_READ_INPUT_TOKENS,
         );
+        self.normalize_if_absent(
+            &format!("{prefix}.usage.inputTokenDetails.cacheReadTokens"),
+            GEN_AI_CACHE_READ_INPUT_TOKENS,
+        );
+        self.normalize_if_absent(
+            &format!("{prefix}.usage.inputTokenDetails.cacheWriteTokens"),
+            GEN_AI_CACHE_WRITE_INPUT_TOKENS,
+        );
 
         self.normalize_if_absent(&format!("{prefix}.prompt.messages"), "ai.prompt.messages");
         self.normalize_if_absent(&format!("{prefix}.response.text"), "ai.response.text");

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -1126,11 +1126,23 @@ pub fn should_keep_attribute(attribute: &str) -> bool {
         return false;
     }
 
-    // Newer AI SDK operation-prefixed prompt attributes (normalized to ai.prompt.messages)
-    if attribute.ends_with(".prompt.messages")
-        && AISDK_OPERATION_PREFIXES
+    // Newer AI SDK operation-prefixed attributes that have been normalized to
+    // standard `ai.*` / `gen_ai.*` keys. Remove the originals to save storage.
+    const AISDK_NORMALIZED_SUFFIXES: &[&str] = &[
+        ".prompt.messages",
+        ".response.text",
+        ".response.toolCalls",
+        ".response.object",
+        ".usage.inputTokens",
+        ".usage.outputTokens",
+        ".usage.cachedInputTokens",
+    ];
+    if AISDK_OPERATION_PREFIXES
+        .iter()
+        .any(|p| attribute.starts_with(p))
+        && AISDK_NORMALIZED_SUFFIXES
             .iter()
-            .any(|p| attribute.starts_with(p))
+            .any(|s| attribute.ends_with(s))
     {
         return false;
     }

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -9,7 +9,6 @@ use indexmap::IndexMap;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tracing::warn;
 use uuid::Uuid;
 
 use crate::{
@@ -255,8 +254,7 @@ impl SpanAttributes {
     fn normalize_if_absent(&mut self, source_key: &str, target_key: &str) {
         if !self.raw_attributes.contains_key(target_key) {
             if let Some(value) = self.raw_attributes.get(source_key).cloned() {
-                self.raw_attributes
-                    .insert(target_key.to_string(), value);
+                self.raw_attributes.insert(target_key.to_string(), value);
             }
         }
     }
@@ -293,19 +291,8 @@ impl SpanAttributes {
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
 
-        let cache_total = cache_write_tokens + cache_read_tokens;
-        if cache_total > total_input_tokens && total_input_tokens > 0 {
-            warn!(
-                total_input_tokens,
-                cache_write_tokens,
-                cache_read_tokens,
-                "Cache tokens ({}) exceed total input tokens ({}). Token breakdown may be inaccurate.",
-                cache_total,
-                total_input_tokens
-            );
-        }
-
-        let regular_input_tokens = (total_input_tokens - cache_total).max(0);
+        let regular_input_tokens =
+            (total_input_tokens - (cache_write_tokens + cache_read_tokens)).max(0);
 
         InputTokens {
             regular_input_tokens,
@@ -3462,14 +3449,8 @@ mod tests {
                 "stream.prompt.messages".to_string(),
                 json!("[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}]"),
             ),
-            (
-                "stream.response.text".to_string(),
-                json!("Hi there!"),
-            ),
-            (
-                "stream.response.toolCalls".to_string(),
-                json!("[]"),
-            ),
+            ("stream.response.text".to_string(), json!("Hi there!")),
+            ("stream.response.toolCalls".to_string(), json!("[]")),
         ]);
 
         let mut span = Span {
@@ -3527,9 +3508,7 @@ mod tests {
             Some(&json!(14))
         );
         assert_eq!(
-            span.attributes
-                .raw_attributes
-                .get("aisdk.model.provider"),
+            span.attributes.raw_attributes.get("aisdk.model.provider"),
             Some(&json!("openai.chat"))
         );
     }
@@ -3568,10 +3547,7 @@ mod tests {
         assert_eq!(span.span_type, SpanType::LLM);
         assert_eq!(span.attributes.input_tokens().total(), 50);
         assert_eq!(span.attributes.output_tokens(), 100);
-        assert_eq!(
-            span.attributes.request_model(),
-            Some("gpt-4o".to_string())
-        );
+        assert_eq!(span.attributes.request_model(), Some("gpt-4o".to_string()));
         assert_eq!(
             span.attributes.provider_name(&span.name),
             Some("openai".to_string())
@@ -3588,7 +3564,10 @@ mod tests {
             ("gen_ai.system".to_string(), json!("existing-provider")),
             // These should be ignored since standard keys already exist
             ("aisdk.model.id".to_string(), json!("overwrite-model")),
-            ("aisdk.model.provider".to_string(), json!("overwrite.provider")),
+            (
+                "aisdk.model.provider".to_string(),
+                json!("overwrite.provider"),
+            ),
             ("stream.usage.inputTokens".to_string(), json!(999)),
             ("stream.usage.outputTokens".to_string(), json!(888)),
         ]);
@@ -3667,7 +3646,9 @@ mod tests {
             ("streamObject.usage.outputTokens".to_string(), json!(60)),
             (
                 "streamObject.prompt.messages".to_string(),
-                json!("[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"extract data\"}]}]"),
+                json!(
+                    "[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"extract data\"}]}]"
+                ),
             ),
         ]);
 

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -97,25 +97,19 @@ pub async fn get_llm_usage_for_span(
             input_cost = cost_entry.input_cost;
             output_cost = cost_entry.output_cost;
             total_cost = input_cost + output_cost;
-        } else if total_tokens > 0 {
-            warn!(
-                span_name,
-                model,
-                provider = provider_name.as_deref().unwrap_or("unknown"),
-                "No pricing found for model. Cost will be reported as 0."
+        }
+    } else if let Some(provider) = attributes
+        .raw_attributes
+        .get(GEN_AI_SYSTEM)
+        .and_then(|v| v.as_str())
+    {
+        // Span has gen_ai.system but no model name.
+        if total_tokens > 0 {
+            log::warn!(
+                "LLM span has tokens but no model name. Cost cannot be calculated. Provider: [{}].",
+                provider,
             );
         }
-    } else if attributes.raw_attributes.contains_key(GEN_AI_SYSTEM) && total_tokens > 0 {
-        // Span has gen_ai.system but no model name.
-        warn!(
-            span_name,
-            provider = attributes
-                .raw_attributes
-                .get(GEN_AI_SYSTEM)
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown"),
-            "LLM span has tokens but no model name. Cost cannot be calculated."
-        );
     }
 
     SpanUsage {

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -18,8 +18,9 @@ use crate::{
 
 use super::span_attributes::{
     ANTHROPIC_REQUEST_SERVICE_TIER, ANTHROPIC_RESPONSE_SERVICE_TIER, GEN_AI_REQUEST_BATCH,
-    GEN_AI_REQUEST_SERVICE_TIER, GEN_AI_RESPONSE_SERVICE_TIER, GEN_AI_USAGE_AUDIO_INPUT_TOKENS,
-    GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS, GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_1H_TOKENS,
+    GEN_AI_REQUEST_SERVICE_TIER, GEN_AI_RESPONSE_SERVICE_TIER, GEN_AI_SYSTEM,
+    GEN_AI_USAGE_AUDIO_INPUT_TOKENS, GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS,
+    GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_1H_TOKENS,
     GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_5M_TOKENS, GEN_AI_USAGE_REASONING_TOKENS,
     OPENAI_REQUEST_SERVICE_TIER, OPENAI_RESPONSE_SERVICE_TIER,
 };
@@ -96,7 +97,25 @@ pub async fn get_llm_usage_for_span(
             input_cost = cost_entry.input_cost;
             output_cost = cost_entry.output_cost;
             total_cost = input_cost + output_cost;
+        } else if total_tokens > 0 {
+            warn!(
+                span_name,
+                model,
+                provider = provider_name.as_deref().unwrap_or("unknown"),
+                "No pricing found for model. Cost will be reported as 0."
+            );
         }
+    } else if attributes.raw_attributes.contains_key(GEN_AI_SYSTEM) && total_tokens > 0 {
+        // Span has gen_ai.system but no model name.
+        warn!(
+            span_name,
+            provider = attributes
+                .raw_attributes
+                .get(GEN_AI_SYSTEM)
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown"),
+            "LLM span has tokens but no model name. Cost cannot be calculated."
+        );
     }
 
     SpanUsage {

--- a/frontend/components/playground/utils.tsx
+++ b/frontend/components/playground/utils.tsx
@@ -141,7 +141,13 @@ export const parseTools = (tools?: string) => {
 };
 
 const parseAiSdkToolsFromSpan = (
-  tools?: { name: string; type: string; description?: string; parameters: Record<string, any> }[]
+  tools?: {
+    name: string;
+    type: string;
+    description?: string;
+    parameters?: Record<string, any>;
+    inputSchema?: Record<string, any>;
+  }[]
 ) =>
   tools
     ? JSON.stringify(
@@ -150,7 +156,7 @@ const parseAiSdkToolsFromSpan = (
             ...acc,
             [tool.name]: {
               description: tool.description || "",
-              parameters: tool.parameters,
+              parameters: tool.parameters || tool.inputSchema,
             },
           }),
           {}

--- a/frontend/components/traces/tool-list.tsx
+++ b/frontend/components/traces/tool-list.tsx
@@ -24,7 +24,14 @@ export const extractToolsFromAttributes = (attributes: Record<string, any>): Too
       return aiPromptTools.map((tool: any) => ({
         name: get(tool, "name", ""),
         description: get(tool, "description", ""),
-        parameters: typeof tool.parameters === "string" ? tool.parameters : JSON.stringify(tool.parameters || {}),
+        parameters:
+          typeof tool.parameters === "string"
+            ? tool.parameters
+            : tool.parameters
+              ? JSON.stringify(tool.parameters)
+              : typeof tool.inputSchema === "string"
+                ? tool.inputSchema
+                : JSON.stringify(tool.inputSchema || {}),
       }));
     } catch (e) {
       console.error("Failed to parse ai.prompt.tools:", e);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core span parsing/normalization and attribute filtering, which can affect token/cost extraction and stored trace data; changes are well-covered by new tests but impact is broad.
> 
> **Overview**
> Adds support for newer Vercel AI SDK/Mastra span attributes by **normalizing `aisdk.*` and operation-prefixed keys (e.g. `stream.*`, `generateText.*`) into existing `gen_ai.*` / `ai.*` fields** so token/model/provider and input/output extraction continues to work.
> 
> Updates LLM span detection to treat `aisdk.*` as LLM, stores `llm.usage.total_tokens` when setting usage, drops now-redundant operation-prefixed attributes to reduce storage, and adds extensive tests plus a cost-calculation warning when `gen_ai.system` exists but model is missing.
> 
> Frontend tool parsing is made more flexible by falling back from `parameters` to `inputSchema` for AI SDK tool definitions in both playground config building and trace tool list rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c903fb04adc49fc191a79fa93b10ad2765ae4b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->