### PR TITLE
refactor/show all tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 target/
 .claude/
 .agent-browser/
-.agent-team/TODO.md
+.agent-team/

--- a/frontend/components/tags/span-tags-list.tsx
+++ b/frontend/components/tags/span-tags-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Plus, Tag } from "lucide-react";
+import { Tag } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo } from "react";
 import useSWR from "swr";
@@ -11,14 +11,15 @@ import { useToast } from "@/lib/hooks/use-toast";
 import { type SpanTag, type TagClass } from "@/lib/traces/types";
 import { cn, swrFetcher } from "@/lib/utils";
 
+import { Badge } from "../ui/badge";
 import TagsDropdown, { type Tag as TagType } from "./tags-dropdown";
 
-interface SpanTagsButtonProps {
+interface SpanTagsListProps {
   spanId: string;
   className?: string;
 }
 
-const SpanTagsButton = ({ spanId, className }: SpanTagsButtonProps) => {
+const SpanTagsList = ({ spanId, className }: SpanTagsListProps) => {
   const { projectId } = useParams();
   const { toast } = useToast();
 
@@ -146,38 +147,31 @@ const SpanTagsButton = ({ spanId, className }: SpanTagsButtonProps) => {
   };
 
   return (
-    <TagsDropdown
-      tags={tags}
-      tagClasses={tagClasses}
-      onAttach={onAttach}
-      onDetach={onDetach}
-      onCreateAndAttach={onCreateAndAttach}
-    >
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
-          {tags.length > 0 ? (
-            <div className="flex -space-x-[6px]">
-              {tags.slice(0, 5).map((tag) => (
-                <div
-                  key={tag.id}
-                  className={cn("size-3.5 border border-background rounded-full", !tag.color && "bg-gray-300")}
-                  style={tag.color ? { background: tag.color } : undefined}
-                />
-              ))}
-              {tags.length > 5 && (
-                <div className="size-3.5 border border-border rounded-full bg-muted flex items-center justify-center">
-                  <Plus className="size-2" />
-                </div>
-              )}
-            </div>
-          ) : (
-            <Tag className="size-3.5" />
-          )}
-          {tags.length === 0 ? "Tags" : tags.length === 1 ? tags[0].name : `Tags (${tags.length})`}
-        </Button>
-      </DropdownMenuTrigger>
-    </TagsDropdown>
+    <>
+      <TagsDropdown
+        tags={tags}
+        tagClasses={tagClasses}
+        onAttach={onAttach}
+        onDetach={onDetach}
+        onCreateAndAttach={onCreateAndAttach}
+      >
+        <DropdownMenuTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
+              <Tag className="size-3.5" />
+              Tags
+            </Button>
+          </DropdownMenuTrigger>
+        </DropdownMenuTrigger>
+      </TagsDropdown>
+      {tags.map(({ name, color }) => (
+        <Badge variant="outline" className="rounded-full gap-1">
+          <div className="rounded-full size-2.5" style={{ backgroundColor: color }} />
+          {name}
+        </Badge>
+      ))}
+    </>
   );
 };
 
-export default SpanTagsButton;
+export default SpanTagsList;

--- a/frontend/components/tags/span-tags-list.tsx
+++ b/frontend/components/tags/span-tags-list.tsx
@@ -156,17 +156,15 @@ const SpanTagsList = ({ spanId, className }: SpanTagsListProps) => {
         onCreateAndAttach={onCreateAndAttach}
       >
         <DropdownMenuTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
-              <Tag className="size-3.5" />
-              Tags
-            </Button>
-          </DropdownMenuTrigger>
+          <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
+            <Tag className="size-3.5" />
+            Tags
+          </Button>
         </DropdownMenuTrigger>
       </TagsDropdown>
       {tags.map(({ name, color, id }) => (
         <Badge key={id} variant="outline" className="rounded-full gap-1">
-          <div className="rounded-full size-2.5" style={{ backgroundColor: color }} />
+          <div className="rounded-full size-2.5 bg-gray-300" style={{ backgroundColor: color }} />
           {name}
         </Badge>
       ))}

--- a/frontend/components/tags/span-tags-list.tsx
+++ b/frontend/components/tags/span-tags-list.tsx
@@ -164,8 +164,8 @@ const SpanTagsList = ({ spanId, className }: SpanTagsListProps) => {
           </DropdownMenuTrigger>
         </DropdownMenuTrigger>
       </TagsDropdown>
-      {tags.map(({ name, color }) => (
-        <Badge variant="outline" className="rounded-full gap-1">
+      {tags.map(({ name, color, id }) => (
+        <Badge key={id} variant="outline" className="rounded-full gap-1">
           <div className="rounded-full size-2.5" style={{ backgroundColor: color }} />
           {name}
         </Badge>

--- a/frontend/components/tags/trace-tags-list.tsx
+++ b/frontend/components/tags/trace-tags-list.tsx
@@ -156,8 +156,8 @@ const TraceTagsList = ({ traceId, className }: TraceTagsListProps) => {
           </Button>
         </DropdownMenuTrigger>
       </TagsDropdown>
-      {tags.map(({ name, color }) => (
-        <Badge variant="outline" className="rounded-full gap-1">
+      {tags.map(({ name, color, id }) => (
+        <Badge key={id} variant="outline" className="rounded-full gap-1">
           <div className="rounded-full size-2.5" style={{ backgroundColor: color }} />
           {name}
         </Badge>

--- a/frontend/components/tags/trace-tags-list.tsx
+++ b/frontend/components/tags/trace-tags-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Plus, Tag } from "lucide-react";
+import { Tag } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
 import useSWR from "swr";
@@ -11,14 +11,15 @@ import { useToast } from "@/lib/hooks/use-toast";
 import { type TagClass } from "@/lib/traces/types";
 import { cn, swrFetcher } from "@/lib/utils";
 
+import { Badge } from "../ui/badge";
 import TagsDropdown, { type Tag as TagType } from "./tags-dropdown";
 
-interface TraceTagsButtonProps {
+interface TraceTagsListProps {
   traceId: string;
   className?: string;
 }
 
-const TraceTagsButton = ({ traceId, className }: TraceTagsButtonProps) => {
+const TraceTagsList = ({ traceId, className }: TraceTagsListProps) => {
   const { projectId } = useParams();
   const { toast } = useToast();
 
@@ -140,38 +141,29 @@ const TraceTagsButton = ({ traceId, className }: TraceTagsButtonProps) => {
   };
 
   return (
-    <TagsDropdown
-      tags={tags}
-      tagClasses={tagClasses}
-      onAttach={onAttach}
-      onDetach={onDetach}
-      onCreateAndAttach={onCreateAndAttach}
-    >
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
-          {tags.length > 0 ? (
-            <div className="flex -space-x-[6px]">
-              {tags.slice(0, 5).map((tag) => (
-                <div
-                  key={tag.id}
-                  className={cn("size-3.5 border border-background rounded-full", !tag.color && "bg-gray-300")}
-                  style={tag.color ? { background: tag.color } : undefined}
-                />
-              ))}
-              {tags.length > 5 && (
-                <div className="size-3.5 border border-border rounded-full bg-muted flex items-center justify-center">
-                  <Plus className="size-2" />
-                </div>
-              )}
-            </div>
-          ) : (
+    <>
+      <TagsDropdown
+        tags={tags}
+        tagClasses={tagClasses}
+        onAttach={onAttach}
+        onDetach={onDetach}
+        onCreateAndAttach={onCreateAndAttach}
+      >
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
             <Tag className="size-3.5" />
-          )}
-          {tags.length === 0 ? "Tags" : tags.length === 1 ? tags[0].name : `Tags (${tags.length})`}
-        </Button>
-      </DropdownMenuTrigger>
-    </TagsDropdown>
+            Tags
+          </Button>
+        </DropdownMenuTrigger>
+      </TagsDropdown>
+      {tags.map(({ name, color }) => (
+        <Badge variant="outline" className="rounded-full gap-1">
+          <div className="rounded-full size-2.5" style={{ backgroundColor: color }} />
+          {name}
+        </Badge>
+      ))}
+    </>
   );
 };
 
-export default TraceTagsButton;
+export default TraceTagsList;

--- a/frontend/components/tags/trace-tags-list.tsx
+++ b/frontend/components/tags/trace-tags-list.tsx
@@ -158,7 +158,7 @@ const TraceTagsList = ({ traceId, className }: TraceTagsListProps) => {
       </TagsDropdown>
       {tags.map(({ name, color, id }) => (
         <Badge key={id} variant="outline" className="rounded-full gap-1">
-          <div className="rounded-full size-2.5" style={{ backgroundColor: color }} />
+          <div className="rounded-full size-2.5 bg-gray-300" style={{ backgroundColor: color }} />
           {name}
         </Badge>
       ))}

--- a/frontend/components/traces/span-controls.tsx
+++ b/frontend/components/traces/span-controls.tsx
@@ -4,7 +4,7 @@ import { useParams } from "next/navigation";
 import { type PropsWithChildren, useCallback, useMemo } from "react";
 
 import EvaluatorScoresList from "@/components/evaluators/evaluator-scores-list";
-import SpanTagsButton from "@/components/tags/span-tags-button";
+import SpanTagsList from "@/components/tags/span-tags-list";
 import AddToLabelingQueuePopover from "@/components/traces/add-to-labeling-queue-popover";
 import ErrorCard from "@/components/traces/error-card";
 import ExportSpansPopover from "@/components/traces/export-spans-popover";
@@ -118,7 +118,7 @@ export function SpanControls({ children, span }: PropsWithChildren<SpanControlsP
           <div className="flex gap-2 gap-y-1 flex-wrap items-center">
             <AddToLabelingQueuePopover spanId={span.spanId} traceId={span.traceId} />
             <ExportSpansPopover span={span} />
-            <SpanTagsButton spanId={span.spanId} />
+            <SpanTagsList spanId={span.spanId} />
           </div>
           <EvaluatorScoresList spanId={span.spanId} />
         </div>

--- a/frontend/components/traces/trace-view/header/index.tsx
+++ b/frontend/components/traces/trace-view/header/index.tsx
@@ -5,7 +5,7 @@ import { memo, useEffect, useMemo } from "react";
 import { shallow } from "zustand/shallow";
 
 import { jsonSchemaToSchemaFields } from "@/components/signals/utils";
-import TraceTagsButton from "@/components/tags/trace-tags-button";
+import TraceTagsList from "@/components/tags/trace-tags-list";
 import ShareTraceButton from "@/components/traces/share-trace-button";
 import TraceViewSearch from "@/components/traces/trace-view/search";
 import { type TraceViewSpan, useTraceViewStore } from "@/components/traces/trace-view/store";
@@ -165,6 +165,11 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
               </Button>
             </span>
           )}
+          {trace?.metadata && (
+            <span className={HEADER_ITEM_CLS}>
+              <Metadata metadata={trace?.metadata} />
+            </span>
+          )}
           {signalCount > 0 && (
             <span className={HEADER_ITEM_CLS}>
               <Button
@@ -180,14 +185,7 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
               </Button>
             </span>
           )}
-          <span className={HEADER_ITEM_CLS}>
-            <TraceTagsButton traceId={traceId} />
-          </span>
-          {trace?.metadata && (
-            <span className={HEADER_ITEM_CLS}>
-              <Metadata metadata={trace?.metadata} />
-            </span>
-          )}
+          <TraceTagsList traceId={traceId} />
         </div>
         {trace && <ShareTraceButton projectId={projectId} />}
       </div>


### PR DESCRIPTION
List all tags in trace view header and span view header

<img width="1013" height="665" alt="image" src="https://github.com/user-attachments/assets/2eacb5eb-c7b0-448d-aff7-c90b258f5f99" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that changes tag rendering and layout but keeps the same fetch/mutate APIs and tag attach/detach logic.
> 
> **Overview**
> Updates trace and span tag controls to **always render all attached tags as inline `Badge`s** next to a simplified `Tags` dropdown trigger, replacing the prior compact dot/count button UI.
> 
> Also tweaks trace header layout (moves `Metadata` earlier and removes the extra wrapper around the tags control) and broadens `.gitignore` to ignore the entire `.agent-team/` directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d782d972021db94c0311cf47ad50204772fcb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->