### PR TITLE
Unpin clickhouse server image version

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -18,6 +18,10 @@ services:
       retries: 3
 
   clickhouse:
+    # Version 26.3 will break queries on the spans_v0 view, if they are
+    # not filtered by trace_id and/or ordered by start_time. This is a
+    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
+    # We will pin to the earliest stable version once this is fixed
     image: clickhouse/clickhouse-server:latest
     pull_policy: always
     container_name: clickhouse

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -18,7 +18,7 @@ services:
       retries: 3
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.12
+    image: clickhouse/clickhouse-server:latest
     pull_policy: always
     container_name: clickhouse
     volumes:
@@ -53,7 +53,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
+      test:
+        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -66,7 +67,7 @@ services:
     environment:
       PORT: 8903
     healthcheck:
-      test: [ "CMD", "sleep", "5" ]
+      test: ["CMD", "sleep", "5"]
       interval: 10s
       timeout: 6s
       retries: 3
@@ -79,11 +80,11 @@ services:
       - "7281:7281" # OTLP / gRPC
     environment:
       QW_DATA_DIR: /quickwit/qwdata
-    command: [ "run" ]
+    command: ["run"]
     volumes:
       - quickwit-data:/quickwit/qwdata
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:7280/health/livez" ]
+      test: ["CMD", "curl", "-f", "http://localhost:7280/health/livez"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -16,7 +16,7 @@ services:
       retries: 3
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.12
+    image: clickhouse/clickhouse-server:latest
     pull_policy: always
     container_name: clickhouse
     volumes:
@@ -47,7 +47,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
+      test:
+        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
       retries: 5
@@ -61,7 +62,7 @@ services:
     environment:
       PORT: 8903
     healthcheck:
-      test: [ "CMD", "sleep", "5" ]
+      test: ["CMD", "sleep", "5"]
       interval: 10s
       timeout: 6s
       retries: 3
@@ -74,11 +75,11 @@ services:
       - "7281:7281" # OTLP / gRPC
     environment:
       QW_DATA_DIR: /quickwit/qwdata
-    command: [ "run" ]
+    command: ["run"]
     volumes:
       - quickwit-data:/quickwit/qwdata
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:7280/health/livez" ]
+      test: ["CMD", "curl", "-f", "http://localhost:7280/health/livez"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -16,6 +16,10 @@ services:
       retries: 3
 
   clickhouse:
+    # Version 26.3 will break queries on the spans_v0 view, if they are
+    # not filtered by trace_id and/or ordered by start_time. This is a
+    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
+    # We will pin to the earliest stable version once this is fixed
     image: clickhouse/clickhouse-server:latest
     pull_policy: always
     container_name: clickhouse

--- a/docker-compose-local-dev-full.yml
+++ b/docker-compose-local-dev-full.yml
@@ -19,6 +19,10 @@ services:
       retries: 3
 
   clickhouse:
+    # Version 26.3 will break queries on the spans_v0 view, if they are
+    # not filtered by trace_id and/or ordered by start_time. This is a
+    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
+    # We will pin to the earliest stable version once this is fixed
     image: clickhouse/clickhouse-server:latest
     pull_policy: always
     container_name: clickhouse

--- a/docker-compose-local-dev-full.yml
+++ b/docker-compose-local-dev-full.yml
@@ -19,7 +19,7 @@ services:
       retries: 3
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.12
+    image: clickhouse/clickhouse-server:latest
     pull_policy: always
     container_name: clickhouse
     ports:

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -18,13 +18,14 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
+      test:
+        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
       retries: 5
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.12
+    image: clickhouse/clickhouse-server:latest
     pull_policy: always
     container_name: clickhouse
     ports:
@@ -59,11 +60,11 @@ services:
       - "7281:7281" # OTLP / gRPC
     environment:
       QW_DATA_DIR: /quickwit/qwdata
-    command: [ "run" ]
+    command: ["run"]
     volumes:
       - quickwit-data:/quickwit/qwdata
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:7280/health/livez" ]
+      test: ["CMD", "curl", "-f", "http://localhost:7280/health/livez"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -76,7 +77,7 @@ services:
     environment:
       PORT: 8903
     healthcheck:
-      test: [ "CMD", "sleep", "5" ]
+      test: ["CMD", "sleep", "5"]
       interval: 10s
       timeout: 6s
       retries: 3

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -25,6 +25,10 @@ services:
       retries: 5
 
   clickhouse:
+    # Version 26.3 will break queries on the spans_v0 view, if they are
+    # not filtered by trace_id and/or ordered by start_time. This is a
+    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
+    # We will pin to the earliest stable version once this is fixed
     image: clickhouse/clickhouse-server:latest
     pull_policy: always
     container_name: clickhouse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,13 +18,14 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
+      test:
+        ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
       retries: 5
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.12
+    image: clickhouse/clickhouse-server:latest
     container_name: clickhouse
     pull_policy: always
     volumes:
@@ -53,7 +54,7 @@ services:
     environment:
       PORT: 8903
     healthcheck:
-      test: [ "CMD", "sleep", "5" ]
+      test: ["CMD", "sleep", "5"]
       interval: 10s
       timeout: 6s
       retries: 3
@@ -66,11 +67,11 @@ services:
       - "7281:7281" # OTLP / gRPC
     environment:
       QW_DATA_DIR: /quickwit/qwdata
-    command: [ "run" ]
+    command: ["run"]
     volumes:
       - quickwit-data:/quickwit/qwdata
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:7280/health/livez" ]
+      test: ["CMD", "curl", "-f", "http://localhost:7280/health/livez"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       retries: 5
 
   clickhouse:
+    # Version 26.3 will break queries on the spans_v0 view, if they are
+    # not filtered by trace_id and/or ordered by start_time. This is a
+    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
+    # We will pin to the earliest stable version once this is fixed
     image: clickhouse/clickhouse-server:latest
     container_name: clickhouse
     pull_policy: always


### PR DESCRIPTION
Rationale: It is correct to pin the version to a known working one; however 26.3 had quite a few breaking changes, and so reverting a version to older than it completely loses all the data (It is possible to restore it, but requires some dangerous manual action on the clickhouse-server container).

Plan: wait for https://github.com/ClickHouse/ClickHouse/pull/101218 to be merged and released, and then pin to that version.

Tradeoff: the Clickhouse bug breaks queries on SELECT * FROM spans_v0(project_id={project_id:UUID}) ORDER BY start_time, so spans page and certain queries (not filtered to trace_id) will break in SQL query editor and dashboards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because moving `clickhouse/clickhouse-server` from a pinned version to `:latest` can introduce unexpected ClickHouse behavior and query regressions across environments depending on when images are pulled.
> 
> **Overview**
> Updates all docker-compose variants to run `clickhouse/clickhouse-server:latest` instead of the pinned `25.12`, with an inline note about a known ClickHouse 26.3 regression affecting `spans_v0` queries.
> 
> Also normalizes a few compose YAML array syntaxes for `healthcheck.test` and `command` (Postgres `pg_isready`, Query Engine sleep, Quickwit run/curl) without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff7d10dc35d82430be3b4e926655a13b09c1e6da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->