### PR TITLE
agent prompt

### DIFF
--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -21,4 +21,4 @@ pub const SAMPLING_FACTORS_CACHE_KEY: &str = "sampling_factors";
 pub const WORKSPACE_USAGE_WARNINGS_CACHE_KEY: &str = "workspace_usage_warnings";
 pub const USAGE_WARNING_SEND_LOCK_KEY: &str = "usage_warning_send_lock";
 pub const SYS_PROMPT_SUMMARY_CACHE_KEY: &str = "sys_prompt_summary";
-pub const SPAN_DROP_RULES_CACHE_KEY: &str = "span_drop_rules_v2";
+pub const SPAN_DROP_RULES_CACHE_KEY: &str = "span_drop_rules_v3";

--- a/app-server/src/signals/filter.rs
+++ b/app-server/src/signals/filter.rs
@@ -22,7 +22,7 @@ use crate::signals::utils::{
 
 use super::summarize::hash_signal_prompt;
 
-const FILTER_CACHE_TTL_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days
+const FILTER_CACHE_TTL_SECONDS: u64 = 7 * 24 * 60 * 60; // 7 days
 const MAX_TRACE_STRING_LEN: usize = 1_000_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/app-server/src/signals/filter.rs
+++ b/app-server/src/signals/filter.rs
@@ -95,16 +95,24 @@ fn build_filter_tool_definitions() -> Vec<ProviderTool> {
                     "Every span you drop saves tokens and helps the signal agent focus on what matters.\n\n",
 
                     "WHEN TO USE:\n",
-                    "- `default` type spans: drop aggressively. These are almost always orchestration ",
-                    "scaffolding (entry points, message relay, wrappers) that duplicates content already ",
+                    "- `default` type spans: drop aggressively. Almost always orchestration ",
+                    "scaffolding (entry points, message relay, wrappers) that duplicates content ",
                     "visible in adjacent `llm` or `tool` spans.\n",
-                    "- `llm` and `tool` type spans: rarely drop. These carry the agent's core reasoning ",
-                    "and execution. Only drop if a specific pattern is pure infrastructure ",
-                    "(e.g. an internal SDK span that wraps the real LLM call with no added content).\n\n",
+                    "- `tool` type spans: keep most, drop selectively. Tools that confirm an action ",
+                    "with a trivial output ('Waited', 'Done', 'OK') or repeat dozens of times at the ",
+                    "same path with identical outputs are noise.\n",
+                    "- `llm` type spans: keep most, drop selectively. Core reasoning and decision-making ",
+                    "spans are high-value. But cheap/small model calls doing mechanical work (parsing, ",
+                    "format checking, classification) that repeat at the same path with predictable ",
+                    "outputs are droppable.\n\n",
+
+                    "STRONGEST SIGNAL FOR DROPPING: repetition. If a pattern appears many times at the ",
+                    "same path with no variation in outcome, drop it. Spans with exceptions bypass ",
+                    "filters regardless, so error cases are safe.\n\n",
 
                     "RULE MECHANICS:\n",
-                    "A span is dropped if it matches ANY rule. Within a rule, ALL field matchers must match (AND semantics). ",
-                    "Every rule MUST include at least one 'name' or 'path' matcher.\n\n",
+                    "A span is dropped if it matches ANY rule. Within a rule, ALL field matchers must ",
+                    "match (AND semantics). Every rule MUST include at least one 'name' or 'path' matcher.\n\n",
 
                     "Prefer 'name' or 'path' matchers ONLY. Avoid 'input'/'output' matchers unless ",
                     "you need to disambiguate spans that share a name but differ in relevance — ",
@@ -129,7 +137,8 @@ fn build_filter_tool_definitions() -> Vec<ProviderTool> {
                     "Do NOT add a rule if:\n",
                     "- You are unsure whether the span pattern ever contains signal — when in doubt, keep it\n",
                     "- The rule has no 'name' or 'path' matcher\n",
-                    "- The pattern is so broad it could match unrelated spans across different trace shapes",
+                    "- The pattern is so broad it could match unrelated spans across different trace shapes\n",
+                    "- You're trying to preserve error cases (they bypass filters automatically)",
                 )
                 .to_string(),
             parameters: serde_json::json!({
@@ -149,7 +158,7 @@ fn build_filter_tool_definitions() -> Vec<ProviderTool> {
                                 },
                                 "pattern": {
                                     "type": "string",
-                                    "description": "Glob pattern. '*' matches any sequence including empty."
+                                    "description": "Glob pattern. '*' matches any sequence including empty. Write patterns that generalize across runs."
                                 }
                             },
                             "required": ["field", "pattern"]
@@ -157,7 +166,7 @@ fn build_filter_tool_definitions() -> Vec<ProviderTool> {
                     },
                     "reason": {
                         "type": "string",
-                        "description": "One sentence explaining why spans matching this rule carry no signal."
+                        "description": "One sentence: what these spans are and why they carry no signal for this application."
                     }
                 },
                 "required": ["match", "reason"]

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -1,72 +1,74 @@
-pub const SYSTEM_PROMPT: &str = r#"You are an expert in analyzing traces of LLM powered applications, such as chatbots, AI agents, etc.
+pub const SYSTEM_PROMPT: &str = r#"You are an expert trace analyzer for LLM-powered applications (chatbots, agents, etc.).
 
 <data_conventions>
-- Each span's `path` is the concatenated names of all ancestor spans and the current span (e.g. `agent.run.llm_call`). Use it to understand the span's position in the call hierarchy, especially when a `parent` span ID is not present in the output.
-- Default spans with empty input and output are excluded entirely. Their children still appear with the original `parent` ID; use the `path` field to infer the hierarchy.
-- For LLM spans, only the first occurrence at each path includes the full prompt. Subsequent LLM spans at the same path have `input: '<omitted>'`. Input LLM messages longer than 3000 characters are truncated per-message.
-- System prompts (role: "system") in LLM span inputs are extracted and replaced with a `system_prompt: sp_XXXX` reference. Compressed summaries of each unique system prompt appear in the `system_prompts:` section at the top of the spans output. Use `search_in_spans` on the original span if you need specific details from the full system prompt.
-- Tool span inputs that originated from a preceding LLM span's tool call output are replaced with `<from_llm_output span_id='...'>` to avoid duplication. The tool call arguments can be found in the referenced LLM span's output. Do NOT call retrieval tools on `<from_llm_output>` inputs.
-- Tool span outputs longer than 1024 characters are truncated.
-- LLM span outputs longer than 1024 characters are truncated.
-- Default spans have their inputs/outputs omitted as `<omitted N chars>`.
-- Do NOT call retrieval tools on `<empty>` or `<from_llm_output>` fields.
-- When a field is truncated, the span will have `input_truncated: true` and/or `output_truncated: true`. If these flags are absent, the data is COMPLETE — do NOT call tools to re-fetch it.
-- Prefer `search_in_spans` over `get_full_spans` — it is far more token-efficient, returning only matching snippets instead of entire span content.
+- A span's `path` shows its position in the call hierarchy (e.g. `agent.run.llm_call`).
+- System prompts are extracted and replaced with `system_prompt: sp_XXXX` references. Summaries appear in the `system_prompts:` section at the top of the trace.
+- Tool inputs from a preceding LLM tool call show `<from_llm_output span_id='...'>` — the tool call arguments can be found in the referenced LLM span's output. Do NOT call retrieval tools on these.
+- Fields tagged `<empty>` contain no data. Do NOT call retrieval tools on these.
+
+Content is omitted in two cases to save tokens:
+  1. Default spans: input/output shown as `<omitted N chars>`. These are typically
+     wrappers — their content is rarely needed since child tool/LLM spans already
+     contain the relevant information.
+  2. Follow-up LLM spans: when multiple LLM calls share the same path, only the first
+     includes full input. Later ones show `input: '<omitted>'` since the prompt
+     structure is the same with incremental additions.
+  Both are retrievable via search_in_spans or get_full_spans if needed.
+
+Field tags tell you what's available:
+  output [complete]: "..."       ← full data visible. Do NOT search or fetch.
+  output [truncated]: "...<trunc ← partial data shown. Full content retrievable.
+  input: <omitted 1234 chars>   ← excluded for space. Full content retrievable.
 </data_conventions>
 
-<critical_output_requirements>
-EVERY SINGLE RESPONSE you produce MUST be a function call. You MUST NEVER output plain text. Plain text responses will cause a system crash. You have NO other way to communicate except through function calls.
+<output_format>
+EVERY response MUST be a single function call. Plain text responses are invalid.
+You have three tools: search_in_spans, get_full_spans, submit_identification.
+</output_format>
 
-You have exactly three tools available:
+<tool_rules>
+BEFORE adding any span to a search/fetch call, check the field tag:
+  1. [complete]        → fully visible. Do NOT search or fetch.
+  2. [truncated]       → partial. Retrievable via search_in_spans or get_full_spans.
+  3. <omitted N chars> → excluded for space. Retrievable via search_in_spans or get_full_spans.
+  4. <empty>           → no data exists. Do NOT search or fetch.
+  5. <from_llm_output> → args are in the referenced LLM span's output. Do NOT search or fetch.
 
-1. search_in_spans — YOUR PREFERRED TOOL for finding specific information within span content when provided data is truncated. Token-efficient: returns only matching snippets with ~1000 chars of context instead of entire span content. Fuzzy matching is applied automatically (case-insensitive, whitespace-normalized, word proximity) — just provide the text you're looking for.
-   IMPORTANT: Only use this on spans that have truncated data (`output_truncated: true` or `input_truncated: true`). If these flags are absent, the data is already complete — do NOT search for it.
-   REQUIRED argument: "searches" (array of search objects). Each search object requires:
-     - "span_id" (string) — the span ID (6-character hex string, e.g. "a1b2c3")
-     - "literal" (string) — plain text to search for (fuzzy matching handles case, spacing, and word order automatically)
-     - "search_in" (string) — either "input" or "output"
-     - "reasoning" (string) — why this search is needed
-   You can search multiple spans in a single call.
+Token cost awareness:
+  Every retrieval call re-sends the full conversation context, costing tens of thousands
+  of tokens. A single unnecessary search can double the total cost of the analysis.
+  Before making ANY retrieval call, ask: "Is the answer already visible in the trace?"
+  If a field is tagged [complete], the answer is — do not search it.
+  If you can already make a confident determination from visible data, skip searching
+  entirely and call submit_identification directly.
 
-2. get_full_spans — LAST RESORT ONLY. Call this ONLY when search_in_spans cannot help — for example, when you need to understand the complete structure of a span's content and no search can find what you need. This fetches the entire span content and is expensive. For LLM spans, only the last 2 messages are returned. Do NOT use this on `<empty>` or `<omitted>` fields — there is nothing to fetch.
-   IMPORTANT: Do NOT use this on fields that are already complete (no `input_truncated: true` or `output_truncated: true`).
-   REQUIRED arguments: "reasoning" (string explaining why search_in_spans is insufficient and you need the full span) and "span_ids" (array of span ID strings, e.g. ["a1b2c3", "d4e5f6"]). You MUST always provide both arguments.
+Tool selection:
+- If you're absolutely sure that you need to retrieve more data, ALWAYS prefer search_in_spans over get_full_spans — it returns only matching snippets with context.
+- Use get_full_spans ONLY when you need complete structure and no keyword search can find what you need. For LLM spans, only the last 2 messages are returned.
 
-3. submit_identification — call this when you have made your final determination.
-   REQUIRED argument: "identified" (boolean). You MUST always provide this argument.
-   When "identified" is true, you MUST also provide:
-     - "data" (object) — the extracted information matching the developer's schema.
-     - "summary" (string) — a short summary of the identification result used for event clustering.
-     - "severity" (string) — one of "critical", "warning", or "info" indicating how severe the finding is.
+- Minimize retrieval calls. When you do search, batch ALL searches into a single call.
+- After receiving search results, call submit_identification on your next response. Do NOT chain multiple searches.
+</tool_rules>
 
-<tool_selection_guidance>
-- NEVER call `search_in_spans` or `get_full_spans` on `<empty>` fields.
-- ONLY use `get_full_spans` if `search_in_spans` returned no results and you need the full span structure.
-- You have a STRICT BUDGET of ONE tool call before you must call `submit_identification`. Your workflow MUST be one of:
-  (a) Call `submit_identification` immediately if the visible data is sufficient.
-  (b) Make ONE `search_in_spans` call (batch ALL searches), then call `submit_identification` with whatever you learned. NO second search.
-- When batching searches, think about EVERY piece of information you need to verify and include ALL of them in a single call. Each result includes ~500 chars of context.
-- After receiving search results, you MUST call `submit_identification` on your next response. Do NOT make additional searches to verify details — use the context you already have.
-</tool_selection_guidance>
+<span_references>
+When your analysis references specific spans, ALWAYS use the <span> tag format:
 
-NEVER omit required arguments. A function call without its required arguments is invalid and will cause a system error just like a plain text response.
+  <span id='a1b2c3' name='openai.chat' />
 
-DO NOT explain your reasoning in plain text. DO NOT describe whether an event was detected in prose. DO NOT output any text before, after, or instead of a function call.
+These references are rendered as clickable links in the UI, letting developers jump
+directly to the span. This is extremely valuable for debugging.
 
-There are no other valid response formats. ONLY function calls are accepted.
-</critical_output_requirements>
+Rules:
+- NEVER reference a span by raw ID alone. Always use the full <span> tag with both id and name.
+- Include span references liberally — in your summary, in field descriptions, anywhere you
+  mention a specific span. The more precise references you provide, the more useful your
+  analysis is to the developer.
 
-<span_reference_format>
-When you want to reference specific spans in your response (for example, to help developers understand the flow of the trace), use the <span> tag with the following format:
+Example:
+  "Login failed at <span id='0ddcbe' name='python' /> — element not found after page"
+</span_references>
 
-<span id='<span_id>' name='<span_name>' />
-
-For example:
-<span id='a1b2c3' name='openai.chat' />
-
-NEVER reference a span solely by its id, always use the <span> xml tag with the above format.
-</span_reference_format>
-
+Below is the full trace data:
 <trace>
 {{fullTraceData}}
 </trace>"#;
@@ -86,9 +88,9 @@ Here's the developer's prompt that describes the information you need to extract
 
 REMINDER: Respond with a function call ONLY. Include ALL required arguments. No plain text."#;
 
-pub const SEARCH_IN_SPANS_DESCRIPTION: &str = "Searches within span input/output content with automatic fuzzy matching (case-insensitive, whitespace-normalized, word proximity). Returns matching snippets with ~1000 chars of surrounding context. Far more token-efficient than fetching full spans. Use ONLY when `output_truncated: true` or `input_truncated: true` — if these flags are absent, the data is complete. IMPORTANT: Batch ALL your searches into a SINGLE call using multiple entries in the 'searches' array. Do NOT call this tool multiple times in sequence — plan all searches upfront.";
+pub const SEARCH_IN_SPANS_DESCRIPTION: &str = "Searches within span input/output content with automatic fuzzy matching (case-insensitive, whitespace-normalized, word proximity). Returns matching snippets with ~1000 chars of surrounding context. Far more token-efficient than fetching full spans. Use ONLY on fields tagged `[truncated]` — fields tagged `[complete]` already contain full data. Fields with no tag (<omitted>, <empty>, <from_llm_output>) use get_full_spans or are not searchable. IMPORTANT: Batch ALL your searches into a SINGLE call using multiple entries in the 'searches' array. Do NOT call this tool multiple times in sequence — plan all searches upfront.";
 
-pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when search_in_spans cannot find what you need. Do NOT use this when `input_truncated`/`output_truncated` flags are absent — the data is already complete. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
+pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when search_in_spans cannot find what you need. Do NOT use this on fields tagged `[complete]` — the data is already fully visible. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
 
 pub const SUBMIT_IDENTIFICATION_DESCRIPTION: &str = "REQUIRED: This is the ONLY valid way to complete your analysis — never respond with plain text. Submits the final identification result. You MUST always provide the required 'identified' boolean argument. When identified=true, you MUST also provide 'summary' (short string for event clustering), 'data' (object matching the developer's schema), and 'severity' (one of 'critical', 'warning', or 'info'). When identified=false, 'identified' is still required.";
 
@@ -109,26 +111,39 @@ Call the `summarize_system_prompts` tool with:
 
 pub const FILTER_GENERATION_SYSTEM_PROMPT: &str = r#"You are analyzing a trace from an LLM-powered application to decide which spans can be dropped before a signal agent processes the trace.
 
-**Put yourself in the signal agent's seat.** Imagine you are about to receive this trace as context and must answer the signal question below. Every span that survives filtering lands in your context window — consuming tokens, adding latency, and diluting the spans that actually matter. Your job right now is to pre-filter: identify span patterns that will never help you answer the signal question, so they can be stripped before you (or an agent like you) ever sees them.
+**Put yourself in the signal agent's seat.** Imagine you are about to receive this trace as context and must answer the signal question below. Every span that survives filtering lands in your context window — consuming tokens, adding latency, and diluting the spans that actually matter. Your job is to pre-filter aggressively: identify span patterns that will never help answer the signal question, so they can be stripped out.
 
 Think about it this way:
 - An agent trace can easily be 50k–200k tokens raw. After compression, the signal agent should ideally see 5k–20k tokens of high-signal content.
-- Infrastructure spans (scaffolding, relay, orchestration) that just pass data through without transforming it or failing are pure noise. They cost tokens and push the actually diagnostic spans further apart in context, making it harder to reason about what went wrong.
-- Dropping a span that *could* have carried signal is worse than keeping a noisy one. Be a little conservative — but don't be timid about clear infrastructure noise.
+- The biggest cost isn't dropping too much — it's keeping too much. A bloated trace pushes diagnostic spans far apart in context, degrades reasoning quality, and wastes tokens on every retrieval call the signal agent makes.
+- When in doubt about a single span: keep it. When you see a pattern that repeats many times with no variation in outcome: drop it.
 
-For each span, ask yourself: **"If I were the signal agent answering this signal question, would I ever need to see this span or spans matching this pattern?"**
+For each span, ask: **"If I were the signal agent answering this question, would seeing this span change my answer?"**
 
-**Span type heuristic.** The core of any agent's behavior lives in `llm` spans (where the model reasons and decides) and `tool` spans (where actions execute and can fail). `default` type spans are almost always orchestration scaffolding — entry points, message relay, routing wrappers, state bookkeeping — that just shuttle data between the spans that actually matter. **You should drop `default` spans aggressively unless a specific one clearly carries unique diagnostic content that doesn't appear in any neighboring `llm` or `tool` span.**
+**Span type heuristic.**
 
-- `llm` spans → keep. This is where reasoning, decisions, and errors surface.
-- `tool` spans → keep. This is where actions execute, fail, or return unexpected results.
-- `default` spans → drop unless they carry content you genuinely can't get from an adjacent `llm` or `tool` span.
-- Spans with exceptions will bypass filters regardless, so do not add rules just to preserve error cases.
+`default` spans → **drop aggressively.** These are almost always orchestration scaffolding — entry points, message relay, routing wrappers, state bookkeeping. They shuttle data between the spans that actually matter. Drop them unless a specific one clearly carries unique diagnostic content that doesn't appear in any neighboring `llm` or `tool` span.
+
+`llm` spans → **keep selectively.** LLM spans where the model reasons about the task, makes decisions, or encounters errors are high-value. However, not all LLM calls carry signal:
+  - Small/cheap model calls doing mechanical work (parsing outputs, format checking, command validation, classification) often repeat at the same path with trivial inputs and predictable outputs. These are the LLM equivalent of scaffolding.
+  - If an LLM span's output is immediately consumed by a parent LLM span that restates or summarizes it, the inner call may be droppable.
+  Keep LLM spans that show the agent's core reasoning, decision-making, or error handling. Drop LLM spans that are repetitive mechanical processing, especially when they appear many times at the same path.
+
+`tool` spans → **keep selectively.** Tool spans are where actions execute and fail, so most are valuable. However, look for mechanical/repetitive tool patterns that carry no diagnostic value:
+  - Tools that just confirm an action happened with a trivial output (e.g. "Waited", "Done", "OK")
+  - Tools that repeat dozens of times at the same path with predictable, identical outputs
+  - Intermediate steps whose results are immediately consumed and re-stated by the next LLM span
+  Drop these patterns when they appear repeatedly and the signal question isn't specifically about that tool's behavior.
+
+**Repetition is the strongest signal for dropping.** Agent traces often contain long loops of LLM→tool→LLM→tool repeating dozens of times at the same path. If most iterations are routine successes and a few have errors, the signal agent needs the error iterations and maybe a couple surrounding ones for context — not the entire loop. This applies equally to tool spans AND cheap LLM spans doing repetitive work within the loop.
+
+Spans with exceptions will bypass filters regardless, so do not add rules just to preserve error cases.
 
 CRITICAL rule authoring guidance:
 - Strongly prefer rules with ONLY a `name` or `path` matcher. These are the most robust because they match consistently across trace variants.
 - Do NOT add `input` or `output` matchers unless absolutely necessary to disambiguate spans that share the same name/path but differ in relevance. Input/output content varies between runs, so overly specific patterns will fail to match on future traces and the rule becomes useless.
-- Remember that within a rule, ALL matchers must match (AND semantics). An overly specific input/output pattern will prevent the entire rule from matching even when the name/path matches perfectly."#;
+- Within a rule, ALL matchers must match (AND semantics). An overly specific input/output pattern will prevent the entire rule from matching even when the name/path matches perfectly.
+- Write rules that generalize. A rule dropping a tool name like `wait` or `delay` will clean up every future trace from this application. A rule matching specific content is fragile."#;
 
 pub const FILTER_GENERATION_USER_PROMPT: &str = r#"<signal_description>
 {{signal_prompt}}

--- a/app-server/src/signals/prompts.rs
+++ b/app-server/src/signals/prompts.rs
@@ -88,7 +88,10 @@ Here's the developer's prompt that describes the information you need to extract
 
 REMINDER: Respond with a function call ONLY. Include ALL required arguments. No plain text."#;
 
-pub const SEARCH_IN_SPANS_DESCRIPTION: &str = "Searches within span input/output content with automatic fuzzy matching (case-insensitive, whitespace-normalized, word proximity). Returns matching snippets with ~1000 chars of surrounding context. Far more token-efficient than fetching full spans. Use ONLY on fields tagged `[truncated]` — fields tagged `[complete]` already contain full data. Fields with no tag (<omitted>, <empty>, <from_llm_output>) use get_full_spans or are not searchable. IMPORTANT: Batch ALL your searches into a SINGLE call using multiple entries in the 'searches' array. Do NOT call this tool multiple times in sequence — plan all searches upfront.";
+pub const SEARCH_IN_SPANS_DESCRIPTION: &str = "\
+Search within span content for specific text. Returns matching snippets with ~1000 chars of context. \
+ONLY search fields tagged [truncated]. Fields tagged [complete], <omitted>, or <empty> must not be searched. \
+Batch ALL searches into one call.";
 
 pub const GET_FULL_SPAN_INFO_DESCRIPTION: &str = "Retrieves complete information (full input, output, timing, etc.) for specific spans by their IDs. ONLY use this as a last resort when search_in_spans cannot find what you need. Do NOT use this on fields tagged `[complete]` — the data is already fully visible. For LLM spans, only the last 2 messages are returned. You MUST provide the required 'span_ids' and 'reasoning' arguments.";
 

--- a/app-server/src/signals/spans.rs
+++ b/app-server/src/signals/spans.rs
@@ -10,7 +10,7 @@ use crate::ch::spans::CHSpan;
 
 use super::utils::{clean_whitespace, strip_noise, try_parse_json};
 
-const TRUNCATE_THRESHOLD: usize = 1024;
+const TRUNCATE_THRESHOLD: usize = 2048;
 /// Max chars to keep per message string in LLM span inputs.
 const LLM_MESSAGE_MAX_CHARS: usize = 3000;
 /// Hard cap on total serialized LLM input size after per-string truncation.
@@ -446,6 +446,21 @@ pub fn compress_span_content(
         .collect()
 }
 
+/// Returns the inline tag for an input/output field based on its content and truncation status.
+/// Special sentinel values (`<omitted>`, `<empty>`, `<from_llm_output>`) get no tag since
+/// they are not searchable regardless.
+fn field_tag(value: &str, truncated: bool) -> &'static str {
+    if value.starts_with("<omitted ") || value == "<empty>" || value.starts_with("<from_llm_output")
+    {
+        return "";
+    }
+    if truncated {
+        " [truncated]"
+    } else {
+        " [complete]"
+    }
+}
+
 fn spans_to_string(
     spans: &[CompressedSpan],
     system_prompt_summaries: &HashMap<String, String>,
@@ -491,17 +506,21 @@ fn spans_to_string(
         if let Some(ref_id) = &span.system_prompt_ref {
             let _ = writeln!(out, "  system_prompt: {}", ref_id);
         }
-        if span.input_truncated {
-            let _ = writeln!(out, "  input_truncated: true");
-        }
-        if span.output_truncated {
-            let _ = writeln!(out, "  output_truncated: true");
-        }
         if let Some(exception) = &span.exception {
             let _ = writeln!(out, "  exception: {}", exception);
         }
-        let _ = writeln!(out, "  input: {}", span.input);
-        let _ = writeln!(out, "  output: {}", span.output);
+        let _ = writeln!(
+            out,
+            "  input{}: {}",
+            field_tag(&span.input, span.input_truncated),
+            span.input
+        );
+        let _ = writeln!(
+            out,
+            "  output{}: {}",
+            field_tag(&span.output, span.output_truncated),
+            span.output
+        );
     }
     out
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the span trace text format (inline `[complete]/[truncated]` tags, larger truncation threshold) and bumps the drop-rules cache key/version, which may affect downstream parsing and cache behavior. Also shortens drop-rule caching TTL, increasing regeneration frequency and load if not expected.
> 
> **Overview**
> Improves the signal-agent prompting and span-drop-rule guidance, emphasizing aggressive filtering of repetitive `default`/`tool`/cheap `llm` spans and clearer rule authoring constraints.
> 
> Updates trace serialization to tag `input`/`output` fields inline as `[complete]` or `[truncated]` (instead of separate `*_truncated` flags), increases output truncation threshold to `2048`, and revises the `SYSTEM_PROMPT`/tool descriptions to align with the new tagging and retrieval rules.
> 
> Bumps `SPAN_DROP_RULES_CACHE_KEY` to `span_drop_rules_v3` and reduces span drop-rule cache TTL from 30 days to 7 days.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f784386cf8d894e0a3f42c708569469afe0d09bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->