### PR TITLE
feat: move span rendering keys to redis, fallback to system hashing, fix ui

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1682,7 +1682,8 @@ fn main() -> anyhow::Result<()> {
                                     .service(routes::spans::search_spans)
                                     .service(routes::rollouts::run)
                                     .service(routes::rollouts::update_status)
-                                    .service(routes::signals::submit_signal_job),
+                                    .service(routes::signals::submit_signal_job)
+                                    .service(routes::spans::get_skeleton_hashes),
                             )
                             .service(routes::probes::check_health)
                             .service(routes::probes::check_ready)

--- a/app-server/src/routes/spans.rs
+++ b/app-server/src/routes/spans.rs
@@ -13,6 +13,7 @@ use crate::{
     quickwit::client::QuickwitClient,
     routes::ResponseResult,
     search::snippets::SearchSpanHit,
+    signals::utils::structural_skeleton_hash,
     traces::{OBSERVATIONS_EXCHANGE, OBSERVATIONS_ROUTING_KEY, spans::SpanAttributes},
 };
 
@@ -150,3 +151,26 @@ pub async fn search_spans(
     Ok(HttpResponse::Ok().json(results))
 }
 
+
+#[derive(Deserialize)]
+pub struct SkeletonHashRequest {
+    pub texts: Vec<String>,
+}
+
+#[post("skeleton-hashes")]
+pub async fn get_skeleton_hashes(
+    _project_id: web::Path<Uuid>,
+    request: web::Json<SkeletonHashRequest>,
+) -> ResponseResult {
+    let texts = &request.texts;
+
+    if texts.is_empty() || texts.len() > 200 {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "texts must contain between 1 and 200 items"
+        })));
+    }
+
+    let hashes: Vec<String> = texts.iter().map(|t| structural_skeleton_hash(t)).collect();
+
+    Ok(HttpResponse::Ok().json(hashes))
+}

--- a/frontend/components/traces/trace-view/store/base.ts
+++ b/frontend/components/traces/trace-view/store/base.ts
@@ -267,7 +267,7 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
     browserSession: options?.initialTrace?.hasBrowserSession || false,
     sessionTime: undefined,
     sessionStartTime: undefined,
-    tab: "tree",
+    tab: "transcript",
     langGraph: false,
     spanPath: null,
     hasBrowserSession: options?.initialTrace?.hasBrowserSession || false,

