### PR TITLE
fix: raise page size, only public channels

### DIFF
--- a/frontend/lib/actions/slack/index.ts
+++ b/frontend/lib/actions/slack/index.ts
@@ -157,7 +157,7 @@ export async function getSlackChannels(workspaceId: string): Promise<SlackChanne
   const integration = await getIntegrationWithToken(workspaceId);
 
   const response = await fetch(
-    "https://slack.com/api/conversations.list?exclude_archived=true&types=public_channel,private_channel&limit=200",
+    "https://slack.com/api/conversations.list?exclude_archived=true&types=public_channel&limit=1000",
     {
       headers: {
         Authorization: `Bearer ${integration.decryptedToken}`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small change to the Slack `conversations.list` query parameters, mainly affecting which channels appear and how many are returned.
> 
> **Overview**
> Updates Slack channel fetching (`getSlackChannels`) to query only `public_channel` conversations (dropping `private_channel`) and increases the Slack API `limit` from 200 to 1000 to return more results in a single call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038668fa7b56127a8ad7f55231718190450d8258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->