### PR TITLE
add sentry tracing for signals pipeline

### DIFF
--- a/app-server/src/signals/batching.rs
+++ b/app-server/src/signals/batching.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use uuid::Uuid;
 
 use crate::batch_worker::message_handler::{BatchMessageHandler, HandlerResult};
 use crate::batch_worker::{config::BatchingConfig, message_handler::MessageDelivery};

--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -66,6 +66,11 @@ pub async fn handle_failed_runs(
     }
 }
 
+#[tracing::instrument(
+    skip_all,
+    name = "prepare_single_request",
+    fields(project_id, run_id, signal_id, trace_id)
+)]
 pub async fn process_run(
     project_id: Uuid,
     trace_id: Uuid,
@@ -113,11 +118,8 @@ pub async fn process_run(
                 None => {
                     // Cache miss: build unfiltered trace to let the LLM analyze structure,
                     // then generate + cache rules for this and future runs.
-                    let unfiltered_structure = build_trace_structure_string(
-                        &ch_spans,
-                        trace_id,
-                        &HashMap::new(),
-                    );
+                    let unfiltered_structure =
+                        build_trace_structure_string(&ch_spans, trace_id, &HashMap::new());
                     generate_and_cache_drop_rules(
                         &cache,
                         &llm_client,

--- a/app-server/src/signals/pendings_consumer.rs
+++ b/app-server/src/signals/pendings_consumer.rs
@@ -15,7 +15,10 @@ use crate::{
         SignalWorkerConfig,
         provider::{LlmClient, models::ProviderBatchOutput},
         push_to_signals_queue,
-        queue::{SignalJobPendingBatchMessage, SignalMessage, push_to_realtime_queue, push_to_waiting_queue},
+        queue::{
+            SignalJobPendingBatchMessage, SignalMessage, push_to_realtime_queue,
+            push_to_waiting_queue,
+        },
         response_processor::{FailureMetadata, finalize_runs, process_provider_responses},
     },
     worker::{HandlerError, MessageHandler},
@@ -70,6 +73,7 @@ impl MessageHandler for SignalJobPendingBatchHandler {
     }
 }
 
+#[tracing::instrument(skip_all, name = "process_batch_pending", fields(batch_id = %message.batch_id))]
 async fn process(
     message: SignalJobPendingBatchMessage,
     db: Arc<DB>,
@@ -146,6 +150,7 @@ async fn process(
     Ok(())
 }
 
+#[tracing::instrument(skip_all, fields(num_runs = failed_runs.len()))]
 pub async fn retry_or_fail_runs(
     failed_runs: Vec<SignalRun>,
     run_to_message: &HashMap<Uuid, SignalMessage>,
@@ -210,6 +215,7 @@ pub async fn retry_or_fail_runs(
     (permanently_failed_runs, retried_count)
 }
 
+#[tracing::instrument(skip_all, fields(batch_id = %message.batch_id))]
 async fn process_failed_batch(
     message: &SignalJobPendingBatchMessage,
     retryable: bool,
@@ -281,6 +287,7 @@ async fn process_failed_batch(
     Ok(())
 }
 
+#[tracing::instrument(skip_all, fields(batch_id = %message.batch_id))]
 async fn process_pending_batch(
     message: &SignalJobPendingBatchMessage,
     queue: Arc<MessageQueue>,
@@ -291,6 +298,7 @@ async fn process_pending_batch(
         .map_err(|e| HandlerError::transient(e))
 }
 
+#[tracing::instrument(skip_all, fields(batch_id = %message.batch_id))]
 pub async fn process_succeeded_batch(
     message: &SignalJobPendingBatchMessage,
     batch_output: Option<ProviderBatchOutput>,

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -64,6 +64,7 @@ impl SignalJobRealtimeHandler {
 impl MessageHandler for SignalJobRealtimeHandler {
     type Message = SignalMessage;
 
+    #[tracing::instrument(skip_all, name = "realtime_handle")]
     async fn handle(&self, message: Self::Message) -> Result<(), HandlerError> {
         let project_id = message.project_id;
         let signal = &message.signal;
@@ -159,6 +160,7 @@ impl SignalJobRealtimeHandler {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn process_realtime_request(
         &self,
         request: crate::signals::provider::models::ProviderRequest,
@@ -172,23 +174,26 @@ impl SignalJobRealtimeHandler {
         let req_clone = request.clone();
 
         let generate_fn = || async {
-            llm_client
-                .generate_content(&req_clone)
-                .await
-                .map_err(|e| {
-                    if e.is_retryable() {
-                        backoff::Error::transient(e)
-                    } else {
-                        backoff::Error::permanent(e)
-                    }
-                })
+            llm_client.generate_content(&req_clone).await.map_err(|e| {
+                if e.is_retryable() {
+                    backoff::Error::transient(e)
+                } else {
+                    backoff::Error::permanent(e)
+                }
+            })
         };
 
         match backoff::future::retry(backoff, generate_fn).await {
             Ok(response) => {
                 emit_internal_span(
                     self.queue.clone(),
-                    Self::build_submit_span(&message, &self.config, span_input.clone(), span_tools.clone(), None),
+                    Self::build_submit_span(
+                        &message,
+                        &self.config,
+                        span_input.clone(),
+                        span_tools.clone(),
+                        None,
+                    ),
                 )
                 .await;
                 let inline_response = ProviderInlineResponse {
@@ -359,8 +364,8 @@ mod tests {
     use crate::mq::{
         MessageQueue, MessageQueueDeliveryTrait, MessageQueueReceiverTrait, MessageQueueTrait,
     };
-    use crate::signals::provider::mock::{GenerateFailureMode, MockProviderClient};
     use crate::signals::provider::ProviderClient;
+    use crate::signals::provider::mock::{GenerateFailureMode, MockProviderClient};
     use crate::signals::provider::models::ProviderRequest;
     use crate::signals::queue::{SIGNALS_REALTIME_EXCHANGE, SIGNALS_REALTIME_ROUTING_KEY};
     use std::time::Duration;

--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -484,6 +484,7 @@ fn spans_to_string(
 // TODO: move these two functions to CH Query engine for better integration
 // with hybrid deployment mode.
 /// Query trace spans from ClickHouse
+#[tracing::instrument(skip_all, fields(project_id, trace_id))]
 async fn get_trace_spans(
     clickhouse: clickhouse::Client,
     project_id: Uuid,

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -3,6 +3,7 @@
 //! - Pushes results to the Pending Queue for polling
 
 use async_trait::async_trait;
+use opentelemetry::{global, trace::Tracer};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -17,7 +18,6 @@ use crate::{
         queue::{
             SignalJobPendingBatchMessage, SignalJobSubmissionBatchMessage, SignalMessage,
             push_to_pending_queue, push_to_realtime_queue, push_to_signals_queue,
-            push_to_submissions_queue,
         },
         utils::extract_batch_id_from_operation,
     },
@@ -85,9 +85,7 @@ impl MessageHandler for SignalJobSubmissionBatchHandler {
     }
 }
 
-const BATCH_LOCK_TTL_SECONDS: u64 = 7200;
-const BATCH_SUBMITTED_TTL_SECONDS: u64 = 86400;
-
+#[tracing::instrument(skip_all, name = "process_batch_submission", fields(batch_size = msg.messages.len()))]
 async fn process(
     msg: SignalJobSubmissionBatchMessage,
     db: Arc<DB>,
@@ -101,6 +99,10 @@ async fn process(
     let mut all_new_messages: Vec<CHSignalRunMessage> = Vec::new();
     let mut failed_runs: Vec<SignalRun> = Vec::new();
     let mut successful_messages: Vec<SignalMessage> = Vec::new();
+
+    // internal tracing
+    let tracer = global::tracer("app-server");
+    let mut prepare_requests_span = tracer.start("prepare_batch_requests");
 
     for message in msg.messages.iter() {
         let project_id = message.project_id;
@@ -146,6 +148,7 @@ async fn process(
             }
         }
     }
+    prepare_requests_span.end();
 
     if requests.is_empty() {
         log::error!("[SIGNAL JOB] No requests to submit");
@@ -227,6 +230,7 @@ async fn emit_submit_spans(
 
 /// Submit batch to LLM API and push to pending queue on success.
 /// On failure, returns the failed runs and the handler error.
+#[tracing::instrument(skip_all, fields(batch_size = requests.len()))]
 async fn submit_batch_to_llm(
     llm_client: Arc<LlmClient>,
     requests: Vec<ProviderRequestItem>,

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -3,7 +3,7 @@
 //! - Pushes results to the Pending Queue for polling
 
 use async_trait::async_trait;
-use opentelemetry::{global, trace::Tracer};
+use opentelemetry::{global, trace::{Span, Tracer}};
 use std::sync::Arc;
 use uuid::Uuid;
 

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -3,10 +3,6 @@
 //! - Pushes results to the Pending Queue for polling
 
 use async_trait::async_trait;
-use opentelemetry::{
-    global,
-    trace::{Span, Tracer},
-};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -87,26 +83,26 @@ impl MessageHandler for SignalJobSubmissionBatchHandler {
     }
 }
 
-#[tracing::instrument(skip_all, name = "process_batch_submission", fields(batch_size = msg.messages.len()))]
-async fn process(
-    msg: SignalJobSubmissionBatchMessage,
-    db: Arc<DB>,
-    cache: Arc<crate::cache::Cache>,
+#[tracing::instrument(skip_all, name = "prepare_batch_requests", fields(batch_size = messages.len()))]
+async fn prepare_batch_requests(
+    messages: &[SignalMessage],
     clickhouse: clickhouse::Client,
-    queue: Arc<MessageQueue>,
+    cache: Arc<crate::cache::Cache>,
     llm_client: Arc<LlmClient>,
-    config: Arc<SignalWorkerConfig>,
-) -> Result<(), HandlerError> {
-    let mut requests: Vec<ProviderRequestItem> = Vec::with_capacity(msg.messages.len());
+    queue: Arc<MessageQueue>,
+    config: &SignalWorkerConfig,
+) -> (
+    Vec<ProviderRequestItem>,
+    Vec<CHSignalRunMessage>,
+    Vec<SignalRun>,
+    Vec<SignalMessage>,
+) {
+    let mut requests: Vec<ProviderRequestItem> = Vec::with_capacity(messages.len());
     let mut all_new_messages: Vec<CHSignalRunMessage> = Vec::new();
     let mut failed_runs: Vec<SignalRun> = Vec::new();
     let mut successful_messages: Vec<SignalMessage> = Vec::new();
 
-    // internal tracing
-    let tracer = global::tracer("app-server");
-    let mut prepare_requests_span = tracer.start("prepare_batch_requests");
-
-    for message in msg.messages.iter() {
+    for message in messages.iter() {
         let project_id = message.project_id;
         let signal = &message.signal;
         let trace_id = message.trace_id;
@@ -150,7 +146,30 @@ async fn process(
             }
         }
     }
-    prepare_requests_span.end();
+
+    (requests, all_new_messages, failed_runs, successful_messages)
+}
+
+#[tracing::instrument(skip_all, name = "process_batch_submission", fields(batch_size = msg.messages.len()))]
+async fn process(
+    msg: SignalJobSubmissionBatchMessage,
+    db: Arc<DB>,
+    cache: Arc<crate::cache::Cache>,
+    clickhouse: clickhouse::Client,
+    queue: Arc<MessageQueue>,
+    llm_client: Arc<LlmClient>,
+    config: Arc<SignalWorkerConfig>,
+) -> Result<(), HandlerError> {
+    let (requests, all_new_messages, mut failed_runs, successful_messages) =
+        prepare_batch_requests(
+            &msg.messages,
+            clickhouse.clone(),
+            cache.clone(),
+            llm_client.clone(),
+            queue.clone(),
+            &config,
+        )
+        .await;
 
     if requests.is_empty() {
         log::error!("[SIGNAL JOB] No requests to submit");

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -3,12 +3,14 @@
 //! - Pushes results to the Pending Queue for polling
 
 use async_trait::async_trait;
-use opentelemetry::{global, trace::{Span, Tracer}};
+use opentelemetry::{
+    global,
+    trace::{Span, Tracer},
+};
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::{
-    cache::CacheTrait,
     ch::signal_run_messages::{CHSignalRunMessage, insert_signal_run_messages},
     db::DB,
     mq::MessageQueue,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds `tracing::instrument` spans around signal request preparation and batch/realtime processing; low functional impact but it touches core async pipeline code paths and could affect observability/overhead if misconfigured.
> 
> **Overview**
> Adds end-to-end tracing spans across the signals pipeline to improve visibility into request preparation and queue/batch processing.
> 
> Key signal stages are now instrumented with `tracing::instrument` (e.g., `process_run`, batch submission preparation/submission, pending-batch polling, and realtime handling), capturing useful fields like `batch_id`, `trace_id`, `run_id`, and `signal_id`. The submissions consumer is also refactored to split request preparation into a dedicated `prepare_batch_requests` helper for clearer instrumentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f789ff0f1c6a320446177daae8d265e14efa3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->