### PR TITLE
fix

### DIFF
--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -9,6 +9,7 @@ export default withAuth(
     if (req.nextUrl.pathname.startsWith("/uploads/")) {
       const strapiUrl = process.env.STRAPI_URL || "http://localhost:1337";
       const destination = new URL(req.nextUrl.pathname + req.nextUrl.search, strapiUrl);
+      return NextResponse.rewrite(destination);
     }
 
     const token = req.nextauth.token;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small middleware control-flow fix that only affects routing for `/uploads/*` requests and does not change auth or data-handling logic.
> 
> **Overview**
> Fixes the `withAuth` middleware to actually `rewrite` `/uploads/*` requests to the configured Strapi base URL (including query string), instead of falling through into the rest of the middleware logic.
> 
> This ensures upload asset requests are consistently proxied and bypass the API authorization checks as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44eac52533e31215ac18563aad4c12d6c1a1bb70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->