### PR TITLE
feat: visible scroll indicator

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -72,6 +72,8 @@
   --color-llm: hsl(var(--llm));
   --color-llm-foreground: hsl(var(--llm-foreground));
 
+  --color-subagent: hsl(var(--subagent));
+
   /*TODO: unify landing and platform colors*/
   --color-landing-primary-200: rgb(218 135 95);
   --color-landing-primary-300: rgb(213 126 87);
@@ -172,6 +174,7 @@
     --tool: 42 93% 46%;
     --llm: 262 83% 58%;
     --llm-foreground: 272 100% 74%;
+    --subagent: 187 94% 43%;
   }
 
   .dark {

--- a/frontend/components/traces/session-view/session-panel/list.tsx
+++ b/frontend/components/traces/session-view/session-panel/list.tsx
@@ -12,6 +12,10 @@ import {
   InputItem,
   SpanItem,
 } from "@/components/traces/trace-view/transcript/item";
+import {
+  filterToViewport,
+  useReportVisibleTimeRange,
+} from "@/components/traces/trace-view/use-report-visible-time-range";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
@@ -42,6 +46,7 @@ export default function SessionList() {
     toggleTraceExpanded,
     toggleTranscriptGroup,
     setSelectedSpan,
+    setScrollTimeRange,
   } = useSessionViewStore(
     (s) => ({
       projectId: s.projectId,
@@ -56,6 +61,7 @@ export default function SessionList() {
       toggleTraceExpanded: s.toggleTraceExpanded,
       toggleTranscriptGroup: s.toggleTranscriptGroup,
       setSelectedSpan: s.setSelectedSpan,
+      setScrollTimeRange: s.setScrollTimeRange,
     }),
     shallow
   );
@@ -181,6 +187,53 @@ export default function SessionList() {
   });
 
   const items = virtualizer.getVirtualItems();
+
+  // --- Visible time range for the timeline's scroll indicator ---
+  //
+  // Only rows that actually carry a meaningful time range contribute. Spacers
+  // (trace-collapsed-end / trace-expanded-end), user-input, and loading/error/
+  // empty rows are skipped — otherwise a 1-px sliver of an adjacent spacer
+  // would drag min/max to that neighbor trace's full extent.
+  const scrollOffset = virtualizer.scrollOffset ?? 0;
+  const viewportHeight = virtualizer.scrollRect?.height ?? 0;
+
+  const { visibleStartTime, visibleEndTime } = useMemo(() => {
+    const inViewport = filterToViewport(items, scrollOffset, viewportHeight);
+    let min = Infinity;
+    let max = -Infinity;
+    for (const item of inViewport) {
+      const row = flatRows[item.index];
+      if (!row) continue;
+      let startStr: string | undefined;
+      let endStr: string | undefined;
+      if (row.type === "span" || row.type === "group-span") {
+        startStr = row.span.startTime;
+        endStr = row.span.endTime;
+      } else if (row.type === "group-header") {
+        startStr = row.group.startTime;
+        endStr = row.group.endTime;
+      } else if (row.type === "trace-header") {
+        startStr = row.trace.startTime;
+        endStr = row.trace.endTime;
+      }
+      if (startStr && endStr) {
+        const s = new Date(startStr).getTime();
+        const e = new Date(endStr).getTime();
+        if (s < min) min = s;
+        if (e > max) max = e;
+      }
+    }
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      return { visibleStartTime: undefined, visibleEndTime: undefined };
+    }
+    return { visibleStartTime: min, visibleEndTime: max };
+  }, [items, flatRows, scrollOffset, viewportHeight]);
+
+  useReportVisibleTimeRange({
+    start: visibleStartTime,
+    end: visibleEndTime,
+    setTimeRange: setScrollTimeRange,
+  });
 
   // Declarative scroll-to-selected-span. When `selectedSpan` changes (e.g. via
   // the URL resolver in session-view-content), flat rows rebuild once the

--- a/frontend/components/traces/session-view/session-panel/list.tsx
+++ b/frontend/components/traces/session-view/session-panel/list.tsx
@@ -24,6 +24,9 @@ import { buildSessionFlatRows, formatGap } from "../utils";
 import TraceItem from "./trace-item.tsx";
 import { useSessionSpanPreviews } from "./use-session-span-previews.ts";
 
