### PR TITLE
fix: add 1 day TTL to project api key

### DIFF
--- a/app-server/src/api/utils.rs
+++ b/app-server/src/api/utils.rs
@@ -8,6 +8,8 @@ use crate::{
     db::{self, project_api_keys::ProjectApiKey},
 };
 
+const PROJECT_API_KEY_TTL: u64 = 86400; // seconds == 1 day
+
 pub async fn get_api_key_from_raw_value(
     pool: &PgPool,
     cache: Arc<Cache>,
@@ -21,7 +23,7 @@ pub async fn get_api_key_from_raw_value(
         Ok(None) | Err(_) => {
             let api_key = db::project_api_keys::get_api_key(pool, &api_key_hash).await?;
             let _ = cache
-                .insert::<ProjectApiKey>(&cache_key, api_key.clone())
+                .insert_with_ttl::<ProjectApiKey>(&cache_key, api_key.clone(), PROJECT_API_KEY_TTL)
                 .await;
 
             Ok(api_key)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to cache expiration behavior; may slightly increase DB lookups after TTL expiry but avoids stale/evergreen cache entries.
> 
> **Overview**
> **Caches project API keys with an explicit expiration.** `get_api_key_from_raw_value` now stores `ProjectApiKey` values via `insert_with_ttl` using a new `PROJECT_API_KEY_TTL` constant (1 day), instead of inserting into cache with no TTL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f5c3c6d127af87ddb4490f7925fd429e6e911e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->