### PR TITLE
check gemini batch state and fallback to realtime on failure

### DIFF
--- a/app-server/src/signals/pendings_consumer.rs
+++ b/app-server/src/signals/pendings_consumer.rs
@@ -141,8 +141,17 @@ async fn process(
         .await;
     }
 
-    // Done = true, no error. Check for batch state (expired, failed, etc.) - fallback to realtime
-    if result.state.as_ref() != Some(&ProviderBatchState::Succeeded) {
+    // Done = true, no error. Check for explicit non-success state (expired, failed, etc.)
+    // None state is allowed through (e.g. provider doesn't report metadata)
+    let is_non_success_state = matches!(
+        result.state,
+        Some(
+            ProviderBatchState::Failed
+                | ProviderBatchState::Cancelled
+                | ProviderBatchState::Expired
+        )
+    );
+    if is_non_success_state {
         log::error!(
             "[SIGNAL JOB] Batch {} done but state is {:?}, routing {} runs to realtime queue",
             message.batch_id,
@@ -164,7 +173,7 @@ async fn process(
         return Ok(());
     };
 
-    // Successfull batch with correct state and non-empty response
+    // Successful batch with correct state and non-empty response
     process_succeeded_batch(&message, response, db, queue, clickhouse, config, cache).await
 }
 

--- a/app-server/src/signals/pendings_consumer.rs
+++ b/app-server/src/signals/pendings_consumer.rs
@@ -13,7 +13,10 @@ use crate::{
     signals::SignalRun,
     signals::{
         SignalWorkerConfig,
-        provider::{LlmClient, models::ProviderBatchOutput},
+        provider::{
+            LlmClient,
+            models::{ProviderBatchOutput, ProviderBatchState},
+        },
         push_to_signals_queue,
         queue::{
             SignalJobPendingBatchMessage, SignalMessage, push_to_realtime_queue,
@@ -120,34 +123,61 @@ async fn process(
         result.done
     );
 
-    if result.done {
-        if let Some(error) = result.error {
-            process_failed_batch(
-                &message,
-                true,
-                db,
-                clickhouse,
-                queue,
-                Some(format!("Batch failed: {}", error.message)),
-            )
-            .await?;
-        } else {
-            process_succeeded_batch(
-                &message,
-                result.response,
-                db,
-                queue,
-                clickhouse,
-                config,
-                cache,
-            )
-            .await?;
-        }
-    } else {
-        process_pending_batch(&message, queue, config.clone()).await?;
+    // Done = false, means the batch is still pending
+    if !result.done {
+        return process_pending_batch(&message, queue, config.clone()).await;
     }
 
-    Ok(())
+    // Error = Some, means the batch failed
+    if let Some(error) = result.error {
+        return process_failed_batch(
+            &message,
+            true,
+            db,
+            clickhouse,
+            queue,
+            Some(format!("Batch failed: {}", error.message)),
+        )
+        .await;
+    }
+
+    // Done = true, no error. Check for batch state (expired, failed, etc.) - fallback to realtime
+    if result.state.as_ref() != Some(&ProviderBatchState::Succeeded) {
+        log::error!(
+            "[SIGNAL JOB] Batch {} done but state is {:?}, routing {} runs to realtime queue",
+            message.batch_id,
+            result.state,
+            message.messages.len()
+        );
+        route_to_realtime_queue(&message.messages, queue).await;
+        return Ok(());
+    }
+
+    // Unexpected empty response - route to realtime queue
+    let Some(response) = result.response else {
+        log::error!(
+            "[SIGNAL JOB] Batch {} succeeded but response is missing, routing {} runs to realtime queue",
+            message.batch_id,
+            message.messages.len()
+        );
+        route_to_realtime_queue(&message.messages, queue).await;
+        return Ok(());
+    };
+
+    // Successfull batch with correct state and non-empty response
+    process_succeeded_batch(&message, response, db, queue, clickhouse, config, cache).await
+}
+
+async fn route_to_realtime_queue(messages: &[SignalMessage], queue: Arc<MessageQueue>) {
+    for message in messages {
+        if let Err(e) = push_to_realtime_queue(message.clone(), queue.clone()).await {
+            log::error!(
+                "[SIGNAL JOB] Failed to push run {} to realtime queue: {:?}",
+                message.run_id,
+                e
+            );
+        }
+    }
 }
 
 #[tracing::instrument(skip_all, fields(num_runs = failed_runs.len()))]
@@ -290,18 +320,13 @@ async fn process_pending_batch(
 #[tracing::instrument(skip_all, fields(batch_id = %message.batch_id))]
 pub async fn process_succeeded_batch(
     message: &SignalJobPendingBatchMessage,
-    batch_output: Option<ProviderBatchOutput>,
+    response: ProviderBatchOutput,
     db: Arc<DB>,
     queue: Arc<MessageQueue>,
     clickhouse: clickhouse::Client,
     config: Arc<SignalWorkerConfig>,
     cache: Arc<Cache>,
 ) -> Result<(), HandlerError> {
-    let response = batch_output.ok_or(HandlerError::permanent(anyhow::anyhow!(
-        "Batch succeeded but response is missing for batch_id: {}",
-        message.batch_id
-    )))?;
-
     let mut processed = process_provider_responses(
         &message.messages,
         &response.responses,

--- a/app-server/src/signals/provider/gemini/conversions.rs
+++ b/app-server/src/signals/provider/gemini/conversions.rs
@@ -91,13 +91,29 @@ impl From<GenerateContentBatchOutput> for ProviderBatchOutput {
     }
 }
 
+impl From<JobState> for ProviderBatchState {
+    fn from(state: JobState) -> Self {
+        match state {
+            JobState::BATCH_STATE_UNSPECIFIED => ProviderBatchState::Unspecified,
+            JobState::BATCH_STATE_PENDING => ProviderBatchState::Pending,
+            JobState::BATCH_STATE_RUNNING => ProviderBatchState::Running,
+            JobState::BATCH_STATE_SUCCEEDED => ProviderBatchState::Succeeded,
+            JobState::BATCH_STATE_FAILED => ProviderBatchState::Failed,
+            JobState::BATCH_STATE_CANCELLED => ProviderBatchState::Cancelled,
+            JobState::BATCH_STATE_EXPIRED => ProviderBatchState::Expired,
+        }
+    }
+}
+
 impl From<Operation> for ProviderBatchOperation {
     fn from(op: Operation) -> Self {
+        let state = op.metadata.map(|m| m.state.into());
         ProviderBatchOperation {
             name: op.name,
             done: op.done,
             response: op.response.map(Into::into),
             error: op.error.map(Into::into),
+            state,
         }
     }
 }

--- a/app-server/src/signals/provider/mock.rs
+++ b/app-server/src/signals/provider/mock.rs
@@ -21,8 +21,8 @@ use uuid::Uuid;
 
 use super::models::ProviderRequest;
 use crate::signals::provider::{
-    LanguageModelClient, ProviderBatchOperation, ProviderBatchOutput, ProviderCandidate,
-    ProviderContent, ProviderError, ProviderFinishReason, ProviderFunctionCall,
+    LanguageModelClient, ProviderBatchOperation, ProviderBatchOutput, ProviderBatchState,
+    ProviderCandidate, ProviderContent, ProviderError, ProviderFinishReason, ProviderFunctionCall,
     ProviderInlineResponse, ProviderPart, ProviderRequestItem, ProviderResponse, ProviderResult,
 };
 
@@ -257,6 +257,7 @@ impl LanguageModelClient for MockProviderClient {
             done: false,
             response: None,
             error: None,
+            state: Some(ProviderBatchState::Pending),
         })
     }
 
@@ -284,6 +285,7 @@ impl LanguageModelClient for MockProviderClient {
                 done: false,
                 response: None,
                 error: None,
+                state: Some(ProviderBatchState::Running),
             });
         }
 
@@ -297,6 +299,23 @@ impl LanguageModelClient for MockProviderClient {
             })
             .collect::<Vec<_>>();
 
+        let is_expired = std::env::var("MOCK_LLM_CLIENT_BATCH_EXPIRED")
+            .is_ok_and(|v| v.trim().to_lowercase() == "true");
+
+        if is_expired {
+            log::debug!(
+                "[Mock LLM client] get_batch called. batch_name={}. Returning expired",
+                batch_name
+            );
+            return Ok(ProviderBatchOperation {
+                name: batch_name.to_string(),
+                done: true,
+                response: None,
+                error: None,
+                state: Some(ProviderBatchState::Expired),
+            });
+        }
+
         log::debug!(
             "[Mock LLM client] get_batch called. batch_name={}. Returning done with {} responses",
             batch_name,
@@ -308,6 +327,7 @@ impl LanguageModelClient for MockProviderClient {
             done: true,
             response: Some(ProviderBatchOutput { responses }),
             error: None,
+            state: Some(ProviderBatchState::Succeeded),
         })
     }
 }

