### PR TITLE
blog images proxy

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -50,14 +50,6 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  async rewrites() {
-    return [
-      {
-        source: "/uploads/:path*",
-        destination: `${process.env.STRAPI_URL || "http://localhost:1337"}/uploads/:path*`,
-      },
-    ];
-  },
   images: {
     remotePatterns: [
       {

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -8,8 +8,7 @@ export default withAuth(
   async function middleware(req: NextRequestWithAuth) {
     if (req.nextUrl.pathname.startsWith("/uploads/")) {
       const strapiUrl = process.env.STRAPI_URL || "http://localhost:1337";
-      const destination = new URL(req.nextUrl.pathname, strapiUrl);
-      return NextResponse.rewrite(destination);
+      const destination = new URL(req.nextUrl.pathname + req.nextUrl.search, strapiUrl);
     }
 
     const token = req.nextauth.token;

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -6,6 +6,12 @@ import { isUserMemberOfProject, isUserMemberOfWorkspace } from "@/lib/authorizat
 
 export default withAuth(
   async function middleware(req: NextRequestWithAuth) {
+    if (req.nextUrl.pathname.startsWith("/uploads/")) {
+      const strapiUrl = process.env.STRAPI_URL || "http://localhost:1337";
+      const destination = new URL(req.nextUrl.pathname, strapiUrl);
+      return NextResponse.rewrite(destination);
+    }
+
     const token = req.nextauth.token;
 
     const projectIdMatch = req.nextUrl.pathname.match(/^\/api\/projects(?:\/([^/]+))?/);
@@ -67,6 +73,9 @@ export default withAuth(
         if (req.nextUrl.pathname.startsWith("/api/")) {
           return true;
         }
+        if (req.nextUrl.pathname.startsWith("/uploads/")) {
+          return true;
+        }
         return !!token;
       },
     },
@@ -83,5 +92,6 @@ export const config = {
     "/api/projects/:path+",
     "/api/workspaces/:path+",
     "/api/shared/traces/:path+",
+    "/uploads/:path+",
   ],
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes request routing for `/uploads/*` from a Next.js config rewrite to middleware matching/authorization handling, which can affect static/media delivery paths. The new middleware logic appears incomplete (builds a destination URL but doesn’t forward the request), so there’s a risk of broken image/file loading.
> 
> **Overview**
> Moves `/uploads/*` handling away from `next.config.ts` rewrites and into the NextAuth middleware.
> 
> The middleware now matches `/uploads/:path+` and treats it as publicly authorized, preparing to proxy requests to `STRAPI_URL` (previously done via `rewrites()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ec235b96ee08053d131a65add1808884faba80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->