### PR TITLE
feat: use descriptive tool uses from llm outputs

### DIFF
--- a/frontend/components/traces/trace-view/transcript/collapsed-text-with-more.tsx
+++ b/frontend/components/traces/trace-view/transcript/collapsed-text-with-more.tsx
@@ -1,93 +1,57 @@
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
-
-const MORE_TEXT = "... more";
-const LESS_TEXT = "less";
-const CHARS_PER_PIXEL = 0.155;
-const FALLBACK_WIDTH = 500;
 
 interface CollapsedTextWithMoreProps {
   text: string;
   lineHeight: number;
   maxLines?: number;
-  charsPerPixel?: number;
   className?: string;
 }
 
-function truncateText(text: string, maxChars: number): string | null {
-  if (text.length <= maxChars) return null;
+const LINE_CLAMP_CLASS: Record<number, string> = {
+  1: "line-clamp-1",
+  2: "line-clamp-2",
+  3: "line-clamp-3",
+  4: "line-clamp-4",
+  5: "line-clamp-5",
+  6: "line-clamp-6",
+};
 
-  const cutRegion = text.slice(0, maxChars);
-  const lastSpace = cutRegion.lastIndexOf(" ");
-  if (lastSpace <= 0) return cutRegion.trimEnd();
-  return cutRegion.slice(0, lastSpace);
-}
-
-export function CollapsedTextWithMore({
-  text,
-  lineHeight,
-  maxLines = 4,
-  charsPerPixel = CHARS_PER_PIXEL,
-  className,
-}: CollapsedTextWithMoreProps) {
+export function CollapsedTextWithMore({ text, lineHeight, maxLines = 4, className }: CollapsedTextWithMoreProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [containerWidth, setContainerWidth] = useState(FALLBACK_WIDTH);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const measuredRef = useRef(false);
+  const textRef = useRef<HTMLParagraphElement>(null);
 
-  useEffect(() => {
-    const el = containerRef.current;
+  useLayoutEffect(() => {
+    if (measuredRef.current) return;
+    const el = textRef.current;
     if (!el) return;
-    const observer = new ResizeObserver((entries) => {
-      const width = entries[0]?.contentRect.width;
-      if (width && width > 0) setContainerWidth(width);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
+    setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
+    measuredRef.current = true;
   }, []);
 
-  const charsPerLine = Math.floor(containerWidth * charsPerPixel);
-  const maxChars = charsPerLine * maxLines - MORE_TEXT.length;
-  const truncated = isExpanded ? null : truncateText(text, maxChars);
-  const canCollapse = truncateText(text, maxChars) !== null;
+  const clampClass = LINE_CLAMP_CLASS[maxLines] ?? LINE_CLAMP_CLASS[4];
 
   return (
     <div
-      ref={containerRef}
-      className={cn("text-sm text-secondary-foreground/95 break-all", className)}
+      className={cn("text-sm text-secondary-foreground/95 whitespace-pre-wrap break-words", className)}
       style={{ lineHeight: `${lineHeight + 4}px` }}
     >
-      {truncated !== null ? (
-        <p>
-          {truncated}
-          <button
-            className="text-muted-foreground hover:text-primary-foreground transition-colors cursor-pointer"
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsExpanded(true);
-            }}
-          >
-            {MORE_TEXT}
-          </button>
-        </p>
-      ) : (
-        <p>
-          {text}
-          {canCollapse && (
-            <>
-              {" "}
-              <button
-                className="text-muted-foreground hover:text-primary-foreground transition-colors cursor-pointer"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setIsExpanded(false);
-                }}
-              >
-                {LESS_TEXT}
-              </button>
-            </>
-          )}
-        </p>
+      <p ref={textRef} className={isExpanded ? undefined : clampClass}>
+        {text}
+      </p>
+      {(isOverflowing || isExpanded) && (
+        <button
+          className="text-muted-foreground hover:text-primary-foreground transition-colors cursor-pointer"
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsExpanded((v) => !v);
+          }}
+        >
+          {isExpanded ? "less" : "... more"}
+        </button>
       )}
     </div>
   );

--- a/frontend/lib/actions/spans/previews/heuristic.ts
+++ b/frontend/lib/actions/spans/previews/heuristic.ts
@@ -97,3 +97,34 @@ export const tryHeuristicPreview = (data: unknown): string | null => {
   }
   return firstNonMetaLeaf(parsed);
 };
+
+// Strict allowlist of keys that carry the model's intent in natural language.
+// Must match the llm_tool_only prompt rules exactly.
+const DESCRIPTIVE_KEYS: readonly string[] = [
+  "description",
+  "summary",
+  "title",
+  "goal",
+  "intent",
+  "reasoning",
+  "thought",
+  "instructions",
+  "question",
+  "prompt",
+  "message",
+];
+
+/**
+ * Fallback for the LLM-output tool-only case. Strict allowlist only:
+ * returns the first non-empty value under one of DESCRIPTIVE_KEYS, or null.
+ * No fallback to other fields — matches the prompt's rules so cached and
+ * non-cached paths produce the same shape.
+ */
+export const tryDescriptiveHeuristicPreview = (data: unknown): string | null => {
+  const parsed = deepParseJson(data);
+  for (const key of DESCRIPTIVE_KEYS) {
+    const hit = findByKey(parsed, key);
+    if (hit !== null) return hit;
+  }
+  return null;
+};

--- a/frontend/lib/actions/spans/previews/prompts.ts
+++ b/frontend/lib/actions/spans/previews/prompts.ts
@@ -5,67 +5,104 @@ import { getLanguageModel } from "@/lib/ai/model";
 
 import { flattenPaths } from "./utils.ts";
 
-const PREVIEW_KEY_SYSTEM_PROMPT = `Pick fields from a schema to build a short Mustache preview template. One template per structure.
+export type PreviewVariant = "generic" | "llm_tool_only";
 
-Most inputs are tool-use blocks (Anthropic: {type, id, name, input.*}, OpenAI: {id, type, function.name, function.arguments.*}, Gemini: {functionCall.name, functionCall.args.*}). Prefer the most human-readable scalar from the tool's arguments (input / arguments / args / params) over the tool name.
+const PREVIEW_KEY_SYSTEM_PROMPT = `<task>
+Pick ONE field from each schema to build a short Mustache preview template. Output exactly one template per input structure, in order, as a JSON array.
+</task>
 
-Array access: use .0. for nested arrays. When root is an array (paths start with []), wrap with {{#.}}...{{/.}} and use inner paths.
+<input_format>
+Each <span> lists paths for one structure. A path looks like: \`key.subkey: type [tag] = "sample"\`.
+- type: string | number | boolean | object.
+- tag (optional): [meta] = skip, [id] = skip unless it's the only non-meta scalar.
+- sample (optional): a short example value; use it to judge which field is most human-readable.
+- \`a[]\` = array of scalars (unstable order; never index with .0.). \`a[].b\` = array of objects (indexing with .0. is ok).
+- \`a{*}\` = dictionary with arbitrary keys (cannot be templated; treat as [meta]).
+</input_format>
 
-Rules:
-- Pick the single most descriptive content field. Use {{{ }}} (triple braces). Never add markdown or styling.
-- null ONLY if every field is [meta]/[id] or empty.
-- Prefer scalar fields over primitive arrays. Paths ending in []: type (e.g. ids[]: string, tags[]: string) are primitive-value lists with unstable element order. Never use .0. to index into them. Treat them as [meta] when any scalar field exists. Using .0. is only acceptable for arrays of objects with known nested structure (e.g. choices[].message.content).
-- Dictionary paths: paths containing {*} (e.g. tasks{*}: string) represent objects with dynamic/arbitrary key names that vary across instances. They cannot be referenced in Mustache templates. Treat as [meta].
+<output_format>
+- Use triple braces: \`{{{path}}}\`. No markdown, no styling, no extra text.
+- When root is an array (paths start with \`[]\`), wrap with \`{{#.}}...{{/.}}\` and use inner paths.
+- Return \`null\` only when every field is [meta]/[id]/empty (or for mode=llm_tool_only, see below).
+</output_format>
 
-Field classification:
-- [meta] fields (skip): id, ids, status, type, types, kind, mode, version, role, model, usage, timestamp, duration, finish_reason, token_count, index, logprobs, created, object, system_fingerprint, signature, tool_use_id. Also includes fields whose values are opaque references (serialized object pointers, memory addresses).
-- [id] fields (skip when siblings have scalar content): name, action, command, function, method, tool. These identify what operation runs and are shown in the span header. Never include them in the preview when other scalar content fields exist. Primitive array siblings do not count as content. When an [id] field is the only non-meta scalar (no content sibling, no descriptive nested leaf), surface it per decision order rule 3.
-- Content fields (prefer, in order of preference): description, summary, query, prompt, message, text, content, answer, title, path, url, code, output, result. When multiple exist, pick the earliest-listed one.
+<field_classification>
+- [meta] (always skip): id, ids, status, type, types, kind, mode, version, role, model, usage, timestamp, duration, finish_reason, token_count, index, logprobs, created, object, system_fingerprint, signature, tool_use_id. Also: values that look like opaque references (e.g. \`<Foo at 0x…>\`).
+- [id] (skip when any scalar content sibling exists): name, action, command, function, method, tool. These are already shown in the span header.
+- content (prefer, earliest wins): description, summary, query, prompt, message, text, content, answer, title, path, url, code, output, result.
+</field_classification>
 
-Decision order:
-1. Scalar content field present → {{{field}}}
-2. [id] field present + scalar sibling fields under a nested key (input/arguments/args/params/body or any sub-object) → pick the single most descriptive short string leaf from those siblings as {{{nested.leaf}}}. If the only siblings are [meta], primitive arrays, or null → use the [id] field.
-3. [id] field is the only non-meta scalar field → {{{field}}}
-4. Multiple non-meta, non-id scalar fields → pick the single most descriptive one as {{{field}}}
-5. Deeply nested scalar leaf → {{{path.0.to.0.field}}}
-6. All [meta]/[id]/empty → null
+<decision_order>
+1. Scalar content field present → \`{{{field}}}\`.
+2. [id] with scalar siblings under a nested key (input / arguments / args / params / body / …) → pick the most descriptive short string leaf as \`{{{nested.leaf}}}\`. If siblings are only [meta] / primitive arrays / null → fall through.
+3. [id] is the only non-meta scalar → \`{{{field}}}\`.
+4. Multiple non-meta, non-id scalars → pick the most descriptive one.
+5. Deeply nested scalar leaf → \`{{{a.0.b.0.c}}}\`.
+6. Everything [meta]/[id]/empty → \`null\`.
+</decision_order>
 
-Examples:
-- "choices[].message.content: string" → {{{choices.0.message.content}}}
-- "[].output[].content[].text: string" → {{#.}}{{{output.0.content.0.text}}}{{/.}}
-- Anthropic tool_use: "type: string [meta]" + "id: string [meta]" + "name: string [id]" + "input.command: string" + "input.description: string" → {{{input.description}}}
-- Anthropic tool_use: "type: string [meta]" + "name: string [id]" + "input.query: string" + "input.max_results: number" → {{{input.query}}}
-- Anthropic tool_use: "type: string [meta]" + "name: string [id]" + "input.path: string" + "input.old_str: string" → {{{input.path}}}
-- OpenAI tool_call: "id: string [meta]" + "type: string [meta]" + "function.name: string [id]" + "function.arguments.description: string" → {{{function.arguments.description}}}
-- OpenAI tool_call: "function.name: string [id]" + "function.arguments.query: string" → {{{function.arguments.query}}}
-- Gemini functionCall: "functionCall.name: string [id]" + "functionCall.args.query: string" → {{{functionCall.args.query}}}
-- "name: string [id]" + "input.query: string" + "input.max_results: number" → {{{input.query}}}
-- "action: string [id]" + "params.file_name: string" + "params.old_str: string" → {{{params.file_name}}}
-- "action: string [id]" + "params.keys: string" → {{{params.keys}}}
-- "action: string [id]" + "params.index: number [meta]" → {{{action}}}
-- "command: string [id]" + "ids[]: string [meta]" + "agent_types[]: string" → {{{command}}}
-- "command: string [id]" + "tasks{*}: string" + "kind: string [meta]" → {{{command}}}
-- "name: string [id]" + "arguments.command: string" → {{{arguments.command}}}
-- "command: string" → {{{command}}}
-- "score: number" + "grade: string" → {{{grade}}}
-- "id: string [meta]" + "name: string" + "type: string [meta]" → {{{name}}}
-- "name: string [meta]" + "id: string [meta]" + "type: string [meta]" → null`;
+<mode name="llm_tool_only">
+When a span is tagged \`mode="llm_tool_only"\`, its structure is a single tool's arguments from an LLM output that produced no visible text or thinking. The preview must describe the model's INTENT in natural language.
+Only these keys are allowed, in priority order. Pick the earliest one that exists with a non-empty string sample:
+  \`description\`, \`summary\`, \`title\`, \`goal\`, \`intent\`, \`reasoning\`, \`thought\`, \`instructions\`, \`question\`, \`prompt\`, \`message\`.
+No other key is ever a valid choice — not \`query\`, \`path\`, \`file_path\`, \`url\`, \`command\`, \`code\`, \`pattern\`, \`input\`, \`args\`, \`params\`, \`name\`, \`action\`, etc. If none of the allowed keys exists (or the chosen key's sample is empty / [meta]) → \`null\`.
+Never invent a path, never fall back to "the only available field". \`null\` is the correct answer when no allowed key is present.
+</mode>
+
+<examples mode="generic">
+  <ex in='choices[].message.content: string = "Sure! Here is…"' out="{{{choices.0.message.content}}}"/>
+  <ex in='[].output[].content[].text: string' out="{{#.}}{{{output.0.content.0.text}}}{{/.}}"/>
+  <ex in='type: string [meta] | id: string [meta] | name: string [id] | input.command: string | input.description: string' out="{{{input.description}}}"/>
+  <ex in='name: string [id] | input.query: string | input.max_results: number' out="{{{input.query}}}"/>
+  <ex in='name: string [id] | input.path: string | input.old_str: string' out="{{{input.path}}}"/>
+  <ex in='function.name: string [id] | function.arguments.description: string' out="{{{function.arguments.description}}}"/>
+  <ex in='functionCall.name: string [id] | functionCall.args.query: string' out="{{{functionCall.args.query}}}"/>
+  <ex in='action: string [id] | params.file_name: string | params.old_str: string' out="{{{params.file_name}}}"/>
+  <ex in='action: string [id] | params.index: number [meta]' out="{{{action}}}"/>
+  <ex in='command: string [id] | ids[]: string [meta] | agent_types[]: string' out="{{{command}}}"/>
+  <ex in='command: string [id] | tasks{*}: string | kind: string [meta]' out="{{{command}}}"/>
+  <ex in='command: string' out="{{{command}}}"/>
+  <ex in='score: number | grade: string' out="{{{grade}}}"/>
+  <ex in='id: string [meta] | name: string | type: string [meta]' out="{{{name}}}"/>
+  <ex in='name: string [meta] | id: string [meta] | type: string [meta]' out="null"/>
+</examples>
+
+<examples mode="llm_tool_only">
+  <ex in='description: string = "Fix the login bug in auth.ts"' out="{{{description}}}"/>
+  <ex in='summary: string = "Adds null check to handler"' out="{{{summary}}}"/>
+  <ex in='title: string = "Refactor user service"' out="{{{title}}}"/>
+  <ex in='goal: string = "Improve test coverage for billing module"' out="{{{goal}}}"/>
+  <ex in='reasoning: string = "User wants to verify their subscription renewed"' out="{{{reasoning}}}"/>
+  <ex in='thought: string = "I should read the config first to understand defaults"' out="{{{thought}}}"/>
+  <ex in='question: string = "What is the capital of France?"' out="{{{question}}}"/>
+  <ex in='instructions: string = "Summarize the PR diff in two sentences"' out="{{{instructions}}}"/>
+  <ex in='description: string = "Update onboarding flow" | summary: string = "Also applies to mobile"' out="{{{description}}}"/>
+  <ex in='summary: string = "Adds retry logic" | title: string = "Improve resilience"' out="{{{summary}}}"/>
+  <ex in='description: string = ""' out="null"/>
+</examples>`;
 
 export type PreviewKeyResult = Array<string | null>;
 
 interface SpanStructure {
   data: unknown;
+  variant?: PreviewVariant;
 }
 
 const buildUserMessage = (structures: SpanStructure[]): string => {
   const spanElements = structures
     .map((s, i) => {
       const paths = flattenPaths(s.data);
-      return `<span index="${i}">\n${paths.join("\n")}\n</span>`;
+      const modeAttr = s.variant === "llm_tool_only" ? ' mode="llm_tool_only"' : "";
+      return `<span index="${i}"${modeAttr}>\n${paths.join("\n")}\n</span>`;
     })
     .join("\n");
 
-  return `<structures count="${structures.length}">\n${spanElements}\n</structures>\nReturn exactly ${structures.length} templates as a JSON array of strings (or null). No explanation.`;
+  return `<structures count="${structures.length}">
+${spanElements}
+</structures>
+<response_format>
+Return exactly ${structures.length} templates as a JSON array of strings (use the literal \`null\` for no preview). No prose, no markdown fences.
+</response_format>`;
 };
 
 const parsePreviewKeysResponse = (text: string, expectedLength: number): PreviewKeyResult => {
@@ -76,7 +113,12 @@ const parsePreviewKeysResponse = (text: string, expectedLength: number): Preview
   try {
     const parsed = JSON.parse(jsonMatch[0]);
     if (!Array.isArray(parsed)) return new Array(expectedLength).fill(null);
-    return parsed.map((v: unknown) => (typeof v === "string" ? v : null));
+    return parsed.map((v: unknown) => {
+      if (typeof v !== "string") return null;
+      const t = v.trim();
+      if (t === "" || t.toLowerCase() === "null") return null;
+      return v;
+    });
   } catch {
     return new Array(expectedLength).fill(null);
   }

--- a/frontend/lib/actions/spans/previews/resolve.ts
+++ b/frontend/lib/actions/spans/previews/resolve.ts
@@ -3,10 +3,10 @@ import { observe } from "@lmnr-ai/lmnr";
 import { isAiProviderConfigured } from "@/lib/ai/model";
 import { cache, SPAN_RENDERING_KEY_CACHE_KEY } from "@/lib/cache";
 
-import { tryHeuristicPreview } from "./heuristic";
-import { generatePreviewKeys } from "./prompts";
+import { tryDescriptiveHeuristicPreview, tryHeuristicPreview } from "./heuristic";
+import { generatePreviewKeys, type PreviewVariant } from "./prompts";
 import { matchProviderKey } from "./provider-keys";
-import { extractFirstToolIfToolOnly } from "./tool-detection";
+import { extractToolsIfToolOnly } from "./tool-detection";
 import { classifyPayload, detectOutputStructure, generateFingerprint, validateMustacheKey } from "./utils";
 
 const RENDERING_KEY_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
@@ -16,16 +16,24 @@ export type SpanPreviewResult = Record<string, string | null>;
 const GENERATION_SPAN_TYPES = new Set(["LLM", "CACHED", "TOOL"]);
 
 interface ParsedSpan {
+  key: string;
   spanId: string;
   name: string;
   parsedData: Record<string, unknown> | unknown[];
   fingerprint: string;
+  variant: PreviewVariant;
+  toolIndex?: number;
+  toolName?: string;
 }
 
 /**
  * Classify raw span payloads. Non-generation spans are resolved directly to a
  * truncated string; generation spans with object payloads are returned for
  * further processing by the resolution pipeline.
+ *
+ * Tool-only LLM outputs are split into one `ParsedSpan` entry per tool so
+ * each tool's arguments get their own fingerprint (enabling cache reuse
+ * across different tool mixes) and their own preview rendering.
  */
 function classifyRawSpans(
   rawSpans: Array<{ spanId: string; data: string; name: string }>,
@@ -63,18 +71,36 @@ function classifyRawSpans(
           break;
         }
 
-        // No visible text. For LLM outputs, try to surface the first tool block
-        // so its descriptive fields (e.g. input.description) flow into the key
-        // pipeline instead of rendering an empty string.
-        const tool =
-          spanType === "LLM" || spanType === "CACHED" ? extractFirstToolIfToolOnly(classification.data, hint) : null;
+        // No visible text. For LLM outputs, surface every tool block so each
+        // tool's descriptive fields (e.g. input.description) flow through the
+        // pipeline independently instead of rendering nothing.
+        const tools =
+          spanType === "LLM" || spanType === "CACHED" ? extractToolsIfToolOnly(classification.data, hint) : null;
 
-        const data = (tool ?? classification.data) as Record<string, unknown> | unknown[];
+        if (tools && tools.length > 0) {
+          tools.forEach((tool, toolIndex) => {
+            const toolData = (tool.input ?? {}) as Record<string, unknown> | unknown[];
+            needsProcessing.push({
+              key: `${raw.spanId}#${toolIndex}`,
+              spanId: raw.spanId,
+              name: raw.name,
+              parsedData: toolData,
+              fingerprint: generateFingerprint(`${raw.name}:llm_tool:${tool.name}`, toolData),
+              variant: "llm_tool_only",
+              toolIndex,
+              toolName: tool.name,
+            });
+          });
+          break;
+        }
+
         needsProcessing.push({
+          key: raw.spanId,
           spanId: raw.spanId,
           name: raw.name,
-          parsedData: data,
-          fingerprint: generateFingerprint(tool ? `${raw.name}:tool` : raw.name, data),
+          parsedData: classification.data as Record<string, unknown> | unknown[],
+          fingerprint: generateFingerprint(raw.name, classification.data),
+          variant: "generic",
         });
         break;
       }
@@ -94,11 +120,13 @@ function fillMissing(previews: SpanPreviewResult, spanIds: string[]): SpanPrevie
 
 /**
  * Look up cached LLM-generated Mustache keys by structural fingerprint.
+ * Indexed by each ParsedSpan's `key` (not `spanId`) so tool-only entries
+ * stay separate.
  */
 async function applyCachedKeys(
   projectId: string,
   parsedSpans: ParsedSpan[]
-): Promise<{ resolved: SpanPreviewResult; uncached: ParsedSpan[] }> {
+): Promise<{ resolved: Record<string, string | null>; uncached: ParsedSpan[] }> {
   const uniqueFingerprints = [...new Set(parsedSpans.map((s) => s.fingerprint))];
 
   const cachedEntries = await Promise.all(
@@ -117,7 +145,7 @@ async function applyCachedKeys(
     if (key) fingerprintToKey.set(fingerprint, key);
   }
 
-  const resolved: SpanPreviewResult = {};
+  const resolved: Record<string, string | null> = {};
   const uncached: ParsedSpan[] = [];
   const hitFingerprints = new Set<string>();
 
@@ -130,7 +158,7 @@ async function applyCachedKeys(
 
     const rendered = validateMustacheKey(cachedKey, span.parsedData);
     if (rendered) {
-      resolved[span.spanId] = rendered;
+      resolved[span.key] = rendered;
       hitFingerprints.add(span.fingerprint);
     } else {
       uncached.push(span);
@@ -152,19 +180,19 @@ async function applyCachedKeys(
  * Keys that render successfully are persisted back to the cache.
  */
 async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
-  resolved: SpanPreviewResult;
+  resolved: Record<string, string | null>;
   unresolved: ParsedSpan[];
   keysToSave: Array<{ fingerprint: string; key: string }>;
 }> {
   return observe({ name: "transcript:generate-mustache-keys", input: { spans } }, async () => {
-    const resolved: SpanPreviewResult = {};
+    const resolved: Record<string, string | null> = {};
     const keysToSave: Array<{ fingerprint: string; key: string }> = [];
 
     if (spans.length === 0) return { resolved, unresolved: [], keysToSave };
 
     const seen = new Set<string>();
     const dedupedFingerprints: string[] = [];
-    const structures: Array<{ data: unknown }> = [];
+    const structures: Array<{ data: unknown; variant: PreviewVariant }> = [];
     const fingerprintToSpans = new Map<string, ParsedSpan[]>();
 
     for (const span of spans) {
@@ -177,7 +205,7 @@ async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
       if (!seen.has(span.fingerprint)) {
         seen.add(span.fingerprint);
         dedupedFingerprints.push(span.fingerprint);
-        structures.push({ data: span.parsedData });
+        structures.push({ data: span.parsedData, variant: span.variant });
       }
     }
 
@@ -208,7 +236,7 @@ async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
           validateMustacheKey(key, span.parsedData)
         );
         if (rendered) {
-          resolved[span.spanId] = rendered;
+          resolved[span.key] = rendered;
           keyProducedValidRender = true;
         } else {
           unresolved.push(span);
@@ -226,14 +254,17 @@ async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
 
 /**
  * Last-resort fallback used when the LLM path is unavailable or produced no
- * valid key for a span. Walks priority keys (description, summary, command…)
- * and returns null when no human-readable content can be extracted, so the
- * client renders no preview rather than a raw JSON dump.
+ * valid key for a span. Dispatches based on variant: tool-only LLM entries
+ * use the strictly descriptive-only heuristic (description/summary/title or
+ * null), while generic spans use the full priority-key search.
  */
-function applyHeuristicFallback(spans: ParsedSpan[]): SpanPreviewResult {
-  const resolved: SpanPreviewResult = {};
+function applyHeuristicFallback(spans: ParsedSpan[]): Record<string, string | null> {
+  const resolved: Record<string, string | null> = {};
   for (const span of spans) {
-    resolved[span.spanId] = tryHeuristicPreview(span.parsedData);
+    resolved[span.key] =
+      span.variant === "llm_tool_only"
+        ? tryDescriptiveHeuristicPreview(span.parsedData)
+        : tryHeuristicPreview(span.parsedData);
   }
   return resolved;
 }
@@ -257,6 +288,43 @@ async function saveRenderingKeys(
   );
 }
 
+function assembleToolOnlyPreview(toolNames: string[], perToolRendered: Array<string | null>): string | null {
+  const lines: string[] = [];
+  for (let i = 0; i < toolNames.length; i++) {
+    const v = perToolRendered[i]?.trim();
+    if (v) lines.push(`${toolNames[i]}: ${v}`);
+  }
+  return lines.length > 0 ? lines.join("\n") : null;
+}
+
+function assembleFinalPreviews(
+  keyResolved: Record<string, string | null>,
+  parsedSpans: ParsedSpan[]
+): SpanPreviewResult {
+  const result: SpanPreviewResult = {};
+
+  // Group tool-only entries by their real spanId.
+  const toolOnlyBySpanId = new Map<string, ParsedSpan[]>();
+  for (const span of parsedSpans) {
+    if (span.variant === "llm_tool_only") {
+      const group = toolOnlyBySpanId.get(span.spanId);
+      if (group) group.push(span);
+      else toolOnlyBySpanId.set(span.spanId, [span]);
+    } else {
+      result[span.spanId] = keyResolved[span.key] ?? null;
+    }
+  }
+
+  for (const [spanId, group] of toolOnlyBySpanId) {
+    const ordered = [...group].sort((a, b) => (a.toolIndex ?? 0) - (b.toolIndex ?? 0));
+    const names = ordered.map((s) => s.toolName ?? "");
+    const rendered = ordered.map((s) => keyResolved[s.key] ?? null);
+    result[spanId] = assembleToolOnlyPreview(names, rendered);
+  }
+
+  return result;
+}
+
 export interface ResolveOptions {
   skipGeneration?: boolean;
 }
@@ -265,11 +333,12 @@ export interface ResolveOptions {
  * Run the full preview resolution pipeline on pre-fetched span data:
  *   1. classify raw payloads; resolve inline when a provider schema (OpenAI /
  *      Anthropic / Gemini / LangChain) yields non-empty text/thinking, and
- *      re-route tool-only LLM outputs to their first tool block
+ *      split tool-only LLM outputs into per-tool entries
  *   2. look up cached LLM-generated Mustache keys by fingerprint
  *   3. generate new keys via LLM (when a provider is configured) and persist them
  *   4. fall back to priority-key heuristic for anything still unresolved
  *      (this is the only path for tool spans when no LLM provider is configured)
+ *   5. group per-tool results back into one preview string per span
  */
 export async function resolvePreviews(
   rawSpans: Array<{ spanId: string; data: string; name: string }>,
@@ -286,19 +355,20 @@ export async function resolvePreviews(
   }
 
   const { resolved: cacheResolved, uncached } = await applyCachedKeys(projectId, needsProcessing);
-  const accumulated: SpanPreviewResult = { ...classified, ...cacheResolved };
-  if (uncached.length === 0) {
-    return fillMissing(accumulated, spanIds);
+  let keyResolved: Record<string, string | null> = { ...cacheResolved };
+
+  if (uncached.length > 0) {
+    const llmAvailable = !skipGeneration && isAiProviderConfigured();
+
+    if (!llmAvailable) {
+      keyResolved = { ...keyResolved, ...applyHeuristicFallback(uncached) };
+    } else {
+      const { resolved: llmResolved, unresolved, keysToSave } = await generateKeysViaLlm(uncached);
+      await saveRenderingKeys(projectId, keysToSave);
+      keyResolved = { ...keyResolved, ...llmResolved, ...applyHeuristicFallback(unresolved) };
+    }
   }
 
-  const llmAvailable = !skipGeneration && isAiProviderConfigured();
-
-  if (!llmAvailable) {
-    return fillMissing({ ...accumulated, ...applyHeuristicFallback(uncached) }, spanIds);
-  }
-
-  const { resolved: llmResolved, unresolved, keysToSave } = await generateKeysViaLlm(uncached);
-  await saveRenderingKeys(projectId, keysToSave);
-
-  return fillMissing({ ...accumulated, ...llmResolved, ...applyHeuristicFallback(unresolved) }, spanIds);
+  const assembled = assembleFinalPreviews(keyResolved, needsProcessing);
+  return fillMissing({ ...classified, ...assembled }, spanIds);
 }

--- a/frontend/lib/actions/spans/previews/tool-detection.ts
+++ b/frontend/lib/actions/spans/previews/tool-detection.ts
@@ -19,6 +19,11 @@ type LangChainAssistant = z.infer<typeof LangChainAssistantMessageSchema>;
 
 const isBlank = (v: unknown): boolean => v === null || v === undefined || (isString(v) && v.trim() === "");
 
+export interface ExtractedTool {
+  name: string;
+  input: unknown;
+}
+
 // ---------------------------------------------------------------------------
 // OpenAI — the canonical schema types `function.arguments` as a string, but
 // span payloads reach us already deep-JSON-parsed. Use a lenient schema that
@@ -60,9 +65,16 @@ const openaiHasText = (m: LooseOpenAIMessage): boolean => {
   return false;
 };
 
-const openaiHasTool = (m: LooseOpenAIMessage): boolean => Array.isArray(m.tool_calls) && m.tool_calls.length > 0;
-
-const openaiFirstTool = (msgs: LooseOpenAIMessage[]): unknown => msgs.find(openaiHasTool)?.tool_calls?.[0] ?? null;
+const openaiAllTools = (msgs: LooseOpenAIMessage[]): ExtractedTool[] => {
+  const tools: ExtractedTool[] = [];
+  for (const m of msgs) {
+    if (!Array.isArray(m.tool_calls)) continue;
+    for (const tc of m.tool_calls) {
+      tools.push({ name: tc.function.name, input: tc.function.arguments });
+    }
+  }
+  return tools;
+};
 
 // ---------------------------------------------------------------------------
 // Anthropic — uses the canonical schema; tool_use.input is z.unknown() so
@@ -81,35 +93,36 @@ const anthropicHasText = (msgs: AnthropicMessage[]): boolean =>
     });
   });
 
-const anthropicHasTool = (msgs: AnthropicMessage[]): boolean =>
-  msgs.some((m) => Array.isArray(m.content) && m.content.some(anthropicIsTool));
-
-const anthropicFirstTool = (msgs: AnthropicMessage[]): unknown => {
+const anthropicAllTools = (msgs: AnthropicMessage[]): ExtractedTool[] => {
+  const tools: ExtractedTool[] = [];
   for (const m of msgs) {
     if (!Array.isArray(m.content)) continue;
-    const block = m.content.find(anthropicIsTool);
-    if (block) return block;
+    for (const b of m.content) {
+      if (anthropicIsTool(b) && (b.type === "tool_use" || b.type === "server_tool_use")) {
+        tools.push({ name: b.name, input: b.input });
+      }
+    }
   }
-  return null;
+  return tools;
 };
 
 // ---------------------------------------------------------------------------
 // Gemini
 // ---------------------------------------------------------------------------
 
-const geminiIsFnCall = (p: GeminiPart): boolean => "functionCall" in p;
-
 const geminiHasText = (contents: GeminiContent[]): boolean =>
   contents.some((c) => c.parts.some((p) => "text" in p && !isBlank(p.text)));
 
-const geminiHasTool = (contents: GeminiContent[]): boolean => contents.some((c) => c.parts.some(geminiIsFnCall));
-
-const geminiFirstTool = (contents: GeminiContent[]): unknown => {
+const geminiAllTools = (contents: GeminiContent[]): ExtractedTool[] => {
+  const tools: ExtractedTool[] = [];
   for (const c of contents) {
-    const part = c.parts.find(geminiIsFnCall);
-    if (part) return part;
+    for (const p of c.parts) {
+      if ("functionCall" in p && p.functionCall) {
+        tools.push({ name: p.functionCall.name, input: p.functionCall.args ?? {} });
+      }
+    }
   }
-  return null;
+  return tools;
 };
 
 // ---------------------------------------------------------------------------
@@ -135,47 +148,57 @@ const langchainHasText = (msgs: LangChainAssistant[]): boolean =>
     return false;
   });
 
-const langchainHasTool = (msgs: LangChainAssistant[]): boolean =>
-  msgs.some((m) => Array.isArray(m.tool_calls) && m.tool_calls.length > 0);
-
-const langchainFirstTool = (msgs: LangChainAssistant[]): unknown =>
-  msgs.find((m) => m.tool_calls?.length)?.tool_calls?.[0] ?? null;
+const langchainAllTools = (msgs: LangChainAssistant[]): ExtractedTool[] => {
+  const tools: ExtractedTool[] = [];
+  for (const m of msgs) {
+    if (!Array.isArray(m.tool_calls)) continue;
+    for (const tc of m.tool_calls) {
+      tools.push({ name: tc.name, input: tc.arguments });
+    }
+  }
+  return tools;
+};
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
-const tryOpenAI = (data: unknown): unknown => {
+const tryOpenAI = (data: unknown): ExtractedTool[] | null => {
   const msgs = parseOpenAI(data);
-  if (!msgs || !msgs.some(openaiHasTool) || msgs.some(openaiHasText)) return null;
-  return openaiFirstTool(msgs);
+  if (!msgs || msgs.some(openaiHasText)) return null;
+  const tools = openaiAllTools(msgs);
+  return tools.length > 0 ? tools : null;
 };
 
-const tryAnthropic = (data: unknown): unknown => {
+const tryAnthropic = (data: unknown): ExtractedTool[] | null => {
   const msgs = parseAnthropicOutput(data);
-  if (!msgs || !anthropicHasTool(msgs) || anthropicHasText(msgs)) return null;
-  return anthropicFirstTool(msgs);
+  if (!msgs || anthropicHasText(msgs)) return null;
+  const tools = anthropicAllTools(msgs);
+  return tools.length > 0 ? tools : null;
 };
 
-const tryGemini = (data: unknown): unknown => {
+const tryGemini = (data: unknown): ExtractedTool[] | null => {
   const contents = parseGeminiOutput(data);
-  if (!contents || !geminiHasTool(contents) || geminiHasText(contents)) return null;
-  return geminiFirstTool(contents);
+  if (!contents || geminiHasText(contents)) return null;
+  const tools = geminiAllTools(contents);
+  return tools.length > 0 ? tools : null;
 };
 
-const tryLangChain = (data: unknown): unknown => {
+const tryLangChain = (data: unknown): ExtractedTool[] | null => {
   const msgs = parseLangChain(data);
-  if (!msgs || !langchainHasTool(msgs) || langchainHasText(msgs)) return null;
-  return langchainFirstTool(msgs);
+  if (!msgs || langchainHasText(msgs)) return null;
+  const tools = langchainAllTools(msgs);
+  return tools.length > 0 ? tools : null;
 };
 
 /**
- * If an LLM output has tool calls but no visible text/thinking, return the
- * first tool block so the caller can route it through the preview pipeline.
- * Returns null when no provider matches or the output has displayable text.
+ * If an LLM output has tool calls but no visible text/thinking, return all
+ * tool blocks as `{ name, input }` pairs so the caller can route them through
+ * the preview pipeline individually. Returns null when no provider matches or
+ * the output has displayable text.
  * Pass `hint` from `detectOutputStructure` to skip non-matching parsers.
  */
-export const extractFirstToolIfToolOnly = (data: unknown, hint?: ProviderHint): unknown => {
+export const extractToolsIfToolOnly = (data: unknown, hint?: ProviderHint): ExtractedTool[] | null => {
   switch (hint) {
     case "openai":
       return tryOpenAI(data);

--- a/frontend/lib/actions/spans/previews/utils.ts
+++ b/frontend/lib/actions/spans/previews/utils.ts
@@ -172,6 +172,19 @@ export const generateFingerprint = (spanName: string, data: unknown): string => 
 
 const OPAQUE_VALUE_PATTERN = /^<.+ at 0x[0-9a-fA-F]+>$/;
 
+const SAMPLE_VALUE_MAX_CHARS = 80;
+
+// Short, single-line sample of a scalar value for the LLM prompt. Collapses
+// whitespace so multi-line strings don't blow up the flattened path output.
+const formatSample = (value: string | number | boolean): string => {
+  const raw = typeof value === "string" ? value : String(value);
+  const collapsed = raw.replace(/\s+/g, " ").trim();
+  if (collapsed.length === 0) return '""';
+  const truncated =
+    collapsed.length > SAMPLE_VALUE_MAX_CHARS ? `${collapsed.slice(0, SAMPLE_VALUE_MAX_CHARS)}…` : collapsed;
+  return typeof value === "string" ? `"${truncated.replace(/"/g, '\\"')}"` : truncated;
+};
+
 export const flattenPaths = (data: unknown): string[] => {
   const paths: string[] = [];
 
@@ -182,7 +195,8 @@ export const flattenPaths = (data: unknown): string[] => {
       const lastKey = last(prefix.split("."))?.replace(/\[\]$/, "") ?? "";
       let tag = METADATA_KEYS.has(lastKey) ? " [meta]" : IDENTIFIER_KEYS.has(lastKey) ? " [id]" : "";
       if (!tag && isString(value) && OPAQUE_VALUE_PATTERN.test(value)) tag = " [meta]";
-      paths.push(`${prefix}: ${typeof value}${tag}`);
+      const sample = tag === " [meta]" ? "" : ` = ${formatSample(value)}`;
+      paths.push(`${prefix}: ${typeof value}${tag}${sample}`);
       return;
     }
 
@@ -237,7 +251,9 @@ const prepareRenderTarget = (data: unknown): unknown => addStringifyToObjects(de
 export const validateMustacheKey = (key: string, data: unknown): string | null => {
   try {
     const rendered = Mustache.render(key, prepareRenderTarget(data), undefined, { escape: (v) => v });
-    if (!rendered || rendered.trim() === "" || rendered.includes("[object Object]")) return null;
+    if (!rendered) return null;
+    const trimmed = rendered.trim();
+    if (trimmed === "" || trimmed.toLowerCase() === "null" || rendered.includes("[object Object]")) return null;
     return rendered;
   } catch {
     return null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes span preview generation/caching by splitting tool-only LLM outputs into per-tool entries and altering fallback/validation rules, which can affect what users see in transcripts. Risk is moderate due to behavior changes across multiple providers and cache fingerprinting, but scope is limited to preview rendering.
> 
> **Overview**
> Improves transcript span previews when LLM outputs contain *only tool calls* (no visible text/thinking) by extracting **all** tool invocations, generating/looking up preview keys per tool (with tool-specific fingerprints), then reassembling a single span preview as multi-line `toolName: preview`.
> 
> Adds a new `llm_tool_only` prompt mode with a strict allowlist of intent-like fields (e.g. `description`, `summary`, `goal`), including matching heuristic fallback behavior, plus more robust parsing/validation that treats empty/`"null"` outputs as missing.
> 
> Updates the preview-key prompt inputs to include scalar sample values, and simplifies the transcript UI’s `CollapsedTextWithMore` to use CSS line-clamp overflow detection instead of character-based truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a037de5daeb5ac3634a1cbb672a6472f1810505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->