### PR TITLE
Parse aisdk reasoning input

### DIFF
--- a/app-server/src/language_model/chat_message.rs
+++ b/app-server/src/language_model/chat_message.rs
@@ -151,6 +151,7 @@ pub struct ChatMessageAISDKToolResult {
 #[serde(tag = "type")]
 pub enum ChatMessageContentPart {
     Text(ChatMessageText),
+    Reasoning(ChatMessageText),
     ImageUrl(ChatMessageImageUrl),
     Image(ChatMessageImage),
     Document(ChatMessageDocument),
@@ -263,6 +264,7 @@ pub struct InstrumentationChatMessageAISDKToolResult {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum InstrumentationChatMessageContentPart {
     Text(ChatMessageText),
+    Reasoning(ChatMessageText),
     ImageUrl(InstrumentationChatMessageImageUrl),
     Image(InstrumentationChatMessageImage),
     Document(InstrumentationChatMessageDocument),
@@ -279,6 +281,9 @@ impl ChatMessageContentPart {
     ) -> ChatMessageContentPart {
         match part {
             InstrumentationChatMessageContentPart::Text(text) => ChatMessageContentPart::Text(text),
+            InstrumentationChatMessageContentPart::Reasoning(reasoning) => {
+                ChatMessageContentPart::Reasoning(reasoning)
+            }
             InstrumentationChatMessageContentPart::ImageUrl(image_url) => match image_url {
                 InstrumentationChatMessageImageUrl::OpenAIImageUrl(image_url) => {
                     ChatMessageContentPart::ImageUrl(ChatMessageImageUrl {

--- a/app-server/src/traces/provider/langchain.rs
+++ b/app-server/src/traces/provider/langchain.rs
@@ -381,6 +381,9 @@ impl TryInto<Option<LangChainChatMessageContentPart>> for ChatMessageContentPart
             // LangChain CAN accept tool calls inside content parts, but we put them
             // in the tool_calls field instead, similar to OpenAI, so we skip them here.
             ChatMessageContentPart::ToolCall(_) => Ok(None),
+            // Reasoning parts are model-internal thinking; LangChain has no
+            // equivalent content part, so drop them from outgoing messages.
+            ChatMessageContentPart::Reasoning(_) => Ok(None),
         }
     }
 }

--- a/frontend/lib/spans/types/index.ts
+++ b/frontend/lib/spans/types/index.ts
@@ -85,6 +85,12 @@ const processContentPart = (
         text: part.text,
       };
 
+    case "reasoning":
+      return {
+        type: "reasoning" as const,
+        text: part.text,
+      };
+
     case "image_url":
       if ("image_url" in part) {
         return {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -10,6 +10,11 @@ export type ChatMessageText = {
   text: string;
 };
 
+export type ChatMessageReasoning = {
+  type: "reasoning";
+  text: string;
+};
+
 export type ChatMessageImageUrl =
   | {
       type: "image_url";
@@ -45,6 +50,7 @@ export type ChatMessageToolCall = {
 
 export type ChatMessageContentPart =
   | ChatMessageText
+  | ChatMessageReasoning
   | ChatMessageImageUrl
   | ChatMessageImage
   | ChatMessageDocumentUrl


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `reasoning` content-part variant and drops it during LangChain conversion; this may affect downstream consumers that assume only existing content part types or expect reasoning to be preserved.
> 
> **Overview**
> Adds first-class support for AI SDK `reasoning` content parts across backend and frontend message schemas.
> 
> On the backend, `ChatMessageContentPart` and instrumentation parsing now recognize `reasoning`, while LangChain export explicitly filters `reasoning` parts out of outgoing content. On the frontend, chat message types and span-to-`ModelMessage` conversion now preserve `reasoning` parts instead of treating them as unknown content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d2433a5c2c285b1aeb83535b0844c38595c8ad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->