+/** Sticky trace-header height; used as scroll offset so headers land below it. */
+const STICKY_HEADER_HEIGHT = 36;
+
 /**
  * Virtualized body of the session panel. Reads everything it needs directly
  * from the session-view store — no props. Owns:
@@ -47,6 +50,8 @@ export default function SessionList() {
     toggleTranscriptGroup,
     setSelectedSpan,
     setScrollTimeRange,
+    scrollToGroup,
+    consumeScrollToGroup,
   } = useSessionViewStore(
     (s) => ({
       projectId: s.projectId,
@@ -62,6 +67,8 @@ export default function SessionList() {
       toggleTranscriptGroup: s.toggleTranscriptGroup,
       setSelectedSpan: s.setSelectedSpan,
       setScrollTimeRange: s.setScrollTimeRange,
+      scrollToGroup: s.scrollToGroup,
+      consumeScrollToGroup: s.consumeScrollToGroup,
     }),
     shallow
   );
@@ -261,6 +268,38 @@ export default function SessionList() {
     });
     return () => cancelAnimationFrame(rafId);
   }, [selectedSpan, flatRows, virtualizer]);
+
+  // Scroll the matching group-header row into view in response to a click on
+  // a subagent block in the session timeline. The scroll lands 36px below the
+  // top to clear the sticky trace-header.
+  //
+  // Two passes are needed: `getOffsetForIndex` returns estimates for unmeasured
+  // rows (estimateSize=70 vs real heights), so the first scroll lands close
+  // enough to force measurement, and the second scroll uses the now-accurate
+  // offset.
+  useEffect(() => {
+    if (!scrollToGroup) return;
+    const idx = flatRows.findIndex(
+      (r) =>
+        r.type === "group-header" && r.traceId === scrollToGroup.traceId && r.group.groupId === scrollToGroup.groupId
+    );
+    if (idx === -1) {
+      consumeScrollToGroup();
+      return;
+    }
+
+    const scrollWithOffset = () => {
+      const offset = virtualizer.getOffsetForIndex(idx, "start")?.[0];
+      if (offset !== undefined) virtualizer.scrollToOffset(Math.max(0, offset - STICKY_HEADER_HEIGHT));
+    };
+
+    scrollWithOffset();
+    const rafId = requestAnimationFrame(() => {
+      scrollWithOffset();
+      consumeScrollToGroup();
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [scrollToGroup, flatRows, virtualizer, consumeScrollToGroup]);
 
   // --- Preview fetching (batched across traces) ---
   //

--- a/frontend/components/traces/session-view/session-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-timeline/index.tsx
@@ -170,7 +170,7 @@ function SessionTimeline() {
         onMouseLeave={handleMouseLeaveTimeline}
       >
         <div
-          className="flex h-full"
+          className="flex h-full px-4"
           style={{
             // At zoom=1 the segments fill the visible area; gaps add fixed extra width.
             width: `calc(${100 * zoom}% + ${totalGapWidth * (zoom > 1 ? 1 : 0)}px)`,
@@ -182,7 +182,7 @@ function SessionTimeline() {
             section.type === "segment" ? (
               <div
                 key={`seg-${i}`}
-                className="min-w-0 px-2 overflow-y-clip"
+                className="min-w-0 overflow-y-clip"
                 style={{
                   // flex-grow proportional to duration; segments split the
                   // available space after gaps are subtracted.
@@ -201,7 +201,12 @@ function SessionTimeline() {
                 />
               </div>
             ) : (
-              <SessionTimelineGap key={`gap-${i}`} durationMs={section.gap.durationMs} />
+              <SessionTimelineGap
+                key={`gap-${i}`}
+                durationMs={section.gap.durationMs}
+                startMs={section.gap.startMs}
+                endMs={section.gap.endMs}
+              />
             )
           )}
         </div>

--- a/frontend/components/traces/session-view/session-timeline/session-timeline-gap.tsx
+++ b/frontend/components/traces/session-view/session-timeline/session-timeline-gap.tsx
@@ -1,20 +1,34 @@
 import { memo } from "react";
 
+import { cn } from "@/lib/utils";
+
+import { useSessionViewStore } from "../store";
 import { formatGapDuration, GAP_WIDTH_PX } from "./utils";
 
 interface SessionTimelineGapProps {
   durationMs: number;
+  startMs: number;
+  endMs: number;
 }
 
-function SessionTimelineGap({ durationMs }: SessionTimelineGapProps) {
+function SessionTimelineGap({ durationMs, startMs, endMs }: SessionTimelineGapProps) {
+  // Highlight when the session-panel's visible scroll range spans across this
+  // gap — i.e. the user is looking at rows on both sides of it.
+  const isInRange = useSessionViewStore((s) => {
+    if (s.scrollStartTime === undefined || s.scrollEndTime === undefined) return false;
+    return s.scrollStartTime <= startMs && s.scrollEndTime >= endMs;
+  });
+
   return (
     <div
-      className="flex-shrink-0 bg-muted/30 h-full border-x sticky top-0 grid place-items-center"
+      className={cn("flex-shrink-0 h-full sticky top-0 px-2", isInRange && "bg-muted/75")}
       style={{ width: GAP_WIDTH_PX }}
     >
-      <span className="text-[10px] text-muted-foreground select-none max-w-[20px] text-center">
-        {formatGapDuration(durationMs)}
-      </span>
+      <div className="h-full border-x grid place-items-center">
+        <span className="text-[10px] text-muted-foreground select-none max-w-[20px] text-center">
+          {formatGapDuration(durationMs)}
+        </span>
+      </div>
     </div>
   );
 }

--- a/frontend/components/traces/session-view/session-timeline/session-timeline-segment.tsx
+++ b/frontend/components/traces/session-view/session-timeline/session-timeline-segment.tsx
@@ -6,7 +6,7 @@ import React, { memo, useCallback, useMemo } from "react";
 import { useDynamicTimeIntervals } from "@/components/traces/trace-view/condensed-timeline/use-dynamic-time-intervals";
 import { cn } from "@/lib/utils";
 
-import { type SessionViewSelectedSpan } from "../store";
+import { type SessionViewSelectedSpan, useSessionViewStore } from "../store";
 import SessionTimelineSpanContainerElement from "./session-timeline-span-container";
 import SessionTimelineTraceBarElement from "./session-timeline-trace-bar";
 import { type SessionTimelineSegmentData } from "./utils";
@@ -62,6 +62,28 @@ function SessionTimelineSegment({
 
   const segmentOffsetMs = segment.startTimeMs - sessionStartMs;
 
+  // Scroll indicator — the session panel writes the absolute-ms (start, end)
+  // time range covered by rows in its viewport. This range can span a session
+  // gap when the user is looking at two traces in different clusters, so we
+  // compute the *intersection* with this segment's own time domain rather
+  // than clamping a scrollEnd−scrollStart width. A segment that is wholly
+  // enclosed by the range (neither endpoint inside) is treated as an
+  // intermediate segment the user isn't looking at — render nothing.
+  const scrollStartTime = useSessionViewStore((s) => s.scrollStartTime);
+  const scrollEndTime = useSessionViewStore((s) => s.scrollEndTime);
+  const scrollIndicator = useMemo(() => {
+    if (scrollStartTime === undefined || scrollEndTime === undefined || segment.widthMs <= 0) return null;
+    const startInside = scrollStartTime >= segment.startTimeMs && scrollStartTime < segment.endTimeMs;
+    const endInside = scrollEndTime > segment.startTimeMs && scrollEndTime <= segment.endTimeMs;
+    if (!startInside && !endInside) return null;
+    const intersectStart = Math.max(scrollStartTime, segment.startTimeMs);
+    const intersectEnd = Math.min(scrollEndTime, segment.endTimeMs);
+    if (intersectEnd <= intersectStart) return null;
+    const left = ((intersectStart - segment.startTimeMs) / segment.widthMs) * 100;
+    const right = ((intersectEnd - segment.startTimeMs) / segment.widthMs) * 100;
+    return { left, width: right - left };
+  }, [scrollStartTime, scrollEndTime, segment.startTimeMs, segment.endTimeMs, segment.widthMs]);
+
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const rect = e.currentTarget.getBoundingClientRect();
@@ -93,6 +115,14 @@ function SessionTimelineSegment({
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
+      {/* Scroll indicator — clamped to this segment's time domain */}
+      {scrollIndicator && (
+        <div
+          className="absolute bottom-[-60px] top-0 bg-muted/75 pointer-events-none"
+          style={{ left: `${scrollIndicator.left}%`, width: `${scrollIndicator.width}%` }}
+        />
+      )}
+
       {/* Time marker lines */}
       {timeMarkers.map((marker, i) => (
         <div

--- a/frontend/components/traces/session-view/session-timeline/session-timeline-span-container.tsx
+++ b/frontend/components/traces/session-view/session-timeline/session-timeline-span-container.tsx
@@ -31,10 +31,10 @@ const SessionTimelineSpanContainerElement = ({
   onClick,
   onSpanClick,
 }: SessionTimelineSpanContainerElementProps) => {
-  const { transcriptExpandedGroups, toggleTranscriptGroup } = useSessionViewStore(
+  const { transcriptExpandedGroups, requestScrollToGroup } = useSessionViewStore(
     (s) => ({
       transcriptExpandedGroups: s.transcriptExpandedGroups,
-      toggleTranscriptGroup: s.toggleTranscriptGroup,
+      requestScrollToGroup: s.requestScrollToGroup,
     }),
     shallow
   );
@@ -67,10 +67,11 @@ const SessionTimelineSpanContainerElement = ({
         />
       ))}
 
-      {/* Subagent group wrappers — collapsed = solid cyan over the group's
-          spans; expanded = cyan outline, pointer-events-none so span bars
-          underneath stay interactive. Sync'd with the transcript via the
-          session store's namespaced transcriptExpandedGroups. */}
+      {/* Subagent group wrappers — collapsed = solid cyan, click scrolls the
+          panel list to the group header. Expanded = outline only,
+          pointer-events-none so span bars underneath stay interactive.
+          Collapsed/expanded state is sync'd with the panel transcript via
+          the session store's namespaced transcriptExpandedGroups. */}
       {container.groupBoxes.map((box) => {
         const collapsed = !transcriptExpandedGroups.has(`${container.traceId}::${box.groupId}`);
         return (
@@ -90,7 +91,7 @@ const SessionTimelineSpanContainerElement = ({
               collapsed
                 ? (e) => {
                     e.stopPropagation();
-                    toggleTranscriptGroup(container.traceId, box.groupId);
+                    requestScrollToGroup(container.traceId, box.groupId);
                   }
                 : undefined
             }

--- a/frontend/components/traces/session-view/session-timeline/session-timeline-span-container.tsx
+++ b/frontend/components/traces/session-view/session-timeline/session-timeline-span-container.tsx
@@ -1,6 +1,9 @@
 import React, { memo } from "react";
+import { shallow } from "zustand/shallow";
 
-import { type SessionViewSelectedSpan } from "../store";
+import { cn } from "@/lib/utils";
+
+import { type SessionViewSelectedSpan, useSessionViewStore } from "../store";
 import SessionTimelineSpanBarElement from "./session-timeline-span-bar";
 import { ROW_HEIGHT } from "./session-timeline-trace-bar";
 import { type SessionTimelineSpanContainer } from "./utils";
@@ -28,6 +31,14 @@ const SessionTimelineSpanContainerElement = ({
   onClick,
   onSpanClick,
 }: SessionTimelineSpanContainerElementProps) => {
+  const { transcriptExpandedGroups, toggleTranscriptGroup } = useSessionViewStore(
+    (s) => ({
+      transcriptExpandedGroups: s.transcriptExpandedGroups,
+      toggleTranscriptGroup: s.toggleTranscriptGroup,
+    }),
+    shallow
+  );
+
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     onClick(container.traceId);
@@ -55,6 +66,37 @@ const SessionTimelineSpanContainerElement = ({
           onClick={onSpanClick}
         />
       ))}
+
+      {/* Subagent group wrappers — collapsed = solid cyan over the group's
+          spans; expanded = cyan outline, pointer-events-none so span bars
+          underneath stay interactive. Sync'd with the transcript via the
+          session store's namespaced transcriptExpandedGroups. */}
+      {container.groupBoxes.map((box) => {
+        const collapsed = !transcriptExpandedGroups.has(`${container.traceId}::${box.groupId}`);
+        return (
+          <div
+            key={box.groupId}
+            className={cn(
+              "absolute rounded-xs border border-subagent/70",
+              collapsed ? "bg-subagent/70 cursor-pointer hover:brightness-110 z-10" : "pointer-events-none"
+            )}
+            style={{
+              left: `${box.left}%`,
+              width: `max(${box.width}%, 4px)`,
+              top: box.topRow * ROW_HEIGHT + 1,
+              height: box.rowSpan * ROW_HEIGHT - 2,
+            }}
+            onClick={
+              collapsed
+                ? (e) => {
+                    e.stopPropagation();
+                    toggleTranscriptGroup(container.traceId, box.groupId);
+                  }
+                : undefined
+            }
+          />
+        );
+      })}
     </div>
   );
 };

--- a/frontend/components/traces/session-view/session-timeline/utils.ts
+++ b/frontend/components/traces/session-view/session-timeline/utils.ts
@@ -51,11 +51,19 @@ export interface SessionTimelineSegmentData {
   startTimeMs: number;
   endTimeMs: number;
   durationMs: number;
+  /** Denominator used when positioning elements as % — duration rounded up to
+   *  the next whole second (matches `upperIntervalMs` in the layout routine,
+   *  which mirrors the condensed-timeline convention in trace-view). */
+  widthMs: number;
   totalRows: number;
 }
 
 export interface SessionTimelineGapData {
   durationMs: number;
+  /** Absolute ms time at the end of the previous cluster (= gap start). */
+  startMs: number;
+  /** Absolute ms time at the start of the next cluster (= gap end). */
+  endMs: number;
 }
 
 export type SessionTimelineSection =
@@ -76,8 +84,10 @@ export interface SessionTimelineSections {
 /** Gaps larger than this are collapsed into a divider. */
 export const GAP_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
 
-/** Fixed pixel width for gap dividers. */
-export const GAP_WIDTH_PX = 48;
+/** Fixed pixel width for gap dividers INCLUDING the 8px gutters on each side.
+ *  The gap component owns the gutters so they participate in the
+ *  scroll-indicator highlight when the range straddles the gap. */
+export const GAP_WIDTH_PX = 64;
 
 /** Minimum block height (in rows) for both trace bars and empty/loading
  *  span containers. Matches the 2-row allocation used by the trace bar's
@@ -401,13 +411,17 @@ export function computeSessionTimelineSegments(
         startTimeMs: cluster.startMs,
         endTimeMs: cluster.endMs,
         durationMs,
+        widthMs: Math.max(Math.ceil(durationMs / 1000) * 1000, 1),
         totalRows,
       },
     });
 
     if (i < clusters.length - 1) {
       const gapMs = clusters[i + 1].startMs - cluster.endMs;
-      sections.push({ type: "gap", gap: { durationMs: gapMs } });
+      sections.push({
+        type: "gap",
+        gap: { durationMs: gapMs, startMs: cluster.endMs, endMs: clusters[i + 1].startMs },
+      });
     }
   }
 

--- a/frontend/components/traces/session-view/session-timeline/utils.ts
+++ b/frontend/components/traces/session-view/session-timeline/utils.ts
@@ -3,6 +3,7 @@
 // deduplication once the session timeline design stabilizes.
 
 import { type TraceViewSpan } from "@/components/traces/trace-view/store/base";
+import { computeSubagentGroups } from "@/components/traces/trace-view/store/utils";
 import { type TraceRow } from "@/lib/traces/types";
 import { SPAN_TYPE_TO_COLOR } from "@/lib/traces/utils";
 
@@ -32,6 +33,16 @@ export interface SessionTimelineContainerSpan {
   color: string;
 }
 
+/** Bounding box of a subagent group inside an expanded trace container.
+ *  Coordinates are CONTAINER-RELATIVE (same frame as spans). */
+export interface SessionTimelineSubagentGroupBox {
+  groupId: string;
+  left: number;
+  width: number;
+  topRow: number;
+  rowSpan: number;
+}
+
 /** Expanded trace rendered as a bordered container holding its spans.
  *  Replaces the trace bar entirely when expanded + spans are loaded. */
 export interface SessionTimelineSpanContainer {
@@ -42,6 +53,7 @@ export interface SessionTimelineSpanContainer {
   row: number; // starting row in segment
   rowHeight: number; // number of rows this container occupies (>= 2)
   spans: SessionTimelineContainerSpan[];
+  groupBoxes: SessionTimelineSubagentGroupBox[];
 }
 
 export type SessionTimelineElement = SessionTimelineTraceBar | SessionTimelineSpanContainer;
@@ -164,8 +176,8 @@ function clusterTraces(traces: TraceRow[]): TraceCluster[] {
 function packSpansInContainer(
   spans: TraceViewSpan[],
   trace: TraceRow
-): { spans: SessionTimelineContainerSpan[]; rowCount: number } {
-  if (spans.length === 0) return { spans: [], rowCount: 0 };
+): { spans: SessionTimelineContainerSpan[]; rowCount: number; groupBoxes: SessionTimelineSubagentGroupBox[] } {
+  if (spans.length === 0) return { spans: [], rowCount: 0, groupBoxes: [] };
 
   const traceStartMs = new Date(trace.startTime).getTime();
   const traceEndMs = new Date(trace.endTime).getTime();
@@ -235,7 +247,37 @@ function packSpansInContainer(
     result.push({ span, left, width, row: targetRow, color });
   }
 
-  return { spans: result, rowCount: rowOccupancy.length };
+  // Subagent group wrappers — bounding boxes derived from the packed span
+  // positions above, container-relative. Skips groups with no represented
+  // spans (should be rare — happens if subagent spans are all DEFAULT type
+  // and got filtered upstream).
+  const groups = computeSubagentGroups(spans);
+  const posById = new Map(result.map((r) => [r.span.spanId, r]));
+  const groupBoxes: SessionTimelineSubagentGroupBox[] = [];
+  for (const group of groups) {
+    let minLeft = Infinity;
+    let maxRight = -Infinity;
+    let minRow = Infinity;
+    let maxRow = -Infinity;
+    for (const spanId of group.spanIds) {
+      const pos = posById.get(spanId);
+      if (!pos) continue;
+      if (pos.left < minLeft) minLeft = pos.left;
+      if (pos.left + pos.width > maxRight) maxRight = pos.left + pos.width;
+      if (pos.row < minRow) minRow = pos.row;
+      if (pos.row > maxRow) maxRow = pos.row;
+    }
+    if (!Number.isFinite(minLeft) || !Number.isFinite(maxRight)) continue;
+    groupBoxes.push({
+      groupId: group.groupId,
+      left: minLeft,
+      width: maxRight - minLeft,
+      topRow: minRow,
+      rowSpan: maxRow - minRow + 1,
+    });
+  }
+
+  return { spans: result, rowCount: rowOccupancy.length, groupBoxes };
 }
 
 // ---------------------------------------------------------------------------
@@ -288,7 +330,12 @@ function computeSegmentLayout(
     // Rendered element for this block (without `row` yet — assigned below).
     render:
       | { type: "trace"; shimmer: boolean }
-      | { type: "span-container"; rowHeight: number; spans: SessionTimelineContainerSpan[] };
+      | {
+          type: "span-container";
+          rowHeight: number;
+          spans: SessionTimelineContainerSpan[];
+          groupBoxes: SessionTimelineSubagentGroupBox[];
+        };
   };
 
   const blocks: Block[] = traces
@@ -316,7 +363,7 @@ function computeSegmentLayout(
           left,
           width,
           height: rowHeight,
-          render: { type: "span-container", rowHeight, spans: packed.spans },
+          render: { type: "span-container", rowHeight, spans: packed.spans, groupBoxes: packed.groupBoxes },
         };
       }
 
@@ -361,6 +408,7 @@ function computeSegmentLayout(
         row,
         rowHeight: block.render.rowHeight,
         spans: block.render.spans,
+        groupBoxes: block.render.groupBoxes,
       });
     }
   }

--- a/frontend/components/traces/session-view/store.ts
+++ b/frontend/components/traces/session-view/store.ts
@@ -57,6 +57,9 @@ interface SessionViewState {
   /** Namespaced `${traceId}::${groupId}` set — EXPANDED transcript groups (default collapsed). */
   transcriptExpandedGroups: Set<string>;
 
+  /** One-shot scroll request: timeline click → panel list scrolls to group header. */
+  scrollToGroup: { traceId: string; groupId: string } | null;
+
   // Session timeline
   sessionTimelineEnabled: boolean;
   sessionTimelineZoom: number;
@@ -105,6 +108,8 @@ interface SessionViewActions {
   setTraceSpansError: (traceId: string, error?: string) => void;
 
   toggleTranscriptGroup: (traceId: string, groupId: string) => void;
+  requestScrollToGroup: (traceId: string, groupId: string) => void;
+  consumeScrollToGroup: () => void;
 
   setSessionTimelineEnabled: (enabled: boolean) => void;
   setSessionTimelineZoom: (zoom: number) => void;
@@ -195,6 +200,7 @@ const createSessionViewStore = (options?: { initialSession?: SessionSummary; sto
 
         expandedTraceIds: new Set<string>(),
         transcriptExpandedGroups: new Set<string>(),
+        scrollToGroup: null,
 
         sessionTimelineEnabled: false,
         sessionTimelineZoom: 1,
@@ -327,6 +333,11 @@ const createSessionViewStore = (options?: { initialSession?: SessionSummary; sto
           if (next.has(key)) next.delete(key);
           else next.add(key);
           set({ transcriptExpandedGroups: next });
+        },
+
+        requestScrollToGroup: (traceId, groupId) => set({ scrollToGroup: { traceId, groupId } }),
+        consumeScrollToGroup: () => {
+          if (get().scrollToGroup !== null) set({ scrollToGroup: null });
         },
 
         setSessionTimelineEnabled: (enabled) => set({ sessionTimelineEnabled: enabled }),

--- a/frontend/components/traces/session-view/store.ts
+++ b/frontend/components/traces/session-view/store.ts
@@ -61,6 +61,14 @@ interface SessionViewState {
   sessionTimelineEnabled: boolean;
   sessionTimelineZoom: number;
 
+  // Absolute-ms (start, end) covering the times of rows currently visible in
+  // the session panel virtualizer. Each timeline segment draws a scroll
+  // indicator only if at least one endpoint of the range is inside its own
+  // time domain — segments wholly enclosed by the range (intermediate
+  // segments the user isn't actually looking at) draw nothing.
+  scrollStartTime?: number;
+  scrollEndTime?: number;
+
   // Search state — non-null searchResults means a search is active.
   searchResults?: Record<string, SessionSpansTraceResult>;
   isSearchLoading: boolean;
@@ -100,6 +108,7 @@ interface SessionViewActions {
 
   setSessionTimelineEnabled: (enabled: boolean) => void;
   setSessionTimelineZoom: (zoom: number) => void;
+  setScrollTimeRange: (start?: number, end?: number) => void;
 
   searchSessionSpans: (filters: Filter[], search: string) => Promise<void>;
   clearSearch: () => void;
@@ -189,6 +198,9 @@ const createSessionViewStore = (options?: { initialSession?: SessionSummary; sto
 
         sessionTimelineEnabled: false,
         sessionTimelineZoom: 1,
+
+        scrollStartTime: undefined,
+        scrollEndTime: undefined,
 
         searchResults: undefined,
         isSearchLoading: false,
@@ -319,6 +331,7 @@ const createSessionViewStore = (options?: { initialSession?: SessionSummary; sto
 
         setSessionTimelineEnabled: (enabled) => set({ sessionTimelineEnabled: enabled }),
         setSessionTimelineZoom: (zoom) => set({ sessionTimelineZoom: Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom)) }),
+        setScrollTimeRange: (start, end) => set({ scrollStartTime: start, scrollEndTime: end }),
 
         setSelectedSpan: (selectedSpan) => {
           set({ selectedSpan, spanPanelOpen: !!selectedSpan });

--- a/frontend/components/traces/trace-view/condensed-timeline/index.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/index.tsx
@@ -61,6 +61,7 @@ function CondensedTimeline() {
     spans: condensedSpans,
     startTime: spanTimelineStartMs,
     totalDurationMs,
+    timelineWidthInMilliseconds,
     totalRows,
   } = useMemo(() => getCondensedTimelineData(), [getCondensedTimelineData, storeSpans]);
 
@@ -143,14 +144,14 @@ function CondensedTimeline() {
   const contentHeight = (totalRows + 1) * ROW_HEIGHT;
 
   const scrollIndicator = useMemo(() => {
-    if (scrollStartTime === undefined || scrollEndTime === undefined || totalDurationMs <= 0) return null;
-    const rawLeft = ((scrollStartTime - spanTimelineStartMs) / totalDurationMs) * 100;
-    const rawWidth = ((scrollEndTime - scrollStartTime) / totalDurationMs) * 100;
+    if (scrollStartTime === undefined || scrollEndTime === undefined || timelineWidthInMilliseconds <= 0) return null;
+    const rawLeft = ((scrollStartTime - spanTimelineStartMs) / timelineWidthInMilliseconds) * 100;
+    const rawWidth = ((scrollEndTime - scrollStartTime) / timelineWidthInMilliseconds) * 100;
     const left = Math.max(0, Math.min(100, rawLeft));
     const width = Math.max(0, Math.min(100 - left, rawWidth));
     if (width <= 0) return null;
     return { left, width };
-  }, [scrollStartTime, scrollEndTime, spanTimelineStartMs, totalDurationMs]);
+  }, [scrollStartTime, scrollEndTime, spanTimelineStartMs, timelineWidthInMilliseconds]);
 
   // Render loading and empty states inside the ref'd element to ensure hooks work correctly
   const renderContent = () => {

--- a/frontend/components/traces/trace-view/condensed-timeline/index.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/index.tsx
@@ -36,6 +36,8 @@ function CondensedTimeline() {
     sessionTime,
     sessionStartTime,
     browserSession,
+    scrollStartTime,
+    scrollEndTime,
   } = useTraceViewBaseStore((state) => ({
     getCondensedTimelineData: state.getCondensedTimelineData,
     spans: state.spans,
@@ -51,6 +53,8 @@ function CondensedTimeline() {
     sessionTime: state.sessionTime,
     sessionStartTime: state.sessionStartTime,
     browserSession: state.browserSession,
+    scrollStartTime: state.scrollStartTime,
+    scrollEndTime: state.scrollEndTime,
   }));
 
   const {
@@ -138,6 +142,16 @@ function CondensedTimeline() {
 
   const contentHeight = (totalRows + 1) * ROW_HEIGHT;
 
+  const scrollIndicator = useMemo(() => {
+    if (scrollStartTime === undefined || scrollEndTime === undefined || totalDurationMs <= 0) return null;
+    const rawLeft = ((scrollStartTime - spanTimelineStartMs) / totalDurationMs) * 100;
+    const rawWidth = ((scrollEndTime - scrollStartTime) / totalDurationMs) * 100;
+    const left = Math.max(0, Math.min(100, rawLeft));
+    const width = Math.max(0, Math.min(100 - left, rawWidth));
+    if (width <= 0) return null;
+    return { left, width };
+  }, [scrollStartTime, scrollEndTime, spanTimelineStartMs, totalDurationMs]);
+
   // Render loading and empty states inside the ref'd element to ensure hooks work correctly
   const renderContent = () => {
     if (isSpansLoading) {
@@ -184,6 +198,15 @@ function CondensedTimeline() {
               style={{ left: `${marker.positionPercent}%` }}
             />
           ))}
+
+          {/* Scroll indicator — highlights the time range covered by rows currently
+              visible in the transcript/tree virtualizer */}
+          {scrollIndicator && (
+            <div
+              className="absolute bottom-[-60px] top-0 bg-muted/75 pointer-events-none"
+              style={{ left: `${scrollIndicator.left}%`, width: `${scrollIndicator.width}%` }}
+            />
+          )}
 
           {/* Sticky header - scrolls horizontally with content, sticks vertically */}
           <div

--- a/frontend/components/traces/trace-view/condensed-timeline/index.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/index.tsx
@@ -12,6 +12,7 @@ import CondensedTimelineElement, { ROW_HEIGHT } from "./condensed-timeline-eleme
 import Controls from "./controls";
 import SelectionIndicator from "./selection-indicator";
 import SelectionOverlay from "./selection-overlay";
+import SubagentGroupElement from "./subagent-group-element";
 import { formatTimeMarkerLabel, useDynamicTimeIntervals } from "./use-dynamic-time-intervals";
 import { useHoverNeedle } from "./use-hover-needle";
 import { useScrollToSpan } from "./use-scroll-to-span";
@@ -23,6 +24,7 @@ function CondensedTimeline() {
 
   const {
     getCondensedTimelineData,
+    getCondensedSubagentGroups,
     spans: storeSpans,
     selectedSpan,
     setSelectedSpan,
@@ -38,8 +40,11 @@ function CondensedTimeline() {
     browserSession,
     scrollStartTime,
     scrollEndTime,
+    transcriptExpandedGroups,
+    toggleTranscriptGroup,
   } = useTraceViewBaseStore((state) => ({
     getCondensedTimelineData: state.getCondensedTimelineData,
+    getCondensedSubagentGroups: state.getCondensedSubagentGroups,
     spans: state.spans,
     selectedSpan: state.selectedSpan,
     setSelectedSpan: state.setSelectedSpan,
@@ -55,6 +60,8 @@ function CondensedTimeline() {
     browserSession: state.browserSession,
     scrollStartTime: state.scrollStartTime,
     scrollEndTime: state.scrollEndTime,
+    transcriptExpandedGroups: state.transcriptExpandedGroups,
+    toggleTranscriptGroup: state.toggleTranscriptGroup,
   }));
 
   const {
@@ -66,6 +73,49 @@ function CondensedTimeline() {
   } = useMemo(() => getCondensedTimelineData(), [getCondensedTimelineData, storeSpans]);
 
   const maxSpanCost = useMemo(() => selectMaxSpanCost(), [selectMaxSpanCost, storeSpans]);
+
+  // Subagent groups — reuses the transcript's grouping logic and collapsed state
+  // so toggling a group header in the transcript flips its wrapper in the
+  // timeline too. Bounding boxes come from the already-computed condensed
+  // layout (no separate position math).
+  const subagentGroups = useMemo(() => getCondensedSubagentGroups(), [getCondensedSubagentGroups, storeSpans]);
+
+  const groupBoxes = useMemo(() => {
+    if (subagentGroups.length === 0) return [];
+    const posById = new Map(condensedSpans.map((c) => [c.span.spanId, c]));
+    const boxes: Array<{
+      groupId: string;
+      left: number;
+      width: number;
+      topRow: number;
+      rowSpan: number;
+      collapsed: boolean;
+    }> = [];
+    for (const group of subagentGroups) {
+      let minLeft = Infinity;
+      let maxRight = -Infinity;
+      let minRow = Infinity;
+      let maxRow = -Infinity;
+      for (const spanId of group.spanIds) {
+        const pos = posById.get(spanId);
+        if (!pos) continue;
+        if (pos.left < minLeft) minLeft = pos.left;
+        if (pos.left + pos.width > maxRight) maxRight = pos.left + pos.width;
+        if (pos.row < minRow) minRow = pos.row;
+        if (pos.row > maxRow) maxRow = pos.row;
+      }
+      if (!Number.isFinite(minLeft) || !Number.isFinite(maxRight)) continue;
+      boxes.push({
+        groupId: group.groupId,
+        left: minLeft,
+        width: maxRight - minLeft,
+        topRow: minRow,
+        rowSpan: maxRow - minRow + 1,
+        collapsed: !transcriptExpandedGroups.has(group.groupId),
+      });
+    }
+    return boxes;
+  }, [subagentGroups, condensedSpans, transcriptExpandedGroups]);
 
   // Compute dynamic time markers based on container width and zoom
   const { markers: timeMarkers, setContainerRef } = useDynamicTimeIntervals({
@@ -249,6 +299,22 @@ function CondensedTimeline() {
                 />
               );
             })}
+
+            {/* Subagent group wrappers — collapsed = solid fill covering the group's
+                spans; expanded = cyan outline, pointer-events-none so spans underneath
+                stay interactive */}
+            {groupBoxes.map((box) => (
+              <SubagentGroupElement
+                key={box.groupId}
+                groupId={box.groupId}
+                left={box.left}
+                width={box.width}
+                topRow={box.topRow}
+                rowSpan={box.rowSpan}
+                collapsed={box.collapsed}
+                onToggle={toggleTranscriptGroup}
+              />
+            ))}
 
             {/* Selection overlay - only handles drag selection, clicks go to span elements */}
             <SelectionOverlay

--- a/frontend/components/traces/trace-view/condensed-timeline/index.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/index.tsx
@@ -41,7 +41,7 @@ function CondensedTimeline() {
     scrollStartTime,
     scrollEndTime,
     transcriptExpandedGroups,
-    toggleTranscriptGroup,
+    requestScrollToGroup,
   } = useTraceViewBaseStore((state) => ({
     getCondensedTimelineData: state.getCondensedTimelineData,
     getCondensedSubagentGroups: state.getCondensedSubagentGroups,
@@ -61,7 +61,7 @@ function CondensedTimeline() {
     scrollStartTime: state.scrollStartTime,
     scrollEndTime: state.scrollEndTime,
     transcriptExpandedGroups: state.transcriptExpandedGroups,
-    toggleTranscriptGroup: state.toggleTranscriptGroup,
+    requestScrollToGroup: state.requestScrollToGroup,
   }));
 
   const {
@@ -300,9 +300,9 @@ function CondensedTimeline() {
               );
             })}
 
-            {/* Subagent group wrappers — collapsed = solid fill covering the group's
-                spans; expanded = cyan outline, pointer-events-none so spans underneath
-                stay interactive */}
+            {/* Subagent group wrappers — collapsed = solid fill, click scrolls
+                the transcript to the group header. Expanded = outline only,
+                pointer-events-none so spans underneath stay interactive. */}
             {groupBoxes.map((box) => (
               <SubagentGroupElement
                 key={box.groupId}
@@ -312,7 +312,7 @@ function CondensedTimeline() {
                 topRow={box.topRow}
                 rowSpan={box.rowSpan}
                 collapsed={box.collapsed}
-                onToggle={toggleTranscriptGroup}
+                onRequestScroll={requestScrollToGroup}
               />
             ))}
 

--- a/frontend/components/traces/trace-view/condensed-timeline/subagent-group-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/subagent-group-element.tsx
@@ -11,7 +11,7 @@ interface SubagentGroupElementProps {
   topRow: number;
   rowSpan: number;
   collapsed: boolean;
-  onToggle: (groupId: string) => void;
+  onRequestScroll: (groupId: string) => void;
 }
 
 function SubagentGroupElement({
@@ -21,7 +21,7 @@ function SubagentGroupElement({
   topRow,
   rowSpan,
   collapsed,
-  onToggle,
+  onRequestScroll,
 }: SubagentGroupElementProps) {
   const top = topRow * ROW_HEIGHT + 1;
   const height = rowSpan * ROW_HEIGHT - 2;
@@ -31,8 +31,8 @@ function SubagentGroupElement({
       className={cn(
         "absolute rounded-xs border",
         collapsed
-          ? "bg-subagent/40 cursor-pointer hover:bg-subagent/50 z-10 border-subagent"
-          : "pointer-events-none outline outline-offset-1 outline-subagent/40 bg-subagent/10 border-none"
+          ? "bg-subagent/30 cursor-pointer hover:bg-subagent/40 z-10 border-subagent"
+          : "pointer-events-none outline outline-offset-1 outline-subagent/30 bg-subagent/10 border-none"
       )}
       style={{
         left: `${left}%`,
@@ -43,7 +43,7 @@ function SubagentGroupElement({
       onClick={(e) => {
         if (!collapsed) return;
         e.stopPropagation();
-        onToggle(groupId);
+        onRequestScroll(groupId);
       }}
     />
   );

--- a/frontend/components/traces/trace-view/condensed-timeline/subagent-group-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/subagent-group-element.tsx
@@ -1,0 +1,52 @@
+import React, { memo } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { ROW_HEIGHT } from "./condensed-timeline-element";
+
+interface SubagentGroupElementProps {
+  groupId: string;
+  left: number;
+  width: number;
+  topRow: number;
+  rowSpan: number;
+  collapsed: boolean;
+  onToggle: (groupId: string) => void;
+}
+
+function SubagentGroupElement({
+  groupId,
+  left,
+  width,
+  topRow,
+  rowSpan,
+  collapsed,
+  onToggle,
+}: SubagentGroupElementProps) {
+  const top = topRow * ROW_HEIGHT + 1;
+  const height = rowSpan * ROW_HEIGHT - 2;
+
+  return (
+    <div
+      className={cn(
+        "absolute rounded-xs border",
+        collapsed
+          ? "bg-subagent/40 cursor-pointer hover:bg-subagent/50 z-10 border-subagent"
+          : "pointer-events-none outline outline-offset-1 outline-subagent/40 bg-subagent/10 border-none"
+      )}
+      style={{
+        left: `${left}%`,
+        width: `max(${width}%, 4px)`,
+        top,
+        height,
+      }}
+      onClick={(e) => {
+        if (!collapsed) return;
+        e.stopPropagation();
+        onToggle(groupId);
+      }}
+    />
+  );
+}
+
+export default memo(SubagentGroupElement);

--- a/frontend/components/traces/trace-view/store/base.ts
+++ b/frontend/components/traces/trace-view/store/base.ts
@@ -199,6 +199,9 @@ export interface BaseTraceViewState {
 
   // Transcript mode: IDs of groups the user has expanded
   transcriptExpandedGroups: Set<string>;
+
+  /** One-shot scroll request: timeline click → transcript scrolls to group header. */
+  scrollToGroupId: string | null;
 }
 
 export interface BaseTraceViewActions {
@@ -245,6 +248,8 @@ export interface BaseTraceViewActions {
   consumePendingChatInjection: () => { signalDefinition: string; eventPayload: string } | null;
 
   toggleTranscriptGroup: (groupId: string) => void;
+  requestScrollToGroup: (groupId: string) => void;
+  consumeScrollToGroup: () => void;
 
   getTreeSpans: () => TreeSpan[];
   getCondensedTimelineData: () => CondensedTimelineData;
@@ -307,6 +312,7 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
 
     // Transcript mode: IDs of groups the user has expanded (all collapsed by default)
     transcriptExpandedGroups: new Set<string>(),
+    scrollToGroupId: null,
 
     setHasBrowserSession: (hasBrowserSession: boolean) => set({ hasBrowserSession } as Partial<T>),
     setTrace: (trace) => {
@@ -363,6 +369,11 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
         next.add(groupId);
       }
       set({ transcriptExpandedGroups: next } as Partial<T>);
+    },
+
+    requestScrollToGroup: (groupId: string) => set({ scrollToGroupId: groupId } as Partial<T>),
+    consumeScrollToGroup: () => {
+      if (get().scrollToGroupId !== null) set({ scrollToGroupId: null } as Partial<T>);
     },
 
     setSelectedSpan: (span) => set({ selectedSpan: span, spanPanelOpen: !!span } as Partial<T>),

--- a/frontend/components/traces/trace-view/store/base.ts
+++ b/frontend/components/traces/trace-view/store/base.ts
@@ -11,6 +11,8 @@ import { type SpanType } from "@/lib/traces/types";
 import {
   buildTranscriptListEntries,
   computePathInfoMap,
+  computeSubagentGroups,
+  type CondensedSubagentGroup,
   type CondensedTimelineData,
   transformSpansToCondensedTimeline,
   transformSpansToTree,
@@ -246,6 +248,7 @@ export interface BaseTraceViewActions {
 
   getTreeSpans: () => TreeSpan[];
   getCondensedTimelineData: () => CondensedTimelineData;
+  getCondensedSubagentGroups: () => CondensedSubagentGroup[];
   getTranscriptListData: () => TranscriptListEntry[];
   getHasLangGraph: () => boolean;
 }
@@ -349,6 +352,7 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
       const { spans, condensedTimelineVisibleSpanIds } = get();
       return buildTranscriptListEntries(spans, condensedTimelineVisibleSpanIds);
     },
+    getCondensedSubagentGroups: () => computeSubagentGroups(get().spans),
 
     toggleTranscriptGroup: (groupId: string) => {
       const prev = get().transcriptExpandedGroups;

--- a/frontend/components/traces/trace-view/store/base.ts
+++ b/frontend/components/traces/trace-view/store/base.ts
@@ -162,6 +162,12 @@ export interface BaseTraceViewState {
   condensedTimelineZoom: number;
   isCostHeatmapVisible: boolean;
 
+  // Absolute ms time range covered by rows currently visible in the active
+  // transcript/tree virtualizer. Drives the scroll indicator in the condensed
+  // timeline. Undefined when no view is reporting.
+  scrollStartTime?: number;
+  scrollEndTime?: number;
+
   // Panel visibility
   spanPanelOpen: boolean;
   tracesAgentOpen: boolean;
@@ -220,6 +226,7 @@ export interface BaseTraceViewActions {
   setCondensedTimelineZoom: (zoom: number) => void;
   setIsCostHeatmapVisible: (visible: boolean) => void;
   selectMaxSpanCost: () => number;
+  setScrollTimeRange: (start?: number, end?: number) => void;
 
   // Panel visibility actions
   setSpanPanelOpen: (open: boolean) => void;
@@ -275,6 +282,8 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
     condensedTimelineVisibleSpanIds: new Set(),
     condensedTimelineZoom: 1,
     isCostHeatmapVisible: false,
+    scrollStartTime: undefined,
+    scrollEndTime: undefined,
 
     // Panel visibility defaults
     spanPanelOpen: true,
@@ -399,6 +408,7 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
       set({ condensedTimelineZoom: clamp(zoom, MIN_ZOOM, MAX_ZOOM) } as Partial<T>);
     },
     setIsCostHeatmapVisible: (visible: boolean) => set({ isCostHeatmapVisible: visible } as Partial<T>),
+    setScrollTimeRange: (start, end) => set({ scrollStartTime: start, scrollEndTime: end } as Partial<T>),
     selectMaxSpanCost: () => {
       const spans = get().spans;
       let max = 0;

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -362,6 +362,68 @@ export const computeSubagentBoundaries = (spans: TraceViewSpan[]): Set<string> =
   return boundaryIds;
 };
 
+export interface CondensedSubagentGroup {
+  /** Matches transcriptExpandedGroups keys (`group-<boundarySpanId>`). */
+  groupId: string;
+  /** All span IDs belonging to this subagent group (any span type). */
+  spanIds: string[];
+}
+
+/**
+ * Groups every span under its nearest subagent boundary ancestor, returning
+ * `{groupId, spanIds}` per subagent. Shares `group-<boundary>` naming with
+ * `buildTranscriptListEntries` so the condensed timeline can sync its
+ * collapsed/expanded state with the transcript via `transcriptExpandedGroups`.
+ */
+export const computeSubagentGroups = (allSpans: TraceViewSpan[]): CondensedSubagentGroup[] => {
+  const groupBoundarySet = computeSubagentBoundaries(allSpans);
+  if (groupBoundarySet.size === 0) return [];
+
+  const parentMap = new Map<string, string | undefined>();
+  for (const s of allSpans) parentMap.set(s.spanId, s.parentSpanId);
+
+  const spanGroupCache = new Map<string, string | null>();
+  const findGroupBoundary = (spanId: string): string | null => {
+    if (spanGroupCache.has(spanId)) return spanGroupCache.get(spanId)!;
+    const visited: string[] = [spanId];
+    let current: string | undefined = spanId;
+    let result: string | null = null;
+    while (current) {
+      if (groupBoundarySet.has(current)) {
+        result = current;
+        break;
+      }
+      const parent = parentMap.get(current);
+      if (!parent) break;
+      if (spanGroupCache.has(parent)) {
+        result = spanGroupCache.get(parent)!;
+        break;
+      }
+      visited.push(parent);
+      current = parent;
+    }
+    for (const id of visited) spanGroupCache.set(id, result);
+    return result;
+  };
+
+  const groupSpansMap = new Map<string, string[]>();
+  for (const span of allSpans) {
+    const boundary = findGroupBoundary(span.spanId);
+    if (!boundary) continue;
+    let bucket = groupSpansMap.get(boundary);
+    if (!bucket) {
+      bucket = [];
+      groupSpansMap.set(boundary, bucket);
+    }
+    bucket.push(span.spanId);
+  }
+
+  return Array.from(groupSpansMap.entries()).map(([boundary, spanIds]) => ({
+    groupId: `group-${boundary}`,
+    spanIds,
+  }));
+};
+
 /**
  * Builds the flat list of transcript entries from spans.
  * Handles subagent grouping: spans under a subagent boundary are collapsed

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -72,6 +72,8 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
     toggleTranscriptGroup,
     setTab,
     setScrollTimeRange,
+    scrollToGroupId,
+    consumeScrollToGroup,
   } = useTraceViewBaseStore(
     (state) => ({
       getTranscriptListData: state.getTranscriptListData,
@@ -84,6 +86,8 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
       toggleTranscriptGroup: state.toggleTranscriptGroup,
       setTab: state.setTab,
       setScrollTimeRange: state.setScrollTimeRange,
+      scrollToGroupId: state.scrollToGroupId,
+      consumeScrollToGroup: state.consumeScrollToGroup,
     }),
     shallow
   );
@@ -216,6 +220,15 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
     if (selectedRowIndex < 0 || isSpansLoading) return;
     virtualizer.scrollToIndex(selectedRowIndex, { align: "auto" });
   }, [selectedRowIndex, virtualizer, isSpansLoading]);
+
+  // Scroll the matching group header into view in response to a click on a
+  // subagent block in the condensed timeline.
+  useEffect(() => {
+    if (!scrollToGroupId || isSpansLoading) return;
+    const index = flatRows.findIndex((row) => row.type === "group" && row.groupId === scrollToGroupId);
+    if (index >= 0) virtualizer.scrollToIndex(index, { align: "start" });
+    consumeScrollToGroup();
+  }, [scrollToGroupId, flatRows, virtualizer, isSpansLoading, consumeScrollToGroup]);
 
   const allVisibleSpanIds = useMemo(
     () =>

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -71,6 +71,7 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
     transcriptExpandedGroups,
     toggleTranscriptGroup,
     setTab,
+    setScrollTimeRange,
   } = useTraceViewBaseStore(
     (state) => ({
       getTranscriptListData: state.getTranscriptListData,
@@ -82,6 +83,7 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
       transcriptExpandedGroups: state.transcriptExpandedGroups,
       toggleTranscriptGroup: state.toggleTranscriptGroup,
       setTab: state.setTab,
+      setScrollTimeRange: state.setScrollTimeRange,
     }),
     shallow
   );
@@ -269,7 +271,7 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
     return { visibleStartTime: min, visibleEndTime: max };
   }, [items, flatRows, spansById, scrollOffset, viewportHeight]);
 
-  useReportVisibleTimeRange({ start: visibleStartTime, end: visibleEndTime });
+  useReportVisibleTimeRange({ start: visibleStartTime, end: visibleEndTime, setTimeRange: setScrollTimeRange });
 
   const { previews, inputPreviews, agentNames } = useBatchedSpanPreviews(
     projectId,

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -19,7 +19,10 @@ import {
 } from "@/components/traces/trace-view/transcript/item";
 import { useBatchedSpanPreviews } from "@/components/traces/trace-view/transcript/use-batched-span-previews";
 import { useTraceUserInput } from "@/components/traces/trace-view/transcript/use-trace-user-input";
-import { useReportVisibleTimeRange } from "@/components/traces/trace-view/use-report-visible-time-range";
+import {
+  filterToViewport,
+  useReportVisibleTimeRange,
+} from "@/components/traces/trace-view/use-report-visible-time-range";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton.tsx";
 import { track } from "@/lib/posthog";
@@ -221,10 +224,14 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
     [items, flatRows, transcriptExpandedGroups]
   );
 
+  const scrollOffset = virtualizer.scrollOffset ?? 0;
+  const viewportHeight = virtualizer.scrollRect?.height ?? 0;
+
   const { visibleStartTime, visibleEndTime } = useMemo(() => {
+    const inViewport = filterToViewport(items, scrollOffset, viewportHeight);
     let min = Infinity;
     let max = -Infinity;
-    for (const item of items) {
+    for (const item of inViewport) {
       const row = flatRows[item.index];
       if (!row) continue;
       let startStr: string | undefined;
@@ -260,7 +267,7 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
       return { visibleStartTime: undefined, visibleEndTime: undefined };
     }
     return { visibleStartTime: min, visibleEndTime: max };
-  }, [items, flatRows, spansById]);
+  }, [items, flatRows, spansById, scrollOffset, viewportHeight]);
 
   useReportVisibleTimeRange({ start: visibleStartTime, end: visibleEndTime });
 

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -201,19 +201,18 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
   const selectedRowIndex = useMemo(() => {
     const selectedId = selectedSpan?.spanId;
     if (!selectedId) return -1;
-    return flatRows.findIndex((row) => {
-      switch (row.type) {
-        case "span":
-        case "group-span":
-          return row.span.spanId === selectedId;
-        case "group":
-          return (
-            row.firstSpan.spanId === selectedId || row.firstLlmSpanId === selectedId || row.lastLlmSpanId === selectedId
-          );
-        default:
-          return false;
-      }
-    });
+    // Prefer the actual span row over the group header — when a subagent group is
+    // expanded, clicking a span that is also the group's first/last LLM (or the
+    // boundary span itself) should scroll to the span row, not the group header.
+    const spanRowIndex = flatRows.findIndex(
+      (row) => (row.type === "span" || row.type === "group-span") && row.span.spanId === selectedId
+    );
+    if (spanRowIndex >= 0) return spanRowIndex;
+    return flatRows.findIndex(
+      (row) =>
+        row.type === "group" &&
+        (row.firstSpan.spanId === selectedId || row.firstLlmSpanId === selectedId || row.lastLlmSpanId === selectedId)
+    );
   }, [flatRows, selectedSpan?.spanId]);
 
   useEffect(() => {

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/traces/trace-view/transcript/item";
 import { useBatchedSpanPreviews } from "@/components/traces/trace-view/transcript/use-batched-span-previews";
 import { useTraceUserInput } from "@/components/traces/trace-view/transcript/use-trace-user-input";
+import { useReportVisibleTimeRange } from "@/components/traces/trace-view/use-report-visible-time-range";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton.tsx";
 import { track } from "@/lib/posthog";
@@ -219,6 +220,49 @@ const List = ({ onSpanSelect, isShared = false }: ListProps) => {
       }),
     [items, flatRows, transcriptExpandedGroups]
   );
+
+  const { visibleStartTime, visibleEndTime } = useMemo(() => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const item of items) {
+      const row = flatRows[item.index];
+      if (!row) continue;
+      let startStr: string | undefined;
+      let endStr: string | undefined;
+      switch (row.type) {
+        case "span":
+        case "group-span":
+          startStr = row.span.startTime;
+          endStr = row.span.endTime;
+          break;
+        case "group":
+          startStr = row.startTime;
+          endStr = row.endTime;
+          break;
+        case "group-input": {
+          const s = spansById.get(row.firstLlmSpanId);
+          if (s) {
+            startStr = s.startTime;
+            endStr = s.endTime;
+          }
+          break;
+        }
+        // user-input: no time mapping
+      }
+      if (startStr && endStr) {
+        const s = new Date(startStr).getTime();
+        const e = new Date(endStr).getTime();
+        if (s < min) min = s;
+        if (e > max) max = e;
+      }
+    }
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      return { visibleStartTime: undefined, visibleEndTime: undefined };
+    }
+    return { visibleStartTime: min, visibleEndTime: max };
+  }, [items, flatRows, spansById]);
+
+  useReportVisibleTimeRange({ start: visibleStartTime, end: visibleEndTime });
 
   const { previews, inputPreviews, agentNames } = useBatchedSpanPreviews(
     projectId,

--- a/frontend/components/traces/trace-view/transcript/item/agent-group-header.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/agent-group-header.tsx
@@ -69,16 +69,7 @@ export function AgentGroupHeader({
     >
       <div className={cn("flex flex-col flex-1 min-w-0 px-2 py-2", collapsed && "gap-1")}>
         <div className="flex gap-2 items-center min-w-0">
-          <div
-            className="flex items-center justify-center z-10 rounded shrink-0"
-            style={{
-              backgroundColor: "rgba(6, 182, 212, 0.7)",
-              minWidth: 20,
-              minHeight: 20,
-              width: 20,
-              height: 20,
-            }}
-          >
+          <div className="flex items-center justify-center z-10 rounded shrink-0 bg-subagent/70 size-5 min-w-5 min-h-5">
             <Bot size={14} />
           </div>
           <span className="font-medium text-[13px] whitespace-nowrap truncate">{displayName}</span>

--- a/frontend/components/traces/trace-view/tree/index.tsx
+++ b/frontend/components/traces/trace-view/tree/index.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { memo, useEffect, useMemo, useRef } from "react";
 
 import { type TraceViewSpan, useTraceViewBaseStore } from "@/components/traces/trace-view/store/base";
+import { useReportVisibleTimeRange } from "@/components/traces/trace-view/use-report-visible-time-range";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { useBatchedSpanPreviews } from "../transcript/use-batched-span-previews";
@@ -61,6 +62,25 @@ const Tree = ({ onSpanSelect, isShared = false }: TreeProps) => {
       return spanItem && !spanItem.pending ? spanItem.span.spanId : null;
     })
   ) as string[];
+
+  const { visibleStartTime, visibleEndTime } = useMemo(() => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const item of items) {
+      const spanItem = treeSpans[item.index];
+      if (!spanItem) continue;
+      const s = new Date(spanItem.span.startTime).getTime();
+      const e = new Date(spanItem.span.endTime).getTime();
+      if (s < min) min = s;
+      if (e > max) max = e;
+    }
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      return { visibleStartTime: undefined, visibleEndTime: undefined };
+    }
+    return { visibleStartTime: min, visibleEndTime: max };
+  }, [items, treeSpans]);
+
+  useReportVisibleTimeRange({ start: visibleStartTime, end: visibleEndTime });
 
   const spanTypes = useMemo(() => {
     const types: Record<string, string> = {};

--- a/frontend/components/traces/trace-view/tree/index.tsx
+++ b/frontend/components/traces/trace-view/tree/index.tsx
@@ -21,15 +21,23 @@ interface TreeProps {
 const Tree = ({ onSpanSelect, isShared = false }: TreeProps) => {
   const { projectId } = useParams<{ projectId: string }>();
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { getTreeSpans, spans, trace, isSpansLoading, condensedTimelineVisibleSpanIds, selectedSpan } =
-    useTraceViewBaseStore((state) => ({
-      getTreeSpans: state.getTreeSpans,
-      spans: state.spans,
-      trace: state.trace,
-      isSpansLoading: state.isSpansLoading,
-      condensedTimelineVisibleSpanIds: state.condensedTimelineVisibleSpanIds,
-      selectedSpan: state.selectedSpan,
-    }));
+  const {
+    getTreeSpans,
+    spans,
+    trace,
+    isSpansLoading,
+    condensedTimelineVisibleSpanIds,
+    selectedSpan,
+    setScrollTimeRange,
+  } = useTraceViewBaseStore((state) => ({
+    getTreeSpans: state.getTreeSpans,
+    spans: state.spans,
+    trace: state.trace,
+    isSpansLoading: state.isSpansLoading,
+    condensedTimelineVisibleSpanIds: state.condensedTimelineVisibleSpanIds,
+    selectedSpan: state.selectedSpan,
+    setScrollTimeRange: state.setScrollTimeRange,
+  }));
 
   const treeSpans = useMemo(() => getTreeSpans(), [getTreeSpans, spans, condensedTimelineVisibleSpanIds]);
 
@@ -87,7 +95,7 @@ const Tree = ({ onSpanSelect, isShared = false }: TreeProps) => {
     return { visibleStartTime: min, visibleEndTime: max };
   }, [items, treeSpans, scrollOffset, viewportHeight]);
 
-  useReportVisibleTimeRange({ start: visibleStartTime, end: visibleEndTime });
+  useReportVisibleTimeRange({ start: visibleStartTime, end: visibleEndTime, setTimeRange: setScrollTimeRange });
 
   const spanTypes = useMemo(() => {
     const types: Record<string, string> = {};

--- a/frontend/components/traces/trace-view/tree/index.tsx
+++ b/frontend/components/traces/trace-view/tree/index.tsx
@@ -4,7 +4,10 @@ import { useParams } from "next/navigation";
 import { memo, useEffect, useMemo, useRef } from "react";
 
 import { type TraceViewSpan, useTraceViewBaseStore } from "@/components/traces/trace-view/store/base";
-import { useReportVisibleTimeRange } from "@/components/traces/trace-view/use-report-visible-time-range";
+import {
+  filterToViewport,
+  useReportVisibleTimeRange,
+} from "@/components/traces/trace-view/use-report-visible-time-range";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { useBatchedSpanPreviews } from "../transcript/use-batched-span-previews";
@@ -63,10 +66,14 @@ const Tree = ({ onSpanSelect, isShared = false }: TreeProps) => {
     })
   ) as string[];
 
+  const scrollOffset = virtualizer.scrollOffset ?? 0;
+  const viewportHeight = virtualizer.scrollRect?.height ?? 0;
+
   const { visibleStartTime, visibleEndTime } = useMemo(() => {
+    const inViewport = filterToViewport(items, scrollOffset, viewportHeight);
     let min = Infinity;
     let max = -Infinity;
-    for (const item of items) {
+    for (const item of inViewport) {
       const spanItem = treeSpans[item.index];
       if (!spanItem) continue;
       const s = new Date(spanItem.span.startTime).getTime();
@@ -78,7 +85,7 @@ const Tree = ({ onSpanSelect, isShared = false }: TreeProps) => {
       return { visibleStartTime: undefined, visibleEndTime: undefined };
     }
     return { visibleStartTime: min, visibleEndTime: max };
-  }, [items, treeSpans]);
+  }, [items, treeSpans, scrollOffset, viewportHeight]);
 
   useReportVisibleTimeRange({ start: visibleStartTime, end: visibleEndTime });
 

--- a/frontend/components/traces/trace-view/tree/index.tsx
+++ b/frontend/components/traces/trace-view/tree/index.tsx
@@ -29,6 +29,8 @@ const Tree = ({ onSpanSelect, isShared = false }: TreeProps) => {
     condensedTimelineVisibleSpanIds,
     selectedSpan,
     setScrollTimeRange,
+    scrollToGroupId,
+    consumeScrollToGroup,
   } = useTraceViewBaseStore((state) => ({
     getTreeSpans: state.getTreeSpans,
     spans: state.spans,
@@ -37,6 +39,8 @@ const Tree = ({ onSpanSelect, isShared = false }: TreeProps) => {
     condensedTimelineVisibleSpanIds: state.condensedTimelineVisibleSpanIds,
     selectedSpan: state.selectedSpan,
     setScrollTimeRange: state.setScrollTimeRange,
+    scrollToGroupId: state.scrollToGroupId,
+    consumeScrollToGroup: state.consumeScrollToGroup,
   }));
 
   const treeSpans = useMemo(() => getTreeSpans(), [getTreeSpans, spans, condensedTimelineVisibleSpanIds]);
@@ -64,6 +68,20 @@ const Tree = ({ onSpanSelect, isShared = false }: TreeProps) => {
       return () => cancelAnimationFrame(rafId);
     }
   }, [selectedSpanIndex, virtualizer, isSpansLoading]);
+
+  // Scroll the matching boundary span into view in response to a click on a
+  // subagent block in the condensed timeline. The condensed timeline shares
+  // group ids with the transcript (`group-<boundarySpanId>`), so we strip the
+  // prefix to find the boundary span row in the tree.
+  useEffect(() => {
+    if (!scrollToGroupId || isSpansLoading) return;
+    const boundarySpanId = scrollToGroupId.startsWith("group-") ? scrollToGroupId.slice("group-".length) : null;
+    if (boundarySpanId) {
+      const index = treeSpans.findIndex((item) => item.span.spanId === boundarySpanId);
+      if (index >= 0) virtualizer.scrollToIndex(index, { align: "start" });
+    }
+    consumeScrollToGroup();
+  }, [scrollToGroupId, treeSpans, virtualizer, isSpansLoading, consumeScrollToGroup]);
 
   const items = virtualizer?.getVirtualItems() || [];
 

--- a/frontend/components/traces/trace-view/use-report-visible-time-range.ts
+++ b/frontend/components/traces/trace-view/use-report-visible-time-range.ts
@@ -1,14 +1,18 @@
 import { useEffect, useRef } from "react";
 
-import { useTraceViewBaseStore } from "./store/base";
-
 /**
- * Filter TanStack virtual items down to those actually inside the viewport,
- * excluding the overscan buffer. TanStack Virtual has no built-in accessor for
- * this — `getVirtualItems()` includes the overscan — so we compare each item's
- * pixel range to the virtualizer's scroll offset and scroll-rect height.
+ * Filter TanStack virtual items down to those meaningfully inside the viewport,
+ * excluding the overscan buffer AND edge slivers. TanStack Virtual has no
+ * built-in accessor — `getVirtualItems()` includes overscan.
+ *
+ * We use a center-in-viewport rule rather than any-overlap: a row only counts
+ * if its vertical center is inside `[scrollOffset, scrollOffset+height]`.
+ * Any-overlap is too permissive — a 1px sliver of the next row at the viewport
+ * edge would count as "visible," and if that row carried a wildly different
+ * time (e.g. a trace 24h later), it would drag the reported range across a
+ * session gap and light up segments the user isn't looking at.
  */
-export const filterToViewport = <T extends { start: number; end: number }>(
+export const filterToViewport = <T extends { start: number; size: number }>(
   items: T[],
   scrollOffset: number,
   viewportHeight: number
@@ -16,7 +20,10 @@ export const filterToViewport = <T extends { start: number; end: number }>(
   if (viewportHeight <= 0) return items;
   const top = scrollOffset;
   const bottom = scrollOffset + viewportHeight;
-  return items.filter((item) => item.end > top && item.start < bottom);
+  return items.filter((item) => {
+    const center = item.start + item.size / 2;
+    return center >= top && center < bottom;
+  });
 };
 
 /**
@@ -25,8 +32,15 @@ export const filterToViewport = <T extends { start: number; end: number }>(
  * range when the caller unmounts so a switch between transcript and tree hands
  * ownership cleanly from one producer to the other.
  */
-export const useReportVisibleTimeRange = ({ start, end }: { start?: number; end?: number }) => {
-  const setScrollTimeRange = useTraceViewBaseStore((state) => state.setScrollTimeRange);
+export const useReportVisibleTimeRange = ({
+  start,
+  end,
+  setTimeRange,
+}: {
+  start?: number;
+  end?: number;
+  setTimeRange: (start?: number, end?: number) => void;
+}) => {
   const pendingRef = useRef<{ start?: number; end?: number }>({ start: undefined, end: undefined });
   const rafRef = useRef<number | null>(null);
   const lastRef = useRef<{ start?: number; end?: number }>({ start: undefined, end: undefined });
@@ -39,9 +53,9 @@ export const useReportVisibleTimeRange = ({ start, end }: { start?: number; end?
       const { start: s, end: e } = pendingRef.current;
       if (lastRef.current.start === s && lastRef.current.end === e) return;
       lastRef.current = { start: s, end: e };
-      setScrollTimeRange(s, e);
+      setTimeRange(s, e);
     });
-  }, [start, end, setScrollTimeRange]);
+  }, [start, end, setTimeRange]);
 
   useEffect(
     () => () => {
@@ -50,8 +64,8 @@ export const useReportVisibleTimeRange = ({ start, end }: { start?: number; end?
         rafRef.current = null;
       }
       lastRef.current = { start: undefined, end: undefined };
-      setScrollTimeRange(undefined, undefined);
+      setTimeRange(undefined, undefined);
     },
-    [setScrollTimeRange]
+    [setTimeRange]
   );
 };

--- a/frontend/components/traces/trace-view/use-report-visible-time-range.ts
+++ b/frontend/components/traces/trace-view/use-report-visible-time-range.ts
@@ -3,6 +3,23 @@ import { useEffect, useRef } from "react";
 import { useTraceViewBaseStore } from "./store/base";
 
 /**
+ * Filter TanStack virtual items down to those actually inside the viewport,
+ * excluding the overscan buffer. TanStack Virtual has no built-in accessor for
+ * this — `getVirtualItems()` includes the overscan — so we compare each item's
+ * pixel range to the virtualizer's scroll offset and scroll-rect height.
+ */
+export const filterToViewport = <T extends { start: number; end: number }>(
+  items: T[],
+  scrollOffset: number,
+  viewportHeight: number
+): T[] => {
+  if (viewportHeight <= 0) return items;
+  const top = scrollOffset;
+  const bottom = scrollOffset + viewportHeight;
+  return items.filter((item) => item.end > top && item.start < bottom);
+};
+
+/**
  * Writes the given time range to the store, throttled to one update per animation
  * frame and skipped when the range is unchanged since the last commit. Clears the
  * range when the caller unmounts so a switch between transcript and tree hands

--- a/frontend/components/traces/trace-view/use-report-visible-time-range.ts
+++ b/frontend/components/traces/trace-view/use-report-visible-time-range.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+
+import { useTraceViewBaseStore } from "./store/base";
+
+/**
+ * Writes the given time range to the store, throttled to one update per animation
+ * frame and skipped when the range is unchanged since the last commit. Clears the
+ * range when the caller unmounts so a switch between transcript and tree hands
+ * ownership cleanly from one producer to the other.
+ */
+export const useReportVisibleTimeRange = ({ start, end }: { start?: number; end?: number }) => {
+  const setScrollTimeRange = useTraceViewBaseStore((state) => state.setScrollTimeRange);
+  const pendingRef = useRef<{ start?: number; end?: number }>({ start: undefined, end: undefined });
+  const rafRef = useRef<number | null>(null);
+  const lastRef = useRef<{ start?: number; end?: number }>({ start: undefined, end: undefined });
+
+  useEffect(() => {
+    pendingRef.current = { start, end };
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const { start: s, end: e } = pendingRef.current;
+      if (lastRef.current.start === s && lastRef.current.end === e) return;
+      lastRef.current = { start: s, end: e };
+      setScrollTimeRange(s, e);
+    });
+  }, [start, end, setScrollTimeRange]);
+
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      lastRef.current = { start: undefined, end: undefined };
+      setScrollTimeRange(undefined, undefined);
+    },
+    [setScrollTimeRange]
+  );
+};

--- a/frontend/lib/traces/utils.ts
+++ b/frontend/lib/traces/utils.ts
@@ -4,7 +4,7 @@ export const SPAN_TYPE_TO_COLOR = {
   [SpanType.DEFAULT]: "rgba(96, 165, 250, 0.7)", // 70% opacity blue
   [SpanType.LLM]: "hsl(var(--llm))", // 90% opacity purple
   [SpanType.EXECUTOR]: "rgba(245, 158, 11, 0.7)", // 70% opacity yellow
-  [SpanType.EVALUATOR]: "rgba(6, 182, 212, 0.7)", // 70% opacity cyan
+  [SpanType.EVALUATOR]: "hsl(var(--subagent) / 0.7)",
   [SpanType.EVALUATION]: "rgba(16, 185, 129, 0.7)", // 70% opacity green
   [SpanType.HUMAN_EVALUATOR]: "rgba(244, 114, 182, 0.7)",
   [SpanType.TOOL]: "rgba(227, 160, 8, 0.9)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new cross-component state and virtualizer-derived time-range reporting to drive timeline highlights and scroll-to-group behavior, which could introduce subtle scroll/measurement or state-sync bugs but does not touch security-sensitive logic.
> 
> **Overview**
> Implements a **visible scroll-range indicator** by computing the time span covered by the currently visible virtualized rows (transcript/tree/session panel) and writing it to shared store state via a new `use-report-visible-time-range` helper.
> 
> Updates both the trace condensed timeline and session timeline to render this indicator (including gap highlighting and segment-intersection logic), and adds **clickable subagent group wrappers** in timelines that trigger one-shot scroll requests to bring the corresponding group header/boundary into view.
> 
> Introduces a `subagent` theme color token and reuses it for subagent visuals (including updating evaluator span color), plus small timeline layout tweaks (gap width/padding, group box computation in session timeline layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f03f9318f883bca0d9c16c5516bb8a4d2ef9fde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<img width="820" height="979" alt="image" src="https://github.com/user-attachments/assets/af45b9a8-6169-4911-b0d5-cdfaf5bdd4c9" />
