### PR TITLE
feat: add status, scroll in transcript mode

### DIFF
--- a/frontend/components/traces/trace-view/store/base.ts
+++ b/frontend/components/traces/trace-view/store/base.ts
@@ -1,6 +1,7 @@
 import { clamp, has } from "lodash";
 import { createContext, useContext } from "react";
-import { type StoreApi, useStore } from "zustand";
+import { type StoreApi } from "zustand";
+import { useStoreWithEqualityFn } from "zustand/traditional";
 
 import { type SnippetInfo } from "@/lib/actions/traces/search";
 import { type SpanEvent } from "@/lib/events/types";
@@ -70,6 +71,7 @@ export type TraceViewListSpan = {
   cacheReadInputTokens?: number;
   totalCost: number;
   pending?: boolean;
+  status?: string;
   inputSnippet?: SnippetInfo;
   outputSnippet?: SnippetInfo;
   attributesSnippet?: SnippetInfo;
@@ -455,7 +457,7 @@ export const useTraceViewBaseStore = <T>(
   if (!store) {
     throw new Error("useTraceViewContext must be used within a TraceViewContext provider");
   }
-  return useStore(store, selector, equalityFn);
+  return useStoreWithEqualityFn(store, selector, equalityFn);
 };
 
 export const useTraceViewBaseStoreRaw = () => {

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -261,6 +261,7 @@ export const toLightweight = (span: TraceViewSpan): TraceViewListSpan => ({
   cacheReadInputTokens: span.cacheReadInputTokens,
   totalCost: span.totalCost,
   pending: span.pending,
+  status: span.status,
   inputSnippet: span.inputSnippet,
   outputSnippet: span.outputSnippet,
   attributesSnippet: span.attributesSnippet,

--- a/frontend/components/traces/trace-view/trace-view-content.tsx
+++ b/frontend/components/traces/trace-view/trace-view-content.tsx
@@ -6,7 +6,6 @@ import { shallow } from "zustand/shallow";
 import Chat from "@/components/traces/trace-view/chat";
 import { HumanEvaluatorSpanView } from "@/components/traces/trace-view/human-evaluator-span-view";
 import { type TraceViewSpan, type TraceViewTrace, useTraceViewStore } from "@/components/traces/trace-view/store";
-import { useTraceViewBaseStoreRaw } from "@/components/traces/trace-view/store/base";
 import { enrichSpansWithPending, findSpanToSelect, onRealtimeUpdateSpans } from "@/components/traces/trace-view/utils";
 import { type Filter } from "@/lib/actions/common/filters";
 import { useRealtime } from "@/lib/hooks/use-realtime";
@@ -48,7 +47,6 @@ export default function TraceViewContent({
   const router = useRouter();
   const pathName = usePathname();
   const { projectId } = useParams();
-  const baseStore = useTraceViewBaseStoreRaw();
 
   // Panel visibility states
   const { spanPanelOpen, tracesAgentOpen, setTracesAgentOpen, selectSpanById } = useTraceViewStore(
@@ -225,8 +223,9 @@ export default function TraceViewContent({
         if (urlSpanId && spans.length > 0) {
           const selectedSpan = findSpanToSelect(spans, spanId, searchParams, spanPath);
           setSelectedSpan(selectedSpan);
-        } else if ((baseStore.getState().spanPanelOpen || isAlwaysSelectSpan) && spans.length > 0) {
-          // Auto-select first span if the span panel is open or always-select mode is on
+        } else if (isAlwaysSelectSpan && spans.length > 0) {
+          // Auto-select first span only in the dedicated trace page (always-select mode).
+          // In drawer layouts we leave the selection empty unless the user explicitly opens a span.
           setSelectedSpan(spans[0]);
         } else {
           setSelectedSpan(undefined);
@@ -251,7 +250,6 @@ export default function TraceViewContent({
       setHasBrowserSession,
       setBrowserSession,
       setSelectedSpan,
-      baseStore,
       isAlwaysSelectSpan,
       spanId,
       searchParams,

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -188,6 +188,29 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
 
   const items = virtualizer.getVirtualItems();
 
+  const selectedRowIndex = useMemo(() => {
+    const selectedId = selectedSpan?.spanId;
+    if (!selectedId) return -1;
+    return flatRows.findIndex((row) => {
+      switch (row.type) {
+        case "span":
+        case "group-span":
+          return row.span.spanId === selectedId;
+        case "group":
+          return (
+            row.firstSpan.spanId === selectedId || row.firstLlmSpanId === selectedId || row.lastLlmSpanId === selectedId
+          );
+        default:
+          return false;
+      }
+    });
+  }, [flatRows, selectedSpan?.spanId]);
+
+  useEffect(() => {
+    if (selectedRowIndex < 0 || isSpansLoading) return;
+    virtualizer.scrollToIndex(selectedRowIndex, { align: "auto" });
+  }, [selectedRowIndex, virtualizer, isSpansLoading]);
+
   const allVisibleSpanIds = useMemo(
     () =>
       items.flatMap((item) => {

--- a/frontend/components/traces/trace-view/transcript/item/span-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/span-item.tsx
@@ -149,6 +149,7 @@ export default function SpanItem({
             containerWidth={20}
             containerHeight={20}
             size={14}
+            status={span.status}
             className={cn("shrink-0", { "text-muted-foreground bg-muted": isPending })}
           />
 

--- a/frontend/lib/actions/sessions/extract-input.ts
+++ b/frontend/lib/actions/sessions/extract-input.ts
@@ -54,9 +54,11 @@ export async function extractInputsForGroup(
           results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
           continue;
         }
-        const extracted = applyRegex(cachedRegex, joinedText);
-        if (extracted) {
-          results[trace.traceId] = { inputPreview: extracted, outputPreview: trace.output, outputSpan: null };
+        const result = applyRegex(cachedRegex, joinedText);
+        if (result.kind === "extracted") {
+          results[trace.traceId] = { inputPreview: result.text, outputPreview: trace.output, outputSpan: null };
+        } else if (result.kind === "no-user-request") {
+          results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
         } else {
           allMatched = false;
           break;
@@ -108,11 +110,14 @@ export async function extractInputsForGroup(
         results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
         continue;
       }
-      const extracted = observe({ name: "apply-regex", input: { pattern: regex, text: joinedText } }, () =>
+      const result = observe({ name: "apply-regex", input: { pattern: regex, text: joinedText } }, () =>
         applyRegex(regex, joinedText)
       );
-      if (extracted) {
-        results[trace.traceId] = { inputPreview: extracted, outputPreview: trace.output, outputSpan: null };
+      if (result.kind === "extracted") {
+        results[trace.traceId] = { inputPreview: result.text, outputPreview: trace.output, outputSpan: null };
+        anyMatch = true;
+      } else if (result.kind === "no-user-request") {
+        results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
         anyMatch = true;
       } else {
         results[trace.traceId] = { inputPreview: joinedText, outputPreview: trace.output, outputSpan: null };

--- a/frontend/lib/actions/sessions/extract-input.ts
+++ b/frontend/lib/actions/sessions/extract-input.ts
@@ -24,6 +24,29 @@ export function joinUserParts(parts: TextPart[]): string | null {
   return text.length > 0 ? text : null;
 }
 
+// Structural fingerprint of a user message: sequence of top-level XML-like tags (nested tags ignored), or "plain" for messages with no tags.
+export function fingerprintUserMessage(input: string): string {
+  const TOP_LEVEL_TAG = /<([a-zA-Z_][\w-]*)\b[^>]*>([\s\S]*?)<\/\1\s*>/;
+  const parts: string[] = [];
+  let rest = input;
+
+  while (rest.length > 0) {
+    const match = TOP_LEVEL_TAG.exec(rest);
+    if (!match) {
+      if (rest.trim().length > 0) parts.push("plain");
+      break;
+    }
+    const before = rest.slice(0, match.index);
+    if (before.trim().length > 0) parts.push("plain");
+    const name = match[1].toLowerCase();
+    parts.push(name, `/${name}`);
+    rest = rest.slice(match.index + match[0].length);
+  }
+
+  const deduped = parts.filter((p, i) => !(p === "plain" && parts[i - 1] === "plain"));
+  return deduped.length ? deduped.join(",") : "plain";
+}
+
 interface TraceForExtraction {
   traceId: string;
   output: string | null;
@@ -40,9 +63,10 @@ export async function extractInputsForGroup(
   traces: TraceForExtraction[],
   // Accepts any result shape with text preview fields + a nullable outputSpan;
   // trace-io.ts hydrates the full Span afterwards, this layer only writes text.
-  results: Record<string, { inputPreview: string | null; outputPreview: string | null; outputSpan: unknown }>
+  results: Record<string, { inputPreview: string | null; outputPreview: string | null; outputSpan: unknown }>,
+  fingerprint: string = "plain"
 ): Promise<void> {
-  const cacheKey = `${REGEX_CACHE_PREFIX}${projectId}:${systemHash}`;
+  const cacheKey = `${REGEX_CACHE_PREFIX}${projectId}:${systemHash}:${fingerprint}`;
 
   try {
     const cachedRegex = await cache.get<string>(cacheKey);
@@ -71,7 +95,7 @@ export async function extractInputsForGroup(
       await cache.remove(cacheKey).catch(() => {});
     }
   } catch {
-    // Redis unavailable
+    // ignore cache errors
   }
 
   const samples = traces.slice(0, BATCH_SIZE).filter((t) => t.parsed && t.parsed.userParts.length > 0);
@@ -87,7 +111,8 @@ export async function extractInputsForGroup(
   }
 
   await observe({ name: "trace-io:extract-trace-inputs", input: { projectId } }, async () => {
-    const llmInput = buildDeduplicatedLLMInput(samples.map((s) => s.parsed!.userParts));
+    const allUserParts = samples.map((s) => s.parsed!.userParts);
+    const llmInput = buildDeduplicatedLLMInput(allUserParts);
     const regex = await generateExtractionRegex(llmInput);
 
     if (!regex) {

--- a/frontend/lib/actions/sessions/parse-input.ts
+++ b/frontend/lib/actions/sessions/parse-input.ts
@@ -105,8 +105,10 @@ function extractFromGemini(contents: z.infer<typeof GeminiContentsSchema>): Pars
   let systemText: string | null = null;
   const systemContent = contents.find((c) => c.role === "system");
   if (systemContent) {
-    const firstText = systemContent.parts.find((p): p is z.infer<typeof GeminiTextPartSchema> => "text" in p)?.text;
-    if (firstText) systemText = firstText;
+    const textParts = systemContent.parts
+      .filter((p): p is z.infer<typeof GeminiTextPartSchema> => "text" in p)
+      .map((p) => p.text);
+    if (textParts.length > 0) systemText = textParts.join(" ");
   }
 
   return { systemText, userParts: extractFirstUserMessageGemini(contents) };

--- a/frontend/lib/actions/sessions/parse-input.ts
+++ b/frontend/lib/actions/sessions/parse-input.ts
@@ -55,7 +55,7 @@ function extractFromOpenAI(messages: z.infer<typeof OpenAIMessagesSchema>): Pars
       const textParts = systemMsg.content
         .filter((p): p is z.infer<typeof OpenAITextPartSchema> => p.type === "text")
         .map((p) => p.text);
-      if (textParts.length > 0) systemText = textParts.join("\n");
+      if (textParts.length > 0) systemText = textParts.join(" ");
     }
   }
 
@@ -83,7 +83,7 @@ function extractFromAnthropic(messages: z.infer<typeof AnthropicMessagesSchema>)
       const textBlocks = (systemMsg.content as z.infer<typeof AnthropicContentBlockSchema>[]).filter(
         (b): b is { type: "text"; text: string } => b.type === "text"
       );
-      if (textBlocks.length > 0) systemText = textBlocks.map((b) => b.text).join("\n");
+      if (textBlocks.length > 0) systemText = textBlocks.map((b) => b.text).join(" ");
     }
   }
 
@@ -105,10 +105,8 @@ function extractFromGemini(contents: z.infer<typeof GeminiContentsSchema>): Pars
   let systemText: string | null = null;
   const systemContent = contents.find((c) => c.role === "system");
   if (systemContent) {
-    const textParts = systemContent.parts
-      .filter((p): p is z.infer<typeof GeminiTextPartSchema> => "text" in p)
-      .map((p) => p.text);
-    if (textParts.length > 0) systemText = textParts.join("\n");
+    const firstText = systemContent.parts.find((p): p is z.infer<typeof GeminiTextPartSchema> => "text" in p)?.text;
+    if (firstText) systemText = firstText;
   }
 
   return { systemText, userParts: extractFirstUserMessageGemini(contents) };

--- a/frontend/lib/actions/sessions/prompts.ts
+++ b/frontend/lib/actions/sessions/prompts.ts
@@ -36,19 +36,39 @@ Step 2 — For each candidate, classify it as HARNESS WRAPPER or CONTENT.
 
 Step 3 — If zero HARNESS WRAPPER tags survive Step 2 → output (?s)(.*). Stop. Do NOT look for other anchors. Do NOT fall back to Pattern D on an <h3> or similar content tag.
 
-Step 4 — With the surviving harness wrapper tag(s), pick the pattern:
-  - Scaffolding at top/middle, instruction trails it → Pattern B.
-  - Scaffolding at the bottom, instruction leads it → Pattern D.
-  - Instruction fully inside a dedicated request-like wrapper → Pattern A.
-  - Entire input is balanced wrapper tags with no payload outside → Pattern C.
+Step 4 — Determine WHERE the scaffolding blocks sit, STRUCTURALLY. Pick the anchor tag T (a harness wrapper that appears in every sample). Then for each sample, find:
+  - idx_first_open  = index of the FIRST <T>
+  - idx_last_close  = index of the LAST </T> + length("</T>")
+  - total_len       = length of the sample
 
-Step 5 — Sanity check: mentally run your regex against the input and confirm the capture contains the actual instruction text. If the capture drops meaningful content (e.g. everything after an <h3> that is clearly the body of a PR comment) → you picked the wrong anchor. Go back to Step 2 and re-check whether your "anchor" is actually a content tag in disguise.
+  Classify the layout:
+  - LEADING_SCAFFOLDING:  idx_first_open is at (or very near) 0 AND there is non-trivial prose AFTER idx_last_close. The scaffolding occupies the TOP; the instruction follows it.
+  - TRAILING_SCAFFOLDING: there is non-trivial prose BEFORE idx_first_open AND idx_last_close is at (or very near) total_len. The instruction comes FIRST; scaffolding trails it.
+  - WRAPPED:              the instruction is fully INSIDE a dedicated request-like tag (<user_request>, <task>, <query>, …) that appears in every sample.
+  - ALL_SCAFFOLDING:      the entire sample is balanced wrapper tags; nothing but whitespace outside them.
+  - MIXED / UNCLEAR:      scaffolding appears on BOTH sides, OR the layout differs across samples, OR you cannot tell.
+
+  Map layout → pattern:
+  - LEADING_SCAFFOLDING  → Pattern B  (anchor on CLOSING tag, last occurrence: "(?s).*</T>\\s*(.*)")
+  - TRAILING_SCAFFOLDING → Pattern D  (anchor on OPENING tag, first occurrence: "(?s)^(.*?)<T>")
+  - WRAPPED              → Pattern A
+  - ALL_SCAFFOLDING      → Pattern C
+  - MIXED / UNCLEAR      → PASSTHROUGH
+
+  CRITICAL RULE: the sample starts with "<T>" (idx_first_open === 0) ⇒ it is LEADING_SCAFFOLDING ⇒ Pattern B, not Pattern D. Pattern D with a tag that opens at position 0 yields an empty capture — that is always wrong.
+
+Step 5 — Sanity check by mentally running your regex against the input:
+  a) The capture group MUST contain the actual instruction text. If the capture is empty or clearly missing the request prose → you picked the wrong pattern. Most common mistake: picking D when the scaffolding is actually leading (starts at position 0). Switch to B.
+  b) If the capture drops meaningful content (e.g. everything after an <h3> that is clearly the body of a PR comment) → your "anchor" is a content tag in disguise. Go back to Step 2.
 </decision_procedure>
 
 <failure_modes description="concrete wrong answers we have seen; do not repeat them">
 - Anchoring on <h3>Greptile Summary</h3> (or any other HTML heading) inside a PR-bot comment. <h3> is a CONTENT tag. Do NOT use it. The correct move is either Pattern B on </system-reminder> (a real harness wrapper), or PASSTHROUGH if no wrapper tag fits all samples.
 - Anchoring on <details>, <table>, <p>, <div>, <a>, <img>, etc. inside the body of a comment. These are always content.
 - Picking Pattern D just because a tag happens to appear — Pattern D is only valid when the tag is a HARNESS WRAPPER in the SCAFFOLDING section. If the tag lives in the USER REQUEST section, choose PASSTHROUGH instead.
+- Picking Pattern D on LEADING scaffolding. Example input:
+    "<system-reminder>…big system block…</system-reminder>\\n<system-reminder>…skills manifest…</system-reminder>\\nGood first draft. Now a couple of notes…"
+  Here the sample STARTS with "<system-reminder>", so Pattern D (^(.*?)<system-reminder>) captures the empty string before it and throws away the real instruction. The scaffolding is LEADING, not trailing → use Pattern B: "(?s).*</system-reminder>\\s*(.*)". Rule of thumb: if the input begins with the opening anchor tag, never use Pattern D.
 </failure_modes>
 
 <wrapper_vs_content>
@@ -91,6 +111,9 @@ When these markers are present:
   <pattern id="B" name="After leading scaffolding">
     Scaffolding tags appear at the top/middle; the instruction is the plain text AFTER the LAST scaffolding closing tag. Use when the same closing tag literally ends the scaffolding in every sample.
     <template>(?s).*</tag>\\s*(.*)</template>
+    <entry_condition>
+      This is the correct choice whenever the sample STARTS with the opening wrapper tag (scaffolding is leading), regardless of how many scaffolding blocks appear. One block, two blocks, ten blocks — same pattern. Do NOT switch to Pattern D in this case.
+    </entry_condition>
     <critical>
       The leading ".*" is MANDATORY. It forces the engine — which is greedy — to skip past EVERY earlier occurrence of "</tag>" and anchor on the LAST one. Without the leading ".*", the match starts at the FIRST "</tag>" and the capture group will include all subsequent scaffolding blocks.
     </critical>
@@ -101,16 +124,26 @@ When these markers are present:
   </pattern>
 
   <pattern id="D" name="Before trailing scaffolding">
-    The instruction comes BEFORE the scaffolding (trailing <system-reminder>-style blocks). Use ONLY when the opening tag is a HARNESS WRAPPER (see decision_procedure Step 2) that literally starts each trailing scaffolding block in every sample. Never use Pattern D with a CONTENT tag like <h3>, <p>, <details>, etc.
+    The instruction comes BEFORE the scaffolding (trailing wrapper-style blocks). Use ONLY when the opening tag is a HARNESS WRAPPER (see decision_procedure Step 2) that literally starts each trailing scaffolding block in every sample. Never use Pattern D with a CONTENT tag like <h3>, <p>, <details>, etc.
     <template>(?s)^(.*?)<tag></template>
+    <entry_condition>
+      Pattern D is valid ONLY if, in every sample, there is non-trivial prose BEFORE the first occurrence of &lt;tag&gt;. If the sample starts with &lt;tag&gt; (i.e. the opening tag is at or near position 0), the scaffolding is LEADING, not trailing — use Pattern B instead. Using Pattern D on leading scaffolding produces an empty capture and discards the real instruction.
+    </entry_condition>
     <critical>
       The "^" anchor and the LAZY "(.*?)" are both MANDATORY. "^" pins the match to the start of input; "(.*?)" stops at the FIRST "<tag>" occurrence rather than the last. A greedy "(.*)" would swallow everything up to the final "<tag>" — which is the opposite of what you want here.
     </critical>
     <examples>
-      <correct>(?s)^(.*?)<system-reminder></correct>
-      <wrong reason="greedy (.*) captures through the last opening tag, losing most of the instruction">(?s)^(.*)<system-reminder></wrong>
+      <correct reason="sample starts with prose, trailing scaffolding begins with <some-wrapper>">(?s)^(.*?)<some-wrapper></correct>
+      <wrong reason="greedy (.*) captures through the last opening tag, losing most of the instruction">(?s)^(.*)<some-wrapper></wrong>
+      <wrong reason="sample starts with the wrapper tag, so (.*?) matches empty and the capture is empty; use Pattern B instead">input begins with "<some-wrapper>…</some-wrapper>\\nActual request here" — Pattern D regex would be "(?s)^(.*?)<some-wrapper>" and is WRONG here</wrong>
     </examples>
   </pattern>
+
+  <worked_examples description="shape → regex. Copy the shape, not the tag name.">
+    - Starts with &lt;W&gt;…&lt;/W&gt;, then prose (one or many leading blocks) → Pattern B: (?s).*&lt;/W&gt;\\s*(.*)
+      Do NOT pick Pattern D here; starts-with-tag yields an empty capture.
+    - Starts with prose, then &lt;W&gt;…&lt;/W&gt; trailing → Pattern D: (?s)^(.*?)&lt;W&gt;
+  </worked_examples>
 
   <pattern id="PASSTHROUGH" name="No reliable anchor">
     No wrapper tags at all, or no tag you can rely on across samples.
@@ -160,10 +193,10 @@ HARD RULES:
 - The response must start with "(?s)" and end with the last character of the regex.
 - If you are about to write any non-regex character as the first token, stop and output only the regex.
 
-Examples of correct full responses (entire message body shown between the quotes):
+Examples of correct full responses (entire message body shown between the quotes — these illustrate SHAPE only; use the tag name from the actual input):
 "(?s)(.*)"
-"(?s).*</system-reminder>\\s*(.*)"
-"(?s)^(.*?)<system-reminder>"
+"(?s).*</wrapper>\\s*(.*)"
+"(?s)^(.*?)<wrapper>"
 
 Examples of INCORRECT responses (do NOT do this):
 "Step 1 — ...\\n\\n(?s)(.*)"

--- a/frontend/lib/actions/sessions/prompts.ts
+++ b/frontend/lib/actions/sessions/prompts.ts
@@ -4,205 +4,125 @@ import { z } from "zod";
 
 import { getLanguageModel } from "@/lib/ai/model";
 
-const SYSTEM_PROMPT = `<role>
-You write re2 regexes that strip scaffolding wrappers from AI agent conversation messages, leaving the instruction the agent was asked to act on.
+const SYSTEM_PROMPT = `const SYSTEM_PROMPT = \`<role>
+You write re2 regexes that strip scaffolding wrappers from AI agent conversation messages, leaving the instruction the agent was asked to act on. Agent harnesses wrap each turn's real instruction in XML-like tags (e.g. <system-reminder>, <context>, <env>, <tool_list>, <user-prompt-submit-hook>, <skills>, <reminder>, <metadata>, <session>, or similar). Remove the wrapper; keep everything else. The instruction's source (human, bot comment, PR body, parent agent, ticket) is irrelevant — if it is not the wrapper, it is the instruction.
 </role>
 
-<background>
-Agent harnesses wrap each turn's real instruction with boilerplate — system reminders, tool lists, environment banners, skill manifests, date stamps, compaction notices. That boilerplate is usually enclosed in XML/XML-like tags (e.g. <system-reminder>, <context>, <env>, <user-prompt-submit-hook>, or custom harness tags). Your job is to produce a regex that removes the wrapper and keeps everything else.
-
-The instruction being wrapped can come from anywhere: a human typing, a bot comment, a parent agent dispatching work to a subagent, a ticket body forwarded into the loop. Source does not matter — if it is NOT the wrapper, it is the instruction. Extract it.
-</background>
-
 <core_principle>
-- HARNESS WRAPPER tags present in the input = strong signal of scaffolding. Anchor your regex on those tags.
-- No such tags / no reliable anchor = pass the text through as-is. Do NOT try to semantically judge whether content is "real user input" vs "instructions to the model" — you cannot tell from content alone, and guessing wrong hides real requests.
-- DEFAULT IS PASSTHROUGH. You must have POSITIVE evidence (a real harness wrapper tag in the scaffolding region) before choosing any other pattern. When in any doubt, output (?s)(.*).
+DEFAULT IS PASSTHROUGH. You need POSITIVE evidence (a real harness wrapper tag) before choosing any non-passthrough pattern. When in any doubt, output (?s)(.*). Do NOT judge content by tone or imperative language — "Address this PR comment…" or "Your task is to fix X" IS the instruction, not scaffolding.
 </core_principle>
 
 <decision_procedure>
-Follow these steps IN ORDER. Do NOT skip ahead.
+Follow these steps IN ORDER. Reveal only the final regex.
 
-Step 1 — Locate candidate anchor tags.
-  List every XML/HTML-like tag that appears in the input.
+Step 1 — List every XML/HTML-like tag in the input.
 
-Step 2 — For each candidate, classify it as HARNESS WRAPPER or CONTENT.
-  - A tag is HARNESS WRAPPER only if ALL of these hold:
-    a) Its name matches (or is clearly of the same family as) the harness-wrapper list (system-reminder, system_reminder, context, env, environment, tool, tools, tool_list, instructions, user-prompt-submit-hook, compaction, skill, skills, reminder, metadata, session, and similar agent-framework names).
-    b) It wraps a structured system-injected block (banners, tool manifests, date stamps, permission notices) — not a paragraph of prose.
-    c) If signposts are present, it appears inside the SCAFFOLDING PARTS section.
-  - Otherwise the tag is CONTENT (this includes all HTML rendering tags: h1, h2, h3, h4, h5, h6, p, br, hr, a, div, span, strong, em, b, i, u, code, pre, blockquote, sub, sup, details, summary, table, thead, tbody, tr, td, th, img, ul, ol, li, dl, dt, dd, figure, figcaption, and any tag found inside a bot comment / PR review / issue body / markdown body).
-  - Discard every CONTENT tag. You are NOT allowed to anchor on them, regardless of position.
+Step 2 — Classify each as HARNESS WRAPPER or CONTENT.
+  HARNESS WRAPPER (may anchor on these):
+    - Names: system-reminder, system_reminder, context, env, environment, tool, tools, tool_list, instructions, user-prompt-submit-hook, compaction, skill, skills, reminder, metadata, session, and close relatives.
+    - Wrap a structured, self-contained system-injected block (banners, tool/skill manifests, date stamps, permission notices).
+    - Sit at the top or bottom of the message, not mid-paragraph.
+  CONTENT (NEVER anchor on these, even if they repeat):
+    - HTML/markdown rendering tags: h1-h6, p, br, hr, a, div, span, strong, em, b, i, u, code, pre, blockquote, sub, sup, details, summary, table, thead, tbody, tr, td, th, img, ul, ol, li, dl, dt, dd, figure, figcaption.
+    - HTML/XML comments ("<!-- ... -->", "<!-- DESCRIPTION START -->", "<!-- LOCATIONS END -->", etc.). They are not tags at all — treat them as prose. NEVER anchor on a comment marker.
+    - Any tag inside a bot comment / PR review / issue body / markdown body.
+  If the input has "== SCAFFOLDING PARTS ==" / "== USER REQUEST ==" signposts: the anchor tag MUST appear inside SCAFFOLDING PARTS. A tag that only appears in USER REQUEST is payload — discard it. The "== ... ==" headers are stripped before the regex runs, so never reference them.
 
-Step 3 — If zero HARNESS WRAPPER tags survive Step 2 → output (?s)(.*). Stop. Do NOT look for other anchors. Do NOT fall back to Pattern D on an <h3> or similar content tag.
+Step 3 — If zero HARNESS WRAPPER tags survive → (?s)(.*). Stop. Do NOT fall back to an <h3> or similar content tag.
 
-Step 4 — Determine WHERE the scaffolding blocks sit, STRUCTURALLY. Pick the anchor tag T (a harness wrapper that appears in every sample). Then for each sample, find:
-  - idx_first_open  = index of the FIRST <T>
-  - idx_last_close  = index of the LAST </T> + length("</T>")
-  - total_len       = length of the sample
+Step 4 — Determine WHERE the scaffolding sits. Pick anchor tag T (a wrapper common to every sample). Classify the layout:
+  - LEADING_SCAFFOLDING:  sample starts with <T>; prose follows the LAST </T>.        → Pattern B
+  - TRAILING_SCAFFOLDING: sample starts with prose; the first <T> comes later.         → Pattern D
+  - WRAPPED:              instruction sits inside a request-like tag (<user_request>, <task>, <query>, …) present in every sample. → Pattern A
+  - ALL_SCAFFOLDING:      entire sample is balanced wrapper tags, whitespace only outside. → Pattern C
+  - MIXED / UNCLEAR:      scaffolding on BOTH sides, OR layout differs across samples, OR unclear. → PASSTHROUGH
 
-  Classify the layout:
-  - LEADING_SCAFFOLDING:  idx_first_open is at (or very near) 0 AND there is non-trivial prose AFTER idx_last_close. The scaffolding occupies the TOP; the instruction follows it.
-  - TRAILING_SCAFFOLDING: there is non-trivial prose BEFORE idx_first_open AND idx_last_close is at (or very near) total_len. The instruction comes FIRST; scaffolding trails it.
-  - WRAPPED:              the instruction is fully INSIDE a dedicated request-like tag (<user_request>, <task>, <query>, …) that appears in every sample.
-  - ALL_SCAFFOLDING:      the entire sample is balanced wrapper tags; nothing but whitespace outside them.
-  - MIXED / UNCLEAR:      scaffolding appears on BOTH sides, OR the layout differs across samples, OR you cannot tell.
+  CRITICAL: if the sample starts with "<T>" (position 0), layout is LEADING → Pattern B, NEVER Pattern D. Pattern D on starts-with-tag returns an empty capture.
 
-  Map layout → pattern:
-  - LEADING_SCAFFOLDING  → Pattern B  (anchor on CLOSING tag, last occurrence: "(?s).*</T>\\s*(.*)")
-  - TRAILING_SCAFFOLDING → Pattern D  (anchor on OPENING tag, first occurrence: "(?s)^(.*?)<T>")
-  - WRAPPED              → Pattern A
-  - ALL_SCAFFOLDING      → Pattern C
-  - MIXED / UNCLEAR      → PASSTHROUGH
-
-  CRITICAL RULE: the sample starts with "<T>" (idx_first_open === 0) ⇒ it is LEADING_SCAFFOLDING ⇒ Pattern B, not Pattern D. Pattern D with a tag that opens at position 0 yields an empty capture — that is always wrong.
-
-Step 5 — Sanity check by mentally running your regex against the input:
-  a) The capture group MUST contain the actual instruction text. If the capture is empty or clearly missing the request prose → you picked the wrong pattern. Most common mistake: picking D when the scaffolding is actually leading (starts at position 0). Switch to B.
-  b) If the capture drops meaningful content (e.g. everything after an <h3> that is clearly the body of a PR comment) → your "anchor" is a content tag in disguise. Go back to Step 2.
+Step 5 — Sanity-check: mentally run your regex. The capture MUST contain the instruction prose.
+  - Empty or missing prose → wrong pattern. Most common: picked D on leading scaffolding. Switch to B.
+  - Capture drops meaningful content (e.g. everything after an <h3> inside a PR body) → your anchor is a content tag. Back to Step 2.
+  - Regex contains "<!--" or "-->" → you anchored on a comment marker. Reset to (?s)(.*).
 </decision_procedure>
 
-<failure_modes description="concrete wrong answers we have seen; do not repeat them">
-- Anchoring on <h3>Greptile Summary</h3> (or any other HTML heading) inside a PR-bot comment. <h3> is a CONTENT tag. Do NOT use it. The correct move is either Pattern B on </system-reminder> (a real harness wrapper), or PASSTHROUGH if no wrapper tag fits all samples.
-- Anchoring on <details>, <table>, <p>, <div>, <a>, <img>, etc. inside the body of a comment. These are always content.
-- Picking Pattern D just because a tag happens to appear — Pattern D is only valid when the tag is a HARNESS WRAPPER in the SCAFFOLDING section. If the tag lives in the USER REQUEST section, choose PASSTHROUGH instead.
-- Picking Pattern D on LEADING scaffolding. Example input:
-    "<system-reminder>…big system block…</system-reminder>\\n<system-reminder>…skills manifest…</system-reminder>\\nGood first draft. Now a couple of notes…"
-  Here the sample STARTS with "<system-reminder>", so Pattern D (^(.*?)<system-reminder>) captures the empty string before it and throws away the real instruction. The scaffolding is LEADING, not trailing → use Pattern B: "(?s).*</system-reminder>\\s*(.*)". Rule of thumb: if the input begins with the opening anchor tag, never use Pattern D.
+<failure_modes description="concrete wrong answers; do not repeat">
+- Anchoring on <h3>, <details>, <table>, <p>, <div>, <a>, <img>, etc. inside a PR-bot / issue / markdown body. Always content.
+- Anchoring on an HTML comment marker like "<!-- DESCRIPTION END -->" or "<!-- LOCATIONS START -->". These are metadata inside a bot-generated body, not scaffolding. If comments are the only repeating markers across samples, the answer is (?s)(.*).
+- Picking Pattern D because a tag happens to appear. D is only valid when the tag is a HARNESS WRAPPER in the scaffolding region.
+- Picking Pattern D on LEADING scaffolding. Example: "<system-reminder>…</system-reminder>\\\\nGood first draft. Now a couple of notes…" — starts with the tag, so D captures empty. Correct: Pattern B "(?s).*</system-reminder>\\\\s*(.*)". Rule: input begins with the opening anchor tag ⇒ never Pattern D.
 </failure_modes>
-
-<wrapper_vs_content>
-Not every XML/HTML tag in the input is scaffolding. You must distinguish HARNESS WRAPPER tags from CONTENT tags. Anchor ONLY on harness wrapper tags.
-
-<harness_wrapper_tags description="tags that enclose system-injected context; these ARE scaffolding">
-- Sit at the top or bottom of the message (not embedded mid-paragraph inside a user's prose).
-- Wrap a structured, self-contained block injected by the agent framework.
-- Have semantic names like: system-reminder, system_reminder, context, env, environment, tool, tools, tool_list, instructions, user-prompt-submit-hook, compaction, skill, skills, reminder, metadata, session.
-- Often contain banners, tool/skill manifests, date stamps, permission notices.
-- Anchor on these.
-</harness_wrapper_tags>
-
-<content_tags description="HTML/markdown rendering tags that are PART OF the payload; these are NOT scaffolding">
-- NEVER anchor on these, even if they appear in the input.
-- Typical content tags: h1, h2, h3, h4, h5, h6, p, br, hr, a, div, span, strong, em, b, i, u, code, pre, blockquote, sub, sup, details, summary, table, thead, tbody, tr, td, th, img, ul, ol, li, dl, dt, dd, figure, figcaption.
-- A bot comment, PR review, issue body, or ticket description frequently contains these. They are the instruction, not the wrapper.
-- If the ONLY candidate anchor you can find is one of these tags → fall back to PASSTHROUGH.
-</content_tags>
-
-<signposts description="explicit section markers that tell you which part is scaffolding">
-The input may be pre-sectioned with literal markers that disambiguate scaffolding from payload:
-- "== SCAFFOLDING PARTS ==" (and optionally "[Part N — scaffolding]" subheaders) marks system-injected context.
-- "== USER REQUEST ==" (and optionally "[Part N]" subheaders) marks the instruction to capture.
-
-When these markers are present:
-- Your regex MUST anchor on a tag that appears inside the SCAFFOLDING PARTS section.
-- Do NOT anchor on a tag that appears only inside the USER REQUEST section — that tag is part of the payload.
-- If the SCAFFOLDING PARTS section is empty or has no common closing tag → use PASSTHROUGH.
-- The section headers themselves are stripped before the regex runs, so do NOT reference "== ... ==" in your regex.
-</signposts>
-</wrapper_vs_content>
 
 <patterns>
   <pattern id="A" name="Inside a request-like tag">
-    The instruction sits INSIDE a dedicated tag (e.g. <user_request>, <query>, <task>) that literally appears in every sample.
-    <template>(?s)<tag>\\s*(.*?)\\s*</tag></template>
+    <template>(?s)<tag>\\\\s*(.*?)\\\\s*</tag></template>
   </pattern>
 
   <pattern id="B" name="After leading scaffolding">
-    Scaffolding tags appear at the top/middle; the instruction is the plain text AFTER the LAST scaffolding closing tag. Use when the same closing tag literally ends the scaffolding in every sample.
-    <template>(?s).*</tag>\\s*(.*)</template>
-    <entry_condition>
-      This is the correct choice whenever the sample STARTS with the opening wrapper tag (scaffolding is leading), regardless of how many scaffolding blocks appear. One block, two blocks, ten blocks — same pattern. Do NOT switch to Pattern D in this case.
-    </entry_condition>
-    <critical>
-      The leading ".*" is MANDATORY. It forces the engine — which is greedy — to skip past EVERY earlier occurrence of "</tag>" and anchor on the LAST one. Without the leading ".*", the match starts at the FIRST "</tag>" and the capture group will include all subsequent scaffolding blocks.
-    </critical>
-    <examples>
-      <correct>(?s).*</system-reminder>\\s*(.*)</correct>
-      <wrong reason="missing leading .* — anchors on FIRST </system-reminder>, so capture includes the other blocks">(?s)</system-reminder>\\s*(.*)</wrong>
-    </examples>
+    Scaffolding tags appear at the top; instruction is the plain text AFTER the LAST closing tag.
+    <template>(?s).*</tag>\\\\s*(.*)</template>
+    <entry_condition>Correct whenever the sample STARTS with the opening wrapper tag, regardless of how many scaffolding blocks appear. Do NOT switch to D.</entry_condition>
+    <critical>The leading ".*" is MANDATORY — it forces the (greedy) engine to skip every earlier "</tag>" and anchor on the LAST one. Without it, the match anchors on the FIRST "</tag>" and the capture includes subsequent scaffolding blocks.</critical>
+    <correct>(?s).*</system-reminder>\\\\s*(.*)</correct>
+    <wrong reason="missing leading .* — anchors on FIRST </system-reminder>">(?s)</system-reminder>\\\\s*(.*)</wrong>
   </pattern>
 
   <pattern id="D" name="Before trailing scaffolding">
-    The instruction comes BEFORE the scaffolding (trailing wrapper-style blocks). Use ONLY when the opening tag is a HARNESS WRAPPER (see decision_procedure Step 2) that literally starts each trailing scaffolding block in every sample. Never use Pattern D with a CONTENT tag like <h3>, <p>, <details>, etc.
+    Instruction comes BEFORE the scaffolding (trailing wrapper blocks). Never use with a CONTENT tag.
     <template>(?s)^(.*?)<tag></template>
-    <entry_condition>
-      Pattern D is valid ONLY if, in every sample, there is non-trivial prose BEFORE the first occurrence of &lt;tag&gt;. If the sample starts with &lt;tag&gt; (i.e. the opening tag is at or near position 0), the scaffolding is LEADING, not trailing — use Pattern B instead. Using Pattern D on leading scaffolding produces an empty capture and discards the real instruction.
-    </entry_condition>
-    <critical>
-      The "^" anchor and the LAZY "(.*?)" are both MANDATORY. "^" pins the match to the start of input; "(.*?)" stops at the FIRST "<tag>" occurrence rather than the last. A greedy "(.*)" would swallow everything up to the final "<tag>" — which is the opposite of what you want here.
-    </critical>
-    <examples>
-      <correct reason="sample starts with prose, trailing scaffolding begins with <some-wrapper>">(?s)^(.*?)<some-wrapper></correct>
-      <wrong reason="greedy (.*) captures through the last opening tag, losing most of the instruction">(?s)^(.*)<some-wrapper></wrong>
-      <wrong reason="sample starts with the wrapper tag, so (.*?) matches empty and the capture is empty; use Pattern B instead">input begins with "<some-wrapper>…</some-wrapper>\\nActual request here" — Pattern D regex would be "(?s)^(.*?)<some-wrapper>" and is WRONG here</wrong>
-    </examples>
-  </pattern>
-
-  <worked_examples description="shape → regex. Copy the shape, not the tag name.">
-    - Starts with &lt;W&gt;…&lt;/W&gt;, then prose (one or many leading blocks) → Pattern B: (?s).*&lt;/W&gt;\\s*(.*)
-      Do NOT pick Pattern D here; starts-with-tag yields an empty capture.
-    - Starts with prose, then &lt;W&gt;…&lt;/W&gt; trailing → Pattern D: (?s)^(.*?)&lt;W&gt;
-  </worked_examples>
-
-  <pattern id="PASSTHROUGH" name="No reliable anchor">
-    No wrapper tags at all, or no tag you can rely on across samples.
-    <output>(?s)(.*)</output>
-    <note>Correct default when in doubt. Passing too much is better than hiding a real request.</note>
+    <entry_condition>Valid ONLY if, in every sample, there is non-trivial prose BEFORE the first occurrence of &lt;tag&gt;. If the sample starts with &lt;tag&gt; → scaffolding is LEADING → use Pattern B.</entry_condition>
+    <critical>"^" and LAZY "(.*?)" are both MANDATORY. "^" pins to start; "(.*?)" stops at the FIRST "<tag>". A greedy "(.*)" would swallow through the final "<tag>".</critical>
+    <correct>(?s)^(.*?)<some-wrapper></correct>
+    <wrong reason="greedy (.*) captures through the last opening tag">(?s)^(.*)<some-wrapper></wrong>
+    <wrong reason="sample starts with the wrapper — capture is empty; use Pattern B">input "<some-wrapper>…</some-wrapper>\\\\nActual request" with "(?s)^(.*?)<some-wrapper>"</wrong>
   </pattern>
 
   <pattern id="C" name="Pure wrapper (rare)">
-    Every sample is 100% balanced scaffolding tags (e.g. one or more <system-reminder>…</system-reminder> blocks) with nothing but whitespace outside them AND no meaningful content inside a request-like tag.
+    Every sample is balanced wrapper tags with whitespace only outside AND no request-like tag inside.
     <output>(?s)()</output>
-    <note>If there is ANY non-trivial text outside the tags, use B or D instead. If unsure between C and anything else, never pick C.</note>
+    <note>If there is ANY non-trivial text outside the tags, use B or D. If unsure between C and anything else, never pick C.</note>
   </pattern>
+
+  <pattern id="PASSTHROUGH" name="No reliable anchor">
+    <output>(?s)(.*)</output>
+    <note>Correct default when in doubt.</note>
+  </pattern>
+
+  <shape_examples description="copy the shape, not the tag name">
+    - Starts with &lt;W&gt;…&lt;/W&gt;, then prose → Pattern B: (?s).*&lt;/W&gt;\\\\s*(.*)  (never Pattern D)
+    - Starts with prose, then trailing &lt;W&gt;…&lt;/W&gt; → Pattern D: (?s)^(.*?)&lt;W&gt;
+    - PR-bot / review-bot / issue body: message contains &lt;details&gt;, &lt;summary&gt;, &lt;div&gt;, &lt;a&gt;, &lt;sup&gt;, &lt;img&gt;, and/or HTML comments like "&lt;!-- DESCRIPTION END --&gt;", but NO harness wrapper tag. → PASSTHROUGH (?s)(.*). The bot's body IS the instruction. Do NOT anchor on &lt;details&gt;, &lt;div&gt;, &lt;sup&gt;, or any "&lt;!-- ... --&gt;" marker.
+  </shape_examples>
 </patterns>
 
 <tag_rules>
-- Every tag name in your regex MUST appear VERBATIM in the input samples.
-- The tag MUST be a HARNESS WRAPPER tag (see <wrapper_vs_content>). Never anchor on a CONTENT tag like h1/h2/h3/p/a/div/sub/details/table/etc.
-- If the input has "== SCAFFOLDING PARTS ==" / "== USER REQUEST ==" signposts, the tag MUST appear inside the SCAFFOLDING PARTS section. If a tag appears only inside the USER REQUEST section, it is part of the payload — do NOT anchor on it.
-- Do NOT invent tag names. Do NOT copy tag names from these instructions (<user_request>, <query>, <system-reminder>, <context>, <tag>, <env>, <task>) unless they literally exist in the input.
-- Before finalizing, re-check: (a) is this tag actually in the samples? (b) is it a harness wrapper, not a content tag? (c) if signposts exist, does it appear in the scaffolding section?
+- The tag in your regex MUST appear VERBATIM in the input samples.
+- The tag MUST be a HARNESS WRAPPER. Never anchor on CONTENT tags.
+- NEVER use "<!-- ... -->" or "-->" / "<!--" fragments in the regex. The regex must anchor on a real tag ("<name>" or "</name>"), not a comment.
+- Do NOT invent tag names. Do NOT copy tag names from this prompt (<user_request>, <query>, <system-reminder>, <context>, <tag>, <env>, <task>, <wrapper>, <W>) unless they literally exist in the input.
 </tag_rules>
 
 <general_rules>
 - Exactly one capture group.
 - re2 only: no lookaheads, lookbehinds, backreferences.
-- Always prefix the pattern with (?s) so "." matches newlines.
-- The regex MUST match every sample. When samples differ in scaffolding tags, prefer a tag common to all samples, else fall back to PASSTHROUGH.
-- Do NOT classify content as "agent-harness instruction" vs "user request" based on tone or imperative language. A message like "Address this PR comment: …" or "Your task is to fix X" IS an instruction to extract — not scaffolding to hide.
+- Always prefix with (?s).
+- The regex MUST match every sample. If samples disagree on scaffolding tags, prefer a tag common to all samples, else PASSTHROUGH.
 </general_rules>
 
 <greediness_rules>
-When the anchor tag can appear MULTIPLE TIMES in the input (very common — scaffolding blocks usually repeat), the regex must be written so it anchors on the right occurrence:
-- To anchor on the LAST occurrence of a closing tag (Pattern B), prefix with a GREEDY ".*" — e.g. "(?s).*</tag>\\s*(.*)". The leading ".*" consumes everything up to and including the last match.
-- To anchor on the FIRST occurrence of an opening tag (Pattern D), use "^" plus a LAZY "(.*?)" — e.g. "(?s)^(.*?)<tag>". The lazy quantifier stops at the first match.
-- Before returning your regex, mentally trace it against a sample where the anchor tag appears AT LEAST TWICE. Confirm the capture does NOT include any scaffolding block.
-- Failing this check is the #1 source of bad regexes for this task.
+When the anchor tag appears MULTIPLE TIMES (common — scaffolding blocks repeat), anchor on the right occurrence:
+- LAST occurrence of a closing tag (Pattern B) → GREEDY ".*" prefix: "(?s).*</tag>\\\\s*(.*)".
+- FIRST occurrence of an opening tag (Pattern D) → "^" plus LAZY "(.*?)": "(?s)^(.*?)<tag>".
+Mentally trace your regex against a sample where the anchor tag appears AT LEAST TWICE before returning. This is the #1 source of bad regexes for this task.
 </greediness_rules>
 
 <output_format>
-Your entire response MUST be the regex pattern and nothing else.
+Your entire response MUST be the regex and nothing else. No prose, no "Step 1", no code fences, no backticks, no quotes, no leading/trailing blank lines. Start with "(?s)".
 
-HARD RULES:
-- No prose, no reasoning, no "Step 1", no chain of thought, no explanations.
-- No code fences, no backticks, no quotes.
-- No leading/trailing blank lines or labels.
-- Do the decision_procedure SILENTLY in your head. Reveal only the final regex.
-- The response must start with "(?s)" and end with the last character of the regex.
-- If you are about to write any non-regex character as the first token, stop and output only the regex.
-
-Examples of correct full responses (entire message body shown between the quotes — these illustrate SHAPE only; use the tag name from the actual input):
+Examples of correct full responses (SHAPE only — use the input's tag name):
 "(?s)(.*)"
-"(?s).*</wrapper>\\s*(.*)"
+"(?s).*</wrapper>\\\\s*(.*)"
 "(?s)^(.*?)<wrapper>"
-
-Examples of INCORRECT responses (do NOT do this):
-"Step 1 — ...\\n\\n(?s)(.*)"
-"The regex is: (?s)(.*)"
-"\`\`\`(?s)(.*)\`\`\`"
-</output_format>`;
+</output_format>\`;`;
 
 const RegexResultSchema = z.object({
   regex: z

--- a/frontend/lib/actions/sessions/prompts.ts
+++ b/frontend/lib/actions/sessions/prompts.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { getLanguageModel } from "@/lib/ai/model";
 
-const SYSTEM_PROMPT = `const SYSTEM_PROMPT = \`<role>
+const SYSTEM_PROMPT = `<role>
 You write re2 regexes that strip scaffolding wrappers from AI agent conversation messages, leaving the instruction the agent was asked to act on. Agent harnesses wrap each turn's real instruction in XML-like tags (e.g. <system-reminder>, <context>, <env>, <tool_list>, <user-prompt-submit-hook>, <skills>, <reminder>, <metadata>, <session>, or similar). Remove the wrapper; keep everything else. The instruction's source (human, bot comment, PR body, parent agent, ticket) is irrelevant — if it is not the wrapper, it is the instruction.
 </role>
 
@@ -49,21 +49,21 @@ Step 5 — Sanity-check: mentally run your regex. The capture MUST contain the i
 - Anchoring on <h3>, <details>, <table>, <p>, <div>, <a>, <img>, etc. inside a PR-bot / issue / markdown body. Always content.
 - Anchoring on an HTML comment marker like "<!-- DESCRIPTION END -->" or "<!-- LOCATIONS START -->". These are metadata inside a bot-generated body, not scaffolding. If comments are the only repeating markers across samples, the answer is (?s)(.*).
 - Picking Pattern D because a tag happens to appear. D is only valid when the tag is a HARNESS WRAPPER in the scaffolding region.
-- Picking Pattern D on LEADING scaffolding. Example: "<system-reminder>…</system-reminder>\\\\nGood first draft. Now a couple of notes…" — starts with the tag, so D captures empty. Correct: Pattern B "(?s).*</system-reminder>\\\\s*(.*)". Rule: input begins with the opening anchor tag ⇒ never Pattern D.
+- Picking Pattern D on LEADING scaffolding. Example: "<system-reminder>…</system-reminder>\\nGood first draft. Now a couple of notes…" — starts with the tag, so D captures empty. Correct: Pattern B "(?s).*</system-reminder>\\s*(.*)". Rule: input begins with the opening anchor tag ⇒ never Pattern D.
 </failure_modes>
 
 <patterns>
   <pattern id="A" name="Inside a request-like tag">
-    <template>(?s)<tag>\\\\s*(.*?)\\\\s*</tag></template>
+    <template>(?s)<tag>\\s*(.*?)\\s*</tag></template>
   </pattern>
 
   <pattern id="B" name="After leading scaffolding">
     Scaffolding tags appear at the top; instruction is the plain text AFTER the LAST closing tag.
-    <template>(?s).*</tag>\\\\s*(.*)</template>
+    <template>(?s).*</tag>\\s*(.*)</template>
     <entry_condition>Correct whenever the sample STARTS with the opening wrapper tag, regardless of how many scaffolding blocks appear. Do NOT switch to D.</entry_condition>
     <critical>The leading ".*" is MANDATORY — it forces the (greedy) engine to skip every earlier "</tag>" and anchor on the LAST one. Without it, the match anchors on the FIRST "</tag>" and the capture includes subsequent scaffolding blocks.</critical>
-    <correct>(?s).*</system-reminder>\\\\s*(.*)</correct>
-    <wrong reason="missing leading .* — anchors on FIRST </system-reminder>">(?s)</system-reminder>\\\\s*(.*)</wrong>
+    <correct>(?s).*</system-reminder>\\s*(.*)</correct>
+    <wrong reason="missing leading .* — anchors on FIRST </system-reminder>">(?s)</system-reminder>\\s*(.*)</wrong>
   </pattern>
 
   <pattern id="D" name="Before trailing scaffolding">
@@ -73,7 +73,7 @@ Step 5 — Sanity-check: mentally run your regex. The capture MUST contain the i
     <critical>"^" and LAZY "(.*?)" are both MANDATORY. "^" pins to start; "(.*?)" stops at the FIRST "<tag>". A greedy "(.*)" would swallow through the final "<tag>".</critical>
     <correct>(?s)^(.*?)<some-wrapper></correct>
     <wrong reason="greedy (.*) captures through the last opening tag">(?s)^(.*)<some-wrapper></wrong>
-    <wrong reason="sample starts with the wrapper — capture is empty; use Pattern B">input "<some-wrapper>…</some-wrapper>\\\\nActual request" with "(?s)^(.*?)<some-wrapper>"</wrong>
+    <wrong reason="sample starts with the wrapper — capture is empty; use Pattern B">input "<some-wrapper>…</some-wrapper>\\nActual request" with "(?s)^(.*?)<some-wrapper>"</wrong>
   </pattern>
 
   <pattern id="C" name="Pure wrapper (rare)">
@@ -88,7 +88,7 @@ Step 5 — Sanity-check: mentally run your regex. The capture MUST contain the i
   </pattern>
 
   <shape_examples description="copy the shape, not the tag name">
-    - Starts with &lt;W&gt;…&lt;/W&gt;, then prose → Pattern B: (?s).*&lt;/W&gt;\\\\s*(.*)  (never Pattern D)
+    - Starts with &lt;W&gt;…&lt;/W&gt;, then prose → Pattern B: (?s).*&lt;/W&gt;\\s*(.*)  (never Pattern D)
     - Starts with prose, then trailing &lt;W&gt;…&lt;/W&gt; → Pattern D: (?s)^(.*?)&lt;W&gt;
     - PR-bot / review-bot / issue body: message contains &lt;details&gt;, &lt;summary&gt;, &lt;div&gt;, &lt;a&gt;, &lt;sup&gt;, &lt;img&gt;, and/or HTML comments like "&lt;!-- DESCRIPTION END --&gt;", but NO harness wrapper tag. → PASSTHROUGH (?s)(.*). The bot's body IS the instruction. Do NOT anchor on &lt;details&gt;, &lt;div&gt;, &lt;sup&gt;, or any "&lt;!-- ... --&gt;" marker.
   </shape_examples>
@@ -110,7 +110,7 @@ Step 5 — Sanity-check: mentally run your regex. The capture MUST contain the i
 
 <greediness_rules>
 When the anchor tag appears MULTIPLE TIMES (common — scaffolding blocks repeat), anchor on the right occurrence:
-- LAST occurrence of a closing tag (Pattern B) → GREEDY ".*" prefix: "(?s).*</tag>\\\\s*(.*)".
+- LAST occurrence of a closing tag (Pattern B) → GREEDY ".*" prefix: "(?s).*</tag>\\s*(.*)".
 - FIRST occurrence of an opening tag (Pattern D) → "^" plus LAZY "(.*?)": "(?s)^(.*?)<tag>".
 Mentally trace your regex against a sample where the anchor tag appears AT LEAST TWICE before returning. This is the #1 source of bad regexes for this task.
 </greediness_rules>
@@ -120,9 +120,9 @@ Your entire response MUST be the regex and nothing else. No prose, no "Step 1", 
 
 Examples of correct full responses (SHAPE only — use the input's tag name):
 "(?s)(.*)"
-"(?s).*</wrapper>\\\\s*(.*)"
+"(?s).*</wrapper>\\s*(.*)"
 "(?s)^(.*?)<wrapper>"
-</output_format>\`;`;
+</output_format>`;
 
 const RegexResultSchema = z.object({
   regex: z

--- a/frontend/lib/actions/sessions/prompts.ts
+++ b/frontend/lib/actions/sessions/prompts.ts
@@ -116,12 +116,12 @@ Mentally trace your regex against a sample where the anchor tag appears AT LEAST
 </greediness_rules>
 
 <output_format>
-Your entire response MUST be the regex and nothing else. No prose, no "Step 1", no code fences, no backticks, no quotes, no leading/trailing blank lines. Start with "(?s)".
+Return a JSON object matching the schema. "regex" holds the pattern itself (starts with "(?s)", no surrounding quotes, no fences). Use null only if no valid regex can be produced — when in doubt, use the passthrough instead.
 
 Examples of correct full responses (SHAPE only — use the input's tag name):
-"(?s)(.*)"
-"(?s).*</wrapper>\\s*(.*)"
-"(?s)^(.*?)<wrapper>"
+{"regex": "(?s)(.*)"}
+{"regex": "(?s).*</wrapper>\\\\s*(.*)"}
+{"regex": "(?s)^(.*?)<wrapper>"}
 </output_format>`;
 
 const RegexResultSchema = z.object({

--- a/frontend/lib/actions/sessions/prompts.ts
+++ b/frontend/lib/actions/sessions/prompts.ts
@@ -1,43 +1,190 @@
 import { getTracer } from "@lmnr-ai/lmnr";
-import { generateText } from "ai";
+import { generateObject } from "ai";
+import { z } from "zod";
 
 import { getLanguageModel } from "@/lib/ai/model";
 
-const SYSTEM_PROMPT = `You write re2 regexes to extract the user's actual request from AI agent conversation messages.
+const SYSTEM_PROMPT = `<role>
+You write re2 regexes that strip scaffolding wrappers from AI agent conversation messages, leaving the instruction the agent was asked to act on.
+</role>
 
-The text contains scaffolding blocks wrapped in XML tags mixed with the actual user request.
+<background>
+Agent harnesses wrap each turn's real instruction with boilerplate — system reminders, tool lists, environment banners, skill manifests, date stamps, compaction notices. That boilerplate is usually enclosed in XML/XML-like tags (e.g. <system-reminder>, <context>, <env>, <user-prompt-submit-hook>, or custom harness tags). Your job is to produce a regex that removes the wrapper and keeps everything else.
 
-YOUR TASK: find where the user's actual request is and write a regex that captures ONLY that text.
+The instruction being wrapped can come from anywhere: a human typing, a bot comment, a parent agent dispatching work to a subagent, a ticket body forwarded into the loop. Source does not matter — if it is NOT the wrapper, it is the instruction. Extract it.
+</background>
 
-There are two common patterns — pick the one that matches:
+<core_principle>
+- HARNESS WRAPPER tags present in the input = strong signal of scaffolding. Anchor your regex on those tags.
+- No such tags / no reliable anchor = pass the text through as-is. Do NOT try to semantically judge whether content is "real user input" vs "instructions to the model" — you cannot tell from content alone, and guessing wrong hides real requests.
+- DEFAULT IS PASSTHROUGH. You must have POSITIVE evidence (a real harness wrapper tag in the scaffolding region) before choosing any other pattern. When in any doubt, output (?s)(.*).
+</core_principle>
 
-PATTERN A – The user request is INSIDE a dedicated tag (e.g. <user_request>, <user_message>, <query>).
-Use this when you see a tag whose content is clearly the user's own words, surrounded by system/scaffolding tags.
-Template: (?s)<tag>\\s*(.*?)\\s*</tag>
-Examples:
-- (?s)<user_request>\\s*(.*?)\\s*</user_request>
-- (?s)<query>\\s*(.*?)\\s*</query>
+<decision_procedure>
+Follow these steps IN ORDER. Do NOT skip ahead.
 
-PATTERN B – The user request is AFTER all scaffolding tags (the plain text at the end).
-Use this when scaffolding tags wrap system context and the user request follows the last closing tag.
-Template: (?s).*</tag>\\s*(.*)
-Examples:
-- (?s).*</system-reminder>\\s*(.*)
-- (?s).*</context>\\s*(.*)
+Step 1 — Locate candidate anchor tags.
+  List every XML/HTML-like tag that appears in the input.
 
-RULES:
-- Exactly one capture group that gets the user's actual request.
+Step 2 — For each candidate, classify it as HARNESS WRAPPER or CONTENT.
+  - A tag is HARNESS WRAPPER only if ALL of these hold:
+    a) Its name matches (or is clearly of the same family as) the harness-wrapper list (system-reminder, system_reminder, context, env, environment, tool, tools, tool_list, instructions, user-prompt-submit-hook, compaction, skill, skills, reminder, metadata, session, and similar agent-framework names).
+    b) It wraps a structured system-injected block (banners, tool manifests, date stamps, permission notices) — not a paragraph of prose.
+    c) If signposts are present, it appears inside the SCAFFOLDING PARTS section.
+  - Otherwise the tag is CONTENT (this includes all HTML rendering tags: h1, h2, h3, h4, h5, h6, p, br, hr, a, div, span, strong, em, b, i, u, code, pre, blockquote, sub, sup, details, summary, table, thead, tbody, tr, td, th, img, ul, ol, li, dl, dt, dd, figure, figcaption, and any tag found inside a bot comment / PR review / issue body / markdown body).
+  - Discard every CONTENT tag. You are NOT allowed to anchor on them, regardless of position.
+
+Step 3 — If zero HARNESS WRAPPER tags survive Step 2 → output (?s)(.*). Stop. Do NOT look for other anchors. Do NOT fall back to Pattern D on an <h3> or similar content tag.
+
+Step 4 — With the surviving harness wrapper tag(s), pick the pattern:
+  - Scaffolding at top/middle, instruction trails it → Pattern B.
+  - Scaffolding at the bottom, instruction leads it → Pattern D.
+  - Instruction fully inside a dedicated request-like wrapper → Pattern A.
+  - Entire input is balanced wrapper tags with no payload outside → Pattern C.
+
+Step 5 — Sanity check: mentally run your regex against the input and confirm the capture contains the actual instruction text. If the capture drops meaningful content (e.g. everything after an <h3> that is clearly the body of a PR comment) → you picked the wrong anchor. Go back to Step 2 and re-check whether your "anchor" is actually a content tag in disguise.
+</decision_procedure>
+
+<failure_modes description="concrete wrong answers we have seen; do not repeat them">
+- Anchoring on <h3>Greptile Summary</h3> (or any other HTML heading) inside a PR-bot comment. <h3> is a CONTENT tag. Do NOT use it. The correct move is either Pattern B on </system-reminder> (a real harness wrapper), or PASSTHROUGH if no wrapper tag fits all samples.
+- Anchoring on <details>, <table>, <p>, <div>, <a>, <img>, etc. inside the body of a comment. These are always content.
+- Picking Pattern D just because a tag happens to appear — Pattern D is only valid when the tag is a HARNESS WRAPPER in the SCAFFOLDING section. If the tag lives in the USER REQUEST section, choose PASSTHROUGH instead.
+</failure_modes>
+
+<wrapper_vs_content>
+Not every XML/HTML tag in the input is scaffolding. You must distinguish HARNESS WRAPPER tags from CONTENT tags. Anchor ONLY on harness wrapper tags.
+
+<harness_wrapper_tags description="tags that enclose system-injected context; these ARE scaffolding">
+- Sit at the top or bottom of the message (not embedded mid-paragraph inside a user's prose).
+- Wrap a structured, self-contained block injected by the agent framework.
+- Have semantic names like: system-reminder, system_reminder, context, env, environment, tool, tools, tool_list, instructions, user-prompt-submit-hook, compaction, skill, skills, reminder, metadata, session.
+- Often contain banners, tool/skill manifests, date stamps, permission notices.
+- Anchor on these.
+</harness_wrapper_tags>
+
+<content_tags description="HTML/markdown rendering tags that are PART OF the payload; these are NOT scaffolding">
+- NEVER anchor on these, even if they appear in the input.
+- Typical content tags: h1, h2, h3, h4, h5, h6, p, br, hr, a, div, span, strong, em, b, i, u, code, pre, blockquote, sub, sup, details, summary, table, thead, tbody, tr, td, th, img, ul, ol, li, dl, dt, dd, figure, figcaption.
+- A bot comment, PR review, issue body, or ticket description frequently contains these. They are the instruction, not the wrapper.
+- If the ONLY candidate anchor you can find is one of these tags → fall back to PASSTHROUGH.
+</content_tags>
+
+<signposts description="explicit section markers that tell you which part is scaffolding">
+The input may be pre-sectioned with literal markers that disambiguate scaffolding from payload:
+- "== SCAFFOLDING PARTS ==" (and optionally "[Part N — scaffolding]" subheaders) marks system-injected context.
+- "== USER REQUEST ==" (and optionally "[Part N]" subheaders) marks the instruction to capture.
+
+When these markers are present:
+- Your regex MUST anchor on a tag that appears inside the SCAFFOLDING PARTS section.
+- Do NOT anchor on a tag that appears only inside the USER REQUEST section — that tag is part of the payload.
+- If the SCAFFOLDING PARTS section is empty or has no common closing tag → use PASSTHROUGH.
+- The section headers themselves are stripped before the regex runs, so do NOT reference "== ... ==" in your regex.
+</signposts>
+</wrapper_vs_content>
+
+<patterns>
+  <pattern id="A" name="Inside a request-like tag">
+    The instruction sits INSIDE a dedicated tag (e.g. <user_request>, <query>, <task>) that literally appears in every sample.
+    <template>(?s)<tag>\\s*(.*?)\\s*</tag></template>
+  </pattern>
+
+  <pattern id="B" name="After leading scaffolding">
+    Scaffolding tags appear at the top/middle; the instruction is the plain text AFTER the LAST scaffolding closing tag. Use when the same closing tag literally ends the scaffolding in every sample.
+    <template>(?s).*</tag>\\s*(.*)</template>
+    <critical>
+      The leading ".*" is MANDATORY. It forces the engine — which is greedy — to skip past EVERY earlier occurrence of "</tag>" and anchor on the LAST one. Without the leading ".*", the match starts at the FIRST "</tag>" and the capture group will include all subsequent scaffolding blocks.
+    </critical>
+    <examples>
+      <correct>(?s).*</system-reminder>\\s*(.*)</correct>
+      <wrong reason="missing leading .* — anchors on FIRST </system-reminder>, so capture includes the other blocks">(?s)</system-reminder>\\s*(.*)</wrong>
+    </examples>
+  </pattern>
+
+  <pattern id="D" name="Before trailing scaffolding">
+    The instruction comes BEFORE the scaffolding (trailing <system-reminder>-style blocks). Use ONLY when the opening tag is a HARNESS WRAPPER (see decision_procedure Step 2) that literally starts each trailing scaffolding block in every sample. Never use Pattern D with a CONTENT tag like <h3>, <p>, <details>, etc.
+    <template>(?s)^(.*?)<tag></template>
+    <critical>
+      The "^" anchor and the LAZY "(.*?)" are both MANDATORY. "^" pins the match to the start of input; "(.*?)" stops at the FIRST "<tag>" occurrence rather than the last. A greedy "(.*)" would swallow everything up to the final "<tag>" — which is the opposite of what you want here.
+    </critical>
+    <examples>
+      <correct>(?s)^(.*?)<system-reminder></correct>
+      <wrong reason="greedy (.*) captures through the last opening tag, losing most of the instruction">(?s)^(.*)<system-reminder></wrong>
+    </examples>
+  </pattern>
+
+  <pattern id="PASSTHROUGH" name="No reliable anchor">
+    No wrapper tags at all, or no tag you can rely on across samples.
+    <output>(?s)(.*)</output>
+    <note>Correct default when in doubt. Passing too much is better than hiding a real request.</note>
+  </pattern>
+
+  <pattern id="C" name="Pure wrapper (rare)">
+    Every sample is 100% balanced scaffolding tags (e.g. one or more <system-reminder>…</system-reminder> blocks) with nothing but whitespace outside them AND no meaningful content inside a request-like tag.
+    <output>(?s)()</output>
+    <note>If there is ANY non-trivial text outside the tags, use B or D instead. If unsure between C and anything else, never pick C.</note>
+  </pattern>
+</patterns>
+
+<tag_rules>
+- Every tag name in your regex MUST appear VERBATIM in the input samples.
+- The tag MUST be a HARNESS WRAPPER tag (see <wrapper_vs_content>). Never anchor on a CONTENT tag like h1/h2/h3/p/a/div/sub/details/table/etc.
+- If the input has "== SCAFFOLDING PARTS ==" / "== USER REQUEST ==" signposts, the tag MUST appear inside the SCAFFOLDING PARTS section. If a tag appears only inside the USER REQUEST section, it is part of the payload — do NOT anchor on it.
+- Do NOT invent tag names. Do NOT copy tag names from these instructions (<user_request>, <query>, <system-reminder>, <context>, <tag>, <env>, <task>) unless they literally exist in the input.
+- Before finalizing, re-check: (a) is this tag actually in the samples? (b) is it a harness wrapper, not a content tag? (c) if signposts exist, does it appear in the scaffolding section?
+</tag_rules>
+
+<general_rules>
+- Exactly one capture group.
 - re2 only: no lookaheads, lookbehinds, backreferences.
-- Always prefix with (?s) so . matches newlines.
-- If there is no scaffolding (no XML tag blocks), return: (?s)(.*)
-- Return ONLY the regex, nothing else.`;
+- Always prefix the pattern with (?s) so "." matches newlines.
+- The regex MUST match every sample. When samples differ in scaffolding tags, prefer a tag common to all samples, else fall back to PASSTHROUGH.
+- Do NOT classify content as "agent-harness instruction" vs "user request" based on tone or imperative language. A message like "Address this PR comment: …" or "Your task is to fix X" IS an instruction to extract — not scaffolding to hide.
+</general_rules>
+
+<greediness_rules>
+When the anchor tag can appear MULTIPLE TIMES in the input (very common — scaffolding blocks usually repeat), the regex must be written so it anchors on the right occurrence:
+- To anchor on the LAST occurrence of a closing tag (Pattern B), prefix with a GREEDY ".*" — e.g. "(?s).*</tag>\\s*(.*)". The leading ".*" consumes everything up to and including the last match.
+- To anchor on the FIRST occurrence of an opening tag (Pattern D), use "^" plus a LAZY "(.*?)" — e.g. "(?s)^(.*?)<tag>". The lazy quantifier stops at the first match.
+- Before returning your regex, mentally trace it against a sample where the anchor tag appears AT LEAST TWICE. Confirm the capture does NOT include any scaffolding block.
+- Failing this check is the #1 source of bad regexes for this task.
+</greediness_rules>
+
+<output_format>
+Your entire response MUST be the regex pattern and nothing else.
+
+HARD RULES:
+- No prose, no reasoning, no "Step 1", no chain of thought, no explanations.
+- No code fences, no backticks, no quotes.
+- No leading/trailing blank lines or labels.
+- Do the decision_procedure SILENTLY in your head. Reveal only the final regex.
+- The response must start with "(?s)" and end with the last character of the regex.
+- If you are about to write any non-regex character as the first token, stop and output only the regex.
+
+Examples of correct full responses (entire message body shown between the quotes):
+"(?s)(.*)"
+"(?s).*</system-reminder>\\s*(.*)"
+"(?s)^(.*?)<system-reminder>"
+
+Examples of INCORRECT responses (do NOT do this):
+"Step 1 — ...\\n\\n(?s)(.*)"
+"The regex is: (?s)(.*)"
+"\`\`\`(?s)(.*)\`\`\`"
+</output_format>`;
+
+const RegexResultSchema = z.object({
+  regex: z
+    .string()
+    .nullable()
+    .describe("A re2 regex pattern starting with (?s) with exactly one capture group, or null if none applies."),
+});
 
 export async function generateExtractionRegex(userMessage: string): Promise<string | null> {
   try {
-    const { text } = await generateText({
+    const { object } = await generateObject({
       model: getLanguageModel("lite"),
       system: SYSTEM_PROMPT,
       prompt: userMessage,
+      schema: RegexResultSchema,
       maxRetries: 0,
       temperature: 0,
       abortSignal: AbortSignal.timeout(5000),
@@ -47,18 +194,15 @@ export async function generateExtractionRegex(userMessage: string): Promise<stri
       },
     });
 
-    const pattern = text
-      .trim()
-      .replace(/^[`"']+|[`"']+$/g, "")
-      .trim();
-
-    return pattern || null;
+    return object.regex?.trim() || null;
   } catch {
     return null;
   }
 }
 
-export function applyRegex(pattern: string, text: string): string | null {
+export type ApplyRegexResult = { kind: "extracted"; text: string } | { kind: "no-user-request" } | { kind: "no-match" };
+
+export function applyRegex(pattern: string, text: string): ApplyRegexResult {
   try {
     let flags = "";
     let cleanPattern = pattern;
@@ -70,10 +214,11 @@ export function applyRegex(pattern: string, text: string): string | null {
     const match = regex.exec(text);
     if (match && match[1] != null) {
       const extracted = match[1].trim();
-      if (extracted.length > 0) return extracted;
+      if (extracted.length > 0) return { kind: "extracted", text: extracted };
+      return { kind: "no-user-request" };
     }
   } catch {
     // Invalid regex pattern
   }
-  return null;
+  return { kind: "no-match" };
 }

--- a/frontend/lib/actions/sessions/trace-io.ts
+++ b/frontend/lib/actions/sessions/trace-io.ts
@@ -7,7 +7,7 @@ import { executeQuery } from "@/lib/actions/sql";
 import { type Span } from "@/lib/traces/types";
 import { fetcherJSON } from "@/lib/utils.ts";
 
-import { extractInputsForGroup, joinUserParts } from "./extract-input";
+import { extractInputsForGroup, fingerprintUserMessage, joinUserParts } from "./extract-input";
 import { type ParsedInput, parseExtractedMessages } from "./parse-input";
 
 const bodySchema = z.object({
@@ -105,7 +105,10 @@ export async function getMainAgentIOBatch({
   // endpoint and this function's reliance on parsed.systemText.
   await hydrateMissingPromptHashes(traceData, projectId);
 
-  const bySystemHash = new Map<string, TraceWithParsedInput[]>();
+  // Group by (systemHash, fingerprint). The fingerprint captures the top-level
+  // XML-tag structure of the joined user message so traces whose user messages
+  // share the same scaffolding
+  const byGroupKey = new Map<string, { hash: string; fingerprint: string; traces: TraceWithParsedInput[] }>();
   const noHashTraces: TraceWithParsedInput[] = [];
 
   for (const trace of traceData) {
@@ -113,9 +116,15 @@ export async function getMainAgentIOBatch({
       noHashTraces.push(trace);
       continue;
     }
-    const group = bySystemHash.get(trace.promptHash) ?? [];
-    group.push(trace);
-    bySystemHash.set(trace.promptHash, group);
+    const joined = joinUserParts(trace.parsed?.userParts ?? []);
+    const fingerprint = joined ? fingerprintUserMessage(joined) : "empty";
+    const groupKey = `${trace.promptHash}::${fingerprint}`;
+    const existing = byGroupKey.get(groupKey);
+    if (existing) {
+      existing.traces.push(trace);
+    } else {
+      byGroupKey.set(groupKey, { hash: trace.promptHash, fingerprint, traces: [trace] });
+    }
   }
 
   const results: Record<string, TraceIOResult> = {};
@@ -129,7 +138,9 @@ export async function getMainAgentIOBatch({
   }
 
   await Promise.all(
-    Array.from(bySystemHash.entries()).map(([hash, traces]) => extractInputsForGroup(hash, projectId, traces, results))
+    Array.from(byGroupKey.values()).map(({ hash, fingerprint, traces }) =>
+      extractInputsForGroup(hash, projectId, traces, results, fingerprint)
+    )
   );
 
   for (const traceId of traceIds) {
@@ -174,7 +185,9 @@ export async function getTraceUserInput(traceId: string, projectId: string): Pro
   if (!traceData.promptHash) return rawInput;
 
   const results: Record<string, TraceIOResult> = {};
-  await extractInputsForGroup(traceData.promptHash, projectId, [traceData], results);
+  const fingerprint = fingerprintUserMessage(rawInput);
+  console.log("fingerprint", fingerprint);
+  await extractInputsForGroup(traceData.promptHash, projectId, [traceData], results, fingerprint);
 
   return results[traceId]?.inputPreview ?? rawInput;
 }

--- a/frontend/lib/actions/sessions/trace-io.ts
+++ b/frontend/lib/actions/sessions/trace-io.ts
@@ -186,7 +186,6 @@ export async function getTraceUserInput(traceId: string, projectId: string): Pro
 
   const results: Record<string, TraceIOResult> = {};
   const fingerprint = fingerprintUserMessage(rawInput);
-  console.log("fingerprint", fingerprint);
   await extractInputsForGroup(traceData.promptHash, projectId, [traceData], results, fingerprint);
 
   return results[traceId]?.inputPreview ?? rawInput;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes span selection behavior in trace drawers and updates the LLM-driven input-extraction + regex caching strategy, which could affect what input previews users see if the new grouping/fingerprint or regex application misbehaves.
> 
> **Overview**
> Updates the trace transcript UI to **reflect span `status`** (plumbed through lightweight transcript spans and into `SpanTypeIcon`) and to **auto-scroll the transcript list to the currently selected span**.
> 
> Adjusts trace-view selection behavior so the first span is only auto-selected in *always-select* (dedicated page) mode, avoiding implicit selection in drawer layouts.
> 
> Improves main-agent input extraction by **fingerprinting user-message tag structure** and using it in the regex cache key/grouping, switching regex generation to **structured JSON output** (`generateObject` + schema) and making regex application distinguish between *no match* vs *empty extracted content*; also normalizes multi-part system prompts to join with spaces instead of newlines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d1095e565d6afc3f5482dd155f75ff49d5c1fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->