### PR TITLE
signal pricing

### DIFF
--- a/app-server/src/ch/limits.rs
+++ b/app-server/src/ch/limits.rs
@@ -88,7 +88,7 @@ pub async fn get_workspace_signal_runs_by_project_ids(
 
     let query = "
     SELECT
-      SUM(IF(steps_processed > 0, steps_processed, 1)) as total_signal_runs
+      SUM(steps_processed) as total_signal_runs
     FROM signal_runs FINAL
     WHERE project_id IN { project_ids: Array(UUID) }
     AND signal_runs.updated_at >= { latest_reset_time: DateTime(6) }

--- a/app-server/src/ch/limits.rs
+++ b/app-server/src/ch/limits.rs
@@ -88,11 +88,10 @@ pub async fn get_workspace_signal_runs_by_project_ids(
 
     let query = "
     SELECT
-      COUNT(*) as total_signal_runs
-    FROM signal_runs
+      SUM(IF(steps_processed > 0, steps_processed, 1)) as total_signal_runs
+    FROM signal_runs FINAL
     WHERE project_id IN { project_ids: Array(UUID) }
     AND signal_runs.updated_at >= { latest_reset_time: DateTime(6) }
-    -- Only count completed signal runs
     AND signal_runs.status = 1
     ";
 

--- a/app-server/src/ch/signal_runs.rs
+++ b/app-server/src/ch/signal_runs.rs
@@ -30,6 +30,8 @@ pub struct CHSignalRun {
     pub updated_at: i64,
     /// Mode: 0 = batch, 1 = realtime
     pub mode: u8,
+    /// Number of LLM spans processed after filtering
+    pub steps_processed: u32,
 }
 
 impl From<&SignalRun> for CHSignalRun {
@@ -46,6 +48,7 @@ impl From<&SignalRun> for CHSignalRun {
             error_message: run.error_message.clone().unwrap_or_default(),
             updated_at: chrono_to_nanoseconds(run.updated_at),
             mode: run.mode.as_u8(),
+            steps_processed: run.steps_processed,
         }
     }
 }
@@ -60,7 +63,7 @@ pub async fn get_signal_runs_for_job(
 ) -> Result<Vec<CHSignalRun>> {
     let runs = clickhouse
         .query(
-            "SELECT project_id, signal_id, job_id, trigger_id, run_id, trace_id, status, event_id, error_message, updated_at, mode
+            "SELECT project_id, signal_id, job_id, trigger_id, run_id, trace_id, status, event_id, error_message, updated_at, mode, steps_processed
              FROM signal_runs FINAL
              WHERE project_id = ? AND signal_id = ? AND job_id = ?
              ORDER BY updated_at ASC",

--- a/app-server/src/signals/common.rs
+++ b/app-server/src/signals/common.rs
@@ -35,6 +35,8 @@ pub struct ProcessRunResult {
     pub request: ProviderRequestItem,
     pub new_messages: Vec<CHSignalRunMessage>,
     pub request_start_time: chrono::DateTime<chrono::Utc>,
+    /// Number of LLM spans after filtering (only meaningful on step 0)
+    pub steps_processed: u32,
 }
 
 pub async fn handle_failed_runs(
@@ -93,7 +95,7 @@ pub async fn process_run(
             HandlerError::Transient(anyhow::anyhow!("Failed to query existing messages: {}", e))
         })?;
 
-    let (contents, system_instruction, new_messages) = if existing_messages.is_empty() {
+    let (contents, system_instruction, new_messages, steps_processed) = if existing_messages.is_empty() {
         let ch_spans = get_trace_ch_spans(clickhouse.clone(), project_id, trace_id)
             .await
             .map_err(|e| {
@@ -163,6 +165,10 @@ pub async fn process_run(
 
         // 4. Apply drop rules and build the final trace string
         let ch_spans_for_trace = apply_drop_rules(ch_spans, &drop_rules);
+        let steps_processed = ch_spans_for_trace
+            .iter()
+            .filter(|s| s.span_type == 1)
+            .count() as u32;
         let trace_structure =
             build_trace_structure_string(&ch_spans_for_trace, trace_id, &summarization.summaries);
 
@@ -219,6 +225,7 @@ pub async fn process_run(
             vec![user_content],
             Some(system_instruction_content),
             vec![system_message, user_message],
+            steps_processed,
         )
     } else {
         let mut contents = Vec::new();
@@ -251,7 +258,7 @@ pub async fn process_run(
             }
         }
 
-        (contents, system_instruction, vec![])
+        (contents, system_instruction, vec![], 0)
     };
 
     // 2. Build tool definitions
@@ -284,5 +291,6 @@ pub async fn process_run(
         request,
         new_messages,
         request_start_time: processing_start_time,
+        steps_processed,
     })
 }

--- a/app-server/src/signals/enqueue.rs
+++ b/app-server/src/signals/enqueue.rs
@@ -92,6 +92,7 @@ async fn create_signal_run_and_message(
         event_id: None,
         error_message: None,
         mode: super::SignalMode::from_u8(mode),
+        steps_processed: 0,
     };
 
     let message = SignalMessage {
@@ -107,6 +108,7 @@ async fn create_signal_run_and_message(
         retry_count: 0,
         request_start_time: Utc::now(),
         mode,
+        steps_processed: 0,
     };
 
     (signal_run, message)

--- a/app-server/src/signals/mod.rs
+++ b/app-server/src/signals/mod.rs
@@ -140,6 +140,7 @@ pub struct SignalRun {
     pub event_id: Option<Uuid>,
     pub error_message: Option<String>,
     pub mode: SignalMode,
+    pub steps_processed: u32,
 }
 
 impl SignalRun {
@@ -181,6 +182,7 @@ impl SignalRun {
             event_id: None,
             error_message: None,
             mode: SignalMode::from_u8(message.mode),
+            steps_processed: message.steps_processed,
         }
     }
 
@@ -200,6 +202,7 @@ impl SignalRun {
             event_id: None,
             error_message: None,
             mode: SignalMode::Batch,
+            steps_processed: 0,
         }
     }
 }

--- a/app-server/src/signals/queue.rs
+++ b/app-server/src/signals/queue.rs
@@ -72,6 +72,9 @@ pub struct SignalMessage {
     /// 0 = batch, 1 = realtime. Determines billing and routing.
     #[serde(default)]
     pub mode: u8,
+    /// Number of LLM spans processed after filtering (set on step 0, carried across steps)
+    #[serde(default)]
+    pub steps_processed: u32,
 }
 
 pub async fn push_to_submissions_queue(

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -93,7 +93,7 @@ impl MessageHandler for SignalJobRealtimeHandler {
             }) => {
                 let mut updated_message = message.clone();
                 updated_message.request_start_time = request_start_time;
-                if message.step == 0 {
+                if steps_processed > 0 {
                     updated_message.steps_processed = steps_processed;
                 }
 

--- a/app-server/src/signals/realtime_api.rs
+++ b/app-server/src/signals/realtime_api.rs
@@ -89,9 +89,13 @@ impl MessageHandler for SignalJobRealtimeHandler {
                 request,
                 new_messages,
                 request_start_time,
+                steps_processed,
             }) => {
                 let mut updated_message = message.clone();
                 updated_message.request_start_time = request_start_time;
+                if message.step == 0 {
+                    updated_message.steps_processed = steps_processed;
+                }
 
                 if !new_messages.is_empty() {
                     insert_signal_run_messages(self.clickhouse.clone(), &new_messages)
@@ -418,6 +422,7 @@ mod tests {
             retry_count,
             request_start_time: chrono::Utc::now(),
             mode: 1,
+            steps_processed: 0,
         }
     }
 

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -226,8 +226,7 @@ pub async fn finalize_runs(
     if is_feature_enabled(Feature::UsageLimit) {
         let mut runs_by_project_id: HashMap<Uuid, usize> = HashMap::new();
         for run in succeeded_runs {
-            // Realtime signals are billed as 2 signal runs
-            let cost = if run.mode.is_realtime() { 2 } else { 1 };
+            let cost = run.steps_processed as usize;
             *runs_by_project_id.entry(run.project_id).or_insert(0) += cost;
         }
         let update_futures = runs_by_project_id.into_iter().map(|(project_id, runs)| {

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -153,7 +153,7 @@ async fn prepare_batch_requests(
                 all_new_messages.extend(new_messages);
                 let mut updated_message = message.clone();
                 updated_message.request_start_time = request_start_time;
-                if message.step == 0 {
+                if steps_processed > 0 {
                     updated_message.steps_processed = steps_processed;
                 }
                 successful_messages.push(updated_message);

--- a/app-server/src/signals/submissions_consumer.rs
+++ b/app-server/src/signals/submissions_consumer.rs
@@ -147,11 +147,15 @@ async fn prepare_batch_requests(
                 request,
                 new_messages,
                 request_start_time,
+                steps_processed,
             }) => {
                 requests.push(request);
                 all_new_messages.extend(new_messages);
                 let mut updated_message = message.clone();
                 updated_message.request_start_time = request_start_time;
+                if message.step == 0 {
+                    updated_message.steps_processed = steps_processed;
+                }
                 successful_messages.push(updated_message);
             }
             Err(e) => {

--- a/frontend/lib/actions/usage/limits.ts
+++ b/frontend/lib/actions/usage/limits.ts
@@ -144,8 +144,8 @@ export async function checkSignalRunsLimit(projectId: string, tracesCount: numbe
     const latestResetTime = addMonths(resetTimeDate, completeMonthsElapsed(resetTimeDate, new Date()));
     const latestResetTimeStr = latestResetTime.toISOString().replace(/Z$/, "");
 
-    const signalRunsQuery = `SELECT COUNT(*) as total_signal_runs
-    FROM signal_runs
+    const signalRunsQuery = `SELECT SUM(IF(steps_processed > 0, steps_processed, 1)) as total_signal_runs
+    FROM signal_runs FINAL
     WHERE project_id IN { projectIds: Array(UUID) }
     AND signal_runs.updated_at >= { latestResetTime: DateTime(3, "UTC") }
     AND signal_runs.status = 1`;

--- a/frontend/lib/actions/workspace/index.ts
+++ b/frontend/lib/actions/workspace/index.ts
@@ -279,8 +279,8 @@ export const getWorkspaceUsage = async (workspaceId: string): Promise<WorkspaceU
   }
 
   if (totalSignalRuns === null) {
-    const signalRunsQuery = `SELECT COUNT(*) as total_signal_runs
-    FROM signal_runs
+    const signalRunsQuery = `SELECT SUM(IF(steps_processed > 0, steps_processed, 1)) as total_signal_runs
+    FROM signal_runs FINAL
     WHERE project_id IN { projectIds: Array(UUID) }
     AND signal_runs.updated_at >= { latestResetTime: DateTime(3, "UTC") }
     AND signal_runs.status = 1`;

--- a/frontend/lib/clickhouse/migrations/37_signal_runs_steps_processed.sql
+++ b/frontend/lib/clickhouse/migrations/37_signal_runs_steps_processed.sql
@@ -1,0 +1,2 @@
+-- Add steps_processed column to signal_runs table
+ALTER TABLE signal_runs ADD COLUMN IF NOT EXISTS steps_processed UInt32 DEFAULT 0;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes billing/usage-limit calculations and ClickHouse queries, so incorrect `steps_processed` propagation or null/zero handling could miscount customer usage and impact enforcement.
> 
> **Overview**
> Signal usage accounting is changed from **per-run counting** to **per-step billing** by introducing `steps_processed` on `signal_runs` and using it as the unit for workspace signal-run usage.
> 
> The backend now computes `steps_processed` during step-0 request preparation (counting filtered LLM spans) and carries it through queue messages into persisted `SignalRun`/`CHSignalRun` records; usage-limit updates in `finalize_runs` now add `run.steps_processed` instead of the old fixed 1/2 cost model.
> 
> Both backend and frontend ClickHouse usage queries are updated to read from `signal_runs FINAL` and sum `steps_processed` (frontend falls back to `1` when the column is `0`), and a new ClickHouse migration adds the `steps_processed` column with a default of `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6e48f27e23d6730e18d32b73f4b5d1c6b88510c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->