### PR TITLE
feat: shared trace -> full screen trace if authenticated

### DIFF
--- a/frontend/app/shared/traces/[traceId]/page.tsx
+++ b/frontend/app/shared/traces/[traceId]/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
 import { cache } from "react";
 
 import PageViewTracker from "@/components/common/page-view-tracker";
 import TraceView from "@/components/shared/traces/trace-view";
 import { getSharedSpans } from "@/lib/actions/shared/spans";
-import { getSharedTrace } from "@/lib/actions/shared/trace";
+import { getSharedTrace, getSharedTraceRecord } from "@/lib/actions/shared/trace";
+import { authOptions } from "@/lib/auth";
+import { isUserMemberOfProject } from "@/lib/authorization";
 
 const getCachedSharedTrace = cache((traceId: string) => getSharedTrace({ traceId }));
 
@@ -58,6 +61,19 @@ export default async function SharedTracePage(props: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const { traceId } = await props.params;
+
+  // If the viewer is a member of the project that owns this trace, send them
+  // to the authenticated viewer, which has the full feature set (session pill,
+  // chat, signals, etc.). Logged-out viewers and non-members keep seeing the
+  // public shared viewer. The PG lookup is cached per-request so getSharedTrace
+  // below doesn't re-query for the same record.
+  const sharedTrace = await getSharedTraceRecord(traceId);
+  if (sharedTrace) {
+    const session = await getServerSession(authOptions);
+    if (session?.user?.id && (await isUserMemberOfProject(sharedTrace.projectId, session.user.id))) {
+      redirect(`/project/${sharedTrace.projectId}/traces/${traceId}`);
+    }
+  }
 
   const trace = await getCachedSharedTrace(traceId);
 

--- a/frontend/components/shared/traces/trace-view.tsx
+++ b/frontend/components/shared/traces/trace-view.tsx
@@ -117,8 +117,8 @@ export const PureTraceView = ({ trace, spans, onClose }: TraceViewProps) => {
     <div className="flex flex-col h-full w-full overflow-hidden">
       {!onClose && (
         <div className="flex flex-none items-center border-b px-4 py-3.5 gap-2">
-          <Link className="mr-2" href="/projects">
-            <Image alt="Laminar logo" src={fullLogo} width={120} height={20} />
+          <Link className="mr-2" href="/">
+            <Image alt="Laminar logo" src={fullLogo} width={100} height={20} />
           </Link>
         </div>
       )}

--- a/frontend/lib/actions/shared/trace/index.ts
+++ b/frontend/lib/actions/shared/trace/index.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import { cache } from "react";
 import { z } from "zod/v4";
 
 import { type TraceViewTrace } from "@/components/traces/trace-view/store";
@@ -10,12 +11,17 @@ export const GetSharedTraceSchema = z.object({
   traceId: z.guid(),
 });
 
+// Per-request cache so callers doing the redirect check don't trigger a second
+// Postgres query when getSharedTrace runs for the same traceId in the same
+// request. React's `cache()` is scoped to a single render pass.
+export const getSharedTraceRecord = cache((traceId: string) =>
+  db.query.sharedTraces.findFirst({ where: eq(sharedTraces.id, traceId) })
+);
+
 export async function getSharedTrace(input: z.infer<typeof GetSharedTraceSchema>): Promise<TraceViewTrace | undefined> {
   const { traceId } = GetSharedTraceSchema.parse(input);
 
-  const sharedTrace = await db.query.sharedTraces.findFirst({
-    where: eq(sharedTraces.id, traceId),
-  });
+  const sharedTrace = await getSharedTraceRecord(traceId);
 
   if (!sharedTrace) {
     return undefined;


### PR DESCRIPTION
## Summary
- When a logged-in user lands on `/shared/traces/[traceId]`, check if they're a member of the owning project — if so, redirect to `/project/{projectId}/traces/{traceId}`.
- Logged-out viewers and non-members keep seeing the public shared viewer unchanged.
- Sidesteps the "shared viewer needs a session pill but can't have projectId" problem — authenticated members just get the full-featured viewer.

## Why
The authenticated trace viewer already has the session pill, chat, signals, metadata, user pill, etc. Redirecting members avoids duplicating those into the shared viewer, and avoids leaking `projectId` into public shared responses.

## How
Membership check uses the existing cached `isUserMemberOfProject` helper (30-day Redis TTL). The `sharedTraces` PG lookup is extracted into a `cache()`-wrapped helper (`getSharedTraceRecord`) so the redirect check and `getSharedTrace` share one query per request.

## Test plan
- [ ] Logged-out user on shared trace → sees public shared viewer (unchanged)
- [ ] Logged-in non-member on shared trace → sees public shared viewer (unchanged)
- [ ] Logged-in member on shared trace → redirects to `/project/{projectId}/traces/{traceId}`
- [ ] Trace with no `sharedTraces` row → falls through to existing `notFound()` path
- [ ] `generateMetadata` still renders OG cards for public links

## UX note
A user intentionally sharing a link to a colleague *in the same project* will now have that colleague land in the authenticated viewer instead of the public one — probably a feature (more tools), but flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds session-based membership checks and redirects on the public shared-trace route; mistakes could cause incorrect access routing or redirect loops, though it doesn’t broaden data exposure beyond existing auth checks.
> 
> **Overview**
> **Project members who open a public shared trace are now redirected to the authenticated trace viewer.** `app/shared/traces/[traceId]/page.tsx` looks up the shared-trace record, reads the NextAuth session, and if the user is a member of the owning project, `redirect()`s to `/project/{projectId}/traces/{traceId}`; logged-out users and non-members continue to see the public shared viewer.
> 
> To avoid duplicate DB reads, the shared-trace row fetch is extracted into a per-request cached helper `getSharedTraceRecord()` and `getSharedTrace()` is updated to reuse it. The shared trace UI header link/logo is also adjusted to point to `/` (with a slightly smaller logo).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c8d3a925f03e73381412499649a42b3ff978f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->