### PR TITLE
handle runs in parallel during signal batch submission

### DIFF
--- a/app-server/src/signals/filter.rs
+++ b/app-server/src/signals/filter.rs
@@ -243,6 +243,7 @@ fn parse_drop_rules_from_response(
 /// Call the LLM to generate span drop rules and cache them.
 /// `fingerprint` is typically the `main_agent_hash` from summarization.
 /// Returns the generated rules (may be empty if the LLM finds nothing to drop).
+#[tracing::instrument(skip_all, fields(project_id, signal_id))]
 pub async fn generate_and_cache_drop_rules(
     cache: &Arc<Cache>,
     llm_client: &Arc<LlmClient>,

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -3,7 +3,9 @@
 //! - Pushes results to the Pending Queue for polling
 
 use async_trait::async_trait;
+use futures_util::stream::{self, StreamExt};
 use std::sync::Arc;
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -30,6 +32,8 @@ use crate::{
         utils::{InternalSpan, emit_internal_span, request_to_span_input, request_to_tools_attr},
     },
 };
+
+const DEFAULT_PROCESS_RUN_CONCURRENCY: usize = 16;
 
 pub struct SignalJobSubmissionBatchHandler {
     pub db: Arc<DB>,
@@ -102,26 +106,42 @@ async fn prepare_batch_requests(
     let mut failed_runs: Vec<SignalRun> = Vec::new();
     let mut successful_messages: Vec<SignalMessage> = Vec::new();
 
-    for message in messages.iter() {
-        let project_id = message.project_id;
-        let signal = &message.signal;
-        let trace_id = message.trace_id;
+    let concurrency = get_unsigned_env_with_default(
+        "SIGNALS_PROCESS_RUN_CONCURRENCY",
+        DEFAULT_PROCESS_RUN_CONCURRENCY,
+    );
+    let results: Vec<_> = stream::iter(messages.iter().cloned())
+        .map(|message| {
+            let clickhouse = clickhouse.clone();
+            let cache = cache.clone();
+            let llm_client = llm_client.clone();
+            let queue = queue.clone();
+            let config = config.clone();
+            async move {
+                let result = process_run(
+                    message.project_id,
+                    message.trace_id,
+                    message.run_id,
+                    message.signal.id,
+                    &message.signal.prompt,
+                    &message.signal.structured_output_schema,
+                    clickhouse,
+                    cache,
+                    llm_client,
+                    queue,
+                    &config,
+                )
+                .await;
+                (message, result)
+            }
+            .in_current_span()
+        })
+        .buffer_unordered(concurrency)
+        .collect()
+        .await;
 
-        match process_run(
-            project_id,
-            trace_id,
-            message.run_id,
-            signal.id,
-            &signal.prompt,
-            &signal.structured_output_schema,
-            clickhouse.clone(),
-            cache.clone(),
-            llm_client.clone(),
-            queue.clone(),
-            &config,
-        )
-        .await
-        {
+    for (message, result) in results {
+        match result {
             Ok(ProcessRunResult {
                 request,
                 new_messages,
@@ -134,13 +154,14 @@ async fn prepare_batch_requests(
                 successful_messages.push(updated_message);
             }
             Err(e) => {
+                let signal_id = message.signal.id;
                 log::error!(
                     "[SIGNAL JOB] Failed to process run {}: {:?}",
                     message.run_id,
                     e
                 );
                 failed_runs.push(
-                    SignalRun::from_message(message, signal.id)
+                    SignalRun::from_message(&message, signal_id)
                         .failed(&format!("Failed to process run: {}", e)),
                 );
             }

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -154,14 +154,13 @@ async fn prepare_batch_requests(
                 successful_messages.push(updated_message);
             }
             Err(e) => {
-                let signal_id = message.signal.id;
                 log::error!(
                     "[SIGNAL JOB] Failed to process run {}: {:?}",
                     message.run_id,
                     e
                 );
                 failed_runs.push(
-                    SignalRun::from_message(&message, signal_id)
+                    SignalRun::from_message(&message, message.signal.id)
                         .failed(&format!("Failed to process run: {}", e)),
                 );
             }

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -109,7 +109,8 @@ async fn prepare_batch_requests(
     let concurrency = get_unsigned_env_with_default(
         "SIGNALS_PROCESS_RUN_CONCURRENCY",
         DEFAULT_PROCESS_RUN_CONCURRENCY,
-    );
+    )
+    .max(1);
     let results: Vec<_> = stream::iter(messages.iter().cloned())
         .map(|message| {
             let clickhouse = clickhouse.clone();

--- a/app-server/src/signals/summarize.rs
+++ b/app-server/src/signals/summarize.rs
@@ -169,6 +169,7 @@ fn parse_summarization_response(
 /// Summarize all extracted system prompts and identify the main agent prompt.
 /// Uses a single combined cache key. On hit, returns cached result.
 /// On miss, makes one LLM call to summarize all prompts together.
+#[tracing::instrument(skip_all, fields(project_id, signal_id, num_prompts = extracted.len()))]
 pub async fn summarize_system_prompts(
     cache: &Arc<Cache>,
     llm_client: &Arc<LlmClient>,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces bounded parallelism when preparing signal batch requests, which can change processing order and increase load on ClickHouse/cache/LLM components if misconfigured. Additional tracing instrumentation is low risk but may slightly increase log/span volume.
> 
> **Overview**
> Speeds up signal batch submissions by running `process_run` for each message concurrently (bounded via `SIGNALS_PROCESS_RUN_CONCURRENCY`, default 16) using `buffer_unordered`, instead of sequentially iterating runs.
> 
> Adds tracing instrumentation to `summarize_system_prompts` and `generate_and_cache_drop_rules` to enrich spans with `project_id`/`signal_id` and prompt counts for easier debugging/observability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aadc65baa7ced947c395f679e2985413bc754152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->