### PR TITLE
send error logs to sentry as events

### DIFF
--- a/app-server/Cargo.lock
+++ b/app-server/Cargo.lock
@@ -4323,9 +4323,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -4364,7 +4362,9 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -4761,13 +4761,14 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "sentry"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f925d575b468e88b079faf590a8dd0c9c99e2ec29e9bab663ceb8b45056312f"
+checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
 dependencies = [
+ "cfg_aliases",
  "httpdate",
  "native-tls",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "sentry-actix",
  "sentry-backtrace",
  "sentry-contexts",
@@ -4782,9 +4783,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bac0f6b8621fa0f85e298901e51161205788322e1a995e3764329020368058"
+checksum = "9453d18fc9a45d841636004aad50288d80cc07c34a9e88cd4397cb66e6356f67"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -4795,9 +4796,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb1ef7534f583af20452b1b1bf610a60ed9c8dd2d8485e7bd064efc556a78fb"
+checksum = "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
 dependencies = [
  "backtrace",
  "regex",
@@ -4806,9 +4807,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd6be899d9938390b6d1ec71e2f53bd9e57b6a9d8b1d5b049e5c364e7da9078"
+checksum = "9b88a90baa654d7f0e1f4b667f6b434293d9f72c71bef16b197c76af5b7d5803"
 dependencies = [
  "hostname",
  "libc",
@@ -4820,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ab054c34b87f96c3e4701bea1888317cde30cc7e4a6136d2c48454ab96661c"
+checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
 dependencies = [
  "rand 0.9.2",
  "sentry-types",
@@ -4833,9 +4834,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5637ec550dc6f8c49a711537950722d3fc4baa6fd433c371912104eaff31e2a5"
+checksum = "dd9646a972b57896d4a92ed200cf76139f8e30b3cfd03b6662ae59926d26633c"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -4843,9 +4844,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-opentelemetry"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08926a6116cc9a269fded849527efbd063b35767c22afbde222694e4cdfac44e"
+checksum = "9bc924b98e6dfda307aa0ccacf388fd35ceca3ffd59fd8a382ef5ec9bcaccf10"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -4854,9 +4855,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f02c7162f7b69b8de872b439d4696dc1d65f80b13ddd3c3831723def4756b63"
+checksum = "6127d3d304ba5ce0409401e85aae538e303a569f8dbb031bf64f9ba0f7174346"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4864,9 +4865,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dd47df349a80025819f3d25c3d2f751df705d49c65a4cdc0f130f700972a48"
+checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
 dependencies = [
  "bitflags",
  "sentry-backtrace",
@@ -4877,9 +4878,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecbd63e9d15a26a40675ed180d376fcb434635d2e33de1c24003f61e3e2230d"
+checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
 dependencies = [
  "debugid",
  "hex",

--- a/app-server/Cargo.toml
+++ b/app-server/Cargo.toml
@@ -44,7 +44,7 @@ resend-rs = "0.21"
 rmcp = {version = "1", features = ["server"]}
 rustls = {version = "0.23", features = ["ring"]}
 # Sentry SDK must be compatible with the opentelemetry version. For sentry = 0.46.0, opentelemetry = 0.29
-sentry = {version = "0.46.0", features = ["opentelemetry"]}
+sentry = {version = "0.47.0", features = ["opentelemetry", "tracing"]}
 schemars = {version = "1", features = ["uuid1"]}
 serde = "1.0"
 serde_json = {version = "1.0.149", features = ["preserve_order"]}
@@ -59,6 +59,7 @@ tonic = {version = "0.14", features = ["gzip"]}
 tonic-prost = "0.14"
 tracing = {version = "0.1.41", features = ["attributes"]}
 # Tracing opentelemetry must be compatible with the opentelemetry version. For tracing-opentelemetry = 0.30.0, opentelemetry = 0.29
+# Mappings usually updated on major releases: https://github.com/tokio-rs/tracing-opentelemetry/releases
 tracing-opentelemetry = "0.30.0"
 tracing-subscriber = {version = "0.3", features = ["env-filter", "fmt"]}
 unicode-normalization = "0.1"

--- a/app-server/src/instrumentation/mod.rs
+++ b/app-server/src/instrumentation/mod.rs
@@ -7,23 +7,41 @@
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
+use sentry::integrations::tracing::EventFilter;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
-pub fn setup_tracing(enable_otel: bool) {
+pub fn setup_tracing_and_logging(enable_otel: bool) {
     let env_filter = if std::env::var("RUST_LOG").is_ok_and(|s| !s.is_empty()) {
         EnvFilter::from_default_env()
     } else {
         EnvFilter::new("info")
     };
 
+    let sentry_dsn_set = std::env::var("SENTRY_DSN").is_ok();
+
+    let sentry_layer = (enable_otel && sentry_dsn_set).then(|| {
+        sentry::integrations::tracing::layer().event_filter(|md| match *md.level() {
+            tracing::Level::ERROR => EventFilter::Event,
+            _ => EventFilter::Ignore,
+        })
+    });
+
+    // Alternative: direct send logs to sentry Logs. This is slightly easier to read all logs, but is
+    // - harder to configure alerting
+    // - comes at additional cost
+    // This requires enable_logs = true on sentry ClientOptions, and cargo add sentry -F logs
+    // let sentry_layer = (enable_otel && sentry_dsn_set)
+    //     .then(|| sentry::integrations::tracing::layer().with_filter(LevelFilter::ERROR));
+
     let registry = tracing_subscriber::registry()
         .with(env_filter)
-        .with(tracing_subscriber::fmt::layer());
+        .with(tracing_subscriber::fmt::layer())
+        .with(sentry_layer);
 
     if enable_otel {
         let mut provider_builder = SdkTracerProvider::builder();
 
-        if std::env::var("SENTRY_DSN").is_ok() {
+        if sentry_dsn_set {
             provider_builder = provider_builder.with_span_processor(
                 sentry::integrations::opentelemetry::SentrySpanProcessor::new(),
             );

--- a/app-server/src/instrumentation/mod.rs
+++ b/app-server/src/instrumentation/mod.rs
@@ -17,7 +17,7 @@ pub fn setup_tracing_and_logging(enable_otel: bool) {
         EnvFilter::new("info")
     };
 
-    let sentry_dsn_set = std::env::var("SENTRY_DSN").is_ok();
+    let sentry_dsn_set = std::env::var("SENTRY_DSN").is_ok_and(|s| !s.is_empty());
 
     let sentry_layer = (enable_otel && sentry_dsn_set).then(|| {
         sentry::integrations::tracing::layer().event_filter(|md| match *md.level() {

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -165,10 +165,6 @@ fn main() -> anyhow::Result<()> {
             environment: Some(Cow::Owned(
                 env::var("ENVIRONMENT").unwrap_or("development".to_string()),
             )),
-            before_send: Some(Arc::new(|_| {
-                // We don't want Sentry to record events. We only use it for OTel tracing.
-                None
-            })),
             ..Default::default()
         },
     ));
@@ -178,7 +174,7 @@ fn main() -> anyhow::Result<()> {
         drop(_sentry_guard);
     }
 
-    instrumentation::setup_tracing(is_feature_enabled(Feature::Tracing));
+    instrumentation::setup_tracing_and_logging(is_feature_enabled(Feature::Tracing));
 
     let http_payload_limit: usize = env::var("HTTP_PAYLOAD_LIMIT")
         .unwrap_or(String::from("5242880")) // default to 5MB


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes error reporting behavior by sending `tracing` ERROR events to Sentry, which can increase event volume/cost and alter alerting/noise characteristics. Also bumps Sentry/reqwest-related dependencies, which may affect telemetry and HTTP client behavior indirectly.
> 
> **Overview**
> **Enables Sentry event capture for server-side errors** by adding a Sentry `tracing` subscriber layer that forwards only `tracing::Level::ERROR` events when OpenTelemetry is enabled and `SENTRY_DSN` is set.
> 
> Upgrades Sentry crates to `0.47.0` (enabling the `tracing` feature) and removes the previous `before_send` drop-filter so Sentry can now receive events, while keeping OTel span processing via `SentrySpanProcessor` when configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b4914a4c169124dfd4717f0e3ffae27a486405b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->