### PR TITLE
filter out cc skip spans by response model as well

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -923,10 +923,15 @@ impl Span {
             }
             // For older versions of our proxy, apply similar heuristics here directly
             if self.attributes.is_claude_code_span()
-                && self
+                && (self
                     .attributes
                     .request_model()
                     .is_some_and(|m| m.to_lowercase().contains("haiku"))
+                || self
+                    .attributes
+                    .response_model()
+                    .is_some_and(|m| m.to_lowercase().contains("haiku"))
+                )
                 // input check is relatively heavy, so perform it after simpler checks
                 && self.is_input_cc_bash_check()
             {


### PR DESCRIPTION
Current version of CC proxy does not catch the request model for Bedrock because it's send in URL path not in request body. Improves backend filtering. CC proxy fix is planned separately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts span filtering logic for `anthropic.messages`, which can change what data is persisted to ClickHouse by dropping additional spans when only the response model is available.
> 
> **Overview**
> Tightens the ClickHouse span filter for legacy Claude Code `anthropic.messages` spans by treating a `haiku` match in `gen_ai.response.model` as equivalent to `gen_ai.request.model` when deciding to skip noisy Bash-check spans.
> 
> This improves backend-side skipping for cases where the request model isn’t captured (e.g., some Bedrock/proxy variants), while keeping the heavier input heuristic (`is_input_cc_bash_check`) as the final gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3af1168c14571763f2319a3fd5fa228d1bbc0b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->