### PR TITLE
severity notification

### DIFF
--- a/app-server/src/ch/signal_events.rs
+++ b/app-server/src/ch/signal_events.rs
@@ -25,6 +25,8 @@ pub struct CHSignalEvent {
     /// Timestamp in nanoseconds
     pub timestamp: i64,
     pub summary: String,
+    /// 0 = info, 1 = warning, 2 = critical
+    pub severity: u8,
 }
 
 impl CHSignalEvent {
@@ -38,6 +40,7 @@ impl CHSignalEvent {
         payload: Value,
         timestamp: chrono::DateTime<chrono::Utc>,
         summary: String,
+        severity: u8,
     ) -> Self {
         Self {
             id,
@@ -49,6 +52,7 @@ impl CHSignalEvent {
             payload: payload.to_string(),
             timestamp: chrono_to_nanoseconds(timestamp),
             summary,
+            severity,
         }
     }
 

--- a/app-server/src/signals/postprocess.rs
+++ b/app-server/src/signals/postprocess.rs
@@ -26,39 +26,42 @@ pub async fn process_event_notifications_and_clustering(
     let event_name = signal_event.name().to_string();
     let attributes = signal_event.payload_value().unwrap_or_default();
 
-    let alerts = db::alert_targets::get_alerts_for_event(&db.pool, project_id, &event_name).await?;
+    if signal_event.severity >= 1 {
+        let alerts =
+            db::alert_targets::get_alerts_for_event(&db.pool, project_id, &event_name).await?;
 
-    for alert in alerts {
-        let notification_message = notifications::NotificationMessage {
-            definition_type: NotificationDefinitionType::Alert,
-            definition_id: alert.alert_id,
-            workspace_id: alert.workspace_id,
-            project_id: Some(project_id),
-            notifications: vec![NotificationKind::EventIdentification {
-                project_id,
-                trace_id,
-                event_name: event_name.clone(),
-                extracted_information: Some(attributes.clone()),
-            }],
-        };
+        for alert in alerts {
+            let notification_message = notifications::NotificationMessage {
+                definition_type: NotificationDefinitionType::Alert,
+                definition_id: alert.alert_id,
+                workspace_id: alert.workspace_id,
+                project_id: Some(project_id),
+                notifications: vec![NotificationKind::EventIdentification {
+                    project_id,
+                    trace_id,
+                    event_name: event_name.clone(),
+                    extracted_information: Some(attributes.clone()),
+                }],
+            };
 
-        let serialized_size = serde_json::to_vec(&notification_message)
-            .map(|v| v.len())
-            .unwrap_or(0);
-        if serialized_size >= mq_max_payload() {
-            log::error!(
-                "MQ payload limit exceeded for event {}: payload size [{}]",
-                event_name,
-                serialized_size,
-            );
-        } else if let Err(e) =
-            notifications::push_to_notification_queue(notification_message, queue.clone()).await
-        {
-            log::error!(
-                "Failed to push to notification queue for event {}: {:?}",
-                event_name,
-                e
-            );
+            let serialized_size = serde_json::to_vec(&notification_message)
+                .map(|v| v.len())
+                .unwrap_or(0);
+            if serialized_size >= mq_max_payload() {
+                log::error!(
+                    "MQ payload limit exceeded for event {}: payload size [{}]",
+                    event_name,
+                    serialized_size,
+                );
+            } else if let Err(e) =
+                notifications::push_to_notification_queue(notification_message, queue.clone()).await
+            {
+                log::error!(
+                    "Failed to push to notification queue for event {}: {:?}",
+                    event_name,
+                    e
+                );
+            }
         }
     }
 

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -37,6 +37,7 @@ You have exactly three tools available:
    When "identified" is true, you MUST also provide:
      - "data" (object) — the extracted information matching the developer's schema.
      - "summary" (string) — a short summary of the identification result used for event clustering.
+     - "severity" (string) — one of "critical", "warning", or "info" indicating how severe the finding is.
 
 <tool_selection_guidance>
 - NEVER call `search_in_spans` or `get_full_spans` on `<empty>` fields.
@@ -73,7 +74,7 @@ NEVER reference a span solely by its id, always use the <span> xml tag with the 
 pub const IDENTIFICATION_PROMPT: &str = r#"You are analyzing a trace to answer a developer's question. The developer has defined a signal with a prompt and a structured output schema. Your job is to determine whether the information described by the developer's prompt can be found in the trace, and if so, extract it as structured data matching their schema.
 
 There are exactly two outcomes:
-- The information IS present in the trace: call submit_identification with identified=true, along with the extracted "data" and a short "summary".
+- The information IS present in the trace: call submit_identification with identified=true, along with the extracted "data", a short "summary", and a "severity" assessment ("critical", "warning", or "info").
 - The information is NOT present in the trace: call submit_identification with identified=false.
 
 Follow the developer's prompt strictly. Extract only what the prompt asks for — nothing more. The developer's prompt may use phrasing like "You are ..." or other instructional language; interpret their intent but always return your result through a function call, never as plain text.
@@ -89,9 +90,9 @@ pub const SEARCH_IN_SPANS_DESCRIPTION: &str = "Searches within span input/output
 
 pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when search_in_spans cannot find what you need. Do NOT use this when `input_truncated`/`output_truncated` flags are absent — the data is already complete. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
 
-pub const SUBMIT_IDENTIFICATION_DESCRIPTION: &str = "REQUIRED: This is the ONLY valid way to complete your analysis — never respond with plain text. Submits the final identification result. You MUST always provide the required 'identified' boolean argument. When identified=true, you MUST also provide 'summary' (short string for event clustering) and 'data' (object matching the developer's schema). When identified=false, 'identified' is still required.";
+pub const SUBMIT_IDENTIFICATION_DESCRIPTION: &str = "REQUIRED: This is the ONLY valid way to complete your analysis — never respond with plain text. Submits the final identification result. You MUST always provide the required 'identified' boolean argument. When identified=true, you MUST also provide 'summary' (short string for event clustering), 'data' (object matching the developer's schema), and 'severity' (one of 'critical', 'warning', or 'info'). When identified=false, 'identified' is still required.";
 
-pub const MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE: &str = "The previous function call was malformed. Please retry calling the same function. Make sure to use the expected function call formatting and include ALL required arguments. For search_in_spans: 'searches' array is required, each search with 'span_id', 'literal', 'search_in', and 'reasoning'. For get_full_spans: 'reasoning' and 'span_ids' are required. For submit_identification: 'identified' is required, and when identified=true, 'summary' and 'data' are also required.";
+pub const MALFORMED_FUNCTION_CALL_RETRY_GUIDANCE: &str = "The previous function call was malformed. Please retry calling the same function. Make sure to use the expected function call formatting and include ALL required arguments. For search_in_spans: 'searches' array is required, each search with 'span_id', 'literal', 'search_in', and 'reasoning'. For get_full_spans: 'reasoning' and 'span_ids' are required. For submit_identification: 'identified' is required, and when identified=true, 'summary', 'data', and 'severity' are also required.";
 
 pub const BATCH_SUMMARIZATION_PROMPT: &str = r#"Given this signal description that a developer wants to detect in traces:
 <signal_description>

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -47,6 +47,7 @@ pub enum StepResult {
     CompletedWithEvent {
         attributes: serde_json::Value,
         summary: String,
+        severity: u8,
     },
     RequiresNextStep {
         reason: NextStepReason,
@@ -154,12 +155,14 @@ pub async fn process_provider_responses(
             StepResult::CompletedWithEvent {
                 attributes,
                 summary,
+                severity,
             } => {
                 match handle_create_event(
                     signal_message,
                     &run,
                     attributes,
                     summary,
+                    severity,
                     clickhouse.clone(),
                     db.clone(),
                     queue.clone(),
@@ -468,10 +471,12 @@ async fn process_single_response(
             StepResult::CompletedWithEvent {
                 attributes,
                 summary,
+                severity,
             } => (
                 StepResult::CompletedWithEvent {
                     attributes,
                     summary,
+                    severity,
                 },
                 new_messages,
             ),
@@ -683,11 +688,23 @@ pub async fn handle_tool_call(
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string())
                 .unwrap_or_default();
+            let severity = function_call
+                .args
+                .as_ref()
+                .and_then(|args| args.get("severity"))
+                .and_then(|v| v.as_str())
+                .map(|s| match s {
+                    "critical" => 2u8,
+                    "warning" => 1u8,
+                    _ => 0u8,
+                })
+                .unwrap_or(0u8);
 
             if identified {
                 StepResult::CompletedWithEvent {
                     attributes,
                     summary,
+                    severity,
                 }
             } else {
                 StepResult::CompletedNoEvent
@@ -706,6 +723,7 @@ pub async fn handle_create_event(
     run: &SignalRun,
     attributes: serde_json::Value,
     summary: String,
+    severity: u8,
     clickhouse: clickhouse::Client,
     db: Arc<DB>,
     queue: Arc<MessageQueue>,
@@ -747,6 +765,7 @@ pub async fn handle_create_event(
         attrs,
         timestamp,
         summary,
+        severity,
     );
     insert_signal_events(clickhouse, vec![signal_event.clone()]).await?;
 

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -238,8 +238,10 @@ pub async fn finalize_runs(
             let cache = cache.clone();
             let queue = queue.clone();
             async move {
-                if let Err(e) =
-                    update_workspace_signal_runs_used(db, clickhouse, cache, queue, project_id, runs).await
+                if let Err(e) = update_workspace_signal_runs_used(
+                    db, clickhouse, cache, queue, project_id, runs,
+                )
+                .await
                 {
                     log::error!("Failed to update workspace signal runs used: {}", e);
                 }
@@ -696,9 +698,16 @@ pub async fn handle_tool_call(
                 .map(|s| match s {
                     "critical" => 2u8,
                     "warning" => 1u8,
-                    _ => 0u8,
+                    "info" => 0u8,
+                    other => {
+                        log::warn!(
+                            "Unknown severity value '{}', defaulting to warning (1)",
+                            other
+                        );
+                        1u8
+                    }
                 })
-                .unwrap_or(0u8);
+                .unwrap_or(1u8);
 
             if identified {
                 StepResult::CompletedWithEvent {

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -707,7 +707,7 @@ pub async fn handle_tool_call(
                         1u8
                     }
                 })
-                .unwrap_or(1u8);
+                .unwrap_or(0u8);
 
             if identified {
                 StepResult::CompletedWithEvent {

--- a/app-server/src/signals/tools.rs
+++ b/app-server/src/signals/tools.rs
@@ -119,6 +119,11 @@ pub fn build_tool_definitions(output_schema: &Value) -> ProviderTool {
                     "summary":  {
                         "type": "string",
                         "description": "REQUIRED when identified=true. A short summary of the identification result, used for clustering of events. You MUST provide this field whenever identified=true."
+                    },
+                    "severity": {
+                        "type": "string",
+                        "enum": ["critical", "warning", "info"],
+                        "description": "REQUIRED when identified=true. The severity of the identified event. 'critical' = system failures or problems with severe user impact that demand immediate attention. 'warning' = degraded behavior, notable issues, or problems that should be reviewed soon. 'info' = minor observations, expected edge cases, or low-impact findings."
                     }
                 },
                 "required": ["identified"]
@@ -223,9 +228,9 @@ pub async fn get_full_spans(
                 end: nanoseconds_to_iso(ch_span.end_time),
                 status: ch_span.status.clone(),
                 input: clean_whitespace(&stringify_value(&input_value)),
-                output: clean_whitespace(&stringify_value(
-                    &try_parse_json(&strip_noise(&ch_span.output)),
-                )),
+                output: clean_whitespace(&stringify_value(&try_parse_json(&strip_noise(
+                    &ch_span.output,
+                )))),
                 parent,
                 exception,
             }

--- a/app-server/src/signals/tools.rs
+++ b/app-server/src/signals/tools.rs
@@ -126,7 +126,7 @@ pub fn build_tool_definitions(output_schema: &Value) -> ProviderTool {
                         "description": "REQUIRED when identified=true. The severity of the identified event. 'critical' = system failures or problems with severe user impact that demand immediate attention. 'warning' = degraded behavior, notable issues, or problems that should be reviewed soon. 'info' = minor observations, expected edge cases, or low-impact findings."
                     }
                 },
-                "required": ["identified"]
+                "required": ["identified", "severity"]
             }),
         },
     ];

--- a/app-server/src/signals/tools.rs
+++ b/app-server/src/signals/tools.rs
@@ -126,7 +126,7 @@ pub fn build_tool_definitions(output_schema: &Value) -> ProviderTool {
                         "description": "REQUIRED when identified=true. The severity of the identified event. 'critical' = system failures or problems with severe user impact that demand immediate attention. 'warning' = degraded behavior, notable issues, or problems that should be reviewed soon. 'info' = minor observations, expected edge cases, or low-impact findings."
                     }
                 },
-                "required": ["identified", "severity"]
+                "required": ["identified"]
             }),
         },
     ];

--- a/frontend/lib/clickhouse/migrations/39_signal_events_severity.sql
+++ b/frontend/lib/clickhouse/migrations/39_signal_events_severity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE signal_events ADD COLUMN IF NOT EXISTS severity UInt8 DEFAULT 0;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new persisted `severity` field for signal events and changes notification behavior to only alert on warning/critical events, which could affect downstream consumers and alerting expectations. Requires ClickHouse schema migration and coordinated rollout with any writers/readers of `signal_events`.
> 
> **Overview**
> Adds a `severity` attribute to signal identification results, stores it on `signal_events` in ClickHouse, and threads it through the signal response processing pipeline (LLM `submit_identification` → `StepResult` → `CHSignalEvent`).
> 
> Alert notifications are now *suppressed for low-severity events* by gating alert target lookups/queue pushes on `severity >= 1` (warning/critical). Includes a ClickHouse migration to add `signal_events.severity UInt8 DEFAULT 0` and updates tool/prompt contracts to require a `severity` string when `identified=true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc7c2806bee3ae3b9cd7537748dbac18e7c93a03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->