### PR TITLE
ui notifications

### DIFF
--- a/app-server/src/notifications/mod.rs
+++ b/app-server/src/notifications/mod.rs
@@ -10,6 +10,7 @@ use crate::ch::notifications::CHNotification;
 use crate::ch::service::ClickhouseService;
 use crate::db::DB;
 use crate::mq::{MessageQueue, MessageQueueTrait};
+use crate::mq::utils::mq_max_payload;
 use crate::reports::email_template::NoteworthyEvent;
 use crate::worker::{HandlerError, MessageHandler};
 
@@ -287,6 +288,20 @@ impl MessageHandler for NotificationHandler {
                 notification_ids: notification_ids.clone(),
                 notifications: message.notifications.clone(),
             };
+
+            let serialized_size = serde_json::to_vec(&delivery)
+                .map(|v| v.len())
+                .unwrap_or(0);
+            if serialized_size >= mq_max_payload() {
+                failures += 1;
+                log::error!(
+                    "[Notifications] MQ payload limit exceeded for delivery message. \
+                     payload size: [{}], target: {:?}",
+                    serialized_size,
+                    delivery.target,
+                );
+                continue;
+            }
 
             if let Err(e) = push_to_deliveries_queue(delivery, self.queue.clone()).await {
                 failures += 1;

--- a/app-server/src/notifications/mod.rs
+++ b/app-server/src/notifications/mod.rs
@@ -9,8 +9,8 @@ use crate::cache::{Cache, CacheTrait, keys::USAGE_WARNING_SEND_LOCK_KEY};
 use crate::ch::notifications::CHNotification;
 use crate::ch::service::ClickhouseService;
 use crate::db::DB;
-use crate::mq::{MessageQueue, MessageQueueTrait};
 use crate::mq::utils::mq_max_payload;
+use crate::mq::{MessageQueue, MessageQueueTrait};
 use crate::reports::email_template::NoteworthyEvent;
 use crate::worker::{HandlerError, MessageHandler};
 
@@ -289,9 +289,18 @@ impl MessageHandler for NotificationHandler {
                 notifications: message.notifications.clone(),
             };
 
-            let serialized_size = serde_json::to_vec(&delivery)
-                .map(|v| v.len())
-                .unwrap_or(0);
+            let serialized_size = match serde_json::to_vec(&delivery) {
+                Ok(v) => v.len(),
+                Err(e) => {
+                    failures += 1;
+                    log::error!(
+                        "[Notifications] Failed to serialize delivery message: {:?}, target: {:?}",
+                        e,
+                        delivery.target,
+                    );
+                    continue;
+                }
+            };
             if serialized_size >= mq_max_payload() {
                 failures += 1;
                 log::error!(

--- a/frontend/app/api/workspaces/[workspaceId]/notifications/route.ts
+++ b/frontend/app/api/workspaces/[workspaceId]/notifications/route.ts
@@ -1,0 +1,61 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { getWebNotifications, markNotificationAsRead } from "@/lib/actions/notifications";
+import { authOptions } from "@/lib/auth";
+import { isProjectInWorkspace } from "@/lib/authorization";
+
+export async function GET(request: NextRequest, props: { params: Promise<{ workspaceId: string }> }) {
+  const { workspaceId } = await props.params;
+
+  try {
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const projectId = request.nextUrl.searchParams.get("projectId");
+    if (!projectId) {
+      return NextResponse.json({ error: "projectId query parameter is required" }, { status: 400 });
+    }
+    if (!(await isProjectInWorkspace(projectId, workspaceId))) {
+      return NextResponse.json({ error: "Project does not belong to this workspace" }, { status: 400 });
+    }
+    const result = await getWebNotifications({ userId, projectId });
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch notifications." },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest, props: { params: Promise<{ workspaceId: string }> }) {
+  const { workspaceId } = await props.params;
+
+  try {
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const body = await request.json();
+    const { notificationId, projectId } = body;
+    if (!notificationId || !projectId) {
+      return NextResponse.json({ error: "notificationId and projectId are required" }, { status: 400 });
+    }
+    if (!(await isProjectInWorkspace(projectId, workspaceId))) {
+      return NextResponse.json({ error: "Project does not belong to this workspace" }, { status: 400 });
+    }
+    await markNotificationAsRead({ userId, notificationId, projectId });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to mark notification as read." },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/project/[projectId]/layout.tsx
+++ b/frontend/app/project/[projectId]/layout.tsx
@@ -6,6 +6,7 @@ import { type ReactNode } from "react";
 import PostHogClient from "@/app/posthog";
 import PostHogIdentifier from "@/app/posthog-identifier";
 import SessionSyncProvider from "@/components/auth/session-sync-provider";
+import NotificationPanel from "@/components/notifications/notification-panel";
 import ProjectSidebar from "@/components/project/sidebar";
 import ProjectUsageBanner from "@/components/project/usage-banner";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
@@ -54,9 +55,14 @@ export default async function ProjectIdLayout(props: { children: ReactNode; para
         <PostHogIdentifier email={user.email} />
         <ProjectContextProvider workspace={workspace} projects={projects} project={projectDetails}>
           <div className="fixed inset-0 flex overflow-clip md:pt-2 bg-sidebar">
-            <SidebarProvider cookieName={projectSidebarCookieName} className="bg-sidebar" defaultOpen={defaultOpen}>
+            <SidebarProvider
+              cookieName={projectSidebarCookieName}
+              className="bg-sidebar overflow-clip"
+              defaultOpen={defaultOpen}
+            >
               <ProjectSidebar details={projectDetails} />
-              <SidebarInset className="flex flex-col h-[calc(100%-8px)]! border-l border-t flex-1 md:rounded-tl-lg overflow-hidden">
+              <SidebarInset className="relative flex flex-col h-[calc(100%-8px)]! border-l border-t flex-1 md:rounded-tl-lg overflow-clip">
+                <NotificationPanel />
                 {showBanner && <ProjectUsageBanner details={projectDetails} />}
                 {children}
               </SidebarInset>

--- a/frontend/app/project/[projectId]/layout.tsx
+++ b/frontend/app/project/[projectId]/layout.tsx
@@ -55,13 +55,9 @@ export default async function ProjectIdLayout(props: { children: ReactNode; para
         <PostHogIdentifier email={user.email} />
         <ProjectContextProvider workspace={workspace} projects={projects} project={projectDetails}>
           <div className="fixed inset-0 flex overflow-clip md:pt-2 bg-sidebar">
-            <SidebarProvider
-              cookieName={projectSidebarCookieName}
-              className="bg-sidebar overflow-clip"
-              defaultOpen={defaultOpen}
-            >
+            <SidebarProvider cookieName={projectSidebarCookieName} className="bg-sidebar" defaultOpen={defaultOpen}>
               <ProjectSidebar details={projectDetails} />
-              <SidebarInset className="relative flex flex-col h-[calc(100%-8px)]! border-l border-t flex-1 md:rounded-tl-lg overflow-clip">
+              <SidebarInset className="relative flex flex-col h-[calc(100%-8px)]! border-l border-t flex-1 md:rounded-tl-lg overflow-hidden">
                 <NotificationPanel />
                 {showBanner && <ProjectUsageBanner details={projectDetails} />}
                 {children}

--- a/frontend/components/notifications/notification-panel.tsx
+++ b/frontend/components/notifications/notification-panel.tsx
@@ -173,7 +173,7 @@ const NotificationItem = ({
             handleExpand();
           }}
         >
-          <div className="max-h-22 overflow-hidden">
+          <div className="max-h-21 overflow-hidden">
             <NotificationDetails formatted={formatted} projectId={projectId} />
           </div>
           <div

--- a/frontend/components/notifications/notification-panel.tsx
+++ b/frontend/components/notifications/notification-panel.tsx
@@ -75,7 +75,7 @@ export const formatNotification = (notification: WebNotification): FormattedNoti
     const noteworthyEvents = report.noteworthy_events ?? [];
 
     return {
-      title: report.title || "Signal Events Summary",
+      title: "Signal Events Summary",
       summary: `${events} new event${events !== 1 ? "s" : ""} among ${signalCount} signal${signalCount !== 1 ? "s" : ""} in the last ${periodType}`,
       aiSummary,
       noteworthyEvents,

--- a/frontend/components/notifications/notification-panel.tsx
+++ b/frontend/components/notifications/notification-panel.tsx
@@ -96,8 +96,8 @@ const NotificationDetails = ({ formatted, projectId }: { formatted: FormattedNot
     {formatted.noteworthyEvents.length > 0 && (
       <div className="flex flex-col gap-1.5 mt-1">
         <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Noteworthy events</span>
-        {formatted.noteworthyEvents.slice(0, 3).map((event, i) => (
-          <div key={i} className="flex flex-col gap-0.5">
+        {formatted.noteworthyEvents.slice(0, 3).map((event) => (
+          <div key={event.trace_id} className="flex flex-col gap-0.5">
             <div className="flex items-center gap-1.5">
               <span className="text-[11px] font-medium text-foreground">{event.signal_name}</span>
               <span className="text-[10px] text-muted-foreground/70">{formatRelativeTime(event.timestamp)}</span>

--- a/frontend/components/notifications/notification-panel.tsx
+++ b/frontend/components/notifications/notification-panel.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { ChevronDown, ChevronUp, X } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import useSWR from "swr";
+
+import { useNotificationPanelStore } from "@/components/notifications/notification-store";
+import { useProjectContext } from "@/contexts/project-context";
+import { type WebNotification } from "@/lib/actions/notifications";
+import { cn, formatRelativeTime, swrFetcher } from "@/lib/utils";
+
+interface NoteworthyEvent {
+  signal_name: string;
+  summary: string;
+  timestamp: string;
+  trace_id: string;
+}
+
+interface SignalsReport {
+  workspace_name: string;
+  project_id: string;
+  project_name: string;
+  title: string;
+  period_label: string;
+  period_start: string;
+  period_end: string;
+  signal_event_counts: Record<string, number>;
+  ai_summary: string;
+  noteworthy_events: NoteworthyEvent[];
+}
+
+interface FormattedNotification {
+  title: string;
+  summary: string;
+  aiSummary: string | null;
+  noteworthyEvents: NoteworthyEvent[];
+}
+
+// TODO: refactor this to have a more generic notification format, currently implemented only for signal events reports
+export const formatNotification = (notification: WebNotification): FormattedNotification | null => {
+  try {
+    const payload: { SignalsReport: SignalsReport } = JSON.parse(notification.payload);
+    const report = payload.SignalsReport;
+    if (!report) {
+      return null;
+    }
+
+    const periodStartMs = new Date(report.period_start).getTime();
+    const periodEndMs = new Date(report.period_end).getTime();
+
+    // Hide weekly-style rollups to avoid duplicating info already shown by daily reports.
+    if (!Number.isNaN(periodStartMs) && !Number.isNaN(periodEndMs)) {
+      const periodDays = (periodEndMs - periodStartMs) / (1000 * 60 * 60 * 24);
+      if (periodDays > 3) {
+        return null;
+      }
+    }
+
+    const events = Object.values(report.signal_event_counts).reduce((a, b) => a + b, 0);
+    const signalCount = Object.keys(report.signal_event_counts).length;
+    const periodType = (() => {
+      if (Number.isNaN(periodStartMs) || Number.isNaN(periodEndMs)) {
+        return "selected period";
+      }
+
+      const diffDays = Math.max(1, Math.round((periodEndMs - periodStartMs) / (1000 * 60 * 60 * 24)));
+      if (diffDays > 1) {
+        return `${diffDays} days`;
+      }
+      return "day";
+    })();
+
+    const aiSummary = report.ai_summary || null;
+    const noteworthyEvents = report.noteworthy_events ?? [];
+
+    return {
+      title: report.title || "Signal Events Summary",
+      summary: `${events} new event${events !== 1 ? "s" : ""} among ${signalCount} signal${signalCount !== 1 ? "s" : ""} in the last ${periodType}`,
+      aiSummary,
+      noteworthyEvents,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const NotificationDetails = ({ formatted, projectId }: { formatted: FormattedNotification; projectId?: string }) => (
+  <>
+    {formatted.aiSummary && (
+      <div className="flex flex-col gap-1 mt-1">
+        <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Summary</span>
+        <p className="text-xs text-secondary-foreground leading-relaxed">{formatted.aiSummary}</p>
+      </div>
+    )}
+    {formatted.noteworthyEvents.length > 0 && (
+      <div className="flex flex-col gap-1.5 mt-1">
+        <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Noteworthy events</span>
+        {formatted.noteworthyEvents.slice(0, 3).map((event, i) => (
+          <div key={i} className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[11px] font-medium text-foreground">{event.signal_name}</span>
+              <span className="text-[10px] text-muted-foreground/70">{formatRelativeTime(event.timestamp)}</span>
+            </div>
+            <span className="text-xs text-muted-foreground leading-snug">{event.summary}</span>
+            {projectId && (
+              <Link
+                href={`/project/${projectId}/traces/${event.trace_id}?chat=true`}
+                className="text-[11px] text-muted-foreground underline hover:text-foreground mt-0.5 w-fit"
+                onClick={(e) => e.stopPropagation()}
+              >
+                View trace
+              </Link>
+            )}
+          </div>
+        ))}
+      </div>
+    )}
+  </>
+);
+
+const NotificationItem = ({
+  notification,
+  formatted,
+  projectId,
+  onMarkAsRead,
+}: {
+  notification: WebNotification;
+  formatted: FormattedNotification;
+  projectId?: string;
+  onMarkAsRead: (notificationId: string) => void;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails = formatted.aiSummary || formatted.noteworthyEvents.length > 0;
+  const isUnread = !notification.isRead;
+
+  const markAsRead = () => {
+    if (isUnread) {
+      onMarkAsRead(notification.id);
+    }
+  };
+
+  const handleExpand = () => {
+    setExpanded(true);
+    markAsRead();
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-1.5 border-b px-3 py-3 transition-colors",
+        isUnread ? "bg-secondary/40 cursor-pointer" : "bg-transparent"
+      )}
+      onClick={markAsRead}
+    >
+      <div className="flex items-center justify-between">
+        <span className={cn("text-xs text-foreground", isUnread ? "font-semibold" : "font-medium")}>
+          {formatted.title}
+        </span>
+        <div className="flex items-center gap-1.5 shrink-0 ml-2">
+          {isUnread && <span className="size-1.5 rounded-full bg-orange-500 shrink-0" />}
+          <span className="text-[11px] text-muted-foreground/70">{formatRelativeTime(notification.createdAt)}</span>
+        </div>
+      </div>
+      <span className={cn("text-xs", isUnread ? "text-foreground/80" : "text-muted-foreground")}>
+        {formatted.summary}
+      </span>
+      {hasDetails && !expanded && (
+        <div
+          className="relative cursor-pointer"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleExpand();
+          }}
+        >
+          <div className="max-h-22 overflow-hidden">
+            <NotificationDetails formatted={formatted} projectId={projectId} />
+          </div>
+          <div
+            className={cn(
+              "absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t to-transparent pointer-events-none",
+              isUnread ? "from-secondary/40" : "from-background"
+            )}
+          />
+          <button className="relative flex items-center gap-1 text-[11px] text-primary hover:text-primary/80 transition-colors w-fit mt-1">
+            <ChevronDown className="size-3" />
+            Show more
+          </button>
+        </div>
+      )}
+      {expanded && (
+        <>
+          <NotificationDetails formatted={formatted} projectId={projectId} />
+          <button
+            onClick={() => setExpanded(false)}
+            className="flex items-center gap-1 text-[11px] text-primary hover:text-primary/80 transition-colors w-fit"
+          >
+            <ChevronUp className="size-3" />
+            Show less
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
+
+const NotificationPanel = () => {
+  const { isOpen, close } = useNotificationPanelStore();
+  const { workspace, project } = useProjectContext();
+
+  const swrKey = workspace && project ? `/api/workspaces/${workspace.id}/notifications?projectId=${project.id}` : null;
+
+  const { data: notifications, mutate } = useSWR<WebNotification[]>(swrKey, swrFetcher);
+
+  const formattedNotifications = notifications
+    ?.map((n) => ({
+      notification: n,
+      formatted: formatNotification(n),
+    }))
+    .filter(
+      (item): item is { notification: WebNotification; formatted: FormattedNotification } => item.formatted !== null
+    );
+
+  const hasNotifications = formattedNotifications && formattedNotifications.length > 0;
+
+  const handleMarkAsRead = async (notificationId: string) => {
+    if (!workspace || !project) return;
+
+    mutate((current) => current?.map((n) => (n.id === notificationId ? { ...n, isRead: true } : n)), false);
+
+    try {
+      const res = await fetch(`/api/workspaces/${workspace.id}/notifications`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notificationId, projectId: project.id }),
+      });
+      if (!res.ok) {
+        mutate();
+      }
+    } catch {
+      mutate();
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-y-0 left-0 z-50 w-104 bg-background border-r shadow-lg",
+        "transition-transform duration-200 ease-in-out",
+        isOpen ? "translate-x-0" : "-translate-x-full"
+      )}
+    >
+      <div className="flex flex-col h-full">
+        <div className="flex items-center justify-between border-b px-3 py-2 shrink-0">
+          <span className="text-sm font-medium">Notifications</span>
+          <button
+            onClick={close}
+            className="flex items-center justify-center rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {!hasNotifications ? (
+            <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
+              No notifications yet
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              {formattedNotifications.map(({ notification, formatted }) => (
+                <NotificationItem
+                  key={notification.id}
+                  notification={notification}
+                  formatted={formatted}
+                  projectId={project?.id}
+                  onMarkAsRead={handleMarkAsRead}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationPanel;

--- a/frontend/components/notifications/notification-store.ts
+++ b/frontend/components/notifications/notification-store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface NotificationPanelStore {
+  isOpen: boolean;
+  toggle: () => void;
+  close: () => void;
+}
+
+export const useNotificationPanelStore = create<NotificationPanelStore>()((set) => ({
+  isOpen: false,
+  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+  close: () => set({ isOpen: false }),
+}));

--- a/frontend/components/notifications/notification-trigger.tsx
+++ b/frontend/components/notifications/notification-trigger.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Bell } from "lucide-react";
+import useSWR from "swr";
+
+import { formatNotification } from "@/components/notifications/notification-panel";
+import { useNotificationPanelStore } from "@/components/notifications/notification-store";
+import { useProjectContext } from "@/contexts/project-context";
+import { type WebNotification } from "@/lib/actions/notifications";
+import { cn, swrFetcher } from "@/lib/utils";
+
+const NotificationTrigger = () => {
+  const { workspace, project } = useProjectContext();
+  const { isOpen, toggle } = useNotificationPanelStore();
+
+  const swrKey = workspace && project ? `/api/workspaces/${workspace.id}/notifications?projectId=${project.id}` : null;
+  const { data: notifications } = useSWR<WebNotification[]>(swrKey, swrFetcher);
+
+  const hasUnread = notifications?.some((n) => !n.isRead && formatNotification(n) !== null) ?? false;
+
+  return (
+    <button
+      onClick={toggle}
+      className={cn(
+        "relative flex items-center justify-center rounded-md p-1",
+        "text-secondary-foreground hover:bg-secondary/60 transition-colors",
+        isOpen && "bg-secondary/60"
+      )}
+    >
+      <Bell className="size-4" />
+      {hasUnread && <span className="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-orange-500" />}
+    </button>
+  );
+};
+
+export default NotificationTrigger;

--- a/frontend/components/project/sidebar/header.tsx
+++ b/frontend/components/project/sidebar/header.tsx
@@ -9,6 +9,7 @@ import React, { useEffect } from "react";
 import useSWR from "swr";
 
 import { useSessionSync } from "@/components/auth/session-sync-provider";
+import NotificationTrigger from "@/components/notifications/notification-trigger";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar.tsx";
 import {
   DropdownMenu,
@@ -61,107 +62,112 @@ const ProjectSidebarHeader = ({ projectId, workspaceId }: { workspaceId: string;
   return (
     <SidebarHeader className="px-0 mt-2">
       <SidebarMenu>
-        <SidebarMenuItem className="m-0 px-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <SidebarMenuButton className={cn("flex items-center justify-center", { border: !open && !openMobile })}>
-                <AnimatePresence mode="wait" initial={false}>
-                  {!open && !openMobile ? (
-                    <motion.span
-                      key="collapsed"
-                      initial={{ opacity: 0, scale: 0.5, width: 0 }}
-                      animate={{ opacity: 1, scale: 1, width: "auto" }}
-                      exit={{ opacity: 0, scale: 0.5, width: 0 }}
-                      transition={{ duration: 0.1 }}
-                      className="flex items-center justify-center"
-                    >
-                      {project?.name?.at(0)?.toUpperCase()}
-                    </motion.span>
-                  ) : (
-                    <motion.div
-                      key="expanded"
-                      initial={{ opacity: 0, scale: 0.5 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      exit={{ opacity: 0, scale: 0.5 }}
-                      transition={{ duration: 0.1 }}
-                      className="flex items-center w-full"
-                    >
-                      <span className="truncate font-medium leading-tight">{project?.name}</span>
-                      <ChevronsUpDown className="ml-auto size-4" />
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </SidebarMenuButton>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg text-xs"
-              align="start"
-              sideOffset={4}
-              side={isMobile ? "bottom" : "right"}
-            >
-              <DropdownMenuLabel className="flex gap-2 p-1">
-                <Avatar className="h-8 w-8 rounded-lg">
-                  <AvatarImage src={user.image ?? ""} alt="avatar" />
-                  <AvatarFallback className="rounded-lg">{user.name?.at(0)?.toUpperCase() || "L"}</AvatarFallback>
-                </Avatar>
-                <div className="grid flex-1 text-left leading-tight">
-                  <span className="text-muted-foreground">Logged in as</span>
-                  <span className="text-sidebar-foreground">{user.email}</span>
-                </div>
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-muted-foreground p-1">
-                Projects{currentWorkspace ? ` in ${currentWorkspace.name}` : ""}
-              </DropdownMenuLabel>
-              {projects.map((project) => (
-                <Link
-                  key={project.id}
-                  passHref
-                  href={`/project/${project.id}/traces`}
-                  onClick={() => setLastProjectIdCookie(project.id)}
+        <SidebarMenuItem className="m-0 px-2 flex items-center">
+          <div className="flex-1 overflow-hidden">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton
+                  className={cn("flex items-center justify-center px-1.5", { border: !open && !openMobile })}
                 >
-                  <DropdownMenuItem
-                    className={cn("cursor-pointer", {
-                      "bg-accent": project.id === projectId,
-                    })}
+                  <AnimatePresence mode="wait" initial={false}>
+                    {!open && !openMobile ? (
+                      <motion.span
+                        key="collapsed"
+                        initial={{ opacity: 0, scale: 0.5, width: 0 }}
+                        animate={{ opacity: 1, scale: 1, width: "auto" }}
+                        exit={{ opacity: 0, scale: 0.5, width: 0 }}
+                        transition={{ duration: 0.1 }}
+                        className="flex items-center justify-center"
+                      >
+                        {project?.name?.at(0)?.toUpperCase()}
+                      </motion.span>
+                    ) : (
+                      <motion.div
+                        key="expanded"
+                        initial={{ opacity: 0, scale: 0.5 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.5 }}
+                        transition={{ duration: 0.1 }}
+                        className="flex items-center w-full"
+                      >
+                        <span className="truncate font-medium leading-tight">{project?.name}</span>
+                        <ChevronsUpDown className="ml-auto size-4 shrink-0" />
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg text-xs"
+                align="start"
+                sideOffset={4}
+                side={isMobile ? "bottom" : "right"}
+              >
+                <DropdownMenuLabel className="flex gap-2 p-1">
+                  <Avatar className="h-8 w-8 rounded-lg">
+                    <AvatarImage src={user.image ?? ""} alt="avatar" />
+                    <AvatarFallback className="rounded-lg">{user.name?.at(0)?.toUpperCase() || "L"}</AvatarFallback>
+                  </Avatar>
+                  <div className="grid flex-1 text-left leading-tight">
+                    <span className="text-muted-foreground">Logged in as</span>
+                    <span className="text-sidebar-foreground">{user.email}</span>
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-muted-foreground p-1">
+                  Projects{currentWorkspace ? ` in ${currentWorkspace.name}` : ""}
+                </DropdownMenuLabel>
+                {projects.map((project) => (
+                  <Link
+                    key={project.id}
+                    passHref
+                    href={`/project/${project.id}/traces`}
+                    onClick={() => setLastProjectIdCookie(project.id)}
                   >
-                    <span className="text-xs text-sidebar-foreground font-medium">{project.name}</span>
-                  </DropdownMenuItem>
-                </Link>
-              ))}
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-muted-foreground p-1">Workspaces</DropdownMenuLabel>
-              {workspaces?.map((w) => (
-                <Link key={w.id} passHref href={`/workspace/${w.id}`}>
-                  <DropdownMenuItem
-                    onSelect={() => setLastWorkspaceIdCookie(w.id)}
-                    className={cn("cursor-pointer", {
-                      "bg-accent": w.id === workspaceId,
-                    })}
-                  >
-                    <div title={w.name} className="text-xs text-sidebar-foreground font-medium truncate">
-                      {w.name}
-                    </div>
-                    <span
-                      className={cn(
-                        "text-xs text-secondary-foreground py-0 px-1.5 rounded-md bg-secondary/40 font-mono border border-secondary-foreground/20",
-                        {
-                          "border-primary bg-primary/10 text-primary": w.tierName === "Pro",
-                        }
-                      )}
+                    <DropdownMenuItem
+                      className={cn("cursor-pointer", {
+                        "bg-accent": project.id === projectId,
+                      })}
                     >
-                      {w.tierName}
-                    </span>
-                  </DropdownMenuItem>
-                </Link>
-              ))}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleLogout}>
-                <LogOut />
-                <span className="text-xs">Log out</span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+                      <span className="text-xs text-sidebar-foreground font-medium">{project.name}</span>
+                    </DropdownMenuItem>
+                  </Link>
+                ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-muted-foreground p-1">Workspaces</DropdownMenuLabel>
+                {workspaces?.map((w) => (
+                  <Link key={w.id} passHref href={`/workspace/${w.id}`}>
+                    <DropdownMenuItem
+                      onSelect={() => setLastWorkspaceIdCookie(w.id)}
+                      className={cn("cursor-pointer", {
+                        "bg-accent": w.id === workspaceId,
+                      })}
+                    >
+                      <div title={w.name} className="text-xs text-sidebar-foreground font-medium truncate">
+                        {w.name}
+                      </div>
+                      <span
+                        className={cn(
+                          "text-xs text-secondary-foreground py-0 px-1.5 rounded-md bg-secondary/40 font-mono border border-secondary-foreground/20",
+                          {
+                            "border-primary bg-primary/10 text-primary": w.tierName === "Pro",
+                          }
+                        )}
+                      >
+                        {w.tierName}
+                      </span>
+                    </DropdownMenuItem>
+                  </Link>
+                ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleLogout}>
+                  <LogOut />
+                  <span className="text-xs">Log out</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          {(open || openMobile) && <NotificationTrigger />}
         </SidebarMenuItem>
       </SidebarMenu>
     </SidebarHeader>

--- a/frontend/lib/actions/notifications/index.ts
+++ b/frontend/lib/actions/notifications/index.ts
@@ -46,6 +46,7 @@ export const getWebNotifications = async (
       FROM notifications
       WHERE project_id = {projectId: UUID}
         AND created_at >= now() - INTERVAL 1 MONTH
+        AND definition_type = 'REPORT'
       ORDER BY created_at DESC
       LIMIT {limit: UInt32}
     `,

--- a/frontend/lib/actions/notifications/index.ts
+++ b/frontend/lib/actions/notifications/index.ts
@@ -1,0 +1,86 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod/v4";
+
+import { clickhouseClient } from "@/lib/clickhouse/client";
+import { db } from "@/lib/db/drizzle";
+import { notificationReads } from "@/lib/db/migrations/schema";
+
+export interface WebNotification {
+  id: string;
+  projectId: string;
+  workspaceId: string;
+  definitionType: string;
+  definitionId: string;
+  payload: string;
+  createdAt: string;
+  isRead: boolean;
+}
+
+const GetWebNotificationsSchema = z.object({
+  projectId: z.guid(),
+  userId: z.guid(),
+  limit: z.number().int().positive().optional().default(30),
+});
+
+const MarkNotificationAsReadSchema = z.object({
+  userId: z.guid(),
+  notificationId: z.guid(),
+  projectId: z.guid(),
+});
+
+export const getWebNotifications = async (
+  input: z.input<typeof GetWebNotificationsSchema>
+): Promise<WebNotification[]> => {
+  const { projectId, userId, limit } = GetWebNotificationsSchema.parse(input);
+
+  const result = await clickhouseClient.query({
+    query: `
+      SELECT
+        notification_id as id,
+        project_id as projectId,
+        workspace_id as workspaceId,
+        definition_type as definitionType,
+        definition_id as definitionId,
+        payload,
+        formatDateTime(created_at, '%Y-%m-%dT%H:%i:%S.%fZ') as createdAt
+      FROM notifications
+      WHERE project_id = {projectId: UUID}
+        AND created_at >= now() - INTERVAL 1 MONTH
+      ORDER BY created_at DESC
+      LIMIT {limit: UInt32}
+    `,
+    query_params: { projectId, limit },
+    format: "JSONEachRow",
+  });
+
+  const notifications = (await result.json()) as Omit<WebNotification, "isRead">[];
+
+  if (notifications.length === 0) {
+    return [];
+  }
+
+  const notificationIds = notifications.map((n) => n.id);
+  const readRows = await db
+    .select({ notificationId: notificationReads.notificationId })
+    .from(notificationReads)
+    .where(
+      and(
+        eq(notificationReads.projectId, projectId),
+        eq(notificationReads.userId, userId),
+        inArray(notificationReads.notificationId, notificationIds)
+      )
+    );
+
+  const readIds = new Set(readRows.map((r) => r.notificationId));
+
+  return notifications.map((n) => ({
+    ...n,
+    isRead: readIds.has(n.id),
+  }));
+};
+
+export const markNotificationAsRead = async (input: z.infer<typeof MarkNotificationAsReadSchema>): Promise<void> => {
+  const { userId, notificationId, projectId } = MarkNotificationAsReadSchema.parse(input);
+
+  await db.insert(notificationReads).values({ userId, notificationId, projectId }).onConflictDoNothing();
+};

--- a/frontend/lib/authorization/index.ts
+++ b/frontend/lib/authorization/index.ts
@@ -143,6 +143,16 @@ export const isUserMemberOfWorkspace = async (workspaceId: string, userId: strin
   return isMember;
 };
 
+export const isProjectInWorkspace = async (projectId: string, workspaceId: string): Promise<boolean> => {
+  const result = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(and(eq(projects.id, projectId), eq(projects.workspaceId, workspaceId)))
+    .limit(1);
+
+  return result.length > 0;
+};
+
 /**
  * Returns the user's role in the workspace, or null if they are not a member.
  * Not cached — intended for middleware role checks on sensitive routes.

--- a/frontend/lib/db/migrations/0080_third_cammi.sql
+++ b/frontend/lib/db/migrations/0080_third_cammi.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "notification_reads" (
+	"project_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"notification_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "notification_reads_pkey" PRIMARY KEY("project_id","user_id","notification_id")
+);
+--> statement-breakpoint
+ALTER TABLE "notification_reads" ADD CONSTRAINT "notification_reads_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "notification_reads" ADD CONSTRAINT "notification_reads_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/frontend/lib/db/migrations/meta/0080_snapshot.json
+++ b/frontend/lib/db/migrations/meta/0080_snapshot.json
@@ -1,0 +1,3772 @@
+{
+  "id": "522ec4b4-6df4-4386-9759-1faa4f32ca88",
+  "prevId": "55507a2e-aff5-488f-9046-83b83d599d1b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alert_targets": {
+      "name": "alert_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_targets_alert_id_fkey": {
+          "name": "alert_targets_alert_id_fkey",
+          "tableFrom": "alert_targets",
+          "tableTo": "alerts",
+          "columnsFrom": ["alert_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_targets_project_id_fkey": {
+          "name": "alert_targets_project_id_fkey",
+          "tableFrom": "alert_targets",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alerts_project_id_fkey": {
+          "name": "alerts_project_id_fkey",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable insert for authenticated users only": {
+          "name": "Enable insert for authenticated users only",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["service_role"],
+          "using": "true",
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_model_costs": {
+      "name": "custom_model_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costs": {
+          "name": "costs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_model_costs_project_id_fkey": {
+          "name": "custom_model_costs_project_id_fkey",
+          "tableFrom": "custom_model_costs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_model_costs_project_id_provider_model_unique": {
+          "name": "custom_model_costs_project_id_provider_model_unique",
+          "nullsNotDistinct": false,
+          "columns": ["project_id", "provider", "model"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_charts": {
+      "name": "dashboard_charts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_charts_project_id_fkey": {
+          "name": "dashboard_charts_project_id_fkey",
+          "tableFrom": "dashboard_charts",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_export_jobs": {
+      "name": "dataset_export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dataset_export_jobs_dataset_id_fkey": {
+          "name": "dataset_export_jobs_dataset_id_fkey",
+          "tableFrom": "dataset_export_jobs",
+          "tableTo": "datasets",
+          "columnsFrom": ["dataset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_export_jobs_project_id_fkey": {
+          "name": "dataset_export_jobs_project_id_fkey",
+          "tableFrom": "dataset_export_jobs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dataset_export_jobs_project_dataset_key": {
+          "name": "dataset_export_jobs_project_dataset_key",
+          "nullsNotDistinct": false,
+          "columns": ["dataset_id", "project_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_parquets": {
+      "name": "dataset_parquets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parquet_path": {
+          "name": "parquet_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dataset_parquets_dataset_id_fkey": {
+          "name": "dataset_parquets_dataset_id_fkey",
+          "tableFrom": "dataset_parquets",
+          "tableTo": "datasets",
+          "columnsFrom": ["dataset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_parquets_project_id_fkey": {
+          "name": "dataset_parquets_project_id_fkey",
+          "tableFrom": "dataset_parquets",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "indexed_on": {
+          "name": "indexed_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "datasets_project_id_hash_idx": {
+          "name": "datasets_project_id_hash_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_project_id_fkey": {
+          "name": "datasets_project_id_fkey",
+          "tableFrom": "datasets",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluations": {
+      "name": "evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "evaluations_project_id_hash_idx": {
+          "name": "evaluations_project_id_hash_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluations_project_id_fkey": {
+          "name": "evaluations_project_id_fkey",
+          "tableFrom": "evaluations",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "select_by_next_api_key": {
+          "name": "select_by_next_api_key",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["anon", "authenticated"],
+          "using": "is_evaluation_id_accessible_for_api_key(api_key(), id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluator_scores": {
+      "name": "evaluator_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evaluator_id": {
+          "name": "evaluator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluator_scores_project_id_fkey": {
+          "name": "evaluator_scores_project_id_fkey",
+          "tableFrom": "evaluator_scores",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluator_span_paths": {
+      "name": "evaluator_span_paths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evaluator_id": {
+          "name": "evaluator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "span_path": {
+          "name": "span_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluator_span_paths_evaluator_id_fkey": {
+          "name": "evaluator_span_paths_evaluator_id_fkey",
+          "tableFrom": "evaluator_span_paths",
+          "tableTo": "evaluators",
+          "columnsFrom": ["evaluator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluator_span_paths_project_id_fkey": {
+          "name": "evaluator_span_paths_project_id_fkey",
+          "tableFrom": "evaluator_span_paths",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluators": {
+      "name": "evaluators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluator_type": {
+          "name": "evaluator_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluators_project_id_fkey": {
+          "name": "evaluators_project_id_fkey",
+          "tableFrom": "evaluators",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_cluster_configs": {
+      "name": "event_cluster_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_template": {
+          "name": "value_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_source": {
+          "name": "event_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_cluster_configs_project_id_fkey": {
+          "name": "event_cluster_configs_project_id_fkey",
+          "tableFrom": "event_cluster_configs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_cluster_configs_project_id_event_name_source_key": {
+          "name": "event_cluster_configs_project_id_event_name_source_key",
+          "nullsNotDistinct": false,
+          "columns": ["event_name", "project_id", "event_source"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_definitions": {
+      "name": "event_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_semantic": {
+          "name": "is_semantic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "structured_output": {
+          "name": "structured_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_definitions_project_id_fkey": {
+          "name": "event_definitions_project_id_fkey",
+          "tableFrom": "event_definitions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_definitions_project_id_name_key": {
+          "name": "event_definitions_project_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": ["name", "project_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeling_queue_items": {
+      "name": "labeling_queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "labeling_queue_items_queue_id_idempotency_key_idx": {
+          "name": "labeling_queue_items_queue_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "queue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(idempotency_key IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeling_queue_items_queue_id_idx": {
+          "name": "labeling_queue_items_queue_id_idx",
+          "columns": [
+            {
+              "expression": "queue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeling_queue_items_queue_ordering_idx": {
+          "name": "labeling_queue_items_queue_ordering_idx",
+          "columns": [
+            {
+              "expression": "queue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labelling_queue_items_queue_id_fkey": {
+          "name": "labelling_queue_items_queue_id_fkey",
+          "tableFrom": "labeling_queue_items",
+          "tableTo": "labeling_queues",
+          "columnsFrom": ["queue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeling_queues": {
+      "name": "labeling_queues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotation_schema": {
+          "name": "annotation_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labeling_queues_project_id_fkey": {
+          "name": "labeling_queues_project_id_fkey",
+          "tableFrom": "labeling_queues",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_prices": {
+      "name": "llm_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_price_per_million": {
+          "name": "input_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_price_per_million": {
+          "name": "output_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_cached_price_per_million": {
+          "name": "input_cached_price_per_million",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_prices": {
+          "name": "additional_prices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members_of_workspaces": {
+      "name": "members_of_workspaces",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_role": {
+          "name": "member_role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        }
+      },
+      "indexes": {
+        "members_of_workspaces_user_id_idx": {
+          "name": "members_of_workspaces_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_of_workspaces_user_id_fkey": {
+          "name": "members_of_workspaces_user_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "members_of_workspaces_workspace_id_fkey": {
+          "name": "members_of_workspaces_workspace_id_fkey",
+          "tableFrom": "members_of_workspaces",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_of_workspaces_user_workspace_unique": {
+          "name": "members_of_workspaces_user_workspace_unique",
+          "nullsNotDistinct": false,
+          "columns": ["workspace_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_costs": {
+      "name": "model_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costs": {
+          "name": "costs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_costs_model_unique": {
+          "name": "model_costs_model_unique",
+          "nullsNotDistinct": false,
+          "columns": ["model"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reads": {
+      "name": "notification_reads",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_reads_project_id_fkey": {
+          "name": "notification_reads_project_id_fkey",
+          "tableFrom": "notification_reads",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_reads_user_id_fkey": {
+          "name": "notification_reads_user_id_fkey",
+          "tableFrom": "notification_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notification_reads_pkey": {
+          "name": "notification_reads_pkey",
+          "columns": ["project_id", "user_id", "notification_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playgrounds": {
+      "name": "playgrounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_messages": {
+          "name": "prompt_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[{\"role\":\"user\",\"content\":\"\"}]'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1024
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1'"
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playgrounds_project_id_fkey": {
+          "name": "playgrounds_project_id_fkey",
+          "tableFrom": "playgrounds",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_api_keys": {
+      "name": "project_api_keys",
+      "schema": "",
+      "columns": {
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shorthand": {
+          "name": "shorthand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_ingest_only": {
+          "name": "is_ingest_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "project_api_keys_hash_idx": {
+          "name": "project_api_keys_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_project_api_keys_project_id_fkey": {
+          "name": "public_project_api_keys_project_id_fkey",
+          "tableFrom": "project_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_workspace_id_idx": {
+          "name": "projects_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_fkey": {
+          "name": "projects_workspace_id_fkey",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_api_keys": {
+      "name": "provider_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hex": {
+          "name": "nonce_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_api_keys_project_id_fkey": {
+          "name": "provider_api_keys_project_id_fkey",
+          "tableFrom": "provider_api_keys",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_templates": {
+      "name": "render_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "render_templates_project_id_fkey": {
+          "name": "render_templates_project_id_fkey",
+          "tableFrom": "render_templates",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_targets": {
+      "name": "report_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "report_targets_report_id_fkey": {
+          "name": "report_targets_report_id_fkey",
+          "tableFrom": "report_targets",
+          "tableTo": "reports",
+          "columnsFrom": ["report_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_targets_workspace_id_fkey": {
+          "name": "report_targets_workspace_id_fkey",
+          "tableFrom": "report_targets",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekdays": {
+          "name": "weekdays",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_workspace_id_fkey": {
+          "name": "reports_workspace_id_fkey",
+          "tableFrom": "reports",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollout_sessions": {
+      "name": "rollout_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollout_sessions_project_id_fkey": {
+          "name": "rollout_sessions_project_id_fkey",
+          "tableFrom": "rollout_sessions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_evals": {
+      "name": "shared_evals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shared_evals_project_id_fkey": {
+          "name": "shared_evals_project_id_fkey",
+          "tableFrom": "shared_evals",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_payloads": {
+      "name": "shared_payloads",
+      "schema": "",
+      "columns": {
+        "payload_id": {
+          "name": "payload_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shared_payloads_project_id_fkey": {
+          "name": "shared_payloads_project_id_fkey",
+          "tableFrom": "shared_payloads",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_traces": {
+      "name": "shared_traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shared_traces_project_id_fkey": {
+          "name": "shared_traces_project_id_fkey",
+          "tableFrom": "shared_traces",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_jobs": {
+      "name": "signal_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_traces": {
+          "name": "total_traces",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_traces": {
+          "name": "processed_traces",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_traces": {
+          "name": "failed_traces",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "signal_jobs_project_id_idx": {
+          "name": "signal_jobs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_jobs_signal_id_idx": {
+          "name": "signal_jobs_signal_id_idx",
+          "columns": [
+            {
+              "expression": "signal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "signal_jobs_project_id_fkey": {
+          "name": "signal_jobs_project_id_fkey",
+          "tableFrom": "signal_jobs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_jobs_signal_id_fkey": {
+          "name": "signal_jobs_signal_id_fkey",
+          "tableFrom": "signal_jobs",
+          "tableTo": "signals",
+          "columnsFrom": ["signal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_triggers": {
+      "name": "signal_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_triggers_project_id_fkey": {
+          "name": "signal_triggers_project_id_fkey",
+          "tableFrom": "signal_triggers",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_triggers_signal_id_fkey": {
+          "name": "signal_triggers_signal_id_fkey",
+          "tableFrom": "signal_triggers",
+          "tableTo": "signals",
+          "columnsFrom": ["signal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signals": {
+      "name": "signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structured_output_schema": {
+          "name": "structured_output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sample_rate": {
+          "name": "sample_rate",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signals_project_id_fkey": {
+          "name": "signals_project_id_fkey",
+          "tableFrom": "signals",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signals_project_id_name_key": {
+          "name": "signals_project_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": ["project_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_integrations": {
+      "name": "slack_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nonce_hex": {
+          "name": "nonce_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_integrations_workspace_id_fkey": {
+          "name": "slack_integrations_workspace_id_fkey",
+          "tableFrom": "slack_integrations",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_integrations_workspace_id_key": {
+          "name": "slack_integrations_workspace_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["workspace_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.span_rendering_keys": {
+      "name": "span_rendering_keys",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_fingerprint": {
+          "name": "schema_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mustache_key": {
+          "name": "mustache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "span_rendering_keys_project_id_fkey": {
+          "name": "span_rendering_keys_project_id_fkey",
+          "tableFrom": "span_rendering_keys",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "span_rendering_keys_pkey": {
+          "name": "span_rendering_keys_pkey",
+          "columns": ["project_id", "schema_fingerprint"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sql_templates": {
+      "name": "sql_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sql_templates_project_id_fkey": {
+          "name": "sql_templates_project_id_fkey",
+          "tableFrom": "sql_templates",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "subscription_tiers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_retention_days": {
+          "name": "log_retention_days",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bytes_ingested": {
+          "name": "bytes_ingested",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "extra_byte_price": {
+          "name": "extra_byte_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "signal_runs": {
+          "name": "signal_runs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_signal_run_price": {
+          "name": "extra_signal_run_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_classes": {
+      "name": "tag_classes",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rgb(190, 194, 200)'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tag_classes_project_id_fkey": {
+          "name": "tag_classes_project_id_fkey",
+          "tableFrom": "tag_classes",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tag_classes_pkey": {
+          "name": "tag_classes_pkey",
+          "columns": ["name", "project_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "tag_classes_name_project_id_unique": {
+          "name": "tag_classes_name_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name", "project_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traces": {
+      "name": "traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_token_count": {
+          "name": "total_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "input_cost": {
+          "name": "input_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "output_cost": {
+          "name": "output_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "has_browser_session": {
+          "name": "has_browser_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_span_id": {
+          "name": "top_span_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_spans": {
+          "name": "num_spans",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_span_name": {
+          "name": "top_span_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_span_type": {
+          "name": "top_span_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_type": {
+          "name": "trace_type",
+          "type": "trace_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "span_names": {
+          "name": "span_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_span_input": {
+          "name": "root_span_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_span_output": {
+          "name": "root_span_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "traces_pkey": {
+          "name": "traces_pkey",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_project_id_idx": {
+          "name": "traces_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_session_id_idx": {
+          "name": "traces_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_traces_project_id_fkey": {
+          "name": "new_traces_project_id_fkey",
+          "tableFrom": "traces",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "traces_pkey_constraint": {
+          "name": "traces_pkey_constraint",
+          "columns": ["id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "select_by_next_api_key": {
+          "name": "select_by_next_api_key",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["anon", "authenticated"],
+          "using": "is_project_id_accessible_for_api_key(api_key(), project_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traces_agent_chats": {
+      "name": "traces_agent_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "traces_agent_chats_project_id_fkey": {
+          "name": "traces_agent_chats_project_id_fkey",
+          "tableFrom": "traces_agent_chats",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traces_agent_messages": {
+      "name": "traces_agent_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "traces_agent_messages_project_id_fkey": {
+          "name": "traces_agent_messages_project_id_fkey",
+          "tableFrom": "traces_agent_messages",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscription_info": {
+      "name": "user_subscription_info",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_subscription_info_stripe_customer_id_idx": {
+          "name": "user_subscription_info_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscription_info_fkey": {
+          "name": "user_subscription_info_fkey",
+          "tableFrom": "user_subscription_info",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {
+        "Enable insert for authenticated users only": {
+          "name": "Enable insert for authenticated users only",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["service_role"],
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_addons": {
+      "name": "workspace_addons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addon_slug": {
+          "name": "addon_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_addons_workspace_id_fkey": {
+          "name": "workspace_addons_workspace_id_fkey",
+          "tableFrom": "workspace_addons",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_deployments": {
+      "name": "workspace_deployments",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLOUD'"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "private_key_nonce": {
+          "name": "private_key_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "data_plane_url": {
+          "name": "data_plane_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "data_plane_url_nonce": {
+          "name": "data_plane_url_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_invitations_workspace_id_fkey": {
+          "name": "workspace_invitations_workspace_id_fkey",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_usage": {
+      "name": "workspace_usage",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "signal_runs": {
+          "name": "signal_runs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_reported_date": {
+          "name": "last_reported_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('day'::text, now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_usage_workspace_id_fkey": {
+          "name": "workspace_usage_workspace_id_fkey",
+          "tableFrom": "workspace_usage",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_usage_limits": {
+      "name": "workspace_usage_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_usage_limits_workspace_id_fkey": {
+          "name": "workspace_usage_limits_workspace_id_fkey",
+          "tableFrom": "workspace_usage_limits",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_usage_limits_workspace_id_limit_type_unique": {
+          "name": "workspace_usage_limits_workspace_id_limit_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["workspace_id", "limit_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_usage_warnings": {
+      "name": "workspace_usage_warnings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_item": {
+          "name": "usage_item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_notified_at": {
+          "name": "last_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_usage_warnings_workspace_id_fkey": {
+          "name": "workspace_usage_warnings_workspace_id_fkey",
+          "tableFrom": "workspace_usage_warnings",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_usage_warnings_workspace_id_usage_item_limit_value_un": {
+          "name": "workspace_usage_warnings_workspace_id_usage_item_limit_value_un",
+          "nullsNotDistinct": false,
+          "columns": ["workspace_id", "usage_item", "limit_value"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_seats": {
+          "name": "additional_seats",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "reset_time": {
+          "name": "reset_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_tier_id_fkey": {
+          "name": "workspaces_tier_id_fkey",
+          "tableFrom": "workspaces",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": ["tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_machine_status": {
+      "name": "agent_machine_status",
+      "schema": "public",
+      "values": ["not_started", "running", "paused", "stopped"]
+    },
+    "public.agent_message_type": {
+      "name": "agent_message_type",
+      "schema": "public",
+      "values": ["user", "assistant", "step", "error"]
+    },
+    "public.span_type": {
+      "name": "span_type",
+      "schema": "public",
+      "values": [
+        "DEFAULT",
+        "LLM",
+        "PIPELINE",
+        "EXECUTOR",
+        "EVALUATOR",
+        "EVALUATION",
+        "TOOL",
+        "HUMAN_EVALUATOR",
+        "EVENT"
+      ]
+    },
+    "public.tag_source": {
+      "name": "tag_source",
+      "schema": "public",
+      "values": ["MANUAL", "AUTO", "CODE"]
+    },
+    "public.trace_type": {
+      "name": "trace_type",
+      "schema": "public",
+      "values": ["DEFAULT", "EVENT", "EVALUATION", "PLAYGROUND"]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": ["member", "owner", "admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -561,6 +561,13 @@
       "when": 1774978896688,
       "tag": "0079_abandoned_gorgon",
       "breakpoints": true
+    },
+    {
+      "idx": 80,
+      "version": "7",
+      "when": 1775557271129,
+      "tag": "0080_third_cammi",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/db/migrations/schema.ts
+++ b/frontend/lib/db/migrations/schema.ts
@@ -1064,6 +1064,29 @@ export const signalTriggers = pgTable(
   ]
 );
 
+export const notificationReads = pgTable(
+  "notification_reads",
+  {
+    projectId: uuid("project_id").notNull(),
+    userId: uuid("user_id").notNull(),
+    notificationId: uuid("notification_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.projectId, table.userId, table.notificationId], name: "notification_reads_pkey" }),
+    foreignKey({
+      columns: [table.projectId],
+      foreignColumns: [projects.id],
+      name: "notification_reads_project_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "notification_reads_user_id_fkey",
+    }).onDelete("cascade"),
+  ]
+);
+
 export const spanRenderingKeys = pgTable(
   "span_rendering_keys",
   {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new authenticated API routes and a Postgres table to track per-user read state, plus client UI that fetches/updates this state; also introduces MQ payload-size enforcement that can now drop oversized delivery fan-outs. Risk is moderate due to new persistence and request paths affecting notification visibility and delivery reliability.
> 
> **Overview**
> **Adds in-app notifications.** The project layout now includes a slide-out `NotificationPanel` and a sidebar bell trigger (Zustand state + SWR fetching) that renders recent report notifications and marks them read.
> 
> **Introduces notification APIs + read tracking.** New `/api/workspaces/[workspaceId]/notifications` `GET`/`POST` endpoints fetch recent ClickHouse `notifications` for a project and persist per-user read state in a new Postgres `notification_reads` table (Drizzle schema + migration), with an added `isProjectInWorkspace` guard.
> 
> **Hardens backend fan-out.** The Rust notifications handler now serializes each delivery message to pre-check size against `mq_max_payload()` and skips publishing/logs an error when the MQ payload limit would be exceeded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5653aa62c7ba81c9fa35ad37f48a3d5a34ef0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->