### PR TITLE
fix: tags overflow — scrollable tooltip, capped circles

### DIFF
--- a/frontend/components/tags/pick-tag.tsx
+++ b/frontend/components/tags/pick-tag.tsx
@@ -57,11 +57,13 @@ const PickTag = ({ tags, tagClasses, query, setQuery, setStep, onAttach, onDetac
 
       {(!isEmpty(selected) || !isEmpty(available)) && <DropdownMenuSeparator />}
 
-      {!isEmpty(selected) && <SelectedTags tags={selected} onDetach={onDetach} />}
+      <div className="max-h-72 overflow-y-auto">
+        {!isEmpty(selected) && <SelectedTags tags={selected} onDetach={onDetach} />}
 
-      {!isEmpty(selected) && !isEmpty(available) && <DropdownMenuSeparator />}
+        {!isEmpty(selected) && !isEmpty(available) && <DropdownMenuSeparator />}
 
-      {!isEmpty(available) && <AvailableTags tags={available} onAttach={onAttach} />}
+        {!isEmpty(available) && <AvailableTags tags={available} onAttach={onAttach} />}
+      </div>
       {query && !hasExactMatch && available.length + selected.length < 5 && (
         <>
           <DropdownMenuSeparator />

--- a/frontend/components/tags/span-tags-button.tsx
+++ b/frontend/components/tags/span-tags-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Tag } from "lucide-react";
+import { Plus, Tag } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo } from "react";
 import useSWR from "swr";
@@ -157,18 +157,23 @@ const SpanTagsButton = ({ spanId, className }: SpanTagsButtonProps) => {
         <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
           {tags.length > 0 ? (
             <div className="flex -space-x-[6px]">
-              {tags.map((tag) => (
+              {tags.slice(0, 5).map((tag) => (
                 <div
                   key={tag.id}
                   className={cn("size-3.5 border border-background rounded-full", !tag.color && "bg-gray-300")}
                   style={tag.color ? { background: tag.color } : undefined}
                 />
               ))}
+              {tags.length > 5 && (
+                <div className="size-3.5 border border-border rounded-full bg-muted flex items-center justify-center">
+                  <Plus className="size-2" />
+                </div>
+              )}
             </div>
           ) : (
             <Tag className="size-3.5" />
           )}
-          {tags.length === 1 ? tags.at(0)?.name : "Tags"}
+          {tags.length === 0 ? "Tags" : tags.length === 1 ? tags[0].name : `Tags (${tags.length})`}
         </Button>
       </DropdownMenuTrigger>
     </TagsDropdown>

--- a/frontend/components/tags/tags-cell.tsx
+++ b/frontend/components/tags/tags-cell.tsx
@@ -1,4 +1,5 @@
 import { TooltipPortal } from "@radix-ui/react-tooltip";
+import { Plus } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
 import useSWR from "swr";
@@ -6,6 +7,8 @@ import useSWR from "swr";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { type TagClass } from "@/lib/traces/types";
 import { cn, swrFetcher } from "@/lib/utils";
+
+const MAX_VISIBLE_CIRCLES = 5;
 
 interface TagsCellProps {
   tags: string[];
@@ -35,13 +38,18 @@ const TagsCell = ({ tags }: TagsCellProps) => {
         <TooltipTrigger asChild>
           <div className="flex items-center gap-1.5">
             <div className="flex flex-row items-center -space-x-2">
-              {resolvedTags.map((tag) => (
+              {resolvedTags.slice(0, MAX_VISIBLE_CIRCLES).map((tag) => (
                 <div
                   key={tag.name}
                   className={cn("size-4 rounded-full border-2 border-secondary", !tag.color && "bg-gray-300")}
                   style={tag.color ? { backgroundColor: tag.color } : undefined}
                 />
               ))}
+              {resolvedTags.length > MAX_VISIBLE_CIRCLES && (
+                <div className="size-4 rounded-full border-2 border-border bg-muted flex items-center justify-center">
+                  <Plus className="size-2" />
+                </div>
+              )}
             </div>
             <span className="text-secondary-foreground text-xs">
               {count} tag{count === 1 ? "" : "s"}
@@ -49,7 +57,7 @@ const TagsCell = ({ tags }: TagsCellProps) => {
           </div>
         </TooltipTrigger>
         <TooltipPortal>
-          <TooltipContent side="bottom" className="px-3 py-2 border">
+          <TooltipContent side="bottom" className="px-3 py-2 border max-h-48 overflow-y-auto">
             <div className="flex flex-col gap-1.5 items-start text-secondary-foreground">
               {resolvedTags.map((tag) => (
                 <div key={tag.name} className="flex flex-row items-center gap-2">

--- a/frontend/components/tags/tags-dropdown.tsx
+++ b/frontend/components/tags/tags-dropdown.tsx
@@ -44,7 +44,7 @@ const TagsDropdown = ({
       }}
     >
       {children}
-      <DropdownMenuContent className="max-h-96 overflow-y-auto" side="bottom" align="start">
+      <DropdownMenuContent className="max-h-96" side="bottom" align="start">
         {step === 0 ? (
           <PickTag
             tags={tags}

--- a/frontend/components/tags/tags-dropdown.tsx
+++ b/frontend/components/tags/tags-dropdown.tsx
@@ -44,7 +44,7 @@ const TagsDropdown = ({
       }}
     >
       {children}
-      <DropdownMenuContent className="max-h-96" side="bottom" align="start">
+      <DropdownMenuContent className="max-h-96 overflow-y-auto" side="bottom" align="start">
         {step === 0 ? (
           <PickTag
             tags={tags}

--- a/frontend/components/tags/trace-tags-button.tsx
+++ b/frontend/components/tags/trace-tags-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Tag } from "lucide-react";
+import { Plus, Tag } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
 import useSWR from "swr";
@@ -151,18 +151,23 @@ const TraceTagsButton = ({ traceId, className }: TraceTagsButtonProps) => {
         <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
           {tags.length > 0 ? (
             <div className="flex -space-x-[6px]">
-              {tags.map((tag) => (
+              {tags.slice(0, 5).map((tag) => (
                 <div
                   key={tag.id}
                   className={cn("size-3.5 border border-background rounded-full", !tag.color && "bg-gray-300")}
                   style={tag.color ? { background: tag.color } : undefined}
                 />
               ))}
+              {tags.length > 5 && (
+                <div className="size-3.5 border border-border rounded-full bg-muted flex items-center justify-center">
+                  <Plus className="size-2" />
+                </div>
+              )}
             </div>
           ) : (
             <Tag className="size-3.5" />
           )}
-          {tags.length === 1 ? tags.at(0)?.name : "Tags"}
+          {tags.length === 0 ? "Tags" : tags.length === 1 ? tags[0].name : `Tags (${tags.length})`}
         </Button>
       </DropdownMenuTrigger>
     </TagsDropdown>

--- a/frontend/components/traces/trace-view/header/index.tsx
+++ b/frontend/components/traces/trace-view/header/index.tsx
@@ -165,14 +165,6 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
               </Button>
             </span>
           )}
-          {trace?.metadata && (
-            <span className={HEADER_ITEM_CLS}>
-              <Metadata metadata={trace?.metadata} />
-            </span>
-          )}
-          <span className={HEADER_ITEM_CLS}>
-            <TraceTagsButton traceId={traceId} />
-          </span>
           {signalCount > 0 && (
             <span className={HEADER_ITEM_CLS}>
               <Button
@@ -186,6 +178,14 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
                 <Radio size={14} className="mr-1" />
                 Signals ({signalCount})
               </Button>
+            </span>
+          )}
+          <span className={HEADER_ITEM_CLS}>
+            <TraceTagsButton traceId={traceId} />
+          </span>
+          {trace?.metadata && (
+            <span className={HEADER_ITEM_CLS}>
+              <Metadata metadata={trace?.metadata} />
             </span>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Tags tooltip in trace table now scrolls when there are many tags (`max-h-48 overflow-y-auto`)
- Tags dropdown popover scrolls with many tag classes (`overflow-y-auto` on existing `max-h-96`)
- Tag circle indicators capped at 5 with a `+` overflow circle (`bg-muted border-border`) in `TagsCell`, `TraceTagsButton`, and `SpanTagsButton`
- Button text: "Tags" (0 tags), tag name (1 tag), "Tags (N)" (2+ tags)

## Test plan
- [ ] Open a trace with 6+ tags — verify only 5 circles + overflow indicator show in table cell and header button
- [ ] Hover the tags cell — tooltip should scroll if many tags
- [ ] Open tag dropdown on a project with many tag classes — should scroll
- [ ] Verify single-tag traces show the tag name, multi-tag show "Tags (N)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes to tag rendering (capping visible indicators and adding scroll containers) plus a small header reordering; no backend or data model changes.
> 
> **Overview**
> Improves tag UI handling when many tags exist by **capping visible tag circles to 5** and showing a `+` overflow indicator in `TraceTagsButton`, `SpanTagsButton`, and `TagsCell`.
> 
> Makes overflow content usable by adding **scrollable containers** to the tag picker list (`PickTag`) and the tags tooltip (`TagsCell`). Also tweaks tag button labeling to show `Tags`, the single tag name, or `Tags (N)`, and reorders `TraceTagsButton`/`Metadata` placement in the trace header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98561da5d59a648ea2fbda3c9210e51a38f216c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->