### PR TITLE
skeleton hash

### DIFF
--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -23,7 +23,7 @@ use crate::{
         },
         spans::{
             build_trace_structure_string, extract_system_prompts_with_paths, get_trace_ch_spans,
-            hash_system_prompt,
+            structural_skeleton_hash,
         },
         summarize::summarize_system_prompts,
         tools::build_tool_definitions,
@@ -120,7 +120,7 @@ pub async fn process_run(
             ch_spans
                 .iter()
                 .find(|s| s.parent_span_id.is_nil() || s.parent_span_id == Uuid::nil())
-                .map(|s| hash_system_prompt(&s.name))
+                .map(|s| structural_skeleton_hash(&s.name))
         });
 
         // 3. Resolve span drop rules (cached or generated)

--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -115,8 +115,8 @@ pub async fn process_run(
         )
         .await;
 
-        // 2. Use main_agent_hash as fingerprint; fall back to root span name
-        let fingerprint = summarization.main_agent_hash.clone().or_else(|| {
+        // 2. Use summary-based fingerprint for drop rules cache; fall back to root span name
+        let fingerprint = summarization.fingerprint.clone().or_else(|| {
             ch_spans
                 .iter()
                 .find(|s| s.parent_span_id.is_nil() || s.parent_span_id == Uuid::nil())
@@ -137,14 +137,12 @@ pub async fn process_run(
                     rules
                 }
                 None => {
+                    log::info!(
+                        "Filter cache miss for trace {} (fingerprint={}), generating rules",
+                        trace_id, fp,
+                    );
                     let unfiltered_structure =
                         build_trace_structure_string(&ch_spans, trace_id, &summarization.summaries);
-
-                    let main_prompt_text = summarization
-                        .main_agent_hash
-                        .as_ref()
-                        .and_then(|h| extracted.get(h))
-                        .map(|p| p.text.as_str());
                     generate_and_cache_drop_rules(
                         &cache,
                         &llm_client,
@@ -155,7 +153,6 @@ pub async fn process_run(
                         prompt,
                         fp,
                         &unfiltered_structure,
-                        main_prompt_text,
                     )
                     .await
                 }

--- a/app-server/src/signals/filter.rs
+++ b/app-server/src/signals/filter.rs
@@ -241,7 +241,7 @@ fn parse_drop_rules_from_response(
 }
 
 /// Call the LLM to generate span drop rules and cache them.
-/// `fingerprint` is typically the `main_agent_hash` from summarization.
+/// `fingerprint` is typically the summary-based fingerprint from summarization.
 /// Returns the generated rules (may be empty if the LLM finds nothing to drop).
 pub async fn generate_and_cache_drop_rules(
     cache: &Arc<Cache>,
@@ -253,7 +253,6 @@ pub async fn generate_and_cache_drop_rules(
     signal_prompt: &str,
     fingerprint: &str,
     trace_string: &str,
-    main_agent_system_prompt: Option<&str>,
 ) -> Vec<DropRule> {
     if trace_string.len() > MAX_TRACE_STRING_LEN {
         log::info!(
@@ -344,7 +343,7 @@ pub async fn generate_and_cache_drop_rules(
                 serde_json::json!({
                     "project_id": project_id,
                     "signal_id": signal_id,
-                    "main_agent_system_prompt": main_agent_system_prompt.unwrap_or_default(),
+                    "fingerprint": fingerprint,
                 })
                 .as_object()
                 .unwrap()

--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -182,8 +182,7 @@ fn content_overlap_score(needle_words: &HashSet<String>, haystack_words: &HashSe
     matched as f64 / needle_words.len() as f64
 }
 
-// Re-export from utils for backwards compatibility
-pub use super::utils::hash_system_prompt;
+pub use super::utils::structural_skeleton_hash;
 
 /// Extract the system message from a parsed LLM input message array.
 /// Returns `(system_text, remaining_messages)` if a `role: "system"` message is found.
@@ -234,24 +233,6 @@ pub fn extract_system_message(parsed: &Value) -> Option<(String, Value)> {
     Some((sys_text, Value::Array(remaining)))
 }
 
-/// Scan all LLM spans and extract unique system prompts.
-/// Returns a map of `hash -> full_system_prompt_text` for all unique system prompts found.
-#[allow(dead_code)]
-pub fn extract_system_prompts(ch_spans: &[CHSpan]) -> HashMap<String, String> {
-    let mut result: HashMap<String, String> = HashMap::new();
-    for span in ch_spans {
-        if span.span_type != 1 {
-            continue;
-        }
-        let parsed = try_parse_json(&strip_noise(&span.input));
-        if let Some((sys_text, _)) = extract_system_message(&parsed) {
-            let hash = hash_system_prompt(&sys_text);
-            result.entry(hash).or_insert(sys_text);
-        }
-    }
-    result
-}
-
 #[derive(Debug)]
 pub struct ExtractedSystemPrompt {
     pub text: String,
@@ -271,7 +252,7 @@ pub fn extract_system_prompts_with_paths(
         }
         let parsed = try_parse_json(&strip_noise(&span.input));
         if let Some((sys_text, _)) = extract_system_message(&parsed) {
-            let hash = hash_system_prompt(&sys_text);
+            let hash = structural_skeleton_hash(&sys_text);
             result.entry(hash).or_insert_with(|| ExtractedSystemPrompt {
                 text: sys_text,
                 path: span.path.clone(),
@@ -367,7 +348,7 @@ pub fn compress_span_content(
 
                     let input_to_process =
                         if let Some((sys_text, remaining)) = extract_system_message(&parsed) {
-                            let hash = hash_system_prompt(&sys_text);
+                            let hash = structural_skeleton_hash(&sys_text);
                             if system_prompt_summaries.contains_key(&hash) {
                                 sys_prompt_ref = Some(format!("sp_{}", hash));
                                 remaining
@@ -1243,28 +1224,28 @@ mod tests {
     }
 
     // ===================================================================
-    // hash_system_prompt
+    // structural_skeleton_hash
     // ===================================================================
 
     #[test]
     fn test_hash_stability() {
-        let hash1 = hash_system_prompt("You are a helpful assistant.");
-        let hash2 = hash_system_prompt("You are a helpful assistant.");
+        let hash1 = structural_skeleton_hash("You are a helpful assistant.");
+        let hash2 = structural_skeleton_hash("You are a helpful assistant.");
         assert_eq!(hash1, hash2);
         assert_eq!(hash1.len(), 8);
     }
 
     #[test]
     fn test_hash_whitespace_normalization() {
-        let hash1 = hash_system_prompt("You  are\n a   helpful\tassistant.");
-        let hash2 = hash_system_prompt("You are a helpful assistant.");
+        let hash1 = structural_skeleton_hash("You  are\n a   helpful\tassistant.");
+        let hash2 = structural_skeleton_hash("You are a helpful assistant.");
         assert_eq!(hash1, hash2);
     }
 
     #[test]
     fn test_hash_case_normalization() {
-        let hash1 = hash_system_prompt("You Are A Helpful Assistant.");
-        let hash2 = hash_system_prompt("you are a helpful assistant.");
+        let hash1 = structural_skeleton_hash("You Are A Helpful Assistant.");
+        let hash2 = structural_skeleton_hash("you are a helpful assistant.");
         assert_eq!(hash1, hash2);
     }
 
@@ -1300,10 +1281,10 @@ mod tests {
             ),
         ];
 
-        let extracted = extract_system_prompts(&spans);
+        let extracted = extract_system_prompts_with_paths(&spans);
         assert_eq!(extracted.len(), 1);
-        let (_, text) = extracted.iter().next().unwrap();
-        assert_eq!(text, sys_prompt);
+        let (hash, _) = extracted.iter().next().unwrap();
+        assert_eq!(hash, &structural_skeleton_hash(sys_prompt));
     }
 
     #[test]
@@ -1318,8 +1299,10 @@ mod tests {
             make_span(Uuid::new_v4(), Uuid::nil(), "llm_b", 1, 2000, &input, "b"),
         ];
 
-        let extracted = extract_system_prompts(&spans);
+        let extracted = extract_system_prompts_with_paths(&spans);
         assert_eq!(extracted.len(), 1);
+        let (hash, _) = extracted.iter().next().unwrap();
+        assert_eq!(hash, &structural_skeleton_hash(sys_prompt));
     }
 
     // ===================================================================
@@ -1333,7 +1316,7 @@ mod tests {
             r#"[{{"role":"system","content":"{}"}},{{"role":"user","content":"Help me"}}]"#,
             sys_prompt
         );
-        let hash = hash_system_prompt(sys_prompt);
+        let hash = structural_skeleton_hash(sys_prompt);
         let summaries: HashMap<String, String> = [(
             hash.clone(),
             "Customer support agent. Be polite.".to_string(),
@@ -1396,7 +1379,7 @@ mod tests {
             r#"[{{"role":"system","content":"{}"}},{{"role":"user","content":"Do X"}}]"#,
             sys_prompt
         );
-        let hash = hash_system_prompt(sys_prompt);
+        let hash = structural_skeleton_hash(sys_prompt);
         let summary = "Safety-focused AI agent with strict rules.".to_string();
         let summaries: HashMap<String, String> =
             [(hash.clone(), summary.clone())].into_iter().collect();

--- a/app-server/src/signals/summarize.rs
+++ b/app-server/src/signals/summarize.rs
@@ -212,9 +212,11 @@ pub async fn summarize_system_prompts(
     }
 
     log::info!(
-        "Summarization cache miss for {} prompts (skeleton={}), generating",
+        "Summarization cache miss for {} prompts (skeleton={}), generating. project_id={}, signal_id={}",
         extracted.len(),
         prompts_hash,
+        project_id,
+        signal_id,
     );
 
     let start_time = Utc::now();

--- a/app-server/src/signals/summarize.rs
+++ b/app-server/src/signals/summarize.rs
@@ -20,6 +20,7 @@ use crate::signals::provider::{LlmClient, ProviderThinkingConfig, ProviderThinki
 use crate::signals::spans::ExtractedSystemPrompt;
 use crate::signals::utils::{
     InternalSpan, emit_internal_span, request_to_span_input, request_to_tools_attr,
+    structural_skeleton_hash,
 };
 
 const SUMMARY_CACHE_TTL_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days
@@ -48,10 +49,13 @@ fn cache_key(
     )
 }
 
+use crate::signals::utils::hash_system_prompt;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SummarizationResult {
     pub summaries: HashMap<String, String>,
-    pub main_agent_hash: Option<String>,
+    /// Hash of the main agent's compressed summary text (stable across dynamic prompt content)
+    pub fingerprint: Option<String>,
 }
 
 fn build_prompts_section(extracted: &HashMap<String, ExtractedSystemPrompt>) -> String {
@@ -111,7 +115,7 @@ fn parse_summarization_response(
     extracted: &HashMap<String, ExtractedSystemPrompt>,
 ) -> SummarizationResult {
     let mut summaries = HashMap::new();
-    let mut main_agent_hash = None;
+    let mut main_agent_summary: Option<String> = None;
 
     let parts = response
         .candidates
@@ -152,17 +156,19 @@ fn parse_summarization_response(
                 if !extracted.contains_key(hash) || summary.is_empty() {
                     continue;
                 }
-                summaries.insert(hash.to_string(), summary.to_string());
                 if is_main {
-                    main_agent_hash = Some(hash.to_string());
+                    main_agent_summary = Some(summary.to_string());
                 }
+                summaries.insert(hash.to_string(), summary.to_string());
             }
         }
     }
 
+    let fingerprint = main_agent_summary.map(|s| hash_system_prompt(&s));
+
     SummarizationResult {
         summaries,
-        main_agent_hash,
+        fingerprint,
     }
 }
 
@@ -183,22 +189,33 @@ pub async fn summarize_system_prompts(
         log::info!("No system prompts extracted from trace, skipping summarization");
         return SummarizationResult {
             summaries: HashMap::new(),
-            main_agent_hash: None,
+            fingerprint: None,
         };
     }
 
     let sig_hash = hash_signal_prompt(signal_prompt);
-    let prompt_hashes: Vec<&str> = extracted.keys().map(|s| s.as_str()).collect();
-    let prompts_hash = combined_prompts_hash(&prompt_hashes);
+    let skeleton_hashes: Vec<String> = extracted
+        .values()
+        .map(|p| structural_skeleton_hash(&p.text))
+        .collect();
+    let skeleton_refs: Vec<&str> = skeleton_hashes.iter().map(|s| s.as_str()).collect();
+    let prompts_hash = combined_prompts_hash(&skeleton_refs);
     let key = cache_key(project_id, signal_id, &sig_hash, &prompts_hash);
 
     if let Ok(Some(cached)) = cache.get::<SummarizationResult>(&key).await {
         log::info!(
-            "Using cached summarization result for {} prompts",
-            extracted.len()
+            "Using cached summarization result for {} prompts (skeleton={})",
+            extracted.len(),
+            prompts_hash,
         );
         return cached;
     }
+
+    log::info!(
+        "Summarization cache miss for {} prompts (skeleton={}), generating",
+        extracted.len(),
+        prompts_hash,
+    );
 
     let start_time = Utc::now();
 
@@ -295,7 +312,7 @@ pub async fn summarize_system_prompts(
         }
         None => SummarizationResult {
             summaries: HashMap::new(),
-            main_agent_hash: None,
+            fingerprint: None,
         },
     };
 

--- a/app-server/src/signals/summarize.rs
+++ b/app-server/src/signals/summarize.rs
@@ -110,10 +110,41 @@ fn build_summarization_tool() -> Vec<ProviderTool> {
     }]
 }
 
+/// Build a mapping from content hash → skeleton hash for the extracted prompts.
+fn content_to_skeleton_map(
+    extracted: &HashMap<String, ExtractedSystemPrompt>,
+) -> HashMap<String, String> {
+    extracted
+        .iter()
+        .map(|(content_hash, prompt)| {
+            (
+                content_hash.clone(),
+                structural_skeleton_hash(&prompt.text),
+            )
+        })
+        .collect()
+}
+
+/// Remap skeleton-hash-keyed summaries to content-hash keys using the current extracted prompts.
+fn remap_summaries_to_content_keys(
+    skeleton_summaries: &HashMap<String, String>,
+    extracted: &HashMap<String, ExtractedSystemPrompt>,
+) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+    for (content_hash, prompt) in extracted {
+        let skel = structural_skeleton_hash(&prompt.text);
+        if let Some(summary) = skeleton_summaries.get(&skel) {
+            result.insert(content_hash.clone(), summary.clone());
+        }
+    }
+    result
+}
+
 fn parse_summarization_response(
     response: &crate::signals::provider::models::ProviderResponse,
     extracted: &HashMap<String, ExtractedSystemPrompt>,
 ) -> SummarizationResult {
+    let content_to_skel = content_to_skeleton_map(extracted);
     let mut summaries = HashMap::new();
     let mut main_agent_summary: Option<String> = None;
 
@@ -152,14 +183,17 @@ fn parse_summarization_response(
                     .and_then(|b| b.as_bool())
                     .unwrap_or(false);
 
-                let hash = prompt_id.strip_prefix("sp_").unwrap_or(prompt_id);
-                if !extracted.contains_key(hash) || summary.is_empty() {
+                let content_hash = prompt_id.strip_prefix("sp_").unwrap_or(prompt_id);
+                if !extracted.contains_key(content_hash) || summary.is_empty() {
                     continue;
                 }
                 if is_main {
                     main_agent_summary = Some(summary.to_string());
                 }
-                summaries.insert(hash.to_string(), summary.to_string());
+                // Store by skeleton hash so the cached result is stable across dynamic content
+                if let Some(skel) = content_to_skel.get(content_hash) {
+                    summaries.insert(skel.clone(), summary.to_string());
+                }
             }
         }
     }
@@ -208,7 +242,10 @@ pub async fn summarize_system_prompts(
             extracted.len(),
             prompts_hash,
         );
-        return cached;
+        return SummarizationResult {
+            summaries: remap_summaries_to_content_keys(&cached.summaries, extracted),
+            fingerprint: cached.fingerprint,
+        };
     }
 
     log::info!(
@@ -304,13 +341,18 @@ pub async fn summarize_system_prompts(
 
     let result = match result {
         Some((r, _)) => {
+            // Cache the skeleton-keyed result for stability
             if let Err(e) = cache
                 .insert_with_ttl(&key, r.clone(), SUMMARY_CACHE_TTL_SECONDS)
                 .await
             {
                 log::warn!("Failed to cache summarization result: {:?}", e);
             }
-            r
+            // Return with content-hash keys for the current trace
+            SummarizationResult {
+                summaries: remap_summaries_to_content_keys(&r.summaries, extracted),
+                fingerprint: r.fingerprint,
+            }
         }
         None => SummarizationResult {
             summaries: HashMap::new(),
@@ -319,4 +361,132 @@ pub async fn summarize_system_prompts(
     };
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signals::provider::models::*;
+
+    fn make_extracted(
+        pairs: &[(&str, &str)],
+    ) -> HashMap<String, ExtractedSystemPrompt> {
+        pairs
+            .iter()
+            .map(|(text, path)| {
+                let hash = hash_system_prompt(text);
+                (
+                    hash,
+                    ExtractedSystemPrompt {
+                        text: text.to_string(),
+                        path: path.to_string(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn make_llm_response(summaries_json: serde_json::Value) -> ProviderResponse {
+        ProviderResponse {
+            candidates: Some(vec![ProviderCandidate {
+                content: Some(ProviderContent {
+                    role: Some("model".to_string()),
+                    parts: Some(vec![ProviderPart {
+                        function_call: Some(ProviderFunctionCall {
+                            id: None,
+                            name: "summarize_system_prompts".to_string(),
+                            args: Some(summaries_json),
+                        }),
+                        ..Default::default()
+                    }]),
+                }),
+                finish_reason: Some(ProviderFinishReason::Stop),
+            }]),
+            usage_metadata: None,
+            model_version: None,
+        }
+    }
+
+    #[test]
+    fn test_remap_survives_dynamic_content_change() {
+        // Trace 1: prompt with "Model: gpt-4"
+        let text_v1 = "You are a browser automation agent.\n<config>Model: gpt-4</config>";
+        let extracted_v1 = make_extracted(&[(text_v1, "agent.llm")]);
+        let hash_v1 = hash_system_prompt(text_v1);
+
+        let response = make_llm_response(serde_json::json!({
+            "summaries": [{
+                "prompt_id": format!("sp_{}", hash_v1),
+                "summary": "Browser automation agent that automates web tasks",
+                "is_main_agent_prompt": true
+            }]
+        }));
+
+        // parse_summarization_response stores by skeleton hash
+        let result = parse_summarization_response(&response, &extracted_v1);
+        assert!(!result.summaries.is_empty());
+        assert!(result.fingerprint.is_some());
+
+        // The cached result has skeleton-hash keys, NOT content-hash keys
+        assert!(
+            !result.summaries.contains_key(&hash_v1),
+            "Cached result should NOT use content hash as key"
+        );
+
+        // Trace 2: same template, different config -> different content hash
+        let text_v2 = "You are a browser automation agent.\n<config>Model: claude-3</config>";
+        let extracted_v2 = make_extracted(&[(text_v2, "agent.llm")]);
+        let hash_v2 = hash_system_prompt(text_v2);
+        assert_ne!(hash_v1, hash_v2, "Content hashes must differ");
+
+        // Remap the cached skeleton-keyed summaries to trace 2's content hash
+        let remapped = remap_summaries_to_content_keys(&result.summaries, &extracted_v2);
+
+        assert!(
+            remapped.contains_key(&hash_v2),
+            "Remapped summaries should be keyed by trace 2's content hash ({}), got keys: {:?}",
+            hash_v2,
+            remapped.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            remapped.get(&hash_v2).unwrap(),
+            "Browser automation agent that automates web tasks"
+        );
+    }
+
+    #[test]
+    fn test_remap_with_multiple_prompts() {
+        let main_text = "You are the main orchestrator agent.\n<tools>search</tools>";
+        let sub_text = "You are a helper sub-agent.\n<rules>be concise</rules>";
+        let extracted = make_extracted(&[
+            (main_text, "agent.llm"),
+            (sub_text, "agent.sub.llm"),
+        ]);
+        let main_hash = hash_system_prompt(main_text);
+        let sub_hash = hash_system_prompt(sub_text);
+
+        let response = make_llm_response(serde_json::json!({
+            "summaries": [
+                {
+                    "prompt_id": format!("sp_{}", main_hash),
+                    "summary": "Main orchestrator",
+                    "is_main_agent_prompt": true
+                },
+                {
+                    "prompt_id": format!("sp_{}", sub_hash),
+                    "summary": "Helper sub-agent",
+                    "is_main_agent_prompt": false
+                }
+            ]
+        }));
+
+        let result = parse_summarization_response(&response, &extracted);
+        assert_eq!(result.summaries.len(), 2);
+        assert!(result.fingerprint.is_some());
+
+        let remapped = remap_summaries_to_content_keys(&result.summaries, &extracted);
+        assert_eq!(remapped.len(), 2);
+        assert_eq!(remapped.get(&main_hash).unwrap(), "Main orchestrator");
+        assert_eq!(remapped.get(&sub_hash).unwrap(), "Helper sub-agent");
+    }
 }

--- a/app-server/src/signals/summarize.rs
+++ b/app-server/src/signals/summarize.rs
@@ -49,8 +49,6 @@ fn cache_key(
     )
 }
 
-use crate::signals::utils::hash_system_prompt;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SummarizationResult {
     pub summaries: HashMap<String, String>,
@@ -110,41 +108,10 @@ fn build_summarization_tool() -> Vec<ProviderTool> {
     }]
 }
 
-/// Build a mapping from content hash → skeleton hash for the extracted prompts.
-fn content_to_skeleton_map(
-    extracted: &HashMap<String, ExtractedSystemPrompt>,
-) -> HashMap<String, String> {
-    extracted
-        .iter()
-        .map(|(content_hash, prompt)| {
-            (
-                content_hash.clone(),
-                structural_skeleton_hash(&prompt.text),
-            )
-        })
-        .collect()
-}
-
-/// Remap skeleton-hash-keyed summaries to content-hash keys using the current extracted prompts.
-fn remap_summaries_to_content_keys(
-    skeleton_summaries: &HashMap<String, String>,
-    extracted: &HashMap<String, ExtractedSystemPrompt>,
-) -> HashMap<String, String> {
-    let mut result = HashMap::new();
-    for (content_hash, prompt) in extracted {
-        let skel = structural_skeleton_hash(&prompt.text);
-        if let Some(summary) = skeleton_summaries.get(&skel) {
-            result.insert(content_hash.clone(), summary.clone());
-        }
-    }
-    result
-}
-
 fn parse_summarization_response(
     response: &crate::signals::provider::models::ProviderResponse,
     extracted: &HashMap<String, ExtractedSystemPrompt>,
 ) -> SummarizationResult {
-    let content_to_skel = content_to_skeleton_map(extracted);
     let mut summaries = HashMap::new();
     let mut main_agent_summary: Option<String> = None;
 
@@ -183,22 +150,19 @@ fn parse_summarization_response(
                     .and_then(|b| b.as_bool())
                     .unwrap_or(false);
 
-                let content_hash = prompt_id.strip_prefix("sp_").unwrap_or(prompt_id);
-                if !extracted.contains_key(content_hash) || summary.is_empty() {
+                let hash = prompt_id.strip_prefix("sp_").unwrap_or(prompt_id);
+                if !extracted.contains_key(hash) || summary.is_empty() {
                     continue;
                 }
                 if is_main {
                     main_agent_summary = Some(summary.to_string());
                 }
-                // Store by skeleton hash so the cached result is stable across dynamic content
-                if let Some(skel) = content_to_skel.get(content_hash) {
-                    summaries.insert(skel.clone(), summary.to_string());
-                }
+                summaries.insert(hash.to_string(), summary.to_string());
             }
         }
     }
 
-    let fingerprint = main_agent_summary.map(|s| hash_system_prompt(&s));
+    let fingerprint = main_agent_summary.map(|s| structural_skeleton_hash(&s));
 
     SummarizationResult {
         summaries,
@@ -242,10 +206,7 @@ pub async fn summarize_system_prompts(
             extracted.len(),
             prompts_hash,
         );
-        return SummarizationResult {
-            summaries: remap_summaries_to_content_keys(&cached.summaries, extracted),
-            fingerprint: cached.fingerprint,
-        };
+        return cached;
     }
 
     log::info!(
@@ -341,18 +302,13 @@ pub async fn summarize_system_prompts(
 
     let result = match result {
         Some((r, _)) => {
-            // Cache the skeleton-keyed result for stability
             if let Err(e) = cache
                 .insert_with_ttl(&key, r.clone(), SUMMARY_CACHE_TTL_SECONDS)
                 .await
             {
                 log::warn!("Failed to cache summarization result: {:?}", e);
             }
-            // Return with content-hash keys for the current trace
-            SummarizationResult {
-                summaries: remap_summaries_to_content_keys(&r.summaries, extracted),
-                fingerprint: r.fingerprint,
-            }
+            r
         }
         None => SummarizationResult {
             summaries: HashMap::new(),
@@ -374,7 +330,7 @@ mod tests {
         pairs
             .iter()
             .map(|(text, path)| {
-                let hash = hash_system_prompt(text);
+                let hash = structural_skeleton_hash(text);
                 (
                     hash,
                     ExtractedSystemPrompt {
@@ -408,62 +364,70 @@ mod tests {
     }
 
     #[test]
-    fn test_remap_survives_dynamic_content_change() {
-        // Trace 1: prompt with "Model: gpt-4"
+    fn test_dynamic_content_produces_same_hash() {
+        let text_v1 = "You are a browser automation agent.\n<config>Model: gpt-4</config>";
+        let text_v2 = "You are a browser automation agent.\n<config>Model: claude-3</config>";
+
+        assert_eq!(
+            structural_skeleton_hash(text_v1),
+            structural_skeleton_hash(text_v2),
+            "Same template with different dynamic content should produce the same hash"
+        );
+
+        let extracted_v1 = make_extracted(&[(text_v1, "agent.llm")]);
+        let extracted_v2 = make_extracted(&[(text_v2, "agent.llm")]);
+
+        assert_eq!(
+            extracted_v1.keys().collect::<Vec<_>>(),
+            extracted_v2.keys().collect::<Vec<_>>(),
+            "Both traces should have the same extracted map keys"
+        );
+    }
+
+    #[test]
+    fn test_parse_response_and_cache_hit() {
         let text_v1 = "You are a browser automation agent.\n<config>Model: gpt-4</config>";
         let extracted_v1 = make_extracted(&[(text_v1, "agent.llm")]);
-        let hash_v1 = hash_system_prompt(text_v1);
+        let hash = structural_skeleton_hash(text_v1);
 
         let response = make_llm_response(serde_json::json!({
             "summaries": [{
-                "prompt_id": format!("sp_{}", hash_v1),
+                "prompt_id": format!("sp_{}", hash),
                 "summary": "Browser automation agent that automates web tasks",
                 "is_main_agent_prompt": true
             }]
         }));
 
-        // parse_summarization_response stores by skeleton hash
         let result = parse_summarization_response(&response, &extracted_v1);
-        assert!(!result.summaries.is_empty());
+        assert_eq!(result.summaries.len(), 1);
         assert!(result.fingerprint.is_some());
-
-        // The cached result has skeleton-hash keys, NOT content-hash keys
-        assert!(
-            !result.summaries.contains_key(&hash_v1),
-            "Cached result should NOT use content hash as key"
-        );
-
-        // Trace 2: same template, different config -> different content hash
-        let text_v2 = "You are a browser automation agent.\n<config>Model: claude-3</config>";
-        let extracted_v2 = make_extracted(&[(text_v2, "agent.llm")]);
-        let hash_v2 = hash_system_prompt(text_v2);
-        assert_ne!(hash_v1, hash_v2, "Content hashes must differ");
-
-        // Remap the cached skeleton-keyed summaries to trace 2's content hash
-        let remapped = remap_summaries_to_content_keys(&result.summaries, &extracted_v2);
-
-        assert!(
-            remapped.contains_key(&hash_v2),
-            "Remapped summaries should be keyed by trace 2's content hash ({}), got keys: {:?}",
-            hash_v2,
-            remapped.keys().collect::<Vec<_>>()
-        );
         assert_eq!(
-            remapped.get(&hash_v2).unwrap(),
+            result.summaries.get(&hash).unwrap(),
             "Browser automation agent that automates web tasks"
+        );
+
+        // Simulate cache hit for trace 2 with different config
+        let text_v2 = "You are a browser automation agent.\n<config>Model: claude-3</config>";
+        let hash_v2 = structural_skeleton_hash(text_v2);
+        assert_eq!(hash, hash_v2, "Same skeleton hash");
+
+        // The cached result works directly -- no remap needed
+        assert!(
+            result.summaries.contains_key(&hash_v2),
+            "Cached summaries should be directly usable for trace 2"
         );
     }
 
     #[test]
-    fn test_remap_with_multiple_prompts() {
+    fn test_parse_response_multiple_prompts() {
         let main_text = "You are the main orchestrator agent.\n<tools>search</tools>";
         let sub_text = "You are a helper sub-agent.\n<rules>be concise</rules>";
         let extracted = make_extracted(&[
             (main_text, "agent.llm"),
             (sub_text, "agent.sub.llm"),
         ]);
-        let main_hash = hash_system_prompt(main_text);
-        let sub_hash = hash_system_prompt(sub_text);
+        let main_hash = structural_skeleton_hash(main_text);
+        let sub_hash = structural_skeleton_hash(sub_text);
 
         let response = make_llm_response(serde_json::json!({
             "summaries": [
@@ -483,10 +447,7 @@ mod tests {
         let result = parse_summarization_response(&response, &extracted);
         assert_eq!(result.summaries.len(), 2);
         assert!(result.fingerprint.is_some());
-
-        let remapped = remap_summaries_to_content_keys(&result.summaries, &extracted);
-        assert_eq!(remapped.len(), 2);
-        assert_eq!(remapped.get(&main_hash).unwrap(), "Main orchestrator");
-        assert_eq!(remapped.get(&sub_hash).unwrap(), "Helper sub-agent");
+        assert_eq!(result.summaries.get(&main_hash).unwrap(), "Main orchestrator");
+        assert_eq!(result.summaries.get(&sub_hash).unwrap(), "Helper sub-agent");
     }
 }

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -156,36 +156,36 @@ static XML_TAG_NAME_RE: LazyLock<Regex> =
 /// Resistant to dynamic content inside tags (config values, user context, tool lists)
 /// while preserving the stable identity of the prompt template.
 pub fn structural_skeleton_hash(text: &str) -> String {
-    let normalized = text
+    // Extract first sentence from original text (before whitespace normalization
+    // destroys newline boundaries). Cut at the first '.' or '\n' after 20+ chars.
+    let raw_first_sentence = text
+        .char_indices()
+        .find(|(i, c)| *i >= 20 && (*c == '.' || *c == '\n'))
+        .map(|(i, _)| &text[..i])
+        .unwrap_or_else(|| {
+            let end = text
+                .char_indices()
+                .nth(200)
+                .map(|(i, _)| i)
+                .unwrap_or(text.len());
+            &text[..end]
+        });
+
+    let first_sentence = raw_first_sentence
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
         .to_lowercase();
 
-    // Extract first sentence: up to the first '.' or '\n' that occurs after 20+ chars
-    let first_sentence = normalized
-        .char_indices()
-        .find(|(i, c)| *i >= 20 && (*c == '.' || *c == '\n'))
-        .map(|(i, _)| &normalized[..i])
-        .unwrap_or_else(|| {
-            // No sentence boundary found -- use first 200 chars or the whole thing
-            let end = normalized
-                .char_indices()
-                .nth(200)
-                .map(|(i, _)| i)
-                .unwrap_or(normalized.len());
-            &normalized[..end]
-        });
-
-    // Extract unique XML/HTML tag names
-    let mut tag_names: Vec<&str> = XML_TAG_NAME_RE
+    // Extract unique XML/HTML tag names (lowercased to match normalized first_sentence)
+    let mut tag_names: Vec<String> = XML_TAG_NAME_RE
         .captures_iter(text)
-        .map(|cap| cap.get(1).unwrap().as_str())
+        .map(|cap| cap.get(1).unwrap().as_str().to_lowercase())
         .collect();
     tag_names.sort();
     tag_names.dedup();
 
-    let skeleton = format!("{}|{}", first_sentence.trim(), tag_names.join(","));
+    let skeleton = format!("{}|{}", first_sentence, tag_names.join(","));
     let digest = Sha3_256::digest(skeleton.as_bytes());
     format!("{:x}", digest)[..8].to_string()
 }
@@ -756,11 +756,105 @@ Do not fabricate data.
     #[test]
     fn test_structural_skeleton_hash_case_insensitive() {
         let lower = "You are an AI assistant.\n<rules>be helpful</rules>";
-        let upper = "YOU ARE AN AI ASSISTANT.\n<rules>BE HELPFUL</rules>";
+        let upper = "YOU ARE AN AI ASSISTANT.\n<RULES>BE HELPFUL</RULES>";
 
         assert_eq!(
             structural_skeleton_hash(lower),
             structural_skeleton_hash(upper),
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_newline_boundary() {
+        // First sentence should stop at \n, not include tag content
+        let prompt_a = "You are a browser automation agent\n<config>Model: gpt-4</config>";
+        let prompt_b = "You are a browser automation agent\n<config>Model: claude-3</config>";
+
+        assert_eq!(
+            structural_skeleton_hash(prompt_a),
+            structural_skeleton_hash(prompt_b),
+            "Newline should terminate first sentence before dynamic tag content"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_period_boundary() {
+        // First sentence stops at period; content after differs
+        let v1 = "You are a helpful coding assistant. Today is Monday. User: Alice.";
+        let v2 = "You are a helpful coding assistant. Today is Friday. User: Bob.";
+
+        assert_eq!(
+            structural_skeleton_hash(v1),
+            structural_skeleton_hash(v2),
+            "Only first sentence (up to first period) should matter"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_whitespace_normalization() {
+        let spaced = "You   are  an   AI   assistant.\n<rules>  help  </rules>";
+        let compact = "You are an AI assistant.\n<rules>help</rules>";
+
+        assert_eq!(
+            structural_skeleton_hash(spaced),
+            structural_skeleton_hash(compact),
+            "Extra whitespace in first sentence should not affect hash"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_short_prompt_fallback() {
+        // Less than 20 chars before any boundary -- uses 200-char fallback
+        let short = "Be helpful.";
+        let hash = structural_skeleton_hash(short);
+        assert_eq!(hash.len(), 8, "Should still produce an 8-char hash");
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_tag_order_irrelevant() {
+        let order_a = "You are an AI agent for testing.\n<beta>x</beta>\n<alpha>y</alpha>";
+        let order_b = "You are an AI agent for testing.\n<alpha>z</alpha>\n<beta>w</beta>";
+
+        assert_eq!(
+            structural_skeleton_hash(order_a),
+            structural_skeleton_hash(order_b),
+            "Tag order should not affect hash (tags are sorted)"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_duplicate_tags() {
+        let single = "You are an AI agent for testing.\n<rules>rule 1</rules>";
+        let duped = "You are an AI agent for testing.\n<rules>rule 1</rules>\n<rules>rule 2</rules>";
+
+        assert_eq!(
+            structural_skeleton_hash(single),
+            structural_skeleton_hash(duped),
+            "Duplicate tag names should be deduped"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_same_sentence_different_tags() {
+        let with_rules = "You are an AI agent for testing.\n<rules>be safe</rules>";
+        let with_tools = "You are an AI agent for testing.\n<tools>search, read</tools>";
+
+        assert_ne!(
+            structural_skeleton_hash(with_rules),
+            structural_skeleton_hash(with_tools),
+            "Same sentence but different tag names should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_self_closing_tags() {
+        let normal = "You are an AI agent for testing.\n<config>stuff</config>";
+        let self_closing = "You are an AI agent for testing.\n<config />";
+
+        assert_eq!(
+            structural_skeleton_hash(normal),
+            structural_skeleton_hash(self_closing),
+            "Self-closing tags should extract the same tag name"
         );
     }
 }

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -136,19 +136,6 @@ pub struct InternalSpan {
     pub tools: Option<Value>,
 }
 
-/// Hash a text to a stable short hex identifier.
-/// Normalizes whitespace and lowercases before hashing so minor formatting
-/// variations produce the same hash.
-pub fn hash_system_prompt(text: &str) -> String {
-    let normalized = text
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_lowercase();
-    let digest = Sha3_256::digest(normalized.as_bytes());
-    format!("{:x}", digest)[..8].to_string()
-}
-
 static XML_TAG_NAME_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"<(\w+)[\s/>]").unwrap());
 

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -149,6 +149,47 @@ pub fn hash_system_prompt(text: &str) -> String {
     format!("{:x}", digest)[..8].to_string()
 }
 
+static XML_TAG_NAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<(\w+)[\s/>]").unwrap());
+
+/// Hash a system prompt by its structural skeleton: first sentence + sorted XML tag names.
+/// Resistant to dynamic content inside tags (config values, user context, tool lists)
+/// while preserving the stable identity of the prompt template.
+pub fn structural_skeleton_hash(text: &str) -> String {
+    let normalized = text
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+
+    // Extract first sentence: up to the first '.' or '\n' that occurs after 20+ chars
+    let first_sentence = normalized
+        .char_indices()
+        .find(|(i, c)| *i >= 20 && (*c == '.' || *c == '\n'))
+        .map(|(i, _)| &normalized[..i])
+        .unwrap_or_else(|| {
+            // No sentence boundary found -- use first 200 chars or the whole thing
+            let end = normalized
+                .char_indices()
+                .nth(200)
+                .map(|(i, _)| i)
+                .unwrap_or(normalized.len());
+            &normalized[..end]
+        });
+
+    // Extract unique XML/HTML tag names
+    let mut tag_names: Vec<&str> = XML_TAG_NAME_RE
+        .captures_iter(text)
+        .map(|cap| cap.get(1).unwrap().as_str())
+        .collect();
+    tag_names.sort();
+    tag_names.dedup();
+
+    let skeleton = format!("{}|{}", first_sentence.trim(), tag_names.join(","));
+    let digest = Sha3_256::digest(skeleton.as_bytes());
+    format!("{:x}", digest)[..8].to_string()
+}
+
 /// Try to parse JSON string, return the parsed value or the original string
 pub fn try_parse_json(json_string: &str) -> Value {
     if json_string.is_empty() {
@@ -652,5 +693,74 @@ mod tests {
         let s = result.as_str().unwrap();
         assert!(s.contains("[openai.chat]"), "XML tag should produce named link: {}", s);
         assert!(s.contains(&format!("spanId={}", uuid)));
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_stable_across_dynamic_content() {
+        let prompt_v1 = r#"You are an AI agent designed to automate browser tasks.
+<agent_configuration>
+Model: browser-use-llm
+Proxy: enabled
+Vision: enabled
+</agent_configuration>
+<rules>
+Do not fabricate data.
+</rules>"#;
+
+        let prompt_v2 = r#"You are an AI agent designed to automate browser tasks.
+<agent_configuration>
+Model: gpt-4o
+Proxy: disabled
+Vision: disabled
+</agent_configuration>
+<rules>
+Do not fabricate data.
+</rules>"#;
+
+        assert_eq!(
+            structural_skeleton_hash(prompt_v1),
+            structural_skeleton_hash(prompt_v2),
+            "Same template with different config values should produce the same skeleton hash"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_differs_for_different_agents() {
+        let browser_agent = r#"You are an AI agent designed to automate browser tasks.
+<agent_configuration>Model: x</agent_configuration>
+<rules>Click things</rules>"#;
+
+        let code_agent = r#"You are Claude Code, an AI coding assistant.
+<instructions>Write code</instructions>
+<tools>bash, read, write</tools>"#;
+
+        assert_ne!(
+            structural_skeleton_hash(browser_agent),
+            structural_skeleton_hash(code_agent),
+            "Different agents should produce different skeleton hashes"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_no_tags() {
+        let plain_v1 = "You are a helpful customer support agent. Answer questions politely. Use the knowledge base.";
+        let plain_v2 = "You are a helpful customer support agent. Answer questions politely. Be concise.";
+
+        assert_eq!(
+            structural_skeleton_hash(plain_v1),
+            structural_skeleton_hash(plain_v2),
+            "Same first sentence with no tags should produce the same hash"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_case_insensitive() {
+        let lower = "You are an AI assistant.\n<rules>be helpful</rules>";
+        let upper = "YOU ARE AN AI ASSISTANT.\n<rules>BE HELPFUL</rules>";
+
+        assert_eq!(
+            structural_skeleton_hash(lower),
+            structural_skeleton_hash(upper),
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the hashing/fingerprinting used for prompt summarization and span drop-rule caching, which can affect cache hit rates and which spans get filtered across runs. Logic is well-covered by new unit tests but could still cause unexpected collisions or cache churn in production.
> 
> **Overview**
> Switches system-prompt identification from a raw normalized hash to a new *structure-based* `structural_skeleton_hash` (first sentence + sorted XML tag names) to make prompt IDs stable across dynamic in-tag content.
> 
> Updates summarization and filter/drop-rule caching to key off skeleton hashes and a new summary-derived `fingerprint` (replacing `main_agent_hash` and removing the `main_agent_system_prompt` dependency), and adds additional logging plus expanded unit tests around hash stability and cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 641bf66d1a33098ca14ccbe92b1bb9e60ae023ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->