### PR TITLE
add delay to the submission worker when handling locked batch

### DIFF
--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -89,7 +89,7 @@ impl MessageHandler for SignalJobSubmissionBatchHandler {
     }
 }
 
-const BATCH_LOCK_TTL_SECONDS: u64 = 3600;
+const BATCH_LOCK_TTL_SECONDS: u64 = 7200;
 const BATCH_SUBMITTED_TTL_SECONDS: u64 = 86400;
 
 async fn process(

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -111,10 +111,6 @@ async fn process(
             "[SIGNAL JOB] Batch {} already submitted, skipping",
             batch_message_id
         );
-
-        // Avoid tight redelivery loop when this is the only message in the queue
-        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-
         return Ok(());
     }
 
@@ -130,6 +126,10 @@ async fn process(
                 "[SIGNAL JOB] Batch {} is locked by another worker, re-publishing to back of queue",
                 batch_message_id,
             );
+
+            // Avoid tight redelivery loop
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
             if let Err(e) = push_to_submissions_queue(msg, queue).await {
                 log::error!(
                     "[SIGNAL JOB] Failed to re-publish locked batch {}: {:?}",

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -89,7 +89,7 @@ impl MessageHandler for SignalJobSubmissionBatchHandler {
     }
 }
 
-const BATCH_LOCK_TTL_SECONDS: u64 = 7200;
+const BATCH_LOCK_TTL_SECONDS: u64 = 3600;
 const BATCH_SUBMITTED_TTL_SECONDS: u64 = 86400;
 
 async fn process(
@@ -111,6 +111,10 @@ async fn process(
             "[SIGNAL JOB] Batch {} already submitted, skipping",
             batch_message_id
         );
+
+        // Avoid tight redelivery loop when this is the only message in the queue
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
         return Ok(());
     }
 
@@ -144,8 +148,16 @@ async fn process(
         }
     }
 
-    let result =
-        process_batch(msg, db, cache.clone(), clickhouse, queue, llm_client, config).await;
+    let result = process_batch(
+        msg,
+        db,
+        cache.clone(),
+        clickhouse,
+        queue,
+        llm_client,
+        config,
+    )
+    .await;
 
     if result.is_ok() {
         if let Err(e) = cache
@@ -319,10 +331,7 @@ async fn submit_batch_to_llm(
 ) -> Result<(), (Vec<SignalRun>, HandlerError)> {
     let span_requests = requests.clone();
     match llm_client
-        .create_batch(
-            requests,
-            Some(format!("signal_batch_{}", Uuid::new_v4())),
-        )
+        .create_batch(requests, Some(format!("signal_batch_{}", Uuid::new_v4())))
         .await
     {
         Ok(operation) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to queue-worker control flow; main impact is slightly slower reprocessing of locked/redelivered batches and potential throughput reduction under contention.
> 
> **Overview**
> Adds a 10-second delay in the submissions consumer when a batch lock can’t be acquired before re-publishing the message to the back of the queue, reducing tight redelivery loops under lock contention.
> 
> Also includes minor formatting-only cleanup around the `create_batch` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8522200ce739e8c656d833e666afb0d7d1316a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->