### PR TITLE
fix: posthog identify

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,11 +2,13 @@ import "@/app/globals.css";
 import "@/app/scroll.css";
 
 import { type Metadata } from "next";
+import { getServerSession } from "next-auth";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { type PropsWithChildren } from "react";
 
 import { Toaster } from "@/components/ui/toaster";
 import { type FeatureFlags, FeatureFlagsProvider } from "@/contexts/feature-flags-context";
+import { authOptions } from "@/lib/auth";
 import { Feature, isFeatureEnabled } from "@/lib/features/features.ts";
 import { manrope, sans, spaceGrotesk } from "@/lib/fonts";
 import { PostHogProvider } from "@/lib/posthog";
@@ -73,10 +75,13 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: PropsWithChildren) {
   const featureFlags = Object.fromEntries(Object.values(Feature).map((f) => [f, isFeatureEnabled(f)])) as FeatureFlags;
 
+  const session = await getServerSession(authOptions).catch(() => null);
+  const email = session?.user?.email ?? undefined;
+
   return (
     <html lang="en" className={cn("h-full antialiased", sans.variable, manrope.variable, spaceGrotesk.variable)}>
       <FeatureFlagsProvider flags={featureFlags}>
-        <PostHogProvider telemetryEnabled={featureFlags[Feature.POSTHOG]}>
+        <PostHogProvider telemetryEnabled={featureFlags[Feature.POSTHOG]} email={email}>
           <body className="flex flex-col h-full">
             <NuqsAdapter>
               <div className="flex">

--- a/frontend/components/auth/email-sign-in.tsx
+++ b/frontend/components/auth/email-sign-in.tsx
@@ -37,7 +37,7 @@ export function EmailSignInButton({ callbackUrl, action = "sign_in_attempted" }:
         className="p-4"
         variant={"light"}
         onClick={() => {
-          track("auth", action, { provider: "email" });
+          track("auth", action, { provider: "email" }, { sendInstantly: true });
           signIn("email", {
             callbackUrl,
             email,

--- a/frontend/components/auth/sign-in.tsx
+++ b/frontend/components/auth/sign-in.tsx
@@ -45,7 +45,10 @@ const SignIn = ({ callbackUrl }: SignInProps) => {
   const handleSignIn = async (provider: Provider) => {
     try {
       setIsLoading(provider);
-      track("auth", "sign_in_attempted", { provider });
+      // sendInstantly bypasses posthog-js's batching queue — `signIn` triggers
+      // a window.location redirect almost immediately, which would otherwise
+      // drop the queued event.
+      track("auth", "sign_in_attempted", { provider }, { sendInstantly: true });
       const result = await signIn(provider, { callbackUrl });
 
       if (result && !result.ok) {

--- a/frontend/components/auth/sign-up.tsx
+++ b/frontend/components/auth/sign-up.tsx
@@ -43,7 +43,10 @@ const SignUp = ({ callbackUrl }: SignUpProps) => {
   const handleSignUp = async (provider: Provider) => {
     try {
       setIsLoading(provider);
-      track("auth", "sign_up_attempted", { provider });
+      // sendInstantly bypasses posthog-js's batching queue — `signIn` triggers
+      // a window.location redirect almost immediately, which would otherwise
+      // drop the queued event.
+      track("auth", "sign_up_attempted", { provider }, { sendInstantly: true });
       const result = await signIn(provider, { callbackUrl });
 
       if (result && !result.ok) {

--- a/frontend/components/traces/placeholder/index.tsx
+++ b/frontend/components/traces/placeholder/index.tsx
@@ -22,7 +22,8 @@ export default function TracesPagePlaceholder() {
 
   useEffect(() => {
     track("onboarding", "traces_placeholder_viewed", { from_onboarding: isFromOnboarding });
-  }, [isFromOnboarding]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const eventHandlers = useMemo(
     () => ({

--- a/frontend/lib/posthog/client.ts
+++ b/frontend/lib/posthog/client.ts
@@ -67,9 +67,21 @@ export const reset = () => {
   posthog.reset();
 };
 
-export const track = (feature: Feature, action: string, properties?: Record<string, unknown>) => {
+interface TrackOptions {
+  // Bypass posthog-js's batching queue and send the event immediately.
+  sendInstantly?: boolean;
+}
+
+export const track = (
+  feature: Feature,
+  action: string,
+  properties?: Record<string, unknown>,
+  options?: TrackOptions
+) => {
   if (!initialized) return;
-  posthog.capture(`${feature}:${action}`, properties);
+  posthog.capture(`${feature}:${action}`, properties, {
+    send_instantly: options?.sendInstantly,
+  });
 };
 
 export { posthog };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds server-side session lookup in the root layout to pass user email into PostHog identification, and changes analytics capture behavior around auth flows; these touch global app rendering and send PII (email) to telemetry, so misconfigurations could affect performance or data collection.
> 
> **Overview**
> This PR ensures PostHog is **consistently identifying users by email** by fetching the NextAuth server session in `app/layout.tsx` and passing `email` into `PostHogProvider`.
> 
> It also reduces dropped analytics during login/signup redirects by adding a `sendInstantly` option to `track()` (mapped to PostHog’s `send_instantly`) and using it for auth sign-in/sign-up attempts (including email auth).
> 
> Finally, it adjusts the traces onboarding placeholder page view event to fire only once on mount (suppressing exhaustive-deps) to avoid re-tracking when query params change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d49c55c2368df34a2c0a78fca08861b1ca19ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->