### PR TITLE
don't reevaluate span type

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -714,11 +714,6 @@ impl Span {
 
         self.attributes.normalize_aisdk_attributes();
 
-        // Re-evaluate span type after normalization — gen_ai.system may now be present
-        if self.span_type == SpanType::Default {
-            self.span_type = self.attributes.span_type();
-        }
-
         if self.is_llm_span() {
             if self
                 .attributes

--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -3500,9 +3500,6 @@ mod tests {
 
         span.parse_and_enrich_attributes();
 
-        // Span type should be re-evaluated to LLM after normalization
-        assert_eq!(span.span_type, SpanType::LLM);
-
         // Token counts should be extracted via gen_ai.usage.* normalization
         let input_tokens = span.attributes.input_tokens();
         assert_eq!(input_tokens.total(), 14);
@@ -3563,7 +3560,6 @@ mod tests {
 
         span.parse_and_enrich_attributes();
 
-        assert_eq!(span.span_type, SpanType::LLM);
         assert_eq!(span.attributes.input_tokens().total(), 50);
         assert_eq!(span.attributes.output_tokens(), 100);
         assert_eq!(span.attributes.request_model(), Some("gpt-4o".to_string()));


### PR DESCRIPTION
Checks in the span_type() function assume pure attributes sent from otel clients.

Re-evaluate happened after w  did some processing. This requires a better refactor later, but for now, just remove recently introduced logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span classification behavior, which can affect downstream parsing/routing and how spans are stored or displayed; functional logic is otherwise unchanged and covered by adjusted tests.
> 
> **Overview**
> Stops re-evaluating `span.span_type` inside `Span::parse_and_enrich_attributes()` after `normalize_aisdk_attributes()`, so span type now reflects only what was determined at creation/deserialization time.
> 
> Updates the AI SDK normalization tests to no longer expect a `SpanType::LLM` transition as a side effect of parsing/enrichment, while keeping token/model extraction assertions intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db35a6fd0b9126953b1f99d88401d4b281c104b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->