### PR TITLE
fix: strip billing header from system prompt

### DIFF
--- a/app-server/src/signals/utils.rs
+++ b/app-server/src/signals/utils.rs
@@ -149,10 +149,20 @@ static SPAN_REF_RE: LazyLock<Regex> = LazyLock::new(|| {
 
 static HEX_ID_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[0-9a-fA-F]{6}").unwrap());
 
+// Matches the Claude Code billing header, e.g.
+// `x-anthropic-billing-header: cc_version=2.1.104.8ec; cc_entrypoint=sdk-ts; cch=00000;`
+static CLAUDE_CODE_BILLING_HEADER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"x-anthropic-billing-header:(?:\s*[A-Za-z_][A-Za-z0-9_]*=[^\s;]*;)+").unwrap()
+});
+
 /// Hash a system prompt by its structural skeleton: first sentence + sorted XML tag names.
 /// Resistant to dynamic content inside tags (config values, user context, tool lists)
 /// while preserving the stable identity of the prompt template.
+/// Volatile client/SDK version headers (e.g. Claude Code's `x-anthropic-billing-header`)
+/// are stripped first so the hash is stable across SDK versions.
 pub fn structural_skeleton_hash(text: &str) -> String {
+    let text = CLAUDE_CODE_BILLING_HEADER_REGEX.replace_all(text, "");
+    let text = text.as_ref();
     // Extract first sentence from original text (before whitespace normalization
     // destroys newline boundaries). Cut at the first real sentence boundary after
     // 20+ chars: either a newline, or a '.' followed by whitespace / end-of-text.
@@ -979,6 +989,45 @@ Do not fabricate data.
             structural_skeleton_hash(normal),
             structural_skeleton_hash(self_closing),
             "Self-closing tags should extract the same tag name"
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_ignores_claude_code_billing_header() {
+        let with_header = "x-anthropic-billing-header: cc_version=2.1.112.186; cc_entrypoint=sdk-ts; You are a helpful assistant.";
+        let without = "You are a helpful assistant.";
+        assert_eq!(
+            structural_skeleton_hash(with_header),
+            structural_skeleton_hash(without)
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_ignores_full_billing_header_with_extra_pairs() {
+        let with_header = "x-anthropic-billing-header: cc_version=2.1.104.8ec; cc_entrypoint=sdk-ts; cch=00000; You are a helpful assistant.";
+        let without = "You are a helpful assistant.";
+        assert_eq!(
+            structural_skeleton_hash(with_header),
+            structural_skeleton_hash(without)
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_stable_across_cc_versions() {
+        let v1 = "x-anthropic-billing-header: cc_version=2.1.112.186; cc_entrypoint=sdk-ts; You are Claude Code.";
+        let v2 = "x-anthropic-billing-header: cc_version=2.2.0.1; cc_entrypoint=cli; You are Claude Code.";
+        assert_eq!(
+            structural_skeleton_hash(v1),
+            structural_skeleton_hash(v2)
+        );
+    }
+
+    #[test]
+    fn test_structural_skeleton_hash_stable_without_billing_header() {
+        let text = "You are a helpful assistant.\nAlways respond in JSON.";
+        assert_eq!(
+            structural_skeleton_hash(text),
+            structural_skeleton_hash(text)
         );
     }
 }

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -30,12 +30,6 @@ use super::spans::{SpanAttributes, SpanUsage};
 static SKIP_SPAN_NAME_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^Runnable[A-Z][A-Za-z]*(?:<[A-Za-z_,]+>)*\.task$").unwrap());
 
-// Matches the Claude Code billing header, e.g.
-// `x-anthropic-billing-header: cc_version=2.1.104.8ec; cc_entrypoint=sdk-ts; cch=00000;`
-static CLAUDE_CODE_BILLING_HEADER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"x-anthropic-billing-header:(?:\s*[A-Za-z_][A-Za-z0-9_]*=[^\s;]*;)+").unwrap()
-});
-
 /// Calculate usage for both default and LLM spans
 pub async fn get_llm_usage_for_span(
     // mut because input and output tokens are updated to new convention
@@ -245,16 +239,7 @@ pub fn prepare_span_for_recording(span: &mut Span, span_usage: &SpanUsage) {
 
 fn compute_prompt_hash(input: &Option<Value>) -> Option<String> {
     let (system_text, _) = extract_system_message(input.as_ref()?)?;
-    let stripped = strip_volatile_system_prompt_parts(&system_text);
-    Some(structural_skeleton_hash(&stripped))
-}
-
-/// Strip parts of the system prompt that change between client/SDK versions
-/// (e.g. Claude Code's billing header with `cc_version` and its product intro line)
-fn strip_volatile_system_prompt_parts(system_text: &str) -> String {
-    CLAUDE_CODE_BILLING_HEADER_REGEX
-        .replace_all(system_text, "")
-        .into_owned()
+    Some(structural_skeleton_hash(&system_text))
 }
 
 pub fn serialize_indexmap<T>(index_map: IndexMap<String, T>) -> Option<Value>
@@ -388,15 +373,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn strips_claude_code_billing_header() {
-        let input = "x-anthropic-billing-header: cc_version=2.1.112.186; cc_entrypoint=sdk-ts; You are a helpful assistant.";
-        let stripped = strip_volatile_system_prompt_parts(input);
-        assert!(!stripped.contains("cc_version"));
-        assert!(!stripped.contains("x-anthropic-billing-header"));
-        assert!(stripped.contains("You are a helpful assistant."));
-    }
-
-    #[test]
     fn prompt_hash_stable_across_cc_versions() {
         let input_v1 = json!([
             {
@@ -431,17 +407,6 @@ mod tests {
     }
 
     #[test]
-    fn strips_full_billing_header_with_extra_pairs() {
-        let input = "x-anthropic-billing-header: cc_version=2.1.104.8ec; cc_entrypoint=sdk-ts; cch=00000; You are a helpful assistant.";
-        let stripped = strip_volatile_system_prompt_parts(input);
-        assert!(!stripped.contains("cc_version"));
-        assert!(!stripped.contains("cc_entrypoint"));
-        assert!(!stripped.contains("cch="));
-        assert!(!stripped.contains("x-anthropic-billing-header"));
-        assert!(stripped.contains("You are a helpful assistant."));
-    }
-
-    #[test]
     fn prompt_hash_stable_for_real_claude_agent_payload() {
         let make_input = |version: &str, cch: &str| {
             json!([
@@ -458,11 +423,5 @@ mod tests {
         let h1 = compute_prompt_hash(&Some(make_input("2.1.104.8ec", "00000"))).unwrap();
         let h2 = compute_prompt_hash(&Some(make_input("2.2.0.abc", "ffffff"))).unwrap();
         assert_eq!(h1, h2);
-    }
-
-    #[test]
-    fn leaves_unrelated_prompts_unchanged() {
-        let text = "You are a helpful assistant.\nAlways respond in JSON.";
-        assert_eq!(strip_volatile_system_prompt_parts(text), text);
     }
 }

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -30,6 +30,12 @@ use super::spans::{SpanAttributes, SpanUsage};
 static SKIP_SPAN_NAME_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^Runnable[A-Z][A-Za-z]*(?:<[A-Za-z_,]+>)*\.task$").unwrap());
 
+// Matches the Claude Code billing header, e.g.
+// `x-anthropic-billing-header: cc_version=2.1.104.8ec; cc_entrypoint=sdk-ts; cch=00000;`
+static CLAUDE_CODE_BILLING_HEADER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"x-anthropic-billing-header:(?:\s*[A-Za-z_][A-Za-z0-9_]*=[^\s;]*;)+").unwrap()
+});
+
 /// Calculate usage for both default and LLM spans
 pub async fn get_llm_usage_for_span(
     // mut because input and output tokens are updated to new convention
@@ -239,7 +245,16 @@ pub fn prepare_span_for_recording(span: &mut Span, span_usage: &SpanUsage) {
 
 fn compute_prompt_hash(input: &Option<Value>) -> Option<String> {
     let (system_text, _) = extract_system_message(input.as_ref()?)?;
-    Some(structural_skeleton_hash(&system_text))
+    let stripped = strip_volatile_system_prompt_parts(&system_text);
+    Some(structural_skeleton_hash(&stripped))
+}
+
+/// Strip parts of the system prompt that change between client/SDK versions
+/// (e.g. Claude Code's billing header with `cc_version` and its product intro line)
+fn strip_volatile_system_prompt_parts(system_text: &str) -> String {
+    CLAUDE_CODE_BILLING_HEADER_REGEX
+        .replace_all(system_text, "")
+        .into_owned()
 }
 
 pub fn serialize_indexmap<T>(index_map: IndexMap<String, T>) -> Option<Value>
@@ -365,5 +380,89 @@ fn tranform_model_and_provider(
         // LiteLLM stores "gateway" as "vercel_ai_gateway"
         Some("gateway") => (model_name, Some("vercel_ai_gateway".to_string())),
         _ => (model_name, provider_name),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_claude_code_billing_header() {
+        let input = "x-anthropic-billing-header: cc_version=2.1.112.186; cc_entrypoint=sdk-ts; You are a helpful assistant.";
+        let stripped = strip_volatile_system_prompt_parts(input);
+        assert!(!stripped.contains("cc_version"));
+        assert!(!stripped.contains("x-anthropic-billing-header"));
+        assert!(stripped.contains("You are a helpful assistant."));
+    }
+
+    #[test]
+    fn prompt_hash_stable_across_cc_versions() {
+        let input_v1 = json!([
+            {
+                "role": "system",
+                "content": [
+                    {"text": "x-anthropic-billing-header: cc_version=2.1.112.186; cc_entrypoint=sdk-ts;", "type": "text"},
+                    {"text": "You are Claude Code.", "type": "text"}
+                ]
+            }
+        ]);
+        let input_v2 = json!([
+            {
+                "role": "system",
+                "content": [
+                    {"text": "x-anthropic-billing-header: cc_version=2.2.0.1; cc_entrypoint=cli;", "type": "text"},
+                    {"text": "You are Claude Code.", "type": "text"}
+                ]
+            }
+        ]);
+        let h1 = compute_prompt_hash(&Some(input_v1)).unwrap();
+        let h2 = compute_prompt_hash(&Some(input_v2)).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn prompt_hash_differs_when_body_differs() {
+        let a = json!([{"role": "system", "content": "You are assistant A."}]);
+        let b = json!([{"role": "system", "content": "You are assistant B completely different."}]);
+        let ha = compute_prompt_hash(&Some(a)).unwrap();
+        let hb = compute_prompt_hash(&Some(b)).unwrap();
+        assert_ne!(ha, hb);
+    }
+
+    #[test]
+    fn strips_full_billing_header_with_extra_pairs() {
+        let input = "x-anthropic-billing-header: cc_version=2.1.104.8ec; cc_entrypoint=sdk-ts; cch=00000; You are a helpful assistant.";
+        let stripped = strip_volatile_system_prompt_parts(input);
+        assert!(!stripped.contains("cc_version"));
+        assert!(!stripped.contains("cc_entrypoint"));
+        assert!(!stripped.contains("cch="));
+        assert!(!stripped.contains("x-anthropic-billing-header"));
+        assert!(stripped.contains("You are a helpful assistant."));
+    }
+
+    #[test]
+    fn prompt_hash_stable_for_real_claude_agent_payload() {
+        let make_input = |version: &str, cch: &str| {
+            json!([
+                {
+                    "role": "system",
+                    "content": [
+                        {"text": format!("x-anthropic-billing-header: cc_version={version}; cc_entrypoint=sdk-ts; cch={cch};"), "type": "text"},
+                        {"cache_control": {"type": "ephemeral"}, "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK.", "type": "text"},
+                        {"cache_control": {"type": "ephemeral"}, "text": "<role>\nYou are a senior portfolio manager orchestrating a research workflow.\n</role>", "type": "text"}
+                    ]
+                }
+            ])
+        };
+        let h1 = compute_prompt_hash(&Some(make_input("2.1.104.8ec", "00000"))).unwrap();
+        let h2 = compute_prompt_hash(&Some(make_input("2.2.0.abc", "ffffff"))).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn leaves_unrelated_prompts_unchanged() {
+        let text = "You are a helpful assistant.\nAlways respond in JSON.";
+        assert_eq!(strip_volatile_system_prompt_parts(text), text);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, well-tested change to prompt-hash preprocessing, though it can affect how spans are grouped/deduplicated by `SPAN_PROMPT_HASH`.
> 
> **Overview**
> Makes system-prompt hashing stable across Claude Code/SDK version changes by stripping the `x-anthropic-billing-header` before computing `structural_skeleton_hash`.
> 
> Adds focused unit tests in `signals/utils.rs` and `traces/utils.rs` to ensure the prompt hash remains unchanged across different billing-header variants/versions while still changing when the actual prompt content differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c4123e950eed93fb66f928a59471fa6fa62898. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->