### PR TITLE
feat: improve heuristics in previews, pick tool uses

### DIFF
--- a/frontend/components/traces/snippet-preview.tsx
+++ b/frontend/components/traces/snippet-preview.tsx
@@ -31,13 +31,7 @@ export function SnippetPreview({
   const count = snippetsCount ?? 0;
 
   return (
-    <span
-      className={cn(
-        "flex gap-1.5 min-w-0",
-        variant === "table" ? "items-center" : "items-center justify-center",
-        className
-      )}
-    >
+    <span className={cn("flex gap-1.5 min-w-0 items-center", className)}>
       <span
         className={cn(
           "whitespace-normal break-words text-secondary-foreground",

--- a/frontend/components/traces/trace-view/transcript/item/span-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/span-item.tsx
@@ -16,31 +16,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { isStringDateOld } from "@/lib/traces/utils";
 import { cn } from "@/lib/utils";
 
-function InlinePreviewContent({
-  span,
-  previewText,
-  isLoading,
-}: {
-  span: TraceViewListSpan;
-  previewText: string | null;
-  isLoading: boolean;
-}) {
-  const hasSnippet = !!(span.inputSnippet || span.outputSnippet || span.attributesSnippet);
-
-  if (hasSnippet) {
-    return (
-      <div className="min-w-0 overflow-hidden">
-        <SnippetPreview
-          inputSnippet={span.inputSnippet}
-          outputSnippet={span.outputSnippet}
-          attributesSnippet={span.attributesSnippet}
-          variant="span"
-          className="truncate"
-        />
-      </div>
-    );
-  }
-
+function InlinePreviewContent({ previewText, isLoading }: { previewText: string | null; isLoading: boolean }) {
   if (previewText) {
     return <span className="text-[13px] text-secondary-foreground truncate min-w-0">{previewText}</span>;
   }
@@ -66,7 +42,30 @@ function PendingIndicator({ startTime }: { startTime: string }) {
   return <Skeleton className="w-10 h-4 bg-secondary rounded-md" />;
 }
 
-function LLMOutputPreview({ previewText, isLoading }: { previewText: string | null; isLoading: boolean }) {
+function LLMOutputPreview({
+  span,
+  previewText,
+  isLoading,
+}: {
+  span: TraceViewListSpan;
+  previewText: string | null;
+  isLoading: boolean;
+}) {
+  const hasSnippet = !!(span.inputSnippet || span.outputSnippet || span.attributesSnippet);
+
+  if (hasSnippet) {
+    return (
+      <div className="pl-7">
+        <SnippetPreview
+          inputSnippet={span.inputSnippet}
+          outputSnippet={span.outputSnippet}
+          attributesSnippet={span.attributesSnippet}
+          variant="span"
+        />
+      </div>
+    );
+  }
+
   if (previewText) {
     return (
       <div className="pl-7">
@@ -113,8 +112,9 @@ export default function SpanItem({ span, output, onSpanSelect, inGroup = false }
   const isPending = span.pending;
   const isLoadingOutput = output === undefined;
   const previewText = typeof output === "string" && output !== "" ? output : null;
+  const hasSnippet = !!(span.inputSnippet || span.outputSnippet || span.attributesSnippet);
   const isSelected = selectedSpan?.spanId === span.spanId;
-  const showInlinePreview = !isLLMType && !isPending;
+  const showInlinePreview = !isLLMType && !isPending && !hasSnippet;
 
   return (
     <div
@@ -151,7 +151,7 @@ export default function SpanItem({ span, output, onSpanSelect, inGroup = false }
               <SpanDisplayTooltip isLLM={isLLMType} name={span.name}>
                 <span className="font-medium text-[13px] whitespace-nowrap shrink-0">{getSpanDisplayName(span)}</span>
               </SpanDisplayTooltip>
-              <InlinePreviewContent span={span} previewText={previewText} isLoading={isLoadingOutput} />
+              <InlinePreviewContent previewText={previewText} isLoading={isLoadingOutput} />
             </div>
           ) : (
             <SpanDisplayTooltip isLLM={isLLMType} name={span.name}>
@@ -183,7 +183,9 @@ export default function SpanItem({ span, output, onSpanSelect, inGroup = false }
           </div>
         </div>
 
-        {isLLMType && !isPending && <LLMOutputPreview previewText={previewText} isLoading={isLoadingOutput} />}
+        {!isPending && (isLLMType || hasSnippet) && (
+          <LLMOutputPreview span={span} previewText={previewText} isLoading={isLoadingOutput} />
+        )}
       </div>
     </div>
   );

--- a/frontend/lib/actions/spans/previews/heuristic.ts
+++ b/frontend/lib/actions/spans/previews/heuristic.ts
@@ -1,0 +1,99 @@
+import { isBoolean, isEmpty, isNil, isNumber, isPlainObject, isString } from "lodash";
+
+import { deepParseJson } from "@/lib/actions/common/utils.ts";
+
+import { METADATA_KEYS } from "./utils";
+
+// Descriptive content fields we prefer to surface, in order of preference.
+const PRIORITY_KEYS: readonly string[] = [
+  "description",
+  "summary",
+  "command",
+  "query",
+  "action",
+  "prompt",
+  "message",
+  "text",
+  "content",
+  "answer",
+  "title",
+  "path",
+  "url",
+  "code",
+  "output",
+  "result",
+  "tool",
+  "function",
+  "name",
+];
+
+const isLeaf = (v: unknown): v is string | number | boolean => isString(v) || isNumber(v) || isBoolean(v);
+
+const formatLeaf = (v: string | number | boolean): string | null => {
+  if (isNumber(v) || isBoolean(v)) return String(v);
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+// Recursively find the first non-empty primitive value stored under `target`.
+const findByKey = (value: unknown, target: string): string | null => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const hit = findByKey(item, target);
+      if (hit !== null) return hit;
+    }
+    return null;
+  }
+  if (!isPlainObject(value)) return null;
+
+  const obj = value as Record<string, unknown>;
+  const direct = obj[target];
+  if (isLeaf(direct)) {
+    const formatted = formatLeaf(direct);
+    if (formatted !== null) return formatted;
+  }
+  for (const k of Object.keys(obj)) {
+    if (METADATA_KEYS.has(k)) continue;
+    const hit = findByKey(obj[k], target);
+    if (hit !== null) return hit;
+  }
+  return null;
+};
+
+// Absolute last resort: first non-metadata primitive leaf in declaration order.
+const firstNonMetaLeaf = (value: unknown): string | null => {
+  if (isNil(value)) return null;
+  if (isLeaf(value)) return formatLeaf(value);
+
+  if (Array.isArray(value)) {
+    if (isEmpty(value)) return null;
+    for (const item of value) {
+      const hit = firstNonMetaLeaf(item);
+      if (hit !== null) return hit;
+    }
+    return null;
+  }
+  if (!isPlainObject(value)) return null;
+
+  const obj = value as Record<string, unknown>;
+  for (const k of Object.keys(obj)) {
+    if (METADATA_KEYS.has(k)) continue;
+    const hit = firstNonMetaLeaf(obj[k]);
+    if (hit !== null) return hit;
+  }
+  return null;
+};
+
+/**
+ * Fallback preview used when no AI provider is configured or LLM-key
+ * generation fails. Searches for keys in `PRIORITY_KEYS` order, then falls
+ * back to the first non-metadata primitive leaf. Not cached.
+ */
+export const tryHeuristicPreview = (data: unknown): string | null => {
+  const parsed = deepParseJson(data);
+  for (const key of PRIORITY_KEYS) {
+    const hit = findByKey(parsed, key);
+    if (hit !== null) return hit;
+  }
+  return firstNonMetaLeaf(parsed);
+};

--- a/frontend/lib/actions/spans/previews/prompts.ts
+++ b/frontend/lib/actions/spans/previews/prompts.ts
@@ -19,8 +19,8 @@ Rules:
 
 Field classification:
 - [meta] fields (skip): id, ids, status, type, types, kind, mode, version, role, model, usage, timestamp, duration, finish_reason, token_count, index, logprobs, created, object, system_fingerprint, signature, tool_use_id. Also includes fields whose values are opaque references (serialized object pointers, memory addresses).
-- [id] fields (skip when siblings have scalar content): name, action, function, method, tool. These identify what operation runs and are shown in the span header. Never include them in the preview when other scalar content fields exist. Primitive array siblings do not count as content.
-- Content fields (prefer, in order of preference): description, summary, command, query, action, prompt, message, text, content, answer, title, path, url, code, output, result. When multiple exist, pick the earliest-listed one.
+- [id] fields (skip when siblings have scalar content): name, action, command, function, method, tool. These identify what operation runs and are shown in the span header. Never include them in the preview when other scalar content fields exist. Primitive array siblings do not count as content. When an [id] field is the only non-meta scalar (no content sibling, no descriptive nested leaf), surface it per decision order rule 3.
+- Content fields (prefer, in order of preference): description, summary, query, prompt, message, text, content, answer, title, path, url, code, output, result. When multiple exist, pick the earliest-listed one.
 
 Decision order:
 1. Scalar content field present → {{{field}}}

--- a/frontend/lib/actions/spans/previews/prompts.ts
+++ b/frontend/lib/actions/spans/previews/prompts.ts
@@ -7,6 +7,8 @@ import { flattenPaths } from "./utils.ts";
 
 const PREVIEW_KEY_SYSTEM_PROMPT = `Pick fields from a schema to build a short Mustache preview template. One template per structure.
 
+Most inputs are tool-use blocks (Anthropic: {type, id, name, input.*}, OpenAI: {id, type, function.name, function.arguments.*}, Gemini: {functionCall.name, functionCall.args.*}). Prefer the most human-readable scalar from the tool's arguments (input / arguments / args / params) over the tool name.
+
 Array access: use .0. for nested arrays. When root is an array (paths start with []), wrap with {{#.}}...{{/.}} and use inner paths.
 
 Rules:
@@ -16,13 +18,13 @@ Rules:
 - Dictionary paths: paths containing {*} (e.g. tasks{*}: string) represent objects with dynamic/arbitrary key names that vary across instances. They cannot be referenced in Mustache templates. Treat as [meta].
 
 Field classification:
-- [meta] fields (skip): id, ids, status, type, types, kind, mode, version, role, model, usage, timestamp, duration, finish_reason, token_count, index, logprobs, created, object, system_fingerprint. Also includes fields whose values are opaque references (serialized object pointers, memory addresses).
+- [meta] fields (skip): id, ids, status, type, types, kind, mode, version, role, model, usage, timestamp, duration, finish_reason, token_count, index, logprobs, created, object, system_fingerprint, signature, tool_use_id. Also includes fields whose values are opaque references (serialized object pointers, memory addresses).
 - [id] fields (skip when siblings have scalar content): name, action, function, method, tool. These identify what operation runs and are shown in the span header. Never include them in the preview when other scalar content fields exist. Primitive array siblings do not count as content.
-- Content fields (prefer): content, text, thinking, result, output, message, answer, query, description, summary, url, path. When multiple exist, pick the most descriptive one.
+- Content fields (prefer, in order of preference): description, summary, command, query, action, prompt, message, text, content, answer, title, path, url, code, output, result. When multiple exist, pick the earliest-listed one.
 
 Decision order:
 1. Scalar content field present → {{{field}}}
-2. [id] field present + scalar sibling fields under a nested key (args/arguments/input/params/body or any sub-object) → pick the single most descriptive short string leaf from those siblings as {{{nested.leaf}}}. If the only siblings are [meta], primitive arrays, or null → use the [id] field.
+2. [id] field present + scalar sibling fields under a nested key (input/arguments/args/params/body or any sub-object) → pick the single most descriptive short string leaf from those siblings as {{{nested.leaf}}}. If the only siblings are [meta], primitive arrays, or null → use the [id] field.
 3. [id] field is the only non-meta scalar field → {{{field}}}
 4. Multiple non-meta, non-id scalar fields → pick the single most descriptive one as {{{field}}}
 5. Deeply nested scalar leaf → {{{path.0.to.0.field}}}
@@ -31,6 +33,12 @@ Decision order:
 Examples:
 - "choices[].message.content: string" → {{{choices.0.message.content}}}
 - "[].output[].content[].text: string" → {{#.}}{{{output.0.content.0.text}}}{{/.}}
+- Anthropic tool_use: "type: string [meta]" + "id: string [meta]" + "name: string [id]" + "input.command: string" + "input.description: string" → {{{input.description}}}
+- Anthropic tool_use: "type: string [meta]" + "name: string [id]" + "input.query: string" + "input.max_results: number" → {{{input.query}}}
+- Anthropic tool_use: "type: string [meta]" + "name: string [id]" + "input.path: string" + "input.old_str: string" → {{{input.path}}}
+- OpenAI tool_call: "id: string [meta]" + "type: string [meta]" + "function.name: string [id]" + "function.arguments.description: string" → {{{function.arguments.description}}}
+- OpenAI tool_call: "function.name: string [id]" + "function.arguments.query: string" → {{{function.arguments.query}}}
+- Gemini functionCall: "functionCall.name: string [id]" + "functionCall.args.query: string" → {{{functionCall.args.query}}}
 - "name: string [id]" + "input.query: string" + "input.max_results: number" → {{{input.query}}}
 - "action: string [id]" + "params.file_name: string" + "params.old_str: string" → {{{params.file_name}}}
 - "action: string [id]" + "params.keys: string" → {{{params.keys}}}

--- a/frontend/lib/actions/spans/previews/resolve.ts
+++ b/frontend/lib/actions/spans/previews/resolve.ts
@@ -3,15 +3,15 @@ import { observe } from "@lmnr-ai/lmnr";
 import { isAiProviderConfigured } from "@/lib/ai/model";
 import { cache, SPAN_RENDERING_KEY_CACHE_KEY } from "@/lib/cache";
 
+import { tryHeuristicPreview } from "./heuristic";
 import { generatePreviewKeys } from "./prompts";
 import { matchProviderKey } from "./provider-keys";
+import { extractFirstToolIfToolOnly } from "./tool-detection";
 import {
   classifyPayload,
   detectOutputStructure,
   generateFingerprint,
-  isToolOnlyLlmOutput,
   type ProviderHint,
-  tryHeuristicPreview,
   validateMustacheKey,
 } from "./utils";
 
@@ -63,16 +63,28 @@ function classifyRawSpans(
         resolved[raw.spanId] = "";
         break;
       case "object": {
-        if ((spanType === "LLM" || spanType === "CACHED") && isToolOnlyLlmOutput(classification.data)) {
-          resolved[raw.spanId] = null;
+        const hint = detectOutputStructure(classification.data);
+
+        // Happy path: provider schema extracts non-empty text/thinking → done.
+        const match = matchProviderKey(classification.data, hint);
+        if (match && match.rendered.trim() !== "") {
+          resolved[raw.spanId] = match.rendered;
           break;
         }
+
+        // No visible text. For LLM outputs, try to surface the first tool block
+        // so its descriptive fields (e.g. input.description) flow into the key
+        // pipeline instead of rendering an empty string.
+        const tool =
+          spanType === "LLM" || spanType === "CACHED" ? extractFirstToolIfToolOnly(classification.data, hint) : null;
+
+        const data = (tool ?? classification.data) as Record<string, unknown> | unknown[];
         needsProcessing.push({
           spanId: raw.spanId,
           name: raw.name,
-          parsedData: classification.data,
-          fingerprint: generateFingerprint(raw.name, classification.data),
-          provider: detectOutputStructure(classification.data),
+          parsedData: data,
+          fingerprint: generateFingerprint(tool ? `${raw.name}:tool` : raw.name, data),
+          provider: tool ? "unknown" : hint,
         });
         break;
       }
@@ -88,25 +100,6 @@ function fillMissing(previews: SpanPreviewResult, spanIds: string[]): SpanPrevie
     if (!(id in result)) result[id] = "";
   }
   return result;
-}
-
-/**
- * Match known provider structures (OpenAI, Anthropic, Gemini, LangChain).
- */
-function applyProviderMatching(spans: ParsedSpan[]): { resolved: SpanPreviewResult; unmatched: ParsedSpan[] } {
-  const resolved: SpanPreviewResult = {};
-  const unmatched: ParsedSpan[] = [];
-
-  for (const span of spans) {
-    const match = matchProviderKey(span.parsedData, span.provider);
-    if (match) {
-      resolved[span.spanId] = match.rendered;
-    } else {
-      unmatched.push(span);
-    }
-  }
-
-  return { resolved, unmatched };
 }
 
 /**
@@ -243,8 +236,8 @@ async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
 
 /**
  * Last-resort fallback used when the LLM path is unavailable or produced no
- * valid key for a span. Picks the first primitive leaf (object key order,
- * array index 0) and falls back to a truncated JSON preview.
+ * valid key for a span. Walks priority keys (description, summary, command…)
+ * and falls back to a truncated JSON preview.
  */
 function applyHeuristicFallback(spans: ParsedSpan[]): SpanPreviewResult {
   const resolved: SpanPreviewResult = {};
@@ -279,11 +272,12 @@ export interface ResolveOptions {
 
 /**
  * Run the full preview resolution pipeline on pre-fetched span data:
- *   1. classify raw payloads
+ *   1. classify raw payloads; resolve inline when a provider schema (OpenAI /
+ *      Anthropic / Gemini / LangChain) yields non-empty text/thinking, and
+ *      re-route tool-only LLM outputs to their first tool block
  *   2. look up cached LLM-generated Mustache keys by fingerprint
- *   3. match known provider structures (OpenAI / Anthropic / Gemini / LangChain)
- *   4. generate new keys via LLM (when a provider is configured) and persist them
- *   5. fall back to first-primitive-leaf heuristic for anything still unresolved
+ *   3. generate new keys via LLM (when a provider is configured) and persist them
+ *   4. fall back to priority-key heuristic for anything still unresolved
  *      (this is the only path for tool spans when no LLM provider is configured)
  */
 export async function resolvePreviews(
@@ -301,24 +295,18 @@ export async function resolvePreviews(
   }
 
   const { resolved: cacheResolved, uncached } = await applyCachedKeys(projectId, needsProcessing);
-  let accumulated: SpanPreviewResult = { ...classified, ...cacheResolved };
+  const accumulated: SpanPreviewResult = { ...classified, ...cacheResolved };
   if (uncached.length === 0) {
-    return fillMissing(accumulated, spanIds);
-  }
-
-  const { resolved: providerResolved, unmatched } = applyProviderMatching(uncached);
-  accumulated = { ...accumulated, ...providerResolved };
-  if (unmatched.length === 0) {
     return fillMissing(accumulated, spanIds);
   }
 
   const llmAvailable = !skipGeneration && isAiProviderConfigured();
 
   if (!llmAvailable) {
-    return fillMissing({ ...accumulated, ...applyHeuristicFallback(unmatched) }, spanIds);
+    return fillMissing({ ...accumulated, ...applyHeuristicFallback(uncached) }, spanIds);
   }
 
-  const { resolved: llmResolved, unresolved, keysToSave } = await generateKeysViaLlm(unmatched);
+  const { resolved: llmResolved, unresolved, keysToSave } = await generateKeysViaLlm(uncached);
   await saveRenderingKeys(projectId, keysToSave);
 
   return fillMissing({ ...accumulated, ...llmResolved, ...applyHeuristicFallback(unresolved) }, spanIds);

--- a/frontend/lib/actions/spans/previews/resolve.ts
+++ b/frontend/lib/actions/spans/previews/resolve.ts
@@ -7,13 +7,7 @@ import { tryHeuristicPreview } from "./heuristic";
 import { generatePreviewKeys } from "./prompts";
 import { matchProviderKey } from "./provider-keys";
 import { extractFirstToolIfToolOnly } from "./tool-detection";
-import {
-  classifyPayload,
-  detectOutputStructure,
-  generateFingerprint,
-  type ProviderHint,
-  validateMustacheKey,
-} from "./utils";
+import { classifyPayload, detectOutputStructure, generateFingerprint, validateMustacheKey } from "./utils";
 
 const RENDERING_KEY_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
 
@@ -26,10 +20,7 @@ interface ParsedSpan {
   name: string;
   parsedData: Record<string, unknown> | unknown[];
   fingerprint: string;
-  provider: ProviderHint;
 }
-
-const toJsonPreview = (data: unknown): string => JSON.stringify(data).slice(0, 2000);
 
 /**
  * Classify raw span payloads. Non-generation spans are resolved directly to a
@@ -84,7 +75,6 @@ function classifyRawSpans(
           name: raw.name,
           parsedData: data,
           fingerprint: generateFingerprint(tool ? `${raw.name}:tool` : raw.name, data),
-          provider: tool ? "unknown" : hint,
         });
         break;
       }
@@ -97,7 +87,7 @@ function classifyRawSpans(
 function fillMissing(previews: SpanPreviewResult, spanIds: string[]): SpanPreviewResult {
   const result = { ...previews };
   for (const id of spanIds) {
-    if (!(id in result)) result[id] = "";
+    if (!(id in result)) result[id] = null;
   }
   return result;
 }
@@ -237,12 +227,13 @@ async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
 /**
  * Last-resort fallback used when the LLM path is unavailable or produced no
  * valid key for a span. Walks priority keys (description, summary, command…)
- * and falls back to a truncated JSON preview.
+ * and returns null when no human-readable content can be extracted, so the
+ * client renders no preview rather than a raw JSON dump.
  */
 function applyHeuristicFallback(spans: ParsedSpan[]): SpanPreviewResult {
   const resolved: SpanPreviewResult = {};
   for (const span of spans) {
-    resolved[span.spanId] = tryHeuristicPreview(span.parsedData) ?? toJsonPreview(span.parsedData);
+    resolved[span.spanId] = tryHeuristicPreview(span.parsedData);
   }
   return resolved;
 }

--- a/frontend/lib/actions/spans/previews/tool-detection.ts
+++ b/frontend/lib/actions/spans/previews/tool-detection.ts
@@ -1,0 +1,191 @@
+import { isString } from "lodash";
+import { z } from "zod/v4";
+
+import {
+  type AnthropicContentBlockSchema,
+  type AnthropicMessagesSchema,
+  parseAnthropicOutput,
+} from "@/lib/spans/types/anthropic";
+import { type GeminiContentSchema, type GeminiPartSchema, parseGeminiOutput } from "@/lib/spans/types/gemini";
+import { LangChainAssistantMessageSchema, LangChainMessagesSchema } from "@/lib/spans/types/langchain";
+
+import { type ProviderHint } from "./utils";
+
+type AnthropicMessage = z.infer<typeof AnthropicMessagesSchema>[number];
+type AnthropicBlock = z.infer<typeof AnthropicContentBlockSchema>;
+type GeminiContent = z.infer<typeof GeminiContentSchema>;
+type GeminiPart = z.infer<typeof GeminiPartSchema>;
+type LangChainAssistant = z.infer<typeof LangChainAssistantMessageSchema>;
+
+const isBlank = (v: unknown): boolean => v === null || v === undefined || (isString(v) && v.trim() === "");
+
+// ---------------------------------------------------------------------------
+// OpenAI — the canonical schema types `function.arguments` as a string, but
+// span payloads reach us already deep-JSON-parsed. Use a lenient schema that
+// accepts either shape so detection still works after deep parsing.
+// ---------------------------------------------------------------------------
+
+const LooseOpenAIToolCallSchema = z.looseObject({
+  function: z.looseObject({ name: z.string(), arguments: z.unknown() }),
+});
+
+const LooseOpenAIAssistantSchema = z.looseObject({
+  role: z.literal("assistant"),
+  content: z.union([z.string(), z.array(z.unknown()), z.null()]).optional(),
+  tool_calls: z.array(LooseOpenAIToolCallSchema).nullable().optional(),
+});
+
+const LooseOpenAIChoiceSchema = z.looseObject({ message: LooseOpenAIAssistantSchema });
+const LooseOpenAIOutputSchema = z.union([LooseOpenAIChoiceSchema, z.array(LooseOpenAIChoiceSchema)]);
+
+type LooseOpenAIMessage = z.infer<typeof LooseOpenAIAssistantSchema>;
+
+const parseOpenAI = (data: unknown): LooseOpenAIMessage[] | null => {
+  const result = LooseOpenAIOutputSchema.safeParse(data);
+  if (!result.success) return null;
+  const choices = Array.isArray(result.data) ? result.data : [result.data];
+  return choices.map((c) => c.message);
+};
+
+const openaiHasText = (m: LooseOpenAIMessage): boolean => {
+  const c = m.content;
+  if (isString(c)) return !isBlank(c);
+  if (Array.isArray(c)) {
+    return c.some((p) => {
+      if (typeof p !== "object" || p === null) return false;
+      const part = p as { type?: string; text?: unknown };
+      return part.type === "text" && !isBlank(part.text);
+    });
+  }
+  return false;
+};
+
+const openaiHasTool = (m: LooseOpenAIMessage): boolean => Array.isArray(m.tool_calls) && m.tool_calls.length > 0;
+
+const openaiFirstTool = (msgs: LooseOpenAIMessage[]): unknown => msgs.find(openaiHasTool)?.tool_calls?.[0] ?? null;
+
+// ---------------------------------------------------------------------------
+// Anthropic — uses the canonical schema; tool_use.input is z.unknown() so
+// deep-parsed payloads validate fine.
+// ---------------------------------------------------------------------------
+
+const anthropicIsTool = (b: AnthropicBlock): boolean => b.type === "tool_use" || b.type === "server_tool_use";
+
+const anthropicHasText = (msgs: AnthropicMessage[]): boolean =>
+  msgs.some((m) => {
+    if (!Array.isArray(m.content)) return isString(m.content) && !isBlank(m.content);
+    return m.content.some((b) => {
+      if (b.type === "text") return !isBlank(b.text);
+      if (b.type === "thinking") return !isBlank(b.thinking);
+      return false;
+    });
+  });
+
+const anthropicHasTool = (msgs: AnthropicMessage[]): boolean =>
+  msgs.some((m) => Array.isArray(m.content) && m.content.some(anthropicIsTool));
+
+const anthropicFirstTool = (msgs: AnthropicMessage[]): unknown => {
+  for (const m of msgs) {
+    if (!Array.isArray(m.content)) continue;
+    const block = m.content.find(anthropicIsTool);
+    if (block) return block;
+  }
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Gemini
+// ---------------------------------------------------------------------------
+
+const geminiIsFnCall = (p: GeminiPart): boolean => "functionCall" in p;
+
+const geminiHasText = (contents: GeminiContent[]): boolean =>
+  contents.some((c) => c.parts.some((p) => "text" in p && !isBlank(p.text)));
+
+const geminiHasTool = (contents: GeminiContent[]): boolean => contents.some((c) => c.parts.some(geminiIsFnCall));
+
+const geminiFirstTool = (contents: GeminiContent[]): unknown => {
+  for (const c of contents) {
+    const part = c.parts.find(geminiIsFnCall);
+    if (part) return part;
+  }
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// LangChain
+// ---------------------------------------------------------------------------
+
+const parseLangChain = (data: unknown): LangChainAssistant[] | null => {
+  const singleInput = Array.isArray(data) && data.length === 1 ? data[0] : data;
+  const single = LangChainAssistantMessageSchema.safeParse(singleInput);
+  if (single.success) return [single.data];
+  const multi = LangChainMessagesSchema.safeParse(data);
+  if (!multi.success) return null;
+  return multi.data.filter((m): m is LangChainAssistant => m.role === "assistant" || m.role === "ai");
+};
+
+const langchainHasText = (msgs: LangChainAssistant[]): boolean =>
+  msgs.some((m) => {
+    const c = m.content;
+    if (isString(c)) return !isBlank(c);
+    if (Array.isArray(c)) {
+      return c.some((p) => typeof p === "object" && p !== null && "type" in p && p.type === "text" && !isBlank(p.text));
+    }
+    return false;
+  });
+
+const langchainHasTool = (msgs: LangChainAssistant[]): boolean =>
+  msgs.some((m) => Array.isArray(m.tool_calls) && m.tool_calls.length > 0);
+
+const langchainFirstTool = (msgs: LangChainAssistant[]): unknown =>
+  msgs.find((m) => m.tool_calls?.length)?.tool_calls?.[0] ?? null;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+const tryOpenAI = (data: unknown): unknown => {
+  const msgs = parseOpenAI(data);
+  if (!msgs || !msgs.some(openaiHasTool) || msgs.some(openaiHasText)) return null;
+  return openaiFirstTool(msgs);
+};
+
+const tryAnthropic = (data: unknown): unknown => {
+  const msgs = parseAnthropicOutput(data);
+  if (!msgs || !anthropicHasTool(msgs) || anthropicHasText(msgs)) return null;
+  return anthropicFirstTool(msgs);
+};
+
+const tryGemini = (data: unknown): unknown => {
+  const contents = parseGeminiOutput(data);
+  if (!contents || !geminiHasTool(contents) || geminiHasText(contents)) return null;
+  return geminiFirstTool(contents);
+};
+
+const tryLangChain = (data: unknown): unknown => {
+  const msgs = parseLangChain(data);
+  if (!msgs || !langchainHasTool(msgs) || langchainHasText(msgs)) return null;
+  return langchainFirstTool(msgs);
+};
+
+/**
+ * If an LLM output has tool calls but no visible text/thinking, return the
+ * first tool block so the caller can route it through the preview pipeline.
+ * Returns null when no provider matches or the output has displayable text.
+ * Pass `hint` from `detectOutputStructure` to skip non-matching parsers.
+ */
+export const extractFirstToolIfToolOnly = (data: unknown, hint?: ProviderHint): unknown => {
+  switch (hint) {
+    case "openai":
+      return tryOpenAI(data);
+    case "anthropic":
+      return tryAnthropic(data);
+    case "gemini":
+      return tryGemini(data);
+    case "langchain":
+      return tryLangChain(data);
+  }
+  // No hint or "unknown" — try each parser until one matches.
+  return tryOpenAI(data) ?? tryAnthropic(data) ?? tryGemini(data) ?? tryLangChain(data);
+};

--- a/frontend/lib/actions/spans/previews/utils.ts
+++ b/frontend/lib/actions/spans/previews/utils.ts
@@ -1,4 +1,4 @@
-import { isBoolean, isEmpty, isNil, isNumber, isPlainObject, isString, keys, last, mapValues } from "lodash";
+import { isEmpty, isNil, isPlainObject, isString, last, mapValues } from "lodash";
 import Mustache from "mustache";
 
 import { deepParseJson } from "@/lib/actions/common/utils.ts";
@@ -7,9 +7,12 @@ import { GeminiOutputSchema } from "@/lib/spans/types/gemini";
 import { LangChainAssistantMessageSchema, LangChainMessagesSchema } from "@/lib/spans/types/langchain";
 import { OpenAIOutputSchema } from "@/lib/spans/types/openai";
 
+// ---------------------------------------------------------------------------
+// Payload classification
+// ---------------------------------------------------------------------------
+
 export const deepParseValue = (value: unknown): unknown => {
   if (!isString(value)) return value;
-
   try {
     const parsed = JSON.parse(value);
     return isString(parsed) ? deepParseValue(parsed) : parsed;
@@ -36,82 +39,19 @@ export const classifyPayload = (raw: unknown): PayloadClassification => {
   if (Array.isArray(deepParsed)) {
     return isEmpty(deepParsed) ? { kind: "empty", preview: "" } : { kind: "object", data: deepParsed };
   }
-
   if (isPlainObject(deepParsed)) {
     return isEmpty(deepParsed)
       ? { kind: "empty", preview: "" }
       : { kind: "object", data: deepParsed as Record<string, unknown> };
   }
-
   return { kind: "raw", preview: String(deepParsed) };
 };
 
+// ---------------------------------------------------------------------------
+// Provider detection (schema-based)
+// ---------------------------------------------------------------------------
+
 export type ProviderHint = "openai" | "anthropic" | "gemini" | "langchain" | "unknown";
-
-/**
- * Returns true when the parsed LLM output contains only tool calls
- * and no meaningful text/thinking content worth showing as a preview.
- */
-const hasNoMeaningfulContent = (content: unknown): boolean =>
-  content === null || content === undefined || content === "" || (isString(content) && content.trim().length === 0);
-
-export const isToolOnlyLlmOutput = (data: unknown): boolean => {
-  const unwrapped =
-    Array.isArray(data) && data.length === 1 && isPlainObject(data[0]) ? (data[0] as Record<string, unknown>) : null;
-  const obj = isPlainObject(data) ? (data as Record<string, unknown>) : null;
-
-  // OpenAI: choices[0].message has tool_calls but content is null/empty
-  if (obj && Array.isArray(obj.choices)) {
-    const msg = (obj.choices as unknown[])[0];
-    if (isPlainObject(msg)) {
-      const message = (msg as Record<string, unknown>).message;
-      if (isPlainObject(message)) {
-        const m = message as Record<string, unknown>;
-        if (Array.isArray(m.tool_calls) && m.tool_calls.length > 0 && hasNoMeaningfulContent(m.content)) {
-          return true;
-        }
-      }
-    }
-  }
-
-  // Anthropic: content array has only tool_use blocks
-  const contentHolder = obj ?? unwrapped;
-  if (contentHolder && Array.isArray(contentHolder.content)) {
-    const blocks = contentHolder.content as unknown[];
-    if (
-      blocks.length > 0 &&
-      blocks.every((b) => isPlainObject(b) && (b as Record<string, unknown>).type === "tool_use")
-    ) {
-      return true;
-    }
-  }
-
-  // Gemini: candidates[0].content.parts has only functionCall parts
-  if (obj && Array.isArray(obj.candidates)) {
-    const candidate = (obj.candidates as unknown[])[0];
-    if (isPlainObject(candidate)) {
-      const content = (candidate as Record<string, unknown>).content;
-      if (isPlainObject(content)) {
-        const parts = (content as Record<string, unknown>).parts;
-        if (
-          Array.isArray(parts) &&
-          parts.length > 0 &&
-          parts.every((p) => isPlainObject(p) && "functionCall" in (p as Record<string, unknown>))
-        ) {
-          return true;
-        }
-      }
-    }
-  }
-
-  // Generic: any message (object or array-wrapped) with tool_calls but no content
-  const msg = obj ?? unwrapped;
-  if (msg && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0 && hasNoMeaningfulContent(msg.content)) {
-    return true;
-  }
-
-  return false;
-};
 
 export const detectOutputStructure = (data: unknown): ProviderHint => {
   if (OpenAIOutputSchema.safeParse(data).success) return "openai";
@@ -119,14 +59,19 @@ export const detectOutputStructure = (data: unknown): ProviderHint => {
   if (AnthropicOutputMessageSchema.safeParse(data).success) return "anthropic";
   if (AnthropicOutputMessagesSchema.safeParse(data).success) return "anthropic";
 
-  // LangChain has no dedicated output schema — check for assistant message(s)
+  // LangChain has no dedicated output schema — check for assistant message(s).
   if (LangChainAssistantMessageSchema.safeParse(data).success) return "langchain";
   if (Array.isArray(data) && LangChainMessagesSchema.safeParse(data).success) return "langchain";
 
   return "unknown";
 };
 
-const METADATA_KEYS = new Set([
+// ---------------------------------------------------------------------------
+// Key classification — used by fingerprinting, path flattening, and
+// consumed by the heuristic module.
+// ---------------------------------------------------------------------------
+
+export const METADATA_KEYS: ReadonlySet<string> = new Set([
   "id",
   "ids",
   "status",
@@ -147,15 +92,15 @@ const METADATA_KEYS = new Set([
   "created",
   "object",
   "system_fingerprint",
+  "signature",
+  "tool_use_id",
+  "stop_reason",
 ]);
 
-const IDENTIFIER_KEYS = new Set(["name", "action", "function", "method", "command", "tool"]);
+const IDENTIFIER_KEYS: ReadonlySet<string> = new Set(["name", "action", "function", "method", "command", "tool"]);
 
-/**
- * Keys that indicate an object is a structured response, not a flat dictionary/map.
- * Union of metadata, identifier, and common payload field names.
- */
-const STRUCTURED_FIELD_NAMES = new Set([
+// Keys that indicate an object is a structured response, not a flat dictionary.
+const STRUCTURED_FIELD_NAMES: ReadonlySet<string> = new Set([
   ...METADATA_KEYS,
   ...IDENTIFIER_KEYS,
   "content",
@@ -181,12 +126,8 @@ const STRUCTURED_FIELD_NAMES = new Set([
   "code",
 ]);
 
-/**
- * Returns true when an object looks like a flat key→value map (e.g. locale
- * codes to translations) rather than a structured response with known fields.
- * Requires 3+ entries, all values of the same primitive type, and no keys
- * that match well-known structured field names.
- */
+// True when an object looks like a flat key→value map (e.g. locale codes to
+// translations) rather than a structured response with known fields.
 const isDictionaryLike = (obj: Record<string, unknown>): boolean => {
   const keys = Object.keys(obj);
   if (keys.length < 3) return false;
@@ -195,6 +136,10 @@ const isDictionaryLike = (obj: Record<string, unknown>): boolean => {
   if (firstType !== "string" && firstType !== "number" && firstType !== "boolean") return false;
   return keys.every((k) => typeof obj[k] === firstType);
 };
+
+// ---------------------------------------------------------------------------
+// Structural fingerprinting (cache key basis)
+// ---------------------------------------------------------------------------
 
 const describeShape = (value: unknown): string => {
   if (isNil(value)) return "null";
@@ -207,25 +152,23 @@ const describeShape = (value: unknown): string => {
     const uniqueShapes = [...new Set(value.map(describeShape))].sort();
     return uniqueShapes.length === 1 ? `[]${uniqueShapes[0]}` : `[](${uniqueShapes.join("|")})`;
   }
-
   if (isPlainObject(value)) {
     const obj = value as Record<string, unknown>;
-    if (isDictionaryLike(obj)) {
-      return `{*:${describeShape(obj[Object.keys(obj)[0]])}}`;
-    }
+    if (isDictionaryLike(obj)) return `{*:${describeShape(obj[Object.keys(obj)[0]])}}`;
     const entries = Object.keys(obj)
       .sort()
       .map((key) => `${key}:${describeShape(obj[key])}`);
     return `{${entries.join(",")}}`;
   }
-
   return "unknown";
 };
 
-/**
- * Generate a deterministic schema fingerprint from a JSON structure.
- */
+/** Deterministic schema fingerprint for cache lookups. */
 export const generateFingerprint = (spanName: string, data: unknown): string => `${spanName}:${describeShape(data)}`;
+
+// ---------------------------------------------------------------------------
+// Path flattening — used to build the LLM prompt
+// ---------------------------------------------------------------------------
 
 const OPAQUE_VALUE_PATTERN = /^<.+ at 0x[0-9a-fA-F]+>$/;
 
@@ -238,9 +181,7 @@ export const flattenPaths = (data: unknown): string[] => {
     if (isString(value) || typeof value === "number" || typeof value === "boolean") {
       const lastKey = last(prefix.split("."))?.replace(/\[\]$/, "") ?? "";
       let tag = METADATA_KEYS.has(lastKey) ? " [meta]" : IDENTIFIER_KEYS.has(lastKey) ? " [id]" : "";
-      if (!tag && isString(value) && OPAQUE_VALUE_PATTERN.test(value)) {
-        tag = " [meta]";
-      }
+      if (!tag && isString(value) && OPAQUE_VALUE_PATTERN.test(value)) tag = " [meta]";
       paths.push(`${prefix}: ${typeof value}${tag}`);
       return;
     }
@@ -266,11 +207,12 @@ export const flattenPaths = (data: unknown): string[] => {
   return paths;
 };
 
-/**
- * Add a non-enumerable toString to objects/arrays so Mustache renders them
- * as JSON strings when used as {{variable}}, while still allowing section
- * blocks like {{#obj}}{{field}}{{/obj}} to drill into them.
- */
+// ---------------------------------------------------------------------------
+// Mustache rendering
+// ---------------------------------------------------------------------------
+
+// Attach a non-enumerable toString so Mustache renders objects/arrays as JSON
+// when used as {{var}}, while sections like {{#obj}}{{field}}{{/obj}} still work.
 const addStringifyToObjects = (value: unknown): unknown => {
   if (isNil(value) || isString(value) || typeof value === "number" || typeof value === "boolean") return value;
 
@@ -282,20 +224,15 @@ const addStringifyToObjects = (value: unknown): unknown => {
     attach(mapped, value);
     return mapped;
   }
-
   if (isPlainObject(value)) {
     const result = mapValues(value as Record<string, unknown>, addStringifyToObjects);
     attach(result, value);
     return result;
   }
-
   return value;
 };
 
-const prepareRenderTarget = (data: unknown): unknown => {
-  const deepParsed = deepParseJson(data);
-  return addStringifyToObjects(deepParsed);
-};
+const prepareRenderTarget = (data: unknown): unknown => addStringifyToObjects(deepParseJson(data));
 
 export const validateMustacheKey = (key: string, data: unknown): string | null => {
   try {
@@ -306,38 +243,3 @@ export const validateMustacheKey = (key: string, data: unknown): string | null =
     return null;
   }
 };
-
-function formatPrimitiveLeaf(value: string | number | boolean): string | null {
-  if (isNumber(value) || isBoolean(value)) return String(value);
-  const t = value.trim();
-  return t.length > 0 ? t : null;
-}
-
-function findFirstPrimitiveLeaf(value: unknown): string | null {
-  if (isNil(value)) return null;
-  if (isString(value) || isNumber(value) || isBoolean(value)) return formatPrimitiveLeaf(value);
-
-  if (Array.isArray(value)) {
-    if (isEmpty(value)) return null;
-    return findFirstPrimitiveLeaf(value[0]);
-  }
-
-  if (isPlainObject(value)) {
-    const obj = value as Record<string, unknown>;
-    for (const k of keys(obj)) {
-      const found = findFirstPrimitiveLeaf(obj[k]);
-      if (found !== null) return found;
-    }
-    return null;
-  }
-
-  return null;
-}
-
-/**
- * Last-resort fallback that picks the first primitive leaf (object key order,
- * array index 0). Used by the resolver only when no AI provider is configured
- * or when LLM key generation fails — most hits in practice are tool spans,
- * since LLM outputs match a provider pattern upstream. Not cached.
- */
-export const tryHeuristicPreview = (data: unknown): string | null => findFirstPrimitiveLeaf(deepParseJson(data));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the preview-resolution pipeline and fallback behavior (including returning `null` instead of JSON strings), which may affect what users see for many spans and could impact cached fingerprinting/matching for tool-only outputs.
> 
> **Overview**
> Improves transcript span previews for tool-heavy LLM outputs by detecting “tool-only” responses (OpenAI/Anthropic/Gemini/LangChain) and routing the *first tool call block* through the existing preview-key pipeline instead of rendering empty output.
> 
> Reworks the non-LLM fallback preview logic: introduces a priority-key heuristic (`description`, `summary`, `command`, etc.) that skips metadata fields and returns `null` when nothing meaningful is found (removing the previous raw JSON dump fallback), updates metadata key classification, and adjusts resolver behavior to treat missing previews as `null`.
> 
> Updates span row rendering so snippet-based previews are shown in the expanded/LLM preview area (and inline preview is suppressed when snippets exist), plus minor layout simplification in `SnippetPreview`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 114f06043e728679d42fc8ee71af52761f29a9d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->