--- a/app-server/src/signals/provider/models.rs
+++ b/app-server/src/signals/provider/models.rs
@@ -211,6 +211,17 @@ pub struct ProviderUsageMetadata {
     pub cache_creation_input_tokens: Option<i32>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderBatchState {
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+    Expired,
+    Unspecified,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderBatchOperation {
@@ -221,4 +232,6 @@ pub struct ProviderBatchOperation {
     pub response: Option<ProviderBatchOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ProviderErrorInfo>,
+    #[serde(skip)]
+    pub state: Option<ProviderBatchState>,
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the batch completion decision path for signal runs; incorrect state/response handling could cause premature realtime fallback or missed batch results, though changes are localized to batch providers and the pending consumer.
> 
> **Overview**
> Improves batch-processing robustness by tracking an explicit provider-reported batch `state` (e.g. `Expired`, `Cancelled`, `Failed`) in `ProviderBatchOperation` and wiring Gemini’s operation metadata into that state.
> 
> Updates the pending-batch consumer to treat `done=true` + non-success `state` or missing `response` as a failure mode, logging the condition and routing affected runs to the realtime queue instead of attempting batch finalization; `process_succeeded_batch` now requires a non-optional `ProviderBatchOutput`.
> 
> Extends the mock provider to emit realistic batch states and adds an env-flagged `Expired` scenario for testing the new fallback path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f1fd224936a2a4a8159e07e26d4d3161fad88f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->