### PR TITLE
Add trace deletion support

### DIFF
--- a/app-server/src/api/v1/traces.rs
+++ b/app-server/src/api/v1/traces.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
-use actix_web::{HttpRequest, HttpResponse, post, web};
+use actix_web::{HttpRequest, HttpResponse, delete, post, web};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::{
     db::{DB, project_api_keys::ProjectApiKey, spans::Span},
@@ -18,6 +19,171 @@ use prost::Message;
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RabbitMqSpanMessage {
     pub span: Span,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteTracesRequest {
+    pub trace_ids: Vec<Uuid>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteTracesResponse {
+    pub deleted_traces: usize,
+}
+
+async fn delete_clickhouse_trace_rows(
+    clickhouse: &clickhouse::Client,
+    project_id: Uuid,
+    trace_ids: &[Uuid],
+) -> anyhow::Result<()> {
+    clickhouse
+        .query(
+            "
+            DELETE FROM events_to_clusters
+            WHERE project_id = {project_id: UUID}
+              AND event_id IN (
+                SELECT id
+                FROM signal_events
+                WHERE project_id = {project_id: UUID}
+                  AND trace_id IN {trace_ids: Array(UUID)}
+              )
+            ",
+        )
+        .param("project_id", project_id)
+        .param("trace_ids", trace_ids.to_vec())
+        .with_option("mutations_sync", "1")
+        .execute()
+        .await?;
+
+    clickhouse
+        .query(
+            "
+            DELETE FROM signal_run_messages
+            WHERE project_id = {project_id: UUID}
+              AND run_id IN (
+                SELECT run_id
+                FROM signal_runs FINAL
+                WHERE project_id = {project_id: UUID}
+                  AND trace_id IN {trace_ids: Array(UUID)}
+              )
+            ",
+        )
+        .param("project_id", project_id)
+        .param("trace_ids", trace_ids.to_vec())
+        .with_option("mutations_sync", "1")
+        .execute()
+        .await?;
+
+    const TRACE_DELETE_TABLES: &[(&str, &str)] = &[
+        ("spans", "trace_id"),
+        ("traces_replacing", "id"),
+        ("trace_tags", "trace_id"),
+        ("trace_summaries", "trace_id"),
+        ("browser_session_events", "trace_id"),
+        ("events", "trace_id"),
+        ("logs", "trace_id"),
+        ("signal_runs", "trace_id"),
+        ("signal_events", "trace_id"),
+    ];
+
+    for (table, column) in TRACE_DELETE_TABLES {
+        let query = format!(
+            "
+            DELETE FROM {table}
+            WHERE project_id = {{project_id: UUID}}
+              AND {column} IN {{trace_ids: Array(UUID)}}
+            "
+        );
+
+        clickhouse
+            .query(&query)
+            .param("project_id", project_id)
+            .param("trace_ids", trace_ids.to_vec())
+            .with_option("mutations_sync", "1")
+            .execute()
+            .await?;
+    }
+
+    Ok(())
+}
+
+async fn delete_postgres_trace_rows(
+    db: &DB,
+    project_id: Uuid,
+    trace_ids: &[Uuid],
+) -> anyhow::Result<u64> {
+    let mut tx = db.pool.begin().await?;
+
+    sqlx::query("DELETE FROM traces_agent_messages WHERE project_id = $1 AND trace_id = ANY($2)")
+        .bind(project_id)
+        .bind(trace_ids)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("DELETE FROM traces_agent_chats WHERE project_id = $1 AND trace_id = ANY($2)")
+        .bind(project_id)
+        .bind(trace_ids)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("DELETE FROM shared_traces WHERE project_id = $1 AND id = ANY($2)")
+        .bind(project_id)
+        .bind(trace_ids)
+        .execute(&mut *tx)
+        .await?;
+
+    let deleted_traces = sqlx::query("DELETE FROM traces WHERE project_id = $1 AND id = ANY($2)")
+        .bind(project_id)
+        .bind(trace_ids)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+
+    tx.commit().await?;
+
+    Ok(deleted_traces)
+}
+
+// /v1/traces
+#[delete("")]
+pub async fn delete_traces(
+    req: web::Json<DeleteTracesRequest>,
+    project_api_key: ProjectApiKey,
+    db: web::Data<DB>,
+    clickhouse: web::Data<clickhouse::Client>,
+) -> ResponseResult {
+    let mut trace_ids = req.into_inner().trace_ids;
+    trace_ids.sort_unstable();
+    trace_ids.dedup();
+
+    if project_api_key.is_ingest_only {
+        log::warn!(
+            "Ingest-only API key attempted to delete traces: project_id={}",
+            project_api_key.project_id
+        );
+        return Ok(HttpResponse::Forbidden().json(serde_json::json!({
+            "error": "This API key does not have permission to delete traces"
+        })));
+    }
+
+    if trace_ids.is_empty() {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "traceIds must contain at least one trace id"
+        })));
+    }
+
+    let project_id = project_api_key.project_id;
+    let clickhouse = clickhouse.into_inner();
+    let db = db.into_inner();
+
+    let deleted_traces = delete_postgres_trace_rows(db.as_ref(), project_id, &trace_ids).await?;
+    delete_clickhouse_trace_rows(clickhouse.as_ref(), project_id, &trace_ids).await?;
+
+    Ok(HttpResponse::Ok().json(DeleteTracesResponse {
+        deleted_traces: deleted_traces as usize,
+    }))
 }
 
 // /v1/traces

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1619,7 +1619,10 @@ fn main() -> anyhow::Result<()> {
                             .service(
                                 web::scope("/v1/traces")
                                     .wrap(project_ingestion_auth.clone())
-                                    .service(api::v1::traces::process_traces),
+                                    .service(api::v1::traces::process_traces)
+                                    // The handler blocks ingest-only keys; keeping it in this
+                                    // scope avoids duplicate /v1/traces route registration.
+                                    .service(api::v1::traces::delete_traces),
                             )
                             .service(
                                 web::scope("/v1/spans")

--- a/frontend/app/api/projects/[projectId]/traces/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/route.ts
@@ -40,7 +40,16 @@ export async function GET(req: NextRequest, props: { params: Promise<{ projectId
 export async function DELETE(req: NextRequest, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
   const params = await props.params;
   const projectId = params.projectId;
-  const traceIds = req.nextUrl.searchParams.getAll("traceId");
+  let traceIds: unknown = req.nextUrl.searchParams.getAll("traceId");
+
+  if (Array.isArray(traceIds) && traceIds.length === 0) {
+    try {
+      const body = (await req.json()) as { traceIds?: unknown };
+      traceIds = body.traceIds;
+    } catch {
+      // Keep query-param parsing as the fallback for empty or malformed bodies.
+    }
+  }
 
   const parseResult = DeleteTracesSchema.safeParse({ projectId, traceIds });
 

--- a/frontend/components/traces/traces-table/index.tsx
+++ b/frontend/components/traces/traces-table/index.tsx
@@ -15,8 +15,9 @@ import { defaultTracesColumnOrder, filters, PREVIEW_COLUMN } from "@/components/
 import TracesColumnsMenu from "@/components/traces/traces-table/traces-columns-menu";
 import { useTracesTableStore } from "@/components/traces/traces-table/traces-table-store";
 import DateRangeFilter from "@/components/ui/date-range-filter";
+import DeleteSelectedRows from "@/components/ui/delete-selected-rows";
 import { InfiniteDataTable } from "@/components/ui/infinite-datatable";
-import { useInfiniteScroll } from "@/components/ui/infinite-datatable/hooks";
+import { useInfiniteScroll, useSelection } from "@/components/ui/infinite-datatable/hooks";
 import { DataTableStateProvider, useDataTableStore } from "@/components/ui/infinite-datatable/model/datatable-store";
 import DataTableFilter from "@/components/ui/infinite-datatable/ui/datatable-filter";
 import RefreshButton from "@/components/ui/infinite-datatable/ui/refresh-button.tsx";
@@ -32,7 +33,7 @@ const DEFAULT_TARGET_BARS = 48;
 export default function TracesTable() {
   const customColumns = useTracesTableStore((s) => s.customColumns);
   const defaultColumnOrder = useMemo(
-    () => [...defaultTracesColumnOrder, ...customColumns.map((cc) => `custom:${cc.name}`)],
+    () => ["__row_selection", ...defaultTracesColumnOrder, ...customColumns.map((cc) => `custom:${cc.name}`)],
     [customColumns]
   );
 
@@ -54,7 +55,8 @@ function TracesTableContent() {
 
   const {
     traceId,
-    setTraceId: onRowClick,
+    setTraceId,
+    setSpanId,
     fetchStats,
     incrementStat,
     chartContainerWidth,
@@ -63,6 +65,7 @@ function TracesTableContent() {
   } = useTracesStoreContext((state) => ({
     traceId: state.traceId,
     setTraceId: state.setTraceId,
+    setSpanId: state.setSpanId,
     fetchStats: state.fetchStats,
     incrementStat: state.incrementStat,
     chartContainerWidth: state.chartContainerWidth,
@@ -80,6 +83,7 @@ function TracesTableContent() {
   const sortDirection = (searchParams.get("sortDirection")?.toLowerCase() ?? undefined) as "asc" | "desc" | undefined;
 
   const [realtimeEnabled, setRealtimeEnabled] = useLocalStorage("traces-table:realtime", false);
+  const { rowSelection, onRowSelectionChange } = useSelection();
 
   const { setNavigationRefList } = useTraceViewNavigation();
   const isCurrentTimestampIncluded = !!pastHours || (!!endDate && new Date(endDate) >= new Date());
@@ -121,14 +125,14 @@ function TracesTableContent() {
   useEffect(() => {
     if (effectiveColumns.length === 0) return;
 
-    const pinned = new Set(["status", "preview"]);
-    const visibleIds = new Set(effectiveColumns.map((c) => c.id!));
+    const pinned = new Set(["__row_selection", "status", "preview"]);
+    const visibleIds = new Set(["__row_selection", ...effectiveColumns.map((c) => c.id!)]);
     const hasPreview = visibleIds.has("preview");
 
     const rest = columnOrder.filter((id) => visibleIds.has(id) && !pinned.has(id));
     const newIds = [...visibleIds].filter((id) => !new Set(columnOrder).has(id) && !pinned.has(id));
 
-    const newOrder = ["status", ...(hasPreview ? ["preview"] : []), ...rest, ...newIds];
+    const newOrder = ["__row_selection", "status", ...(hasPreview ? ["preview"] : []), ...rest, ...newIds];
 
     if (newOrder.length !== columnOrder.length || newOrder.some((id, i) => columnOrder[i] !== id)) {
       setColumnOrder(newOrder);
@@ -353,9 +357,9 @@ function TracesTableContent() {
 
   const handleRowClick = useCallback(
     (row: Row<TraceRow>) => {
-      onRowClick?.(row.id);
+      setTraceId(row.id);
     },
-    [onRowClick]
+    [setTraceId]
   );
 
   // Auto-open the chat panel for traces that have meaningful LLM activity.
@@ -390,6 +394,72 @@ function TracesTableContent() {
     [searchParams, router, pathName]
   );
 
+  const handleDeleteTraces = useCallback(
+    async (traceIds: string[]) => {
+      try {
+        const response = await fetch(`/api/projects/${projectId}/traces`, {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ traceIds }),
+        });
+
+        if (!response.ok) {
+          const responseText = await response.text();
+          let message = responseText || "Failed to delete traces";
+          try {
+            message = JSON.parse(responseText).error || message;
+          } catch {
+            // Keep the plain response text.
+          }
+          throw new Error(message);
+        }
+
+        updateData((currentTraces) => currentTraces.filter((trace) => !traceIds.includes(trace.id)));
+        onRowSelectionChange({});
+
+        if (traceId && traceIds.includes(traceId)) {
+          const params = new URLSearchParams(searchParams.toString());
+          params.delete("traceId");
+          params.delete("spanId");
+          router.push(`${pathName}?${params.toString()}`);
+          setTraceId(null);
+          setSpanId(null);
+        }
+
+        if (statsUrl) {
+          fetchStats(statsUrl);
+        }
+
+        toast({
+          title: "Trace deletion requested",
+          description: `Requested deletion of ${traceIds.length} trace${traceIds.length === 1 ? "" : "s"}.`,
+        });
+      } catch (error) {
+        toast({
+          title: "Failed to delete traces",
+          description: error instanceof Error ? error.message : "Please try again.",
+          variant: "destructive",
+        });
+      }
+    },
+    [
+      fetchStats,
+      onRowSelectionChange,
+      pathName,
+      projectId,
+      router,
+      searchParams,
+      setSpanId,
+      setTraceId,
+      statsUrl,
+      toast,
+      traceId,
+      updateData,
+    ]
+  );
+
   const columnLabels = useMemo(
     () =>
       columnDefs.map((column) => ({
@@ -416,14 +486,22 @@ function TracesTableContent() {
         isLoading={isLoading}
         fetchNextPage={fetchNextPage}
         getRowHref={getRowHref}
-        lockedColumns={["status", "preview"]}
+        enableRowSelection
+        state={{ rowSelection }}
+        onRowSelectionChange={onRowSelectionChange}
+        lockedColumns={["__row_selection", "status", "preview"]}
         sortBy={sortBy}
         sortDirection={sortDirection}
         onSort={handleSort}
+        selectionPanel={(selectedRowIds) => (
+          <div className="flex flex-col space-y-2">
+            <DeleteSelectedRows selectedRowIds={selectedRowIds} onDelete={handleDeleteTraces} entityName="traces" />
+          </div>
+        )}
       >
         <div className="flex flex-1 w-full h-full gap-2">
           <DataTableFilter columns={filters} />
-          <TracesColumnsMenu lockedColumns={["status", "preview"]} columnLabels={columnLabels} />
+          <TracesColumnsMenu lockedColumns={["__row_selection", "status", "preview"]} columnLabels={columnLabels} />
           <DateRangeFilter />
           <RefreshButton onClick={handleRefresh} variant="outline" />
           <div className="flex items-center gap-2 px-2 border rounded-md bg-background h-7">

--- a/frontend/lib/actions/traces/index.ts
+++ b/frontend/lib/actions/traces/index.ts
@@ -1,3 +1,4 @@
+import { and, eq, inArray } from "drizzle-orm";
 import { compact } from "lodash";
 import { z } from "zod/v4";
 
@@ -13,6 +14,8 @@ import {
 import { clickhouseClient } from "@/lib/clickhouse/client.ts";
 import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { getTimeRange } from "@/lib/clickhouse/utils";
+import { db } from "@/lib/db/drizzle";
+import { sharedTraces, traces, tracesAgentChats, tracesAgentMessages } from "@/lib/db/migrations/schema";
 import { type TraceRow } from "@/lib/traces/types.ts";
 
 import { DEFAULT_SEARCH_MAX_HITS } from "./utils";
@@ -36,7 +39,7 @@ export const GetTracesSchema = PaginationFiltersSchema.extend({
 
 export const DeleteTracesSchema = z.object({
   projectId: z.guid(),
-  traceIds: z.array(z.string()).min(1),
+  traceIds: z.array(z.guid()).min(1),
 });
 
 export const GetTracesByIdsSchema = z.object({
@@ -235,19 +238,87 @@ export async function getTracesByIds(input: z.infer<typeof GetTracesByIdsSchema>
 }
 
 export async function deleteTraces(input: z.infer<typeof DeleteTracesSchema>) {
-  const { projectId, traceIds } = input;
+  const { projectId, traceIds } = DeleteTracesSchema.parse(input);
+
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(tracesAgentMessages)
+      .where(and(eq(tracesAgentMessages.projectId, projectId), inArray(tracesAgentMessages.traceId, traceIds)));
+    await tx
+      .delete(tracesAgentChats)
+      .where(and(eq(tracesAgentChats.projectId, projectId), inArray(tracesAgentChats.traceId, traceIds)));
+    await tx.delete(sharedTraces).where(and(eq(sharedTraces.projectId, projectId), inArray(sharedTraces.id, traceIds)));
+    await tx.delete(traces).where(and(eq(traces.projectId, projectId), inArray(traces.id, traceIds)));
+  });
 
   await clickhouseClient.command({
     query: `
-        DELETE FROM spans
-        WHERE project_id = {projectId: UUID} 
-            AND trace_id in ({traceIds: Array(UUID)})
-      `,
+      DELETE FROM events_to_clusters
+      WHERE project_id = {projectId: UUID}
+        AND event_id IN (
+          SELECT id
+          FROM signal_events
+          WHERE project_id = {projectId: UUID}
+            AND trace_id IN ({traceIds: Array(UUID)})
+        )
+    `,
     query_params: {
       traceIds,
       projectId,
     },
+    clickhouse_settings: {
+      mutations_sync: "1",
+    },
   });
+
+  await clickhouseClient.command({
+    query: `
+      DELETE FROM signal_run_messages
+      WHERE project_id = {projectId: UUID}
+        AND run_id IN (
+          SELECT run_id
+          FROM signal_runs FINAL
+          WHERE project_id = {projectId: UUID}
+            AND trace_id IN ({traceIds: Array(UUID)})
+        )
+    `,
+    query_params: {
+      traceIds,
+      projectId,
+    },
+    clickhouse_settings: {
+      mutations_sync: "1",
+    },
+  });
+
+  const clickhouseDeletes = [
+    { table: "spans", column: "trace_id" },
+    { table: "traces_replacing", column: "id" },
+    { table: "trace_tags", column: "trace_id" },
+    { table: "trace_summaries", column: "trace_id" },
+    { table: "browser_session_events", column: "trace_id" },
+    { table: "events", column: "trace_id" },
+    { table: "logs", column: "trace_id" },
+    { table: "signal_runs", column: "trace_id" },
+    { table: "signal_events", column: "trace_id" },
+  ];
+
+  for (const { table, column } of clickhouseDeletes) {
+    await clickhouseClient.command({
+      query: `
+        DELETE FROM ${table}
+        WHERE project_id = {projectId: UUID}
+          AND ${column} IN ({traceIds: Array(UUID)})
+      `,
+      query_params: {
+        traceIds,
+        projectId,
+      },
+      clickhouse_settings: {
+        mutations_sync: "1",
+      },
+    });
+  }
 }
 
 export { EVENTS_TRACE_VIEW_WIDTH, TRACES_TRACE_VIEW_WIDTH };


### PR DESCRIPTION
Closes #1179

## Summary

Adds trace deletion support for projects from both the product UI and API path.

This focuses on the deletion gap discussed in the issue. Export/download is already available through the SQL API, so this PR does not change trace export behavior.

## Changes

- Adds trace deletion for `/v1/traces`
- Removes trace-owned rows from ClickHouse trace/span/event/log/signal tables
- Removes related Postgres rows for traces, shared traces, and trace agent chats/messages
- Adds multi-row selection and delete action to the traces table UI
- Clears the selected trace/span from the UI when the currently open trace is deleted

## Verification

- `cargo +1.91.1 check`
- `pnpm lint-staged`
- `./node_modules/.bin/eslint components/traces/traces-table/index.tsx lib/actions/traces/index.ts`
- `pnpm type-check` currently fails on pre-existing missing asset imports under `frontend/assets`; no trace deletion files are included in the remaining type errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a destructive delete path that mutates both Postgres and ClickHouse across many trace-related tables; correctness and performance of the multi-table deletions (and permissions) are the main risks.
> 
> **Overview**
> Adds trace deletion support end-to-end: a new `DELETE /v1/traces` Actix handler (rejecting ingest-only keys) deletes trace-owned rows in Postgres (including agent chats/messages and shared traces) and issues synchronous ClickHouse mutations across spans/trace/event/log/signal tables.
> 
> Updates the Next.js API `DELETE /api/projects/[projectId]/traces` to accept `traceId` query params or a JSON body of `traceIds` (now validated as GUIDs), and switches the frontend trace actions to use a DB transaction plus expanded ClickHouse cleanup.
> 
> Enhances the traces table with multi-row selection and a bulk delete action; after deletion it prunes the removed traces from the table, clears selection, and resets the currently open `traceId`/`spanId` if it was deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d0450288c69a3fde9dd9ef74687cbf809bab6a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->