--- a/frontend/components/traces/trace-view/store/index.tsx
+++ b/frontend/components/traces/trace-view/store/index.tsx
@@ -227,6 +227,14 @@ const createTraceViewStore = (options?: {
       },
       {
         name: options?.storeKey ?? "trace-view-state",
+        version: 1,
+        migrate: (persistedState, version) => {
+          // v0 -> v1: transcript is the new default tab; move legacy users off "tree" once.
+          if (version < 1 && persistedState && typeof persistedState === "object") {
+            (persistedState as Record<string, unknown>).tab = "transcript";
+          }
+          return persistedState as TraceViewStore;
+        },
         partialize: (state) => {
           const persistentTabs = ["tree", "transcript"] as const;
           const tabToPersist = persistentTabs.includes(state.tab as any) ? state.tab : undefined;

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -280,7 +280,8 @@ type LlmSpanInfo = {
   startTime: string;
 };
 
-const MAIN_AGENT_SEARCH_WINDOW = 5;
+// Shared with TOP_PATH_QUERY in lib/actions/sessions/trace-io.ts and useTraceUserInput.
+export const MAIN_AGENT_SEARCH_WINDOW = 5;
 
 /**
  * Detect sub-agent boundary span IDs from in-memory spans.

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -269,17 +269,39 @@ const toLightweight = (span: TraceViewSpan, pathInfoMap: Map<string, PathInfo>):
 
 const NULL_SPAN_ID = "00000000-0000-0000-0000-000000000000";
 
-type LlmGroup = { parentSpanId: string; promptHash: string; idsPath: string[] };
+type LlmSpanInfo = {
+  spanId: string;
+  parentSpanId: string;
+  spanPath: string;
+  spanPathLength: number;
+  promptHash: string;
+  idsPath: string[];
+  inputTokens: number;
+  startTime: string;
+};
+
+const MAIN_AGENT_SEARCH_WINDOW = 5;
 
 /**
- * Detect sub-agent boundary span IDs from in-memory spans using frequency counting.
+ * Detect sub-agent boundary span IDs from in-memory spans.
  *
- * Groups LLM/CACHED spans by (parentSpanId, promptHash), keeps the earliest
- * idsPath per group, then finds the first ancestor ID exclusive to each
- * sub-agent's hash group. See CLAUDE.md for the full algorithm explanation.
+ * Collects individual LLM/CACHED spans (no grouping). Picks the main agent
+ * as the shallowest (shortest span path) among the earliest few LLM calls,
+ * breaking ties by highest input tokens. Splits spans into main vs non-main
+ * via the composite (spanPath, promptHash) key, then walks each non-main
+ * candidate's idsPath to find the first ancestor not in the main agent's
+ * span IDs — that's the boundary. Dedup via Set collapses sibling/loop
+ * iterations sharing a boundary while preserving separate invocations of
+ * the same agent type under different parents.
+ *
+ * Runs on every span arrival (via the transcript's useMemo on `spans`).
+ * The search window is the first MAIN_AGENT_SEARCH_WINDOW LLM spans by
+ * start time, so once that many have arrived the main agent pick is
+ * stable — later arrivals go to indices beyond the window and don't
+ * affect identification.
  */
 export const computeSubagentBoundaries = (spans: TraceViewSpan[]): Set<string> => {
-  const llmGroups = new Map<string, LlmGroup & { minStart: string }>();
+  const llmSpans: LlmSpanInfo[] = [];
 
   for (const span of spans) {
     if (span.spanType !== "LLM" && span.spanType !== "CACHED") continue;
@@ -289,49 +311,47 @@ export const computeSubagentBoundaries = (spans: TraceViewSpan[]): Set<string> =
 
     if (!promptHash || !Array.isArray(idsPath) || idsPath.length === 0) continue;
 
-    const filteredPath = idsPath.filter((id) => id !== NULL_SPAN_ID);
-    const key = `${span.parentSpanId ?? ""}\0${promptHash}`;
+    const spanPathAttr = span.attributes?.["lmnr.span.path"];
+    const spanPathArr = Array.isArray(spanPathAttr) ? spanPathAttr : [];
 
-    const existing = llmGroups.get(key);
-    if (!existing || span.startTime < existing.minStart) {
-      llmGroups.set(key, {
-        parentSpanId: span.parentSpanId ?? "",
-        promptHash,
-        idsPath: filteredPath,
-        minStart: span.startTime,
-      });
-    }
+    llmSpans.push({
+      spanId: span.spanId,
+      parentSpanId: span.parentSpanId ?? "",
+      spanPath: spanPathArr.join("."),
+      spanPathLength: spanPathArr.length,
+      promptHash,
+      idsPath: idsPath.filter((id) => id !== NULL_SPAN_ID),
+      inputTokens: span.inputTokens ?? 0,
+      startTime: span.startTime,
+    });
   }
 
-  const groups = [...llmGroups.values()].sort((a, b) => a.minStart.localeCompare(b.minStart));
-  if (groups.length <= 1) return new Set();
+  if (llmSpans.length <= 1) return new Set();
 
-  const mainHash = groups[0].promptHash;
-  const mainRows = groups.filter((r) => r.promptHash === mainHash);
-  const nonMainRows = groups.filter((r) => r.promptHash !== mainHash);
-  if (nonMainRows.length === 0) return new Set();
+  llmSpans.sort((a, b) => a.startTime.localeCompare(b.startTime));
 
-  const mainParentIds = new Set(mainRows.map((r) => r.parentSpanId));
-  const mainSpanIds = new Set(mainRows.flatMap((r) => r.idsPath));
+  const searchWindow = llmSpans.slice(0, MAIN_AGENT_SEARCH_WINDOW);
+  const mainSpan = searchWindow.reduce((best, s) => {
+    if (s.spanPathLength < best.spanPathLength) return s;
+    if (s.spanPathLength === best.spanPathLength && s.inputTokens > best.inputTokens) return s;
+    return best;
+  });
 
-  const candidates = nonMainRows.filter((r) => !mainParentIds.has(r.parentSpanId));
-  if (candidates.length === 0) return new Set();
+  const mainCompositeKey = `${mainSpan.spanPath}\0${mainSpan.promptHash}`;
+  const compositeKeyOf = (s: LlmSpanInfo) => `${s.spanPath}\0${s.promptHash}`;
 
-  const hashGroupsPerSpan = new Map<string, Set<string>>();
-  for (const c of candidates) {
-    for (const id of c.idsPath) {
-      if (mainSpanIds.has(id)) continue;
-      if (!hashGroupsPerSpan.has(id)) hashGroupsPerSpan.set(id, new Set());
-      hashGroupsPerSpan.get(id)!.add(c.promptHash);
-    }
-  }
+  const mainSpans = llmSpans.filter((s) => compositeKeyOf(s) === mainCompositeKey);
+  const nonMainSpans = llmSpans.filter((s) => compositeKeyOf(s) !== mainCompositeKey);
+  if (nonMainSpans.length === 0) return new Set();
+
+  const mainSpanIds = new Set(mainSpans.flatMap((s) => s.idsPath));
+
+  const candidates = nonMainSpans;
 
   const boundaryIds = new Set<string>();
   for (const c of candidates) {
     for (const id of c.idsPath) {
-      if (mainSpanIds.has(id)) continue;
-      const hGroups = hashGroupsPerSpan.get(id);
-      if (hGroups && hGroups.size === 1) {
+      if (!mainSpanIds.has(id)) {
         boundaryIds.add(id);
         break;
       }

--- a/frontend/components/traces/trace-view/transcript-hint-popover.tsx
+++ b/frontend/components/traces/trace-view/transcript-hint-popover.tsx
@@ -1,0 +1,68 @@
+import { X } from "lucide-react";
+import { type ReactNode, useState } from "react";
+
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+
+const TRANSCRIPT_HINT_STORAGE_KEY = "trace-view:transcript-hint-dismissed";
+
+interface TranscriptHintPopoverProps {
+  /**
+   * Render function for the anchor element. Receives `open` so the trigger
+   * can visually indicate the hint is active (e.g. highlight border).
+   * Must return a single element that forwards refs (e.g. a DropdownMenuTrigger).
+   */
+  children: (state: { open: boolean }) => ReactNode;
+}
+
+export default function TranscriptHintPopover({ children }: TranscriptHintPopoverProps) {
+  const [open, setOpen] = useState(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return !localStorage.getItem(TRANSCRIPT_HINT_STORAGE_KEY);
+    } catch {
+      return false;
+    }
+  });
+
+  const dismiss = () => {
+    setOpen(false);
+    try {
+      localStorage.setItem(TRANSCRIPT_HINT_STORAGE_KEY, "true");
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <Popover open={open}>
+      <PopoverAnchor asChild>{children({ open })}</PopoverAnchor>
+      <PopoverContent
+        side="bottom"
+        align="start"
+        sideOffset={8}
+        className="w-80 p-3 border-primary/60 shadow-lg shadow-primary/10"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <div className="flex items-start gap-2">
+          <div className="flex-1 text-xs leading-relaxed">
+            <div className="font-medium text-primary mb-1">New: Transcript view</div>
+            <p className="text-foreground/80">
+              See what your agents were asked to do and a breakdown of what each agent did. Switch to Tree anytime for
+              detailed, span-by-span inspection.
+            </p>
+          </div>
+          <button
+            onClick={dismiss}
+            className="text-muted-foreground hover:text-foreground -mt-1 -mr-1 p-1 rounded-md hover:bg-secondary"
+            aria-label="Dismiss"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/components/traces/trace-view/transcript/collapsed-text-with-more.tsx
+++ b/frontend/components/traces/trace-view/transcript/collapsed-text-with-more.tsx
@@ -54,7 +54,7 @@ export function CollapsedTextWithMore({
   return (
     <div
       ref={containerRef}
-      className={cn("text-sm text-secondary-foreground/95", className)}
+      className={cn("text-sm text-secondary-foreground/95 break-all", className)}
       style={{ lineHeight: `${lineHeight + 4}px` }}
     >
       {truncated !== null ? (

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -79,13 +79,16 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
     [getTranscriptListData, spans, condensedTimelineVisibleSpanIds]
   );
 
-  const hasLlmSpan = useMemo(() => spans.some((s) => s.spanType === "LLM" || s.spanType === "CACHED"), [spans]);
+  const llmSpanCount = useMemo(
+    () => spans.filter((s) => s.spanType === "LLM" || s.spanType === "CACHED").length,
+    [spans]
+  );
 
-  const { userInput, isLoading: isUserInputLoading } = useTraceUserInput(projectId, trace?.id, isShared, hasLlmSpan);
+  const { userInput, isLoading: isUserInputLoading } = useTraceUserInput(projectId, trace?.id, isShared, llmSpanCount);
   // Render the user-input row whenever we know an LLM span exists (even while
   // its content is still being fetched). This makes the input appear as soon
   // as the first LLM span arrives over realtime.
-  const hasUserInput = hasLlmSpan || isUserInputLoading || !!userInput;
+  const hasUserInput = llmSpanCount > 0 || isUserInputLoading || !!userInput;
 
   const flatRows = useMemo(() => {
     const rows: FlatRow[] = [];

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -19,7 +19,7 @@ import {
 import { useBatchedSpanPreviews } from "@/components/traces/trace-view/transcript/use-batched-span-previews";
 import { useTraceUserInput } from "@/components/traces/trace-view/transcript/use-trace-user-input";
 import { Skeleton } from "@/components/ui/skeleton.tsx";
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils.ts";
 
 interface ListProps {
   onSpanSelect: (span?: TraceViewSpan) => void;
@@ -27,6 +27,8 @@ interface ListProps {
 }
 
 type FlatRow = { type: "user-input" } | TranscriptListEntry;
+
+const isGroupChildType = (type: FlatRow["type"]): boolean => type === "group-span" || type === "group-input";
 
 function getSpanIdsForRow(row: FlatRow, expandedGroups: Set<string>): string[] {
   switch (row.type) {
@@ -286,14 +288,19 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
           {items.map((virtualRow) => {
             const row = flatRows[virtualRow.index];
             if (!row) return null;
-            const isTopLevel = row.type === "group" || row.type === "span" || row.type === "user-input";
-            const isFirst = virtualRow.index === 0;
+            const nextRow = flatRows[virtualRow.index + 1];
+            const isGroupChild = row.type === "group-span" || row.type === "group-input";
+            const isCollapsedGroup = row.type === "group" && (!nextRow || !isGroupChildType(nextRow.type));
+            const isLastGroupChild = isGroupChild && (!nextRow || !isGroupChildType(nextRow.type));
             return (
               <div
                 key={virtualRow.key}
                 data-index={virtualRow.index}
                 ref={virtualizer.measureElement}
-                className={cn(isTopLevel && !isFirst && "pt-2")}
+                className={cn({
+                  "pt-1": row.type === "group",
+                  "pb-1": isCollapsedGroup || isLastGroupChild,
+                })}
               >
                 {renderRow(row)}
               </div>

--- a/frontend/components/traces/trace-view/transcript/item/agent-group-header.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/agent-group-header.tsx
@@ -60,7 +60,7 @@ export function AgentGroupHeader({ group, collapsed, previews, inputPreviews, ag
       )}
       onClick={handleToggle}
     >
-      <div className={cn("flex flex-col flex-1 min-w-0 px-3 py-2", collapsed && "gap-1")}>
+      <div className={cn("flex flex-col flex-1 min-w-0 px-2 py-2", collapsed && "gap-1")}>
         <div className="flex gap-2 items-center min-w-0">
           <div
             className="flex items-center justify-center z-10 rounded shrink-0"

--- a/frontend/components/traces/trace-view/transcript/item/input-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/input-item.tsx
@@ -15,7 +15,7 @@ export function InputItem({ text, isLoading, inGroup }: InputItemProps) {
 
   return (
     <div
-      className={cn("flex flex-col flex-1 min-w-0 px-3 py-2 border-l-4 border-l-transparent gap-1", {
+      className={cn("flex flex-col flex-1 min-w-0 py-2 px-1 border-l-4 border-l-transparent gap-1", {
         "bg-muted/60": inGroup,
       })}
     >

--- a/frontend/components/traces/trace-view/transcript/item/input-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/input-item.tsx
@@ -15,7 +15,7 @@ export function InputItem({ text, isLoading, inGroup }: InputItemProps) {
 
   return (
     <div
-      className={cn("flex flex-col flex-1 min-w-0 py-2 pl-1 pr-2 border-l-4 border-l-transparent gap-1", {
+      className={cn("flex flex-col flex-1 min-w-0 py-2 pl-1 pr-2 border-l-4 border-l-transparent gap-1 bg-blue-400/5", {
         "bg-muted/60": inGroup,
       })}
     >

--- a/frontend/components/traces/trace-view/transcript/item/input-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/input-item.tsx
@@ -15,7 +15,7 @@ export function InputItem({ text, isLoading, inGroup }: InputItemProps) {
 
   return (
     <div
-      className={cn("flex flex-col flex-1 min-w-0 py-2 px-1 border-l-4 border-l-transparent gap-1", {
+      className={cn("flex flex-col flex-1 min-w-0 py-2 pl-1 pr-2 border-l-4 border-l-transparent gap-1", {
         "bg-muted/60": inGroup,
       })}
     >

--- a/frontend/components/traces/trace-view/transcript/item/span-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/span-item.tsx
@@ -119,9 +119,9 @@ export default function SpanItem({ span, output, onSpanSelect, inGroup = false }
   return (
     <div
       className={cn(
-        "flex group/message cursor-pointer transition-all border-l-4",
+        "flex group/message cursor-pointer transition-all border-l-2",
         inGroup ? "hover:bg-muted/80 bg-muted/60" : "hover:bg-secondary",
-        isSelected ? "bg-primary/5 border-l-primary" : "border-l-transparent",
+        isSelected ? "bg-primary/15 border-l-primary hover:bg-primary/20" : "border-l-transparent",
         { "opacity-60": isCached }
       )}
       onClick={() => {
@@ -136,7 +136,7 @@ export default function SpanItem({ span, output, onSpanSelect, inGroup = false }
         </div>
       )}
 
-      <div className="flex flex-col flex-1 min-w-0 py-2 gap-1 pl-1 pr-2">
+      <div className="flex flex-col flex-1 min-w-0 py-2 gap-1 pl-1.5 pr-2">
         <div className="flex gap-2 items-center min-w-0">
           <SpanTypeIcon
             spanType={span.spanType}

--- a/frontend/components/traces/trace-view/transcript/item/span-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/span-item.tsx
@@ -136,7 +136,7 @@ export default function SpanItem({ span, output, onSpanSelect, inGroup = false }
         </div>
       )}
 
-      <div className="flex flex-col flex-1 min-w-0 px-3 py-2 gap-1">
+      <div className={cn("flex flex-col flex-1 min-w-0 py-2 gap-1 px-1")}>
         <div className="flex gap-2 items-center min-w-0">
           <SpanTypeIcon
             spanType={span.spanType}

--- a/frontend/components/traces/trace-view/transcript/item/span-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/span-item.tsx
@@ -136,7 +136,7 @@ export default function SpanItem({ span, output, onSpanSelect, inGroup = false }
         </div>
       )}
 
-      <div className={cn("flex flex-col flex-1 min-w-0 py-2 gap-1 px-1")}>
+      <div className="flex flex-col flex-1 min-w-0 py-2 gap-1 pl-1 pr-2">
         <div className="flex gap-2 items-center min-w-0">
           <SpanTypeIcon
             spanType={span.spanType}

--- a/frontend/components/traces/trace-view/transcript/use-batched-span-previews.tsx
+++ b/frontend/components/traces/trace-view/transcript/use-batched-span-previews.tsx
@@ -1,12 +1,10 @@
-import { get } from "lodash";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useToast } from "@/lib/hooks/use-toast.ts";
-import { SimpleLRU } from "@/lib/simple-lru.ts";
 import { convertToTimeParameters } from "@/lib/time.ts";
 
 export interface BatchedPreviewsHook {
-  previews: Record<string, any>;
+  previews: Record<string, string | null>;
   inputPreviews: Record<string, string | null>;
   agentNames: Record<string, string | null>;
   clearCache: () => void;
@@ -14,10 +12,16 @@ export interface BatchedPreviewsHook {
 
 interface UseBatchedSpanPreviewsOptions {
   debounceMs?: number;
-  maxEntries?: number;
   isShared?: boolean;
 }
 
+/**
+ * Batches span-preview requests behind a debounce. Tracks output and input
+ * fetches independently so a span first seen as a plain row (output only)
+ * correctly fetches its input when the transcript structure later promotes it
+ * into a subagent group header — otherwise the shared ID would short-circuit
+ * the input request and leave group-input rows stuck loading.
+ */
 export function useBatchedSpanPreviews(
   projectId: string | undefined,
   visibleSpanIds: string[],
@@ -27,168 +31,148 @@ export function useBatchedSpanPreviews(
   inputSpanIds?: string[],
   promptHashes?: Record<string, string>
 ): BatchedPreviewsHook {
-  const { debounceMs = 150, maxEntries = 100, isShared = false } = options;
+  const { debounceMs = 150, isShared = false } = options;
   const { toast } = useToast();
-  const cache = useRef(new SimpleLRU<string, any>(maxEntries));
-  const fetching = useRef(new Set<string>());
-  const pendingFetch = useRef(new Set<string>());
+
+  // Union of "pending + in-flight + successfully fetched" per role. The React
+  // state objects below are the fetched-set (keyed by `id in previews`). These
+  // refs add the pending/in-flight layer so we don't re-queue the same ID.
+  const requestedOutputs = useRef(new Set<string>());
+  const requestedInputs = useRef(new Set<string>());
+  const pendingOutputs = useRef(new Set<string>());
+  const pendingInputs = useRef(new Set<string>());
+
   const timer = useRef<NodeJS.Timeout | null>(null);
-  const lastIdsRef = useRef<string>("");
-  const [previews, setPreviews] = useState<Record<string, any>>({});
+
+  const [previews, setPreviews] = useState<Record<string, string | null>>({});
   const [inputPreviews, setInputPreviews] = useState<Record<string, string | null>>({});
   const [agentNames, setAgentNames] = useState<Record<string, string | null>>({});
-  const spanTypesRef = useRef<Record<string, string>>(spanTypes ?? {});
-  const inputSpanIdsRef = useRef<string[]>(inputSpanIds ?? []);
-  const promptHashesRef = useRef<Record<string, string>>(promptHashes ?? {});
 
-  if (spanTypes) {
-    spanTypesRef.current = spanTypes;
-  }
-  if (inputSpanIds) {
-    inputSpanIdsRef.current = inputSpanIds;
-  }
-  if (promptHashes) {
-    promptHashesRef.current = promptHashes;
-  }
+  // Pass-through state refs so fetchBatch always reads the latest values
+  // without being rebuilt on every parent render.
+  const spanTypesRef = useRef(spanTypes ?? {});
+  const promptHashesRef = useRef(promptHashes ?? {});
+  spanTypesRef.current = spanTypes ?? spanTypesRef.current;
+  promptHashesRef.current = promptHashes ?? promptHashesRef.current;
 
-  const fetchBatch = useCallback(
-    async (spanIds: string[]) => {
-      if (spanIds.length === 0 || !trace?.id) return;
+  const runFetch = useCallback(async () => {
+    const outputIds = [...pendingOutputs.current];
+    const inputIds = [...pendingInputs.current];
+    pendingOutputs.current.clear();
+    pendingInputs.current.clear();
 
-      const inputSpanIdSet = new Set(inputSpanIdsRef.current);
-      const batchInputSpanIds = spanIds.filter((id) => inputSpanIdSet.has(id));
+    if (!trace?.id || (outputIds.length === 0 && inputIds.length === 0)) return;
 
-      try {
-        const body: Record<string, any> = {
-          spanIds,
-          spanTypes: spanTypesRef.current,
-        };
+    const spanIds = [...new Set([...outputIds, ...inputIds])];
 
-        if (batchInputSpanIds.length > 0) {
-          body.inputSpanIds = batchInputSpanIds;
+    const body: Record<string, unknown> = {
+      spanIds,
+      spanTypes: spanTypesRef.current,
+    };
 
-          const batchHashes: Record<string, string> = {};
-          for (const id of batchInputSpanIds) {
-            const hash = promptHashesRef.current[id];
-            if (hash) batchHashes[id] = hash;
-          }
-          if (Object.keys(batchHashes).length > 0) {
-            body.promptHashes = batchHashes;
-          }
-        }
+    if (inputIds.length > 0) {
+      body.inputSpanIds = inputIds;
+      const batchHashes: Record<string, string> = {};
+      for (const id of inputIds) {
+        const hash = promptHashesRef.current[id];
+        if (hash) batchHashes[id] = hash;
+      }
+      if (Object.keys(batchHashes).length > 0) body.promptHashes = batchHashes;
+    }
 
-        if (trace?.startTime && trace?.endTime) {
-          const startTime = new Date(new Date(trace.startTime).getTime() - 1000).toISOString();
-          const endTime = new Date(new Date(trace.endTime).getTime() + 1000).toISOString();
+    if (trace.startTime && trace.endTime) {
+      const params = convertToTimeParameters({
+        startTime: new Date(new Date(trace.startTime).getTime() - 1000).toISOString(),
+        endTime: new Date(new Date(trace.endTime).getTime() + 1000).toISOString(),
+      });
+      body.startDate = params.start_time;
+      body.endDate = params.end_time;
+    }
 
-          const params = convertToTimeParameters({ startTime, endTime });
-          body.startDate = params.start_time;
-          body.endDate = params.end_time;
-        }
+    const url = isShared
+      ? `/api/shared/traces/${trace.id}/spans/previews`
+      : `/api/projects/${projectId}/traces/${trace.id}/spans/previews`;
 
-        const url = isShared
-          ? `/api/shared/traces/${trace.id}/spans/previews`
-          : `/api/projects/${projectId}/traces/${trace.id}/spans/previews`;
+    try {
+      const res = await fetch(url, { method: "POST", body: JSON.stringify(body) });
+      if (!res.ok) {
+        const errData = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(errData?.error ?? "Failed to fetch span previews");
+      }
+      const data = (await res.json()) as {
+        previews: Record<string, string | null>;
+        inputPreviews?: Record<string, string | null>;
+        agentNames?: Record<string, string | null>;
+      };
 
-        const response = await fetch(url, {
-          method: "POST",
-          body: JSON.stringify(body),
-        });
-
-        if (!response.ok) {
-          const errorData = (await response.json()) as { error: string };
-          throw new Error(errorData.error || "Failed to fetch span previews");
-        }
-
-        const data = (await response.json()) as {
-          previews: Record<string, string | null>;
-          inputPreviews?: Record<string, string | null>;
-          agentNames?: Record<string, string | null>;
-        };
-
-        spanIds.forEach((id) => {
-          cache.current.set(id, get(data.previews, id, null));
-          fetching.current.delete(id);
-        });
-
+      if (outputIds.length > 0) {
         setPreviews((prev) => {
           const next = { ...prev };
-          spanIds.forEach((id) => {
-            next[id] = cache.current.get(id);
-          });
+          for (const id of outputIds) next[id] = data.previews?.[id] ?? null;
           return next;
         });
-
-        if (data.inputPreviews) {
-          setInputPreviews((prev) => ({ ...prev, ...data.inputPreviews }));
-        }
-
+      }
+      if (inputIds.length > 0) {
+        setInputPreviews((prev) => {
+          const next = { ...prev };
+          for (const id of inputIds) next[id] = data.inputPreviews?.[id] ?? null;
+          return next;
+        });
         if (data.agentNames) {
           setAgentNames((prev) => ({ ...prev, ...data.agentNames }));
         }
-      } catch (error) {
-        toast({
-          variant: "destructive",
-          title: "Error",
-          description:
-            error instanceof Error ? error.message : "Failed to fetch span previews. Please try again later.",
-        });
-
-        spanIds.forEach((id) => {
-          cache.current.set(id, null);
-          fetching.current.delete(id);
-        });
-
+      }
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to fetch span previews.",
+      });
+      if (outputIds.length > 0) {
         setPreviews((prev) => {
           const next = { ...prev };
-          spanIds.forEach((id) => {
-            next[id] = null;
-          });
+          for (const id of outputIds) next[id] = null;
           return next;
         });
       }
-    },
-    [projectId, toast, trace, isShared]
-  );
-
-  const scheduleFetch = useCallback(async () => {
-    if (pendingFetch.current.size === 0) return;
-
-    const toFetch = Array.from(pendingFetch.current);
-    pendingFetch.current.clear();
-
-    toFetch.forEach((id) => fetching.current.add(id));
-    await fetchBatch(toFetch);
-  }, [fetchBatch]);
-
-  const allIds = useMemo(() => [...visibleSpanIds, ...(inputSpanIds ?? [])], [visibleSpanIds, inputSpanIds]);
+      if (inputIds.length > 0) {
+        setInputPreviews((prev) => {
+          const next = { ...prev };
+          for (const id of inputIds) if (!(id in next)) next[id] = null;
+          return next;
+        });
+      }
+    }
+  }, [projectId, toast, trace, isShared]);
 
   useEffect(() => {
-    const currentIdsKey = allIds.join(",");
+    let queued = false;
 
-    if (currentIdsKey === lastIdsRef.current) {
-      return;
+    for (const id of visibleSpanIds) {
+      if (requestedOutputs.current.has(id)) continue;
+      requestedOutputs.current.add(id);
+      pendingOutputs.current.add(id);
+      queued = true;
     }
 
-    lastIdsRef.current = currentIdsKey;
-
-    const newIds = allIds.filter(
-      (id) => !cache.current.has(id) && !fetching.current.has(id) && !pendingFetch.current.has(id)
-    );
-
-    if (newIds.length > 0) {
-      newIds.forEach((id) => pendingFetch.current.add(id));
-
-      if (timer.current) {
-        clearTimeout(timer.current);
-      }
-      timer.current = setTimeout(scheduleFetch, debounceMs);
+    for (const id of inputSpanIds ?? []) {
+      if (requestedInputs.current.has(id)) continue;
+      requestedInputs.current.add(id);
+      pendingInputs.current.add(id);
+      queued = true;
     }
-  }, [allIds, scheduleFetch, debounceMs]);
+
+    if (!queued) return;
+
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(runFetch, debounceMs);
+  }, [visibleSpanIds, inputSpanIds, runFetch, debounceMs]);
 
   const clearCache = useCallback(() => {
-    cache.current.clear();
-    fetching.current.clear();
+    requestedOutputs.current.clear();
+    requestedInputs.current.clear();
+    pendingOutputs.current.clear();
+    pendingInputs.current.clear();
     setPreviews({});
     setInputPreviews({});
     setAgentNames({});

--- a/frontend/components/traces/trace-view/transcript/use-trace-user-input.ts
+++ b/frontend/components/traces/trace-view/transcript/use-trace-user-input.ts
@@ -11,14 +11,15 @@ export function useTraceUserInput(
   projectId: string | undefined,
   traceId: string | undefined,
   isShared: boolean,
-  hasLlmSpan: boolean
+  llmSpanCount: number
 ): UseTraceUserInputResult {
   const { toast } = useToast();
   const [userInput, setUserInput] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  // Track whether we've already successfully resolved input for this trace so
-  // we don't keep refetching on every LLM span arrival.
-  const resolvedRef = useRef<{ traceId: string; input: string | null } | null>(null);
+  // Track the span count we resolved against so we can refetch as more LLM
+  // spans arrive (the server picks the main agent from the first 5, so we
+  // want to refetch until we reach that threshold).
+  const resolvedRef = useRef<{ traceId: string; input: string | null; llmSpanCount: number } | null>(null);
 
   useEffect(() => {
     if (!traceId) {
@@ -30,12 +31,18 @@ export function useTraceUserInput(
     // Only fetch once we know there is at least one LLM span in the trace,
     // since extraction relies on LLM span inputs. Before then, leave the hook
     // in its idle state so the UI can skip rendering a placeholder input row.
-    if (!hasLlmSpan) {
+    if (llmSpanCount === 0) {
       return;
     }
 
-    // If we've already resolved a non-null input for this trace, skip refetch.
-    if (resolvedRef.current?.traceId === traceId && resolvedRef.current.input !== null) {
+    // Once we've resolved a non-null input with 5+ LLM spans visible, the
+    // server has enough candidates to reliably pick the main agent, so stop
+    // refetching on subsequent span arrivals.
+    if (
+      resolvedRef.current?.traceId === traceId &&
+      resolvedRef.current.input !== null &&
+      resolvedRef.current.llmSpanCount >= 5
+    ) {
       return;
     }
 
@@ -58,7 +65,7 @@ export function useTraceUserInput(
         }
         const data = (await res.json()) as { input: string | null };
         setUserInput(data.input);
-        resolvedRef.current = { traceId, input: data.input };
+        resolvedRef.current = { traceId, input: data.input, llmSpanCount };
       } catch (error) {
         if (controller.signal.aborted) return;
         toast({
@@ -74,7 +81,7 @@ export function useTraceUserInput(
     fetchUserInput();
 
     return () => controller.abort();
-  }, [projectId, traceId, isShared, hasLlmSpan, toast]);
+  }, [projectId, traceId, isShared, llmSpanCount, toast]);
 
   return { userInput, isLoading };
 }

--- a/frontend/components/traces/trace-view/transcript/use-trace-user-input.ts
+++ b/frontend/components/traces/trace-view/transcript/use-trace-user-input.ts
@@ -37,8 +37,7 @@ export function useTraceUserInput(
 
     if (
       resolvedRef.current?.traceId === traceId &&
-      resolvedRef.current.input !== null &&
-      resolvedRef.current.llmSpanCount >= MAIN_AGENT_SEARCH_WINDOW
+      (resolvedRef.current.input !== null || resolvedRef.current.llmSpanCount >= MAIN_AGENT_SEARCH_WINDOW)
     ) {
       return;
     }

--- a/frontend/components/traces/trace-view/transcript/use-trace-user-input.ts
+++ b/frontend/components/traces/trace-view/transcript/use-trace-user-input.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
+import { MAIN_AGENT_SEARCH_WINDOW } from "@/components/traces/trace-view/store/utils";
 import { useToast } from "@/lib/hooks/use-toast";
 
 interface UseTraceUserInputResult {
@@ -16,9 +17,8 @@ export function useTraceUserInput(
   const { toast } = useToast();
   const [userInput, setUserInput] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  // Track the span count we resolved against so we can refetch as more LLM
-  // spans arrive (the server picks the main agent from the first 5, so we
-  // want to refetch until we reach that threshold).
+  // Track the span count we resolved against so we can refetch until the
+  // server has at least MAIN_AGENT_SEARCH_WINDOW LLM spans to pick from.
   const resolvedRef = useRef<{ traceId: string; input: string | null; llmSpanCount: number } | null>(null);
 
   useEffect(() => {
@@ -35,13 +35,10 @@ export function useTraceUserInput(
       return;
     }
 
-    // Once we've resolved a non-null input with 5+ LLM spans visible, the
-    // server has enough candidates to reliably pick the main agent, so stop
-    // refetching on subsequent span arrivals.
     if (
       resolvedRef.current?.traceId === traceId &&
       resolvedRef.current.input !== null &&
-      resolvedRef.current.llmSpanCount >= 5
+      resolvedRef.current.llmSpanCount >= MAIN_AGENT_SEARCH_WINDOW
     ) {
       return;
     }

--- a/frontend/components/traces/trace-view/view-dropdown.tsx
+++ b/frontend/components/traces/trace-view/view-dropdown.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, Eye, EyeOff, List, ListTree, type LucideIcon } from "lucide-react";
 
 import { useTraceViewBaseStore } from "@/components/traces/trace-view/store/base";
+import TranscriptHintPopover from "@/components/traces/trace-view/transcript-hint-popover";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -49,18 +50,23 @@ export default function ViewDropdown() {
   return (
     <div className="flex items-center min-w-0">
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            className={cn(
-              "flex items-center h-6 px-1.5 text-xs border rounded-md bg-background focus-visible:outline-0",
-              isTreeView && "rounded-r-none border-r-0 outline-inset -outline-offset-1 hover:bg-secondary"
-            )}
-          >
-            <CurrentIcon size={14} className="mr-1" />
-            <span className="capitalize">{currentView.label}</span>
-            <ChevronDown size={14} className="ml-1" />
-          </button>
-        </DropdownMenuTrigger>
+        <TranscriptHintPopover>
+          {({ open: hintOpen }) => (
+            <DropdownMenuTrigger asChild>
+              <button
+                className={cn(
+                  "flex items-center h-6 px-1.5 text-xs border rounded-md bg-background focus-visible:outline-0",
+                  isTreeView && "rounded-r-none border-r-0 outline-inset -outline-offset-1 hover:bg-secondary",
+                  hintOpen && "border-primary ring-1 ring-primary/40"
+                )}
+              >
+                <CurrentIcon size={14} className="mr-1" />
+                <span className="capitalize">{currentView.label}</span>
+                <ChevronDown size={14} className="ml-1" />
+              </button>
+            </DropdownMenuTrigger>
+          )}
+        </TranscriptHintPopover>
         <DropdownMenuContent align="start">
           {viewTabs.map((option) => {
             const view = viewOptions[option];

--- a/frontend/lib/actions/sessions/parse-input.ts
+++ b/frontend/lib/actions/sessions/parse-input.ts
@@ -13,14 +13,15 @@ export interface ParsedInput {
 }
 
 /**
- * Build a synthetic messages array from the first and second elements
+ * Build a synthetic messages array from the first and last elements
  * extracted by ClickHouse, then parse into typed system + user parts.
- * The second element is expected to be the first user message (arr[2]).
+ * The first element is typically the system message (arr[1]) and the
+ * last element is the most recent user message (arr[length(arr)]).
  */
-export function parseExtractedMessages(firstMessage: string, secondMessage: string): ParsedInput | null {
+export function parseExtractedMessages(firstMessage: string, lastMessage: string): ParsedInput | null {
   const parts: string[] = [];
   if (firstMessage) parts.push(firstMessage);
-  if (secondMessage) parts.push(secondMessage);
+  if (lastMessage) parts.push(lastMessage);
   if (parts.length === 0) return null;
 
   const syntheticJson = `[${parts.join(",")}]`;

--- a/frontend/lib/actions/sessions/trace-io.ts
+++ b/frontend/lib/actions/sessions/trace-io.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v4";
 
 import { processSpanPreviews } from "@/lib/actions/spans/previews";
 import { executeQuery } from "@/lib/actions/sql";
+import { fetcherJSON } from "@/lib/utils.ts";
 
 import { extractInputsForGroup, joinUserParts } from "./extract-input";
 import { type ParsedInput, parseExtractedMessages } from "./parse-input";
@@ -28,7 +29,7 @@ const TOP_PATH_QUERY = `
 const INPUT_QUERY = `
   SELECT
     arr[1] AS first_message,
-    if(length(arr) > 1, arr[2], '') AS second_message,
+    if(length(arr) > 1, arr[length(arr)], '') AS last_message,
     prompt_hash
   FROM (
     SELECT
@@ -55,7 +56,7 @@ const OUTPUT_QUERY = `
 
 interface InputQueryRow {
   first_message: string;
-  second_message: string;
+  last_message: string;
   prompt_hash: string;
 }
 
@@ -81,6 +82,13 @@ export async function getMainAgentIOBatch({
   const parsed = bodySchema.parse({ traceIds });
 
   const traceData = await Promise.all(parsed.traceIds.map((traceId) => fetchTraceData(traceId, projectId)));
+
+  // Back-compat fallback: fill in missing promptHash values by asking app-server
+  // to hash the system prompt we already parsed. Once prompt_hash is populated
+  // for most spans via the ingest pipeline (app-server/src/traces/utils.rs),
+  // this hydration step can be removed together with the /skeleton-hashes
+  // endpoint and this function's reliance on parsed.systemText.
+  await hydrateMissingPromptHashes(traceData, projectId);
 
   const bySystemHash = new Map<string, TraceWithParsedInput[]>();
   const noHashTraces: TraceWithParsedInput[] = [];
@@ -128,12 +136,84 @@ export async function getTraceUserInput(traceId: string, projectId: string): Pro
   const rawInput = joinUserParts(traceData.parsed.userParts);
   if (!rawInput) return null;
 
+  // Back-compat fallback: older spans don't carry a prompt_hash attribute, so
+  // we compute one via app-server from the parsed system text and cache it as
+  // the group key for regex extraction. Remove once ingest-time hashing in
+  // app-server/src/traces/utils.rs has populated most spans with prompt_hash
+  // — then the /skeleton-hashes endpoint and this hydration can go away.
+  await hydrateMissingPromptHashes([traceData], projectId);
+
+  // Without a prompt hash there is no group key to cache the regex under, so
+  // fall back to the raw user text. This should be rare after hydration.
   if (!traceData.promptHash) return rawInput;
 
   const results: Record<string, { input: string | null; output: string | null }> = {};
   await extractInputsForGroup(traceData.promptHash, projectId, [traceData], results);
 
   return results[traceId]?.input ?? rawInput;
+}
+
+// ---------------------------------------------------------------------------
+// Back-compat: client-side prompt-hash hydration.
+//
+// app-server computes a `lmnr.span.prompt_hash` attribute at ingest
+// (see app-server/src/traces/utils.rs::compute_prompt_hash). For spans that
+// pre-date that code path the attribute is missing, so when ClickHouse
+// returns no prompt_hash we fall back to asking app-server's
+// /projects/{projectId}/skeleton-hashes endpoint to compute it from the
+// system text we parsed client-side. This keeps the regex-cache grouping
+// working on historical data.
+//
+// TODO: once ingest-time hashing has backfilled most spans, drop this
+// function, the `/skeleton-hashes` route in app-server, and the reliance on
+// parsed.systemText in this file. At that point a missing prompt_hash can
+// simply short-circuit to returning the raw user input.
+// ---------------------------------------------------------------------------
+
+const SKELETON_BATCH_LIMIT = 200; // must stay in sync with app-server's SkeletonHashRequest cap
+
+async function fetchSkeletonHashes(texts: string[], projectId: string): Promise<string[]> {
+  try {
+    const hashes = await fetcherJSON<string[]>(`/projects/${projectId}/skeleton-hashes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ texts }),
+    });
+    return Array.isArray(hashes) ? hashes : [];
+  } catch {
+    return [];
+  }
+}
+
+async function hydrateMissingPromptHashes(traces: TraceWithParsedInput[], projectId: string): Promise<void> {
+  const toHash: { trace: TraceWithParsedInput; systemText: string }[] = [];
+  for (const trace of traces) {
+    if (trace.promptHash) continue;
+    const systemText = trace.parsed?.systemText?.trim();
+    if (!systemText) continue;
+    toHash.push({ trace, systemText });
+  }
+
+  if (toHash.length === 0) return;
+
+  // Dedup identical system prompts so we only pay once per unique text.
+  const uniqueTexts = [...new Set(toHash.map((e) => e.systemText))];
+
+  const hashByText = new Map<string, string>();
+  for (let offset = 0; offset < uniqueTexts.length; offset += SKELETON_BATCH_LIMIT) {
+    const batch = uniqueTexts.slice(offset, offset + SKELETON_BATCH_LIMIT);
+    const hashes = await fetchSkeletonHashes(batch, projectId);
+    if (hashes.length !== batch.length) continue;
+    for (let i = 0; i < batch.length; i++) {
+      const hash = hashes[i];
+      if (hash) hashByText.set(batch[i], hash);
+    }
+  }
+
+  for (const { trace, systemText } of toHash) {
+    const hash = hashByText.get(systemText);
+    if (hash) trace.promptHash = hash;
+  }
 }
 
 async function fetchTraceInputOnly(traceId: string, projectId: string): Promise<TraceWithParsedInput> {
@@ -159,7 +239,7 @@ async function fetchTraceInputOnly(traceId: string, projectId: string): Promise<
     return { traceId, output: null, parsed: null, promptHash: null };
   }
 
-  const parsed = parseExtractedMessages(inputRows[0].first_message, inputRows[0].second_message);
+  const parsed = parseExtractedMessages(inputRows[0].first_message, inputRows[0].last_message);
   return { traceId, output: null, parsed, promptHash: inputRows[0].prompt_hash || null };
 }
 
@@ -195,7 +275,7 @@ async function fetchTraceData(traceId: string, projectId: string): Promise<Trace
     return { traceId, output: outputText, parsed: null, promptHash: null };
   }
 
-  const parsed = parseExtractedMessages(inputRows[0].first_message, inputRows[0].second_message);
+  const parsed = parseExtractedMessages(inputRows[0].first_message, inputRows[0].last_message);
   return { traceId, output: outputText, parsed, promptHash: inputRows[0].prompt_hash || null };
 }
 

--- a/frontend/lib/actions/sessions/trace-io.ts
+++ b/frontend/lib/actions/sessions/trace-io.ts
@@ -12,17 +12,25 @@ const bodySchema = z.object({
 });
 
 const TOP_PATH_QUERY = `
-    SELECT path
+    SELECT
+      path,
+      prompt_hash AS promptHash
     FROM (
-     SELECT path, total_tokens, start_time
-     FROM spans
-     WHERE trace_id = {traceId: UUID}
-       AND span_type = 'LLM'
-     ORDER BY start_time ASC
-         LIMIT 20
-     )
-    GROUP BY path
-    ORDER BY min(start_time) ASC, sum(total_tokens) DESC
+      SELECT
+        path,
+        input_tokens,
+        start_time,
+        simpleJSONExtractString(attributes, 'lmnr.span.prompt_hash') AS prompt_hash
+      FROM spans
+      WHERE trace_id = {traceId: UUID}
+        AND span_type = 'LLM'
+      ORDER BY start_time ASC
+      LIMIT 5
+    )
+    GROUP BY path, prompt_hash
+    ORDER BY
+      length(splitByChar('.', path)) ASC,
+      max(input_tokens) DESC
     LIMIT 1
 `;
 
@@ -39,6 +47,7 @@ const INPUT_QUERY = `
     WHERE trace_id = {traceId: UUID}
       AND span_type = 'LLM'
       AND path = {path: String}
+      AND simpleJSONExtractString(attributes, 'lmnr.span.prompt_hash') = {promptHash: String}
     ORDER BY start_time ASC
     LIMIT 1
   )
@@ -50,6 +59,7 @@ const OUTPUT_QUERY = `
   WHERE trace_id = {traceId: UUID}
     AND span_type = 'LLM'
     AND path = {path: String}
+    AND simpleJSONExtractString(attributes, 'lmnr.span.prompt_hash') = {promptHash: String}
   ORDER BY start_time DESC
   LIMIT 1
 `;
@@ -217,7 +227,7 @@ async function hydrateMissingPromptHashes(traces: TraceWithParsedInput[], projec
 }
 
 async function fetchTraceInputOnly(traceId: string, projectId: string): Promise<TraceWithParsedInput> {
-  const pathRows = await executeQuery<{ path: string }>({
+  const pathRows = await executeQuery<{ path: string; promptHash: string }>({
     query: TOP_PATH_QUERY,
     parameters: { traceId },
     projectId,
@@ -227,24 +237,29 @@ async function fetchTraceInputOnly(traceId: string, projectId: string): Promise<
     return { traceId, output: null, parsed: null, promptHash: null };
   }
 
-  const topPath = pathRows[0].path;
+  const { path: topPath, promptHash: topPromptHash } = pathRows[0];
 
   const inputRows = await executeQuery<InputQueryRow>({
     query: INPUT_QUERY,
-    parameters: { traceId, path: topPath },
+    parameters: { traceId, path: topPath, promptHash: topPromptHash ?? "" },
     projectId,
   });
 
   if (inputRows.length === 0) {
-    return { traceId, output: null, parsed: null, promptHash: null };
+    return { traceId, output: null, parsed: null, promptHash: topPromptHash || null };
   }
 
   const parsed = parseExtractedMessages(inputRows[0].first_message, inputRows[0].last_message);
-  return { traceId, output: null, parsed, promptHash: inputRows[0].prompt_hash || null };
+  return {
+    traceId,
+    output: null,
+    parsed,
+    promptHash: inputRows[0].prompt_hash || topPromptHash || null,
+  };
 }
 
 async function fetchTraceData(traceId: string, projectId: string): Promise<TraceWithParsedInput> {
-  const pathRows = await executeQuery<{ path: string }>({
+  const pathRows = await executeQuery<{ path: string; promptHash: string }>({
     query: TOP_PATH_QUERY,
     parameters: { traceId },
     projectId,
@@ -254,17 +269,17 @@ async function fetchTraceData(traceId: string, projectId: string): Promise<Trace
     return { traceId, output: null, parsed: null, promptHash: null };
   }
 
-  const topPath = pathRows[0].path;
+  const { path: topPath, promptHash: topPromptHash } = pathRows[0];
 
   const [inputRows, outputRows] = await Promise.all([
     executeQuery<InputQueryRow>({
       query: INPUT_QUERY,
-      parameters: { traceId, path: topPath },
+      parameters: { traceId, path: topPath, promptHash: topPromptHash ?? "" },
       projectId,
     }),
     executeQuery<{ spanId: string; data: string; name: string }>({
       query: OUTPUT_QUERY,
-      parameters: { traceId, path: topPath },
+      parameters: { traceId, path: topPath, promptHash: topPromptHash ?? "" },
       projectId,
     }),
   ]);
@@ -272,11 +287,16 @@ async function fetchTraceData(traceId: string, projectId: string): Promise<Trace
   const outputText = await resolveOutput(outputRows, projectId);
 
   if (inputRows.length === 0) {
-    return { traceId, output: outputText, parsed: null, promptHash: null };
+    return { traceId, output: outputText, parsed: null, promptHash: topPromptHash || null };
   }
 
   const parsed = parseExtractedMessages(inputRows[0].first_message, inputRows[0].last_message);
-  return { traceId, output: outputText, parsed, promptHash: inputRows[0].prompt_hash || null };
+  return {
+    traceId,
+    output: outputText,
+    parsed,
+    promptHash: inputRows[0].prompt_hash || topPromptHash || null,
+  };
 }
 
 async function resolveOutput(

--- a/frontend/lib/actions/sessions/trace-io.ts
+++ b/frontend/lib/actions/sessions/trace-io.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 
+import { MAIN_AGENT_SEARCH_WINDOW } from "@/components/traces/trace-view/store/utils";
 import { processSpanPreviews } from "@/lib/actions/spans/previews";
 import { executeQuery } from "@/lib/actions/sql";
 import { fetcherJSON } from "@/lib/utils.ts";
@@ -25,7 +26,7 @@ const TOP_PATH_QUERY = `
       WHERE trace_id = {traceId: UUID}
         AND span_type = 'LLM'
       ORDER BY start_time ASC
-      LIMIT 5
+      LIMIT ${MAIN_AGENT_SEARCH_WINDOW}
     )
     GROUP BY path, prompt_hash
     ORDER BY

--- a/frontend/lib/actions/spans/previews/input-extraction.ts
+++ b/frontend/lib/actions/spans/previews/input-extraction.ts
@@ -13,7 +13,7 @@ export async function extractUserInputsForSpans(
   const parsedSpans: Array<{ spanId: string; parsed: ParsedInput; rawInput: string; promptHash: string }> = [];
 
   for (const row of rows) {
-    const parsed = parseExtractedMessages(row.firstMessage, row.secondMessage);
+    const parsed = parseExtractedMessages(row.firstMessage, row.lastMessage);
     if (!parsed) {
       userInputs[row.spanId] = null;
       continue;

--- a/frontend/lib/actions/spans/previews/provider-keys.ts
+++ b/frontend/lib/actions/spans/previews/provider-keys.ts
@@ -1,152 +1,110 @@
-import { get, has, isPlainObject } from "lodash";
+import { type z } from "zod/v4";
+
+import {
+  AnthropicTextBlockSchema,
+  AnthropicThinkingBlockSchema,
+  parseAnthropicOutput,
+} from "@/lib/spans/types/anthropic";
+import { type GeminiContentSchema, GeminiTextPartSchema, parseGeminiOutput } from "@/lib/spans/types/gemini";
+import {
+  LangChainAssistantMessageSchema,
+  LangChainMessagesSchema,
+  LangChainTextPartSchema,
+} from "@/lib/spans/types/langchain";
+import { type OpenAIMessageSchema, OpenAITextPartSchema, parseOpenAIOutput } from "@/lib/spans/types/openai";
 
 import { type ProviderHint } from "./utils.ts";
 
-export type ProviderKeyMatch = {
-  key: string;
-  /** When set, use this instead of the original data for Mustache rendering. */
-  data?: unknown;
-  /** When set, skip Mustache rendering entirely and use this string as the preview. */
-  rendered?: string;
+/**
+ * A match resolves the span preview to rendered text. All provider matchers
+ * go through their respective Zod schemas, so no ad-hoc structural checks or
+ * Mustache templates are needed here.
+ */
+export interface ProviderKeyMatch {
+  rendered: string;
+}
+
+const joinNonEmpty = (parts: string[]): string => parts.filter((p) => p.length > 0).join("\n\n");
+
+// ---------------------------------------------------------------------------
+// Per-provider renderers — each takes a message validated by the provider's
+// canonical output schema and extracts its user-visible text.
+// ---------------------------------------------------------------------------
+
+const renderOpenAIMessage = (msg: z.infer<typeof OpenAIMessageSchema>): string => {
+  const content = "content" in msg ? msg.content : null;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return joinNonEmpty(content.map((part) => OpenAITextPartSchema.safeParse(part).data?.text ?? ""));
 };
 
-type Obj = Record<string, unknown>;
-
-const unwrapSingle = (data: unknown): unknown => (Array.isArray(data) && data.length === 1 ? data[0] : data);
-
-const peekInner = (data: unknown, wrapperKey?: string): Obj | null => {
-  if (wrapperKey && isPlainObject(data)) {
-    const first = get(data, [wrapperKey, 0]);
-    return isPlainObject(first) ? (first as Obj) : null;
-  }
-  const item = Array.isArray(data) ? data[0] : data;
-  return isPlainObject(item) ? (item as Obj) : null;
+const renderAnthropicMessage = (msg: { content: unknown }): string => {
+  if (typeof msg.content === "string") return msg.content;
+  if (!Array.isArray(msg.content)) return "";
+  return joinNonEmpty(
+    msg.content.map(
+      (block) =>
+        AnthropicThinkingBlockSchema.safeParse(block).data?.thinking ??
+        AnthropicTextBlockSchema.safeParse(block).data?.text ??
+        ""
+    )
+  );
 };
 
-const hasMessageContent = (choice: Obj): boolean => {
-  const content = get(choice, "message.content");
-  return typeof content === "string" && content.trim().length > 0;
-};
+const renderGeminiMessage = (msg: z.infer<typeof GeminiContentSchema>): string =>
+  joinNonEmpty(msg.parts.map((part) => GeminiTextPartSchema.safeParse(part).data?.text ?? ""));
 
-const hasGeminiText = (candidate: Obj): boolean => typeof get(candidate, "content.parts.0.text") === "string";
-
-const hasAnthropicTextContent = (msg: Obj): boolean => {
-  const content = msg.content;
-  if (Array.isArray(content)) {
-    return content.some(
-      (item) =>
-        isPlainObject(item) &&
-        (((item as Obj).type === "text" &&
-          typeof (item as Obj).text === "string" &&
-          ((item as Obj).text as string).trim().length > 0) ||
-          ((item as Obj).type === "thinking" &&
-            typeof (item as Obj).thinking === "string" &&
-            ((item as Obj).thinking as string).trim().length > 0))
-    );
-  }
-  return typeof content === "string" && content.trim().length > 0 && has(msg, "role");
-};
-
-const isLangChainAssistant = (msg: Obj): boolean => {
-  if (msg.role !== "assistant" && msg.role !== "ai") return false;
-  const content = msg.content;
-  if (typeof content === "string") return content.trim().length > 0;
-  if (Array.isArray(content))
-    return (
-      get(content, "0.type") === "text" &&
-      typeof get(content, "0.text") === "string" &&
-      (get(content, "0.text") as string).trim().length > 0
-    );
-  return false;
+const renderLangChainMessage = (msg: z.infer<typeof LangChainAssistantMessageSchema>): string => {
+  if (typeof msg.content === "string") return msg.content;
+  if (!Array.isArray(msg.content)) return "";
+  return joinNonEmpty(msg.content.map((part) => LangChainTextPartSchema.safeParse(part).data?.text ?? ""));
 };
 
 // ---------------------------------------------------------------------------
-// Mustache key templates
-// ---------------------------------------------------------------------------
-
-const renderAnthropicTextBlocks = (msg: Obj): string => {
-  const content = msg.content as unknown[];
-  const lines: string[] = [];
-  for (const item of content) {
-    if (!isPlainObject(item)) continue;
-    const block = item as Obj;
-    if (block.type === "thinking") {
-      lines.push(block.thinking as string);
-    } else if (block.type === "text") {
-      lines.push(block.text as string);
-    }
-  }
-  return lines.join("\n\n");
-};
-
-// ---------------------------------------------------------------------------
-// Pattern definitions — ordered by priority (first match wins)
+// Pattern definitions — each pattern validates with schemas and renders.
 // ---------------------------------------------------------------------------
 
 interface ProviderPattern {
   provider: ProviderHint;
-  test: (data: unknown) => boolean;
-  resolve: (data: unknown) => ProviderKeyMatch;
+  match: (data: unknown) => ProviderKeyMatch | null;
 }
 
 const patterns: ProviderPattern[] = [
-  // --- OpenAI/Azure text ---
   {
     provider: "openai",
-    test: (data) => {
-      const inner = peekInner(data, "choices") ?? peekInner(data);
-      return inner !== null && hasMessageContent(inner);
-    },
-    resolve: (data) => {
-      if (isPlainObject(data) && has(data, "choices")) return { key: "{{choices.0.message.content}}" };
-      if (Array.isArray(data)) return { key: "{{#.}}{{message.content}}{{/.}}" };
-      return { key: "{{message.content}}" };
+    match: (data) => {
+      const messages = parseOpenAIOutput(data);
+      return messages ? { rendered: joinNonEmpty(messages.map(renderOpenAIMessage)) } : null;
     },
   },
-
-  // --- Anthropic text (with optional thinking blocks) ---
   {
     provider: "anthropic",
-    test: (data) => {
-      const inner = Array.isArray(data) ? data[0] : data;
-      return isPlainObject(inner) && hasAnthropicTextContent(inner as Obj);
-    },
-    resolve: (data) => {
-      const msg = Array.isArray(data) ? (data[0] as Obj) : (data as Obj);
-      if (Array.isArray(msg.content)) return { key: "", rendered: renderAnthropicTextBlocks(msg) };
-      if (Array.isArray(data)) return { key: "{{#.}}{{content}}{{/.}}" };
-      return { key: "{{content}}" };
+    match: (data) => {
+      const messages = parseAnthropicOutput(data);
+      return messages ? { rendered: joinNonEmpty(messages.map(renderAnthropicMessage)) } : null;
     },
   },
-
-  // --- Gemini text ---
   {
     provider: "gemini",
-    test: (data) => {
-      const inner = peekInner(data, "candidates") ?? peekInner(data);
-      return inner !== null && hasGeminiText(inner);
-    },
-    resolve: (data) => {
-      if (isPlainObject(data) && has(data, "candidates")) return { key: "{{candidates.0.content.parts.0.text}}" };
-      if (Array.isArray(data)) return { key: "{{#.}}{{content.parts.0.text}}{{/.}}" };
-      return { key: "{{content.parts.0.text}}" };
+    match: (data) => {
+      const messages = parseGeminiOutput(data);
+      return messages ? { rendered: joinNonEmpty(messages.map(renderGeminiMessage)) } : null;
     },
   },
-
-  // --- LangChain ---
   {
     provider: "langchain",
-    test: (data) => {
-      const inner = unwrapSingle(data);
-      return isPlainObject(inner) && isLangChainAssistant(inner as Obj);
-    },
-    resolve: (data) => {
-      const inner = unwrapSingle(data) as Obj;
-      if (Array.isArray(inner.content)) {
-        const first = (inner.content as unknown[])[0];
-        if (isPlainObject(first) && (first as Obj).type === "text") return { key: "{{content.0.text}}" };
-      }
-      return { key: "{{content}}" };
+    match: (data) => {
+      const single = LangChainAssistantMessageSchema.safeParse(
+        Array.isArray(data) && data.length === 1 ? data[0] : data
+      );
+      if (single.success) return { rendered: renderLangChainMessage(single.data) };
+
+      const multi = LangChainMessagesSchema.safeParse(data);
+      if (!multi.success) return null;
+      const assistants = multi.data.filter(
+        (m): m is z.infer<typeof LangChainAssistantMessageSchema> => m.role === "assistant" || m.role === "ai"
+      );
+      return assistants.length > 0 ? { rendered: joinNonEmpty(assistants.map(renderLangChainMessage)) } : null;
     },
   },
 ];
@@ -154,16 +112,16 @@ const patterns: ProviderPattern[] = [
 export const matchProviderKey = (data: unknown, providerHint?: ProviderHint): ProviderKeyMatch | null => {
   if (providerHint && providerHint !== "unknown") {
     for (const pattern of patterns) {
-      if (pattern.provider === providerHint && pattern.test(data)) {
-        return pattern.resolve(data);
+      if (pattern.provider === providerHint) {
+        const result = pattern.match(data);
+        if (result) return result;
       }
     }
   }
 
   for (const pattern of patterns) {
-    if (pattern.test(data)) {
-      return pattern.resolve(data);
-    }
+    const result = pattern.match(data);
+    if (result) return result;
   }
   return null;
 };

--- a/frontend/lib/actions/spans/previews/queries.ts
+++ b/frontend/lib/actions/spans/previews/queries.ts
@@ -5,7 +5,7 @@ export const PREVIEW_SPAN_TYPES = new Set(["LLM", "CACHED", "TOOL", "EXECUTOR", 
 export interface InputSpanRow {
   spanId: string;
   firstMessage: string;
-  secondMessage: string;
+  lastMessage: string;
   promptHash: string;
 }
 
@@ -60,7 +60,7 @@ export async function fetchSpanData(
             SELECT
               span_id as spanId,
               arr[1] as firstMessage,
-              if(length(arr) > 1, arr[2], '') as secondMessage,
+              if(length(arr) > 1, arr[length(arr)], '') as lastMessage,
               simpleJSONExtractString(attributes, 'lmnr.span.prompt_hash') as promptHash
             FROM (
               SELECT span_id, JSONExtractArrayRaw(input) as arr, attributes

--- a/frontend/lib/actions/spans/previews/resolve.ts
+++ b/frontend/lib/actions/spans/previews/resolve.ts
@@ -1,3 +1,4 @@
+import { isAiProviderConfigured } from "@/lib/ai/model";
 import { cache, SPAN_RENDERING_KEY_CACHE_KEY } from "@/lib/cache";
 
 import { generatePreviewKeys } from "./prompts";
@@ -8,6 +9,7 @@ import {
   generateFingerprint,
   isToolOnlyLlmOutput,
   type ProviderHint,
+  tryHeuristicPreview,
   validateMustacheKey,
 } from "./utils";
 
@@ -27,6 +29,11 @@ interface ParsedSpan {
 
 const toJsonPreview = (data: unknown): string => JSON.stringify(data).slice(0, 2000);
 
+/**
+ * Classify raw span payloads. Non-generation spans are resolved directly to a
+ * truncated string; generation spans with object payloads are returned for
+ * further processing by the resolution pipeline.
+ */
 function classifyRawSpans(
   rawSpans: Array<{ spanId: string; data: string; name: string }>,
   spanTypes: Record<string, string>
@@ -81,6 +88,34 @@ function fillMissing(previews: SpanPreviewResult, spanIds: string[]): SpanPrevie
   return result;
 }
 
+/**
+ * Match known provider structures (OpenAI, Anthropic, Gemini, LangChain).
+ */
+function applyProviderMatching(spans: ParsedSpan[]): { resolved: SpanPreviewResult; unmatched: ParsedSpan[] } {
+  const resolved: SpanPreviewResult = {};
+  const unmatched: ParsedSpan[] = [];
+
+  for (const span of spans) {
+    const match = matchProviderKey(span.parsedData, span.provider);
+    if (!match) {
+      unmatched.push(span);
+      continue;
+    }
+
+    const rendered = match.rendered ?? validateMustacheKey(match.key, match.data ?? span.parsedData);
+    if (rendered) {
+      resolved[span.spanId] = rendered;
+    } else {
+      unmatched.push(span);
+    }
+  }
+
+  return { resolved, unmatched };
+}
+
+/**
+ * Look up cached LLM-generated Mustache keys by structural fingerprint.
+ */
 async function applyCachedKeys(
   projectId: string,
   parsedSpans: ParsedSpan[]
@@ -133,51 +168,26 @@ async function applyCachedKeys(
   return { resolved, uncached };
 }
 
-function applyProviderMatching(
-  uncachedSpans: ParsedSpan[],
-  spanTypes: Record<string, string>
-): { resolved: SpanPreviewResult; needsLlm: ParsedSpan[] } {
-  const resolved: SpanPreviewResult = {};
-  const needsLlm: ParsedSpan[] = [];
-
-  for (const span of uncachedSpans) {
-    const spanType = spanTypes[span.spanId] ?? "";
-    if (!GENERATION_SPAN_TYPES.has(spanType)) {
-      needsLlm.push(span);
-      continue;
-    }
-
-    const match = matchProviderKey(span.parsedData, span.provider);
-    if (!match) {
-      needsLlm.push(span);
-      continue;
-    }
-
-    const rendered = match.rendered ?? validateMustacheKey(match.key, match.data ?? span.parsedData);
-    if (rendered) {
-      resolved[span.spanId] = rendered;
-    } else {
-      needsLlm.push(span);
-    }
-  }
-
-  return { resolved, needsLlm };
-}
-
-async function generateAndApplyKeys(
-  needsLlm: ParsedSpan[]
-): Promise<{ resolved: SpanPreviewResult; keysToSave: Array<{ fingerprint: string; key: string }> }> {
+/**
+ * Ask the LLM to generate Mustache keys for remaining structures.
+ * Keys that render successfully are persisted back to the cache.
+ */
+async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
+  resolved: SpanPreviewResult;
+  unresolved: ParsedSpan[];
+  keysToSave: Array<{ fingerprint: string; key: string }>;
+}> {
   const resolved: SpanPreviewResult = {};
   const keysToSave: Array<{ fingerprint: string; key: string }> = [];
 
-  if (needsLlm.length === 0) return { resolved, keysToSave };
+  if (spans.length === 0) return { resolved, unresolved: [], keysToSave };
 
   const seen = new Set<string>();
   const dedupedFingerprints: string[] = [];
   const structures: Array<{ data: unknown }> = [];
   const fingerprintToSpans = new Map<string, ParsedSpan[]>();
 
-  for (const span of needsLlm) {
+  for (const span of spans) {
     const group = fingerprintToSpans.get(span.fingerprint);
     if (group) {
       group.push(span);
@@ -199,27 +209,27 @@ async function generateAndApplyKeys(
     console.error("Preview key generation failed:", error);
   }
 
+  const unresolved: ParsedSpan[] = [];
+
   for (let i = 0; i < dedupedFingerprints.length; i++) {
     const fingerprint = dedupedFingerprints[i];
     const key = generatedKeys[i] ?? null;
-    const spans = fingerprintToSpans.get(fingerprint) ?? [];
+    const groupSpans = fingerprintToSpans.get(fingerprint) ?? [];
 
     if (!key) {
-      for (const span of spans) {
-        resolved[span.spanId] = toJsonPreview(span.parsedData);
-      }
+      unresolved.push(...groupSpans);
       continue;
     }
 
     let keyProducedValidRender = false;
 
-    for (const span of spans) {
+    for (const span of groupSpans) {
       const rendered = validateMustacheKey(key, span.parsedData);
       if (rendered) {
         resolved[span.spanId] = rendered;
         keyProducedValidRender = true;
       } else {
-        resolved[span.spanId] = toJsonPreview(span.parsedData);
+        unresolved.push(span);
       }
     }
 
@@ -228,13 +238,20 @@ async function generateAndApplyKeys(
     }
   }
 
-  for (const span of needsLlm) {
-    if (!(span.spanId in resolved)) {
-      resolved[span.spanId] = toJsonPreview(span.parsedData);
-    }
-  }
+  return { resolved, unresolved, keysToSave };
+}
 
-  return { resolved, keysToSave };
+/**
+ * Last-resort fallback used when the LLM path is unavailable or produced no
+ * valid key for a span. Picks the first primitive leaf (object key order,
+ * array index 0) and falls back to a truncated JSON preview.
+ */
+function applyHeuristicFallback(spans: ParsedSpan[]): SpanPreviewResult {
+  const resolved: SpanPreviewResult = {};
+  for (const span of spans) {
+    resolved[span.spanId] = tryHeuristicPreview(span.parsedData) ?? toJsonPreview(span.parsedData);
+  }
+  return resolved;
 }
 
 async function saveRenderingKeys(
@@ -262,7 +279,12 @@ export interface ResolveOptions {
 
 /**
  * Run the full preview resolution pipeline on pre-fetched span data:
- * classify → cached Redis keys → provider matching → LLM generation → save keys.
+ *   1. classify raw payloads
+ *   2. look up cached LLM-generated Mustache keys by fingerprint
+ *   3. match known provider structures (OpenAI / Anthropic / Gemini / LangChain)
+ *   4. generate new keys via LLM (when a provider is configured) and persist them
+ *   5. fall back to first-primitive-leaf heuristic for anything still unresolved
+ *      (this is the only path for tool spans when no LLM provider is configured)
  */
 export async function resolvePreviews(
   rawSpans: Array<{ spanId: string; data: string; name: string }>,
@@ -272,32 +294,32 @@ export async function resolvePreviews(
   options: ResolveOptions = {}
 ): Promise<SpanPreviewResult> {
   const { skipGeneration = false } = options;
-  const { resolved: classifiedPreviews, needsProcessing } = classifyRawSpans(rawSpans, spanTypes);
+  const { resolved: classified, needsProcessing } = classifyRawSpans(rawSpans, spanTypes);
 
   if (needsProcessing.length === 0) {
-    return fillMissing(classifiedPreviews, spanIds);
+    return fillMissing(classified, spanIds);
   }
 
-  const { resolved: cachedPreviews, uncached } = await applyCachedKeys(projectId, needsProcessing);
-  const cachedResult = { ...classifiedPreviews, ...cachedPreviews };
-
+  const { resolved: cacheResolved, uncached } = await applyCachedKeys(projectId, needsProcessing);
+  let accumulated: SpanPreviewResult = { ...classified, ...cacheResolved };
   if (uncached.length === 0) {
-    return fillMissing(cachedResult, spanIds);
+    return fillMissing(accumulated, spanIds);
   }
 
-  const { resolved: providerPreviews, needsLlm } = applyProviderMatching(uncached, spanTypes);
-  const providerResult = { ...cachedResult, ...providerPreviews };
-
-  if (skipGeneration || needsLlm.length === 0) {
-    for (const span of needsLlm) {
-      providerResult[span.spanId] = toJsonPreview(span.parsedData);
-    }
-    return fillMissing(providerResult, spanIds);
+  const { resolved: providerResolved, unmatched } = applyProviderMatching(uncached);
+  accumulated = { ...accumulated, ...providerResolved };
+  if (unmatched.length === 0) {
+    return fillMissing(accumulated, spanIds);
   }
 
-  const { resolved: llmPreviews, keysToSave } = await generateAndApplyKeys(needsLlm);
+  const llmAvailable = !skipGeneration && isAiProviderConfigured();
 
+  if (!llmAvailable) {
+    return fillMissing({ ...accumulated, ...applyHeuristicFallback(unmatched) }, spanIds);
+  }
+
+  const { resolved: llmResolved, unresolved, keysToSave } = await generateKeysViaLlm(unmatched);
   await saveRenderingKeys(projectId, keysToSave);
 
-  return fillMissing({ ...providerResult, ...llmPreviews }, spanIds);
+  return fillMissing({ ...accumulated, ...llmResolved, ...applyHeuristicFallback(unresolved) }, spanIds);
 }

--- a/frontend/lib/actions/spans/previews/resolve.ts
+++ b/frontend/lib/actions/spans/previews/resolve.ts
@@ -1,12 +1,7 @@
-import { and, eq, inArray } from "drizzle-orm";
-
-import { db } from "@/lib/db/drizzle";
-import { spanRenderingKeys } from "@/lib/db/migrations/schema";
+import { cache, SPAN_RENDERING_KEY_CACHE_KEY } from "@/lib/cache";
 
 import { generatePreviewKeys } from "./prompts";
 import { matchProviderKey } from "./provider-keys";
-
-export type SpanPreviewResult = Record<string, string | null>;
 import {
   classifyPayload,
   detectOutputStructure,
@@ -15,6 +10,10 @@ import {
   type ProviderHint,
   validateMustacheKey,
 } from "./utils";
+
+const RENDERING_KEY_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+export type SpanPreviewResult = Record<string, string | null>;
 
 const GENERATION_SPAN_TYPES = new Set(["LLM", "CACHED", "TOOL"]);
 
@@ -86,25 +85,27 @@ async function applyCachedKeys(
   projectId: string,
   parsedSpans: ParsedSpan[]
 ): Promise<{ resolved: SpanPreviewResult; uncached: ParsedSpan[] }> {
-  const fingerprints = parsedSpans.map((s) => s.fingerprint);
+  const uniqueFingerprints = [...new Set(parsedSpans.map((s) => s.fingerprint))];
 
-  let cachedKeys: Array<{ schemaFingerprint: string; mustacheKey: string }>;
-  try {
-    cachedKeys = await db
-      .select()
-      .from(spanRenderingKeys)
-      .where(
-        and(eq(spanRenderingKeys.projectId, projectId), inArray(spanRenderingKeys.schemaFingerprint, fingerprints))
-      );
-  } catch (error) {
-    console.error("Failed to look up cached rendering keys:", error);
-    return { resolved: {}, uncached: parsedSpans };
+  const cachedEntries = await Promise.all(
+    uniqueFingerprints.map(async (fingerprint) => {
+      try {
+        const key = await cache.get<string>(SPAN_RENDERING_KEY_CACHE_KEY(projectId, fingerprint));
+        return [fingerprint, key] as const;
+      } catch {
+        return [fingerprint, null] as const;
+      }
+    })
+  );
+
+  const fingerprintToKey = new Map<string, string>();
+  for (const [fingerprint, key] of cachedEntries) {
+    if (key) fingerprintToKey.set(fingerprint, key);
   }
-
-  const fingerprintToKey = new Map(cachedKeys.map((row) => [row.schemaFingerprint, row.mustacheKey]));
 
   const resolved: SpanPreviewResult = {};
   const uncached: ParsedSpan[] = [];
+  const hitFingerprints = new Set<string>();
 
   for (const span of parsedSpans) {
     const cachedKey = fingerprintToKey.get(span.fingerprint);
@@ -116,10 +117,18 @@ async function applyCachedKeys(
     const rendered = validateMustacheKey(cachedKey, span.parsedData);
     if (rendered) {
       resolved[span.spanId] = rendered;
+      hitFingerprints.add(span.fingerprint);
     } else {
       uncached.push(span);
     }
   }
+
+  // Refresh TTL on successful hits so active schemas don't expire.
+  await Promise.all(
+    [...hitFingerprints].map((fingerprint) =>
+      cache.expire(SPAN_RENDERING_KEY_CACHE_KEY(projectId, fingerprint), RENDERING_KEY_TTL_SECONDS).catch(() => false)
+    )
+  );
 
   return { resolved, uncached };
 }
@@ -234,20 +243,17 @@ async function saveRenderingKeys(
 ): Promise<void> {
   if (keysToSave.length === 0) return;
 
-  try {
-    await db
-      .insert(spanRenderingKeys)
-      .values(
-        keysToSave.map(({ fingerprint, key }) => ({
-          projectId,
-          schemaFingerprint: fingerprint,
-          mustacheKey: key,
-        }))
-      )
-      .onConflictDoNothing();
-  } catch (error) {
-    console.error("Failed to save rendering keys:", error);
-  }
+  await Promise.all(
+    keysToSave.map(({ fingerprint, key }) =>
+      cache
+        .set(SPAN_RENDERING_KEY_CACHE_KEY(projectId, fingerprint), key, {
+          expireAfterSeconds: RENDERING_KEY_TTL_SECONDS,
+        })
+        .catch((error) => {
+          console.error("Failed to save rendering key:", error);
+        })
+    )
+  );
 }
 
 export interface ResolveOptions {
@@ -256,7 +262,7 @@ export interface ResolveOptions {
 
 /**
  * Run the full preview resolution pipeline on pre-fetched span data:
- * classify → cached DB keys → provider matching → LLM generation → save keys.
+ * classify → cached Redis keys → provider matching → LLM generation → save keys.
  */
 export async function resolvePreviews(
   rawSpans: Array<{ spanId: string; data: string; name: string }>,

--- a/frontend/lib/actions/spans/previews/resolve.ts
+++ b/frontend/lib/actions/spans/previews/resolve.ts
@@ -97,14 +97,8 @@ function applyProviderMatching(spans: ParsedSpan[]): { resolved: SpanPreviewResu
 
   for (const span of spans) {
     const match = matchProviderKey(span.parsedData, span.provider);
-    if (!match) {
-      unmatched.push(span);
-      continue;
-    }
-
-    const rendered = match.rendered ?? validateMustacheKey(match.key, match.data ?? span.parsedData);
-    if (rendered) {
-      resolved[span.spanId] = rendered;
+    if (match) {
+      resolved[span.spanId] = match.rendered;
     } else {
       unmatched.push(span);
     }

--- a/frontend/lib/actions/spans/previews/utils.ts
+++ b/frontend/lib/actions/spans/previews/utils.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isNil, isPlainObject, isString, last, mapValues } from "lodash";
+import { isBoolean, isEmpty, isNil, isNumber, isPlainObject, isString, keys, last, mapValues } from "lodash";
 import Mustache from "mustache";
 
 import { deepParseJson } from "@/lib/actions/common/utils.ts";
@@ -306,3 +306,38 @@ export const validateMustacheKey = (key: string, data: unknown): string | null =
     return null;
   }
 };
+
+function formatPrimitiveLeaf(value: string | number | boolean): string | null {
+  if (isNumber(value) || isBoolean(value)) return String(value);
+  const t = value.trim();
+  return t.length > 0 ? t : null;
+}
+
+function findFirstPrimitiveLeaf(value: unknown): string | null {
+  if (isNil(value)) return null;
+  if (isString(value) || isNumber(value) || isBoolean(value)) return formatPrimitiveLeaf(value);
+
+  if (Array.isArray(value)) {
+    if (isEmpty(value)) return null;
+    return findFirstPrimitiveLeaf(value[0]);
+  }
+
+  if (isPlainObject(value)) {
+    const obj = value as Record<string, unknown>;
+    for (const k of keys(obj)) {
+      const found = findFirstPrimitiveLeaf(obj[k]);
+      if (found !== null) return found;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Last-resort fallback that picks the first primitive leaf (object key order,
+ * array index 0). Used by the resolver only when no AI provider is configured
+ * or when LLM key generation fails — most hits in practice are tool spans,
+ * since LLM outputs match a provider pattern upstream. Not cached.
+ */
+export const tryHeuristicPreview = (data: unknown): string | null => findFirstPrimitiveLeaf(deepParseJson(data));

--- a/frontend/lib/ai/model.ts
+++ b/frontend/lib/ai/model.ts
@@ -35,19 +35,20 @@ function isBedrockConfigured(): boolean {
   );
 }
 
+/** Non-throwing check: true when any supported AI provider has credentials configured. */
+export function isAiProviderConfigured(): boolean {
+  return isGeminiConfigured() || isBedrockConfigured();
+}
+
 function getActiveProvider(): AIProvider {
-  if (isGeminiConfigured()) {
-    return "gemini";
+  if (!isAiProviderConfigured()) {
+    throw new Error(
+      "No AI provider configured. Set GOOGLE_GENERATIVE_AI_API_KEY for Gemini, " +
+        "or BEDROCK_ENABLED=true with AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION for Anthropic Bedrock."
+    );
   }
 
-  if (isBedrockConfigured()) {
-    return "bedrock";
-  }
-
-  throw new Error(
-    "No AI provider configured. Set GOOGLE_GENERATIVE_AI_API_KEY for Gemini, " +
-      "or BEDROCK_ENABLED=true with AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION for Anthropic Bedrock."
-  );
+  return isGeminiConfigured() ? "gemini" : "bedrock";
 }
 
 export function getLanguageModel(tier: ModelTier = "default"): LanguageModel {

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -195,3 +195,6 @@ export const PROJECT_MEMBER_CACHE_KEY = (projectId: string, userId: string) => `
 
 export const AUTOCOMPLETE_CACHE_KEY = (resource: string, projectId: string, field: string): string =>
   `autocomplete:${resource}:${projectId}:${field}`;
+
+export const SPAN_RENDERING_KEY_CACHE_KEY = (projectId: string, schemaFingerprint: string): string =>
+  `span_rendering_key:${projectId}:${schemaFingerprint}`;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how span preview rendering keys are cached/resolved (DB → Redis + new fallback paths) and adjusts main-agent/user-input extraction queries and heuristics, which could affect transcript correctness on historical traces.
> 
> **Overview**
> **Improves trace transcript UX and stability** by making the Transcript view the default (with persisted-state migration), adding a one-time hint popover, and refining transcript row spacing/word-wrapping.
> 
> **Reworks agent/subagent detection and input/preview fetching**: updates `computeSubagentBoundaries` to pick the “main agent” from the earliest LLM calls using span-path depth and token count, fixes `useBatchedSpanPreviews` to independently track output vs input preview requests, and makes `useTraceUserInput` refetch until enough LLM spans arrive for a stable main-agent pick.
> 
> **Updates backend+data plumbing for historical compatibility**: adds `POST /api/v1/projects/{project_id}/skeleton-hashes` (structural hashing) and updates trace/user-input SQL to use `prompt_hash`, select the *last* user message, and fall back to client-side prompt-hash hydration via the new endpoint when spans lack `lmnr.span.prompt_hash`.
> 
> **Moves span rendering key storage to Redis cache** with TTL refresh on hits, schema-based deduped lookups, conditional LLM key generation only when an AI provider is configured, and a new heuristic preview fallback when generation is unavailable or fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d09c801c461e41ae38395e44f0143a4bb65a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->