### PR TITLE
fix: handle event proper escaping and not retriable

### DIFF
--- a/app-server/src/signals/pendings_consumer.rs
+++ b/app-server/src/signals/pendings_consumer.rs
@@ -168,18 +168,7 @@ pub async fn retry_or_fail_runs(
         let signal_message = run_to_message.get(&run.run_id);
         let metadata = failure_metadata.get(&run.run_id);
 
-        let retryable = if let Some(meta) = metadata {
-            if meta.is_processing_error {
-                true
-            } else {
-                meta.finish_reason
-                    .as_ref()
-                    .map(|fr| fr.is_retryable())
-                    .unwrap_or(true)
-            }
-        } else {
-            true
-        };
+        let retryable = metadata.map(|meta| meta.retryable).unwrap_or(true);
 
         if let Some(msg) = signal_message {
             if retryable && msg.retry_count < max_retry_count {

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -1,8 +1,10 @@
+use backoff::ExponentialBackoffBuilder;
 use regex::Regex;
 use serde::Serialize;
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, LazyLock},
+    time::Duration,
 };
 use uuid::Uuid;
 
@@ -55,13 +57,14 @@ pub enum StepResult {
     Failed {
         error: String,
         finish_reason: Option<FinishReason>,
+        // Whether the error is due to processing the response, not the provider.
+        // Usually due to malformed function calls so is retryable.
         is_processing_error: bool,
     },
 }
 
 pub struct FailureMetadata {
-    pub finish_reason: Option<FinishReason>,
-    pub is_processing_error: bool,
+    pub retryable: bool,
 }
 
 pub struct ProcessedResponses {
@@ -147,6 +150,7 @@ pub async fn process_provider_responses(
         .await;
 
         new_messages.extend(new_run_messages);
+        log::error!("STEP RESULT: {:?}", step_result);
 
         match step_result {
             StepResult::CompletedNoEvent => {
@@ -176,6 +180,7 @@ pub async fn process_provider_responses(
                     }
                     Err(e) => {
                         log::error!("[SIGNAL JOB] Failed to create event: {:?}", e);
+                        failure_metadata.insert(run.run_id, FailureMetadata { retryable: false });
                         failed_runs.push(run.failed(format!("Failed to create event: {}", e)));
                     }
                 }
@@ -191,8 +196,11 @@ pub async fn process_provider_responses(
                 failure_metadata.insert(
                     run.run_id,
                     FailureMetadata {
-                        finish_reason,
-                        is_processing_error,
+                        retryable: is_processing_error
+                            || finish_reason
+                                .as_ref()
+                                .map(|fr| fr.is_retryable())
+                                .unwrap_or(true),
                     },
                 );
                 failed_runs.push(run.failed(error));
@@ -776,15 +784,51 @@ pub async fn handle_create_event(
         summary,
         severity,
     );
-    insert_signal_events(clickhouse, vec![signal_event.clone()]).await?;
 
-    process_event_notifications_and_clustering(
-        db,
-        queue.clone(),
-        signal_message.project_id,
-        run.trace_id,
-        signal_event,
-    )
+    let backoff = ExponentialBackoffBuilder::new()
+        .with_initial_interval(Duration::from_secs(1))
+        .with_multiplier(2.0)
+        .with_max_elapsed_time(Some(Duration::from_secs(10)))
+        .build();
+    let ch_ref = &clickhouse;
+    let event_ref = &signal_event;
+    backoff::future::retry(backoff, || async move {
+        insert_signal_events(ch_ref.clone(), vec![event_ref.clone()])
+            .await
+            .map_err(|e| {
+                log::warn!("[SIGNAL JOB] Retrying insert_signal_events: {:?}", e);
+                backoff::Error::transient(e)
+            })
+    })
+    .await?;
+
+    let backoff = ExponentialBackoffBuilder::new()
+        .with_initial_interval(Duration::from_secs(1))
+        .with_multiplier(2.0)
+        .with_max_elapsed_time(Some(Duration::from_secs(10)))
+        .build();
+    let db_ref = &db;
+    let queue_ref = &queue;
+    let project_id = signal_message.project_id;
+    let trace_id = run.trace_id;
+    let event_for_notif = signal_event.clone();
+    backoff::future::retry(backoff, || {
+        let event = event_for_notif.clone();
+        async move {
+            process_event_notifications_and_clustering(
+                db_ref.clone(),
+                queue_ref.clone(),
+                project_id,
+                trace_id,
+                event,
+            )
+            .await
+            .map_err(|e| {
+                log::warn!("[SIGNAL JOB] Retrying notifications/clustering: {:?}", e);
+                backoff::Error::transient(e)
+            })
+        }
+    })
     .await?;
 
     emit_internal_span(

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -150,7 +150,6 @@ pub async fn process_provider_responses(
         .await;
 
         new_messages.extend(new_run_messages);
-        log::error!("STEP RESULT: {:?}", step_result);
 
         match step_result {
             StepResult::CompletedNoEvent => {

--- a/app-server/src/signals/response_processor.rs
+++ b/app-server/src/signals/response_processor.rs
@@ -791,6 +791,9 @@ pub async fn handle_create_event(
         .build();
     let ch_ref = &clickhouse;
     let event_ref = &signal_event;
+    // NOTE: all errors treated as transient because anyhow::Error doesn't expose
+    // ClickHouse error kinds; permanent errors (schema mismatch, etc.) will retry
+    // until the 10s timeout before propagating.
     backoff::future::retry(backoff, || async move {
         insert_signal_events(ch_ref.clone(), vec![event_ref.clone()])
             .await

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -138,6 +138,17 @@ pub struct InternalSpan {
 
 static XML_TAG_NAME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<(\w+)[\s/>]").unwrap());
 
+static SPAN_XML_TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"<span\s+id=['"]([^'"]+)['"]\s+name=['"]([^'"]+)['"][^>]*/?\s*>"#).unwrap()
+});
+
+static SPAN_REF_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bspans?\s+([0-9a-fA-F]{6}(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)[0-9a-fA-F]{6})*)\b")
+        .unwrap()
+});
+
+static HEX_ID_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[0-9a-fA-F]{6}").unwrap());
+
 /// Hash a system prompt by its structural skeleton: first sentence + sorted XML tag names.
 /// Resistant to dynamic content inside tags (config values, user context, tool lists)
 /// while preserving the stable identity of the prompt template.
@@ -233,10 +244,7 @@ fn replace_span_tags_in_str(
     // 1. Replace proper <span id='...' name='...' /> XML tags.
     //    The LLM prompt in prompts.rs explicitly instructs this attribute order (id before name),
     //    so we rely on it here rather than making the pattern order-agnostic.
-    let xml_pattern =
-        Regex::new(r#"<span\s+id=['"]([^'"]+)['"]\s+name=['"]([^'"]+)['"][^>]*/?\s*>"#).unwrap();
-
-    let after_xml = xml_pattern.replace_all(s, |caps: &regex::Captures| {
+    let after_xml = SPAN_XML_TAG_RE.replace_all(s, |caps: &regex::Captures| {
         let short_id = &caps[1];
         let span_name = &caps[2];
         let real_span_id = span_ids_map
@@ -250,15 +258,9 @@ fn replace_span_tags_in_str(
     });
 
     // 2. Replace informal "span(s) id1, id2, ..." references (single or comma/and-separated)
-    let hex_id_re = Regex::new(r"[0-9a-fA-F]{6}").unwrap();
-    let span_ref_pattern = Regex::new(
-        r"\bspans?\s+([0-9a-fA-F]{6}(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)[0-9a-fA-F]{6})*)\b",
-    )
-    .unwrap();
-
-    let after_informal = span_ref_pattern.replace_all(&after_xml, |caps: &regex::Captures| {
+    let after_informal = SPAN_REF_RE.replace_all(&after_xml, |caps: &regex::Captures| {
         let ids_str = &caps[1];
-        let parts: Vec<String> = hex_id_re
+        let parts: Vec<String> = HEX_ID_RE
             .find_iter(ids_str)
             .map(|m| {
                 let short_id = m.as_str().to_lowercase();

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -36,8 +36,8 @@ static SIGNATURE_FIELD_ESCAPED_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// (for non-JSON contexts like search) separately.
 pub fn strip_noise(raw: &str) -> String {
     let without_images = BASE64_IMAGE_RE.replace_all(raw, "[base64 image omitted]");
-    let without_sigs = SIGNATURE_FIELD_RE
-        .replace_all(&without_images, r#"$1:"[signature omitted]""#);
+    let without_sigs =
+        SIGNATURE_FIELD_RE.replace_all(&without_images, r#"$1:"[signature omitted]""#);
     SIGNATURE_FIELD_ESCAPED_RE
         .replace_all(&without_sigs, r##"$1:\"[signature omitted]\""##)
         .into_owned()
@@ -136,8 +136,7 @@ pub struct InternalSpan {
     pub tools: Option<Value>,
 }
 
-static XML_TAG_NAME_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"<(\w+)[\s/>]").unwrap());
+static XML_TAG_NAME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<(\w+)[\s/>]").unwrap());
 
 /// Hash a system prompt by its structural skeleton: first sentence + sorted XML tag names.
 /// Resistant to dynamic content inside tags (config values, user context, tool lists)
@@ -222,13 +221,20 @@ pub fn replace_span_tags_with_links(
     project_id: Uuid,
     trace_id: Uuid,
 ) -> Result<Value> {
-    let json_str = serde_json::to_string(&attributes)?;
+    replace_span_tags_recursive(attributes, span_ids_map, project_id, trace_id)
+}
 
+fn replace_span_tags_in_str(
+    s: &str,
+    span_ids_map: &HashMap<String, Uuid>,
+    project_id: Uuid,
+    trace_id: Uuid,
+) -> String {
     // 1. Replace proper <span id='...' name='...' /> XML tags
     let xml_pattern =
-        Regex::new(r#"<span\s+id=['"]([^'"]+)['"]\s+name=['"]([^'"]+)['"][^>]*/?\s*>"#)?;
+        Regex::new(r#"<span\s+id=['"]([^'"]+)['"]\s+name=['"]([^'"]+)['"][^>]*/?\s*>"#).unwrap();
 
-    let after_xml = xml_pattern.replace_all(&json_str, |caps: &regex::Captures| {
+    let after_xml = xml_pattern.replace_all(s, |caps: &regex::Captures| {
         let short_id = &caps[1];
         let span_name = &caps[2];
         let real_span_id = span_ids_map
@@ -242,10 +248,11 @@ pub fn replace_span_tags_with_links(
     });
 
     // 2. Replace informal "span(s) id1, id2, ..." references (single or comma/and-separated)
-    let hex_id_re = Regex::new(r"[0-9a-fA-F]{6}")?;
+    let hex_id_re = Regex::new(r"[0-9a-fA-F]{6}").unwrap();
     let span_ref_pattern = Regex::new(
         r"\bspans?\s+([0-9a-fA-F]{6}(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)[0-9a-fA-F]{6})*)\b",
-    )?;
+    )
+    .unwrap();
 
     let after_informal = span_ref_pattern.replace_all(&after_xml, |caps: &regex::Captures| {
         let ids_str = &caps[1];
@@ -265,8 +272,41 @@ pub fn replace_span_tags_with_links(
         parts.join(", ")
     });
 
-    let result: Value = serde_json::from_str(&after_informal)?;
-    Ok(result)
+    after_informal.into_owned()
+}
+
+fn replace_span_tags_recursive(
+    value: Value,
+    span_ids_map: &HashMap<String, Uuid>,
+    project_id: Uuid,
+    trace_id: Uuid,
+) -> Result<Value> {
+    match value {
+        Value::String(s) => Ok(Value::String(replace_span_tags_in_str(
+            &s,
+            span_ids_map,
+            project_id,
+            trace_id,
+        ))),
+        Value::Object(map) => {
+            let new_map: serde_json::Map<String, Value> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let new_v = replace_span_tags_recursive(v, span_ids_map, project_id, trace_id)?;
+                    Ok((k, new_v))
+                })
+                .collect::<Result<_>>()?;
+            Ok(Value::Object(new_map))
+        }
+        Value::Array(arr) => {
+            let new_arr: Vec<Value> = arr
+                .into_iter()
+                .map(|v| replace_span_tags_recursive(v, span_ids_map, project_id, trace_id))
+                .collect::<Result<_>>()?;
+            Ok(Value::Array(new_arr))
+        }
+        other => Ok(other),
+    }
 }
 
 /// Emits an internal tracing span for observability.
@@ -573,10 +613,7 @@ mod tests {
     // ===================================================================
 
     fn make_span_ids_map(pairs: &[(&str, Uuid)]) -> HashMap<String, Uuid> {
-        pairs
-            .iter()
-            .map(|(k, v)| (k.to_string(), *v))
-            .collect()
+        pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
     }
 
     #[test]
@@ -619,9 +656,21 @@ mod tests {
         let input = Value::String("see spans f188ea, 1a2b3c, 4d5e6f for info".to_string());
         let result = replace_span_tags_with_links(input, &map, pid, tid).unwrap();
         let s = result.as_str().unwrap();
-        assert!(s.contains(&format!("spanId={}", u1)), "first ID missing: {}", s);
-        assert!(s.contains(&format!("spanId={}", u2)), "second ID missing: {}", s);
-        assert!(s.contains(&format!("spanId={}", u3)), "third ID missing: {}", s);
+        assert!(
+            s.contains(&format!("spanId={}", u1)),
+            "first ID missing: {}",
+            s
+        );
+        assert!(
+            s.contains(&format!("spanId={}", u2)),
+            "second ID missing: {}",
+            s
+        );
+        assert!(
+            s.contains(&format!("spanId={}", u3)),
+            "third ID missing: {}",
+            s
+        );
     }
 
     #[test]
@@ -634,8 +683,16 @@ mod tests {
         let input = Value::String("spans aabb11 and cc22dd are relevant".to_string());
         let result = replace_span_tags_with_links(input, &map, pid, tid).unwrap();
         let s = result.as_str().unwrap();
-        assert!(s.contains(&format!("spanId={}", u1)), "first ID missing: {}", s);
-        assert!(s.contains(&format!("spanId={}", u2)), "second ID missing: {}", s);
+        assert!(
+            s.contains(&format!("spanId={}", u1)),
+            "first ID missing: {}",
+            s
+        );
+        assert!(
+            s.contains(&format!("spanId={}", u2)),
+            "second ID missing: {}",
+            s
+        );
     }
 
     #[test]
@@ -646,8 +703,7 @@ mod tests {
         let map = make_span_ids_map(&[("aa11bb", u1), ("cc22dd", u2), ("ee33ff", u3)]);
         let pid = Uuid::new_v4();
         let tid = Uuid::new_v4();
-        let input =
-            Value::String("see spans aa11bb, cc22dd, and ee33ff for context".to_string());
+        let input = Value::String("see spans aa11bb, cc22dd, and ee33ff for context".to_string());
         let result = replace_span_tags_with_links(input, &map, pid, tid).unwrap();
         let s = result.as_str().unwrap();
         assert!(s.contains(&format!("spanId={}", u1)), "first: {}", s);
@@ -664,9 +720,17 @@ mod tests {
         let input = Value::String("spans f188ea, 999999 have issues".to_string());
         let result = replace_span_tags_with_links(input, &map, pid, tid).unwrap();
         let s = result.as_str().unwrap();
-        assert!(s.contains(&format!("spanId={}", u1)), "known ID should be linked: {}", s);
+        assert!(
+            s.contains(&format!("spanId={}", u1)),
+            "known ID should be linked: {}",
+            s
+        );
         assert!(s.contains("span 999999"), "unknown ID kept as text: {}", s);
-        assert!(!s.contains(&format!("999999&chat")), "unknown ID should not be linked: {}", s);
+        assert!(
+            !s.contains(&format!("999999&chat")),
+            "unknown ID should not be linked: {}",
+            s
+        );
     }
 
     #[test]
@@ -678,8 +742,36 @@ mod tests {
         let input = Value::String("<span id='abcdef' name='openai.chat' />".to_string());
         let result = replace_span_tags_with_links(input, &map, pid, tid).unwrap();
         let s = result.as_str().unwrap();
-        assert!(s.contains("[openai.chat]"), "XML tag should produce named link: {}", s);
+        assert!(
+            s.contains("[openai.chat]"),
+            "XML tag should produce named link: {}",
+            s
+        );
         assert!(s.contains(&format!("spanId={}", uuid)));
+    }
+
+    #[test]
+    fn test_span_link_xml_tag_with_quotes_in_name() {
+        let uuid = Uuid::new_v4();
+        let map = make_span_ids_map(&[("341c9d", uuid)]);
+        let pid = Uuid::new_v4();
+        let tid = Uuid::new_v4();
+        let input = serde_json::json!({
+            "category": "logic_error",
+            "description": "The sub-agent <span id='341c9d' name='llm: \"claude-sonnet-4-6\"' /> failed to respond."
+        });
+        let result = replace_span_tags_with_links(input, &map, pid, tid).unwrap();
+        let desc = result.get("description").unwrap().as_str().unwrap();
+        assert!(
+            desc.contains(&format!("spanId={}", uuid)),
+            "span link should be present: {}",
+            desc
+        );
+        assert!(
+            !desc.contains("<span"),
+            "span tag should be replaced: {}",
+            desc
+        );
     }
 
     #[test]
@@ -731,7 +823,8 @@ Do not fabricate data.
     #[test]
     fn test_structural_skeleton_hash_no_tags() {
         let plain_v1 = "You are a helpful customer support agent. Answer questions politely. Use the knowledge base.";
-        let plain_v2 = "You are a helpful customer support agent. Answer questions politely. Be concise.";
+        let plain_v2 =
+            "You are a helpful customer support agent. Answer questions politely. Be concise.";
 
         assert_eq!(
             structural_skeleton_hash(plain_v1),
@@ -812,7 +905,8 @@ Do not fabricate data.
     #[test]
     fn test_structural_skeleton_hash_duplicate_tags() {
         let single = "You are an AI agent for testing.\n<rules>rule 1</rules>";
-        let duped = "You are an AI agent for testing.\n<rules>rule 1</rules>\n<rules>rule 2</rules>";
+        let duped =
+            "You are an AI agent for testing.\n<rules>rule 1</rules>\n<rules>rule 2</rules>";
 
         assert_eq!(
             structural_skeleton_hash(single),

--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -230,7 +230,9 @@ fn replace_span_tags_in_str(
     project_id: Uuid,
     trace_id: Uuid,
 ) -> String {
-    // 1. Replace proper <span id='...' name='...' /> XML tags
+    // 1. Replace proper <span id='...' name='...' /> XML tags.
+    //    The LLM prompt in prompts.rs explicitly instructs this attribute order (id before name),
+    //    so we rely on it here rather than making the pattern order-agnostic.
     let xml_pattern =
         Regex::new(r#"<span\s+id=['"]([^'"]+)['"]\s+name=['"]([^'"]+)['"][^>]*/?\s*>"#).unwrap();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches signal run retry behavior and event creation flow by changing what gets retried and adding transient backoff retries around ClickHouse inserts/notification processing; misclassification could increase permanent failures or duplicate work. Also changes JSON attribute rewriting logic, which could affect event attribute formatting/linking.
> 
> **Overview**
> **Signal run retry semantics are simplified and tightened.** `FailureMetadata` now stores a single `retryable` flag, and `retry_or_fail_runs` uses it directly; event-creation failures explicitly mark runs as *non-retryable*.
> 
> **Event creation is made more resilient but time-bounded.** `handle_create_event` now wraps both `insert_signal_events` and `process_event_notifications_and_clustering` in exponential backoff retries (up to ~10s) before failing.
> 
> **Span reference rewriting is safer for JSON and tricky strings.** `replace_span_tags_with_links` now walks the JSON value tree and rewrites only string fields (instead of stringifying/parsing the whole JSON), with shared compiled regexes and an added test covering `<span ... name='..."..."' />` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a715d65adef2325f8bf3fbbd09da8678900de15c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->