### PR TITLE
feat: remove current span from span path grouping, small ui fixes

### DIFF
--- a/frontend/components/traces/trace-view/condensed-timeline/index.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/index.tsx
@@ -42,6 +42,7 @@ function CondensedTimeline() {
     scrollEndTime,
     transcriptExpandedGroups,
     requestScrollToGroup,
+    tab,
   } = useTraceViewBaseStore((state) => ({
     getCondensedTimelineData: state.getCondensedTimelineData,
     getCondensedSubagentGroups: state.getCondensedSubagentGroups,
@@ -62,6 +63,7 @@ function CondensedTimeline() {
     scrollEndTime: state.scrollEndTime,
     transcriptExpandedGroups: state.transcriptExpandedGroups,
     requestScrollToGroup: state.requestScrollToGroup,
+    tab: state.tab,
   }));
 
   const {
@@ -111,11 +113,11 @@ function CondensedTimeline() {
         width: maxRight - minLeft,
         topRow: minRow,
         rowSpan: maxRow - minRow + 1,
-        collapsed: !transcriptExpandedGroups.has(group.groupId),
+        collapsed: tab === "tree" ? false : !transcriptExpandedGroups.has(group.groupId),
       });
     }
     return boxes;
-  }, [subagentGroups, condensedSpans, transcriptExpandedGroups]);
+  }, [subagentGroups, condensedSpans, transcriptExpandedGroups, tab]);
 
   // Compute dynamic time markers based on container width and zoom
   const { markers: timeMarkers, setContainerRef } = useDynamicTimeIntervals({

--- a/frontend/components/traces/trace-view/condensed-timeline/subagent-group-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/subagent-group-element.tsx
@@ -31,8 +31,8 @@ function SubagentGroupElement({
       className={cn(
         "absolute rounded-xs border",
         collapsed
-          ? "bg-subagent/30 cursor-pointer hover:bg-subagent/40 z-10 border-subagent"
-          : "pointer-events-none outline outline-offset-1 outline-subagent/30 bg-subagent/10 border-none"
+          ? "bg-subagent/20 cursor-pointer hover:bg-subagent/30 z-10 border-subagent"
+          : "pointer-events-none outline outline-offset-1 outline-subagent/40 bg-subagent/5 border-none"
       )}
       style={{
         left: `${left}%`,

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -281,6 +281,9 @@ type LlmSpanInfo = {
 };
 
 // Shared with TOP_PATH_QUERY in lib/actions/sessions/trace-io.ts and useTraceUserInput.
+// The parent-path keying (drop trailing leaf segment) used here must also stay
+// in sync with the `arrayPopBack(splitByChar('.', path))` expression in those
+// SQL queries — both pick the same "main agent" identity.
 export const MAIN_AGENT_SEARCH_WINDOW = 5;
 
 /**
@@ -314,11 +317,16 @@ export const computeSubagentBoundaries = (spans: TraceViewSpan[]): Set<string> =
 
     const spanPathAttr = span.attributes?.["lmnr.span.path"];
     const spanPathArr = Array.isArray(spanPathAttr) ? spanPathAttr : [];
+    // Drop the trailing segment (the current span's own name) when keying
+    // subagent identity. The current span name can be dynamic (e.g. tool
+    // names parameterised per call) while still being the same agent step,
+    // so we group by the parent path which is the stable subagent location.
+    const parentSpanPath = spanPathArr.slice(0, -1).join(".");
 
     llmSpans.push({
       spanId: span.spanId,
       parentSpanId: span.parentSpanId ?? "",
-      spanPath: spanPathArr.join("."),
+      spanPath: parentSpanPath,
       spanPathLength: spanPathArr.length,
       promptHash,
       idsPath: idsPath.filter((id) => id !== NULL_SPAN_ID),

--- a/frontend/lib/actions/sessions/trace-io.ts
+++ b/frontend/lib/actions/sessions/trace-io.ts
@@ -16,11 +16,12 @@ const bodySchema = z.object({
 
 const TOP_PATH_QUERY = `
     SELECT
-      path,
+      parent_path AS path,
       prompt_hash AS promptHash
     FROM (
       SELECT
         path,
+        arrayStringConcat(arrayPopBack(splitByChar('.', path)), '.') AS parent_path,
         input_tokens,
         start_time,
         simpleJSONExtractString(attributes, 'lmnr.span.prompt_hash') AS prompt_hash
@@ -30,9 +31,9 @@ const TOP_PATH_QUERY = `
       ORDER BY start_time ASC
       LIMIT ${MAIN_AGENT_SEARCH_WINDOW}
     )
-    GROUP BY path, prompt_hash
+    GROUP BY parent_path, prompt_hash
     ORDER BY
-      length(splitByChar('.', path)) ASC,
+      min(length(splitByChar('.', path))) ASC,
       max(input_tokens) DESC
     LIMIT 1
 `;
@@ -49,7 +50,7 @@ const INPUT_QUERY = `
     FROM spans
     WHERE trace_id = {traceId: UUID}
       AND span_type = 'LLM'
-      AND path = {path: String}
+      AND arrayStringConcat(arrayPopBack(splitByChar('.', path)), '.') = {path: String}
       AND simpleJSONExtractString(attributes, 'lmnr.span.prompt_hash') = {promptHash: String}
     ORDER BY start_time ASC
     LIMIT 1
@@ -61,7 +62,7 @@ const OUTPUT_QUERY = `
   FROM spans
   WHERE trace_id = {traceId: UUID}
     AND span_type = 'LLM'
-    AND path = {path: String}
+    AND arrayStringConcat(arrayPopBack(splitByChar('.', path)), '.') = {path: String}
     AND simpleJSONExtractString(attributes, 'lmnr.span.prompt_hash') = {promptHash: String}
   ORDER BY start_time DESC
   LIMIT 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the span-path key used to identify/group the “main agent” and subagents (both in-memory and in ClickHouse queries), which can affect which spans are selected for transcript grouping and IO extraction.
> 
> **Overview**
> Updates subagent/main-agent identity to **ignore the current span’s leaf path segment** by keying on the *parent* span path, keeping grouping stable when leaf names are dynamic. This is implemented in `computeSubagentBoundaries` and mirrored in `trace-io.ts` ClickHouse queries (`TOP_PATH_QUERY`, `INPUT_QUERY`, `OUTPUT_QUERY`) to ensure consistent main-agent IO selection.
> 
> Tweaks the condensed timeline’s subagent group wrappers: they are now **always treated as expanded in the `tree` tab** (no collapsed overlay), and their collapsed/expanded styling is slightly adjusted for better visual contrast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7303bae41d91788ea02d45ed99583f332ce76f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->