### PR TITLE
feat: realtime evals

### DIFF
--- a/app-server/src/api/v1/evals.rs
+++ b/app-server/src/api/v1/evals.rs
@@ -1,11 +1,15 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
+    ch::evaluation_datapoints::CHEvaluationDatapoint,
     db::{self, DB, project_api_keys::ProjectApiKey},
     evaluations::{
-        EvaluationDatapointResult, insert_evaluation_datapoints, update_evaluation_datapoint,
+        EvaluationDatapointResult, UpdatedDatapointStrings, insert_evaluation_datapoints,
+        update_evaluation_datapoint,
     },
     names::NameGenerator,
+    pubsub::PubSub,
+    realtime::{SseMessage, send_to_key},
     routes::types::ResponseResult,
 };
 use actix_web::{
@@ -62,6 +66,7 @@ pub async fn save_eval_datapoints(
     req: Json<SaveEvalDatapointsRequest>,
     db: web::Data<DB>,
     clickhouse: web::Data<clickhouse::Client>,
+    pubsub: web::Data<Arc<PubSub>>,
     project_api_key: ProjectApiKey,
 ) -> ResponseResult {
     let eval_id = eval_id.into_inner();
@@ -71,7 +76,7 @@ pub async fn save_eval_datapoints(
     let group_name = req.group_name.unwrap_or("default".to_string());
     let clickhouse = clickhouse.into_inner().as_ref().clone();
 
-    insert_evaluation_datapoints(
+    let ch_rows = insert_evaluation_datapoints(
         &db.pool,
         clickhouse,
         points,
@@ -80,6 +85,20 @@ pub async fn save_eval_datapoints(
         &group_name,
     )
     .await?;
+
+    if !ch_rows.is_empty() {
+        let realtime_points: Vec<RealtimeDatapoint> = ch_rows
+            .iter()
+            .map(RealtimeDatapoint::from_ch_insert)
+            .collect();
+        publish_datapoint_upsert(
+            pubsub.get_ref().as_ref(),
+            &project_id,
+            &eval_id,
+            &realtime_points,
+        )
+        .await;
+    }
 
     Ok(HttpResponse::Ok().json(eval_id))
 }
@@ -99,6 +118,7 @@ pub async fn update_eval_datapoint(
     req: Json<UpdateEvalDatapointRequest>,
     db: web::Data<DB>,
     clickhouse: web::Data<clickhouse::Client>,
+    pubsub: web::Data<Arc<PubSub>>,
     project_api_key: ProjectApiKey,
 ) -> ResponseResult {
     let (eval_id, datapoint_id) = path.into_inner();
@@ -106,11 +126,12 @@ pub async fn update_eval_datapoint(
     let clickhouse = clickhouse.into_inner().as_ref().clone();
     let project_id = project_api_key.project_id;
 
-    // Get evaluation group_id for ClickHouse
     let group_id = db::evaluations::get_evaluation_group_id(&db.pool, eval_id, project_id).await?;
 
-    // Update the datapoint by merging with existing
-    update_evaluation_datapoint(
+    let UpdatedDatapointStrings {
+        executor_output: ch_executor_output,
+        scores: ch_scores,
+    } = update_evaluation_datapoint(
         &db.pool,
         clickhouse,
         eval_id,
@@ -123,5 +144,158 @@ pub async fn update_eval_datapoint(
     )
     .await?;
 
+    let realtime_point = RealtimeDatapoint::from_update_strings(
+        datapoint_id,
+        req.trace_id,
+        &ch_executor_output,
+        &ch_scores,
+    );
+    publish_datapoint_upsert(
+        pubsub.get_ref().as_ref(),
+        &project_id,
+        &eval_id,
+        std::slice::from_ref(&realtime_point),
+    )
+    .await;
+
     Ok(HttpResponse::Ok().json(datapoint_id))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RealtimeDatapoint<'a> {
+    id: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trace_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scores: Option<&'a str>,
+}
+
+impl<'a> RealtimeDatapoint<'a> {
+    fn from_ch_insert(row: &'a CHEvaluationDatapoint) -> Self {
+        let trace_id = (!row.trace_id.is_nil()).then_some(row.trace_id);
+        Self {
+            id: row.id,
+            index: Some(row.index),
+            trace_id,
+            data: non_empty(&row.data).map(|s| clip_str(s, TRUNCATE_CHARS)),
+            target: non_empty(&row.target).map(|s| clip_str(s, TRUNCATE_CHARS)),
+            metadata: non_empty(&row.metadata),
+            output: non_empty(&row.executor_output).map(|s| clip_str(s, TRUNCATE_CHARS)),
+            scores: non_empty(&row.scores),
+        }
+    }
+
+    fn from_update_strings(
+        datapoint_id: Uuid,
+        trace_id: Option<Uuid>,
+        executor_output: &'a str,
+        scores: &'a str,
+    ) -> Self {
+        let trace_id = trace_id.filter(|t| !t.is_nil());
+        Self {
+            id: datapoint_id,
+            index: None,
+            trace_id,
+            data: None,
+            target: None,
+            metadata: None,
+            output: non_empty(executor_output).map(|s| clip_str(s, TRUNCATE_CHARS)),
+            scores: non_empty(scores),
+        }
+    }
+}
+
+const TRUNCATE_CHARS: usize = 200;
+
+fn clip_str(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((byte_idx, _)) => &s[..byte_idx],
+        None => s,
+    }
+}
+
+fn non_empty(s: &str) -> Option<&str> {
+    match s.trim() {
+        "" | "{}" | "[]" | "null" => None,
+        _ => Some(s),
+    }
+}
+
+async fn publish_datapoint_upsert(
+    pubsub: &PubSub,
+    project_id: &Uuid,
+    evaluation_id: &Uuid,
+    datapoints: &[RealtimeDatapoint<'_>],
+) {
+    if datapoints.is_empty() {
+        return;
+    }
+    let message = SseMessage {
+        event_type: "datapoint_upsert".to_string(),
+        data: serde_json::json!({ "datapoints": datapoints }),
+    };
+    let key = format!("evaluation_{}", evaluation_id);
+    send_to_key(pubsub, project_id, &key, message).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn clip_str_short_unchanged() {
+        assert_eq!(clip_str("hello", TRUNCATE_CHARS), "hello");
+    }
+
+    #[test]
+    fn clip_str_long_clips_to_max() {
+        let s: String = "a".repeat(500);
+        assert_eq!(clip_str(&s, TRUNCATE_CHARS).chars().count(), TRUNCATE_CHARS);
+    }
+
+    #[test]
+    fn clip_str_multibyte_clips_on_char_boundary() {
+        // 4-byte char × 250 = 250 chars / 1000 bytes. Clip to 200 chars.
+        let s: String = "𝄞".repeat(250);
+        let out = clip_str(&s, TRUNCATE_CHARS);
+        assert_eq!(out.chars().count(), TRUNCATE_CHARS);
+        assert!(out.chars().all(|c| c == '𝄞'));
+    }
+
+    #[test]
+    fn realtime_datapoint_serializes_scores_as_passthrough_string() {
+        let row = CHEvaluationDatapoint {
+            id: Uuid::nil(),
+            evaluation_id: Uuid::nil(),
+            project_id: Uuid::nil(),
+            trace_id: Uuid::nil(),
+            updated_at: 0,
+            data: "{}".into(),
+            target: "{}".into(),
+            metadata: "{}".into(),
+            executor_output: String::new(),
+            index: 0,
+            dataset_id: Uuid::nil(),
+            dataset_datapoint_id: Uuid::nil(),
+            dataset_datapoint_created_at: 0,
+            group_id: "default".into(),
+            scores: r#"{"accuracy":0.9}"#.into(),
+        };
+        let dp = RealtimeDatapoint::from_ch_insert(&row);
+        let v = serde_json::to_value(&dp).unwrap();
+        // Scores arrive as a single string field — frontend handles flattening.
+        assert_eq!(v["scores"], json!(r#"{"accuracy":0.9}"#));
+    }
 }

--- a/app-server/src/api/v1/evals.rs
+++ b/app-server/src/api/v1/evals.rs
@@ -1,15 +1,15 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
-    ch::evaluation_datapoints::CHEvaluationDatapoint,
     db::{self, DB, project_api_keys::ProjectApiKey},
     evaluations::{
-        EvaluationDatapointResult, UpdatedDatapointStrings, insert_evaluation_datapoints,
+        EvaluationDatapointResult, UpdatedDatapointStrings,
+        insert_evaluation_datapoints,
+        realtime::{RealtimeDatapoint, publish_datapoint_upsert, publish_inserted_datapoints},
         update_evaluation_datapoint,
     },
     names::NameGenerator,
     pubsub::PubSub,
-    realtime::{SseMessage, send_to_key},
     routes::types::ResponseResult,
 };
 use actix_web::{
@@ -86,19 +86,7 @@ pub async fn save_eval_datapoints(
     )
     .await?;
 
-    if !ch_rows.is_empty() {
-        let realtime_points: Vec<RealtimeDatapoint> = ch_rows
-            .iter()
-            .map(RealtimeDatapoint::from_ch_insert)
-            .collect();
-        publish_datapoint_upsert(
-            pubsub.get_ref().as_ref(),
-            &project_id,
-            &eval_id,
-            &realtime_points,
-        )
-        .await;
-    }
+    publish_inserted_datapoints(pubsub.get_ref().as_ref(), &project_id, &eval_id, &ch_rows).await;
 
     Ok(HttpResponse::Ok().json(eval_id))
 }
@@ -159,143 +147,4 @@ pub async fn update_eval_datapoint(
     .await;
 
     Ok(HttpResponse::Ok().json(datapoint_id))
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct RealtimeDatapoint<'a> {
-    id: Uuid,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    index: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    trace_id: Option<Uuid>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    target: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    output: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    scores: Option<&'a str>,
-}
-
-impl<'a> RealtimeDatapoint<'a> {
-    fn from_ch_insert(row: &'a CHEvaluationDatapoint) -> Self {
-        let trace_id = (!row.trace_id.is_nil()).then_some(row.trace_id);
-        Self {
-            id: row.id,
-            index: Some(row.index),
-            trace_id,
-            data: non_empty(&row.data).map(|s| clip_str(s, TRUNCATE_CHARS)),
-            target: non_empty(&row.target).map(|s| clip_str(s, TRUNCATE_CHARS)),
-            metadata: non_empty(&row.metadata),
-            output: non_empty(&row.executor_output).map(|s| clip_str(s, TRUNCATE_CHARS)),
-            scores: non_empty(&row.scores),
-        }
-    }
-
-    fn from_update_strings(
-        datapoint_id: Uuid,
-        trace_id: Option<Uuid>,
-        executor_output: &'a str,
-        scores: &'a str,
-    ) -> Self {
-        let trace_id = trace_id.filter(|t| !t.is_nil());
-        Self {
-            id: datapoint_id,
-            index: None,
-            trace_id,
-            data: None,
-            target: None,
-            metadata: None,
-            output: non_empty(executor_output).map(|s| clip_str(s, TRUNCATE_CHARS)),
-            scores: non_empty(scores),
-        }
-    }
-}
-
-const TRUNCATE_CHARS: usize = 200;
-
-fn clip_str(s: &str, max_chars: usize) -> &str {
-    match s.char_indices().nth(max_chars) {
-        Some((byte_idx, _)) => &s[..byte_idx],
-        None => s,
-    }
-}
-
-fn non_empty(s: &str) -> Option<&str> {
-    match s.trim() {
-        "" | "{}" | "[]" | "null" => None,
-        _ => Some(s),
-    }
-}
-
-async fn publish_datapoint_upsert(
-    pubsub: &PubSub,
-    project_id: &Uuid,
-    evaluation_id: &Uuid,
-    datapoints: &[RealtimeDatapoint<'_>],
-) {
-    if datapoints.is_empty() {
-        return;
-    }
-    let message = SseMessage {
-        event_type: "datapoint_upsert".to_string(),
-        data: serde_json::json!({ "datapoints": datapoints }),
-    };
-    let key = format!("evaluation_{}", evaluation_id);
-    send_to_key(pubsub, project_id, &key, message).await;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn clip_str_short_unchanged() {
-        assert_eq!(clip_str("hello", TRUNCATE_CHARS), "hello");
-    }
-
-    #[test]
-    fn clip_str_long_clips_to_max() {
-        let s: String = "a".repeat(500);
-        assert_eq!(clip_str(&s, TRUNCATE_CHARS).chars().count(), TRUNCATE_CHARS);
-    }
-
-    #[test]
-    fn clip_str_multibyte_clips_on_char_boundary() {
-        // 4-byte char × 250 = 250 chars / 1000 bytes. Clip to 200 chars.
-        let s: String = "𝄞".repeat(250);
-        let out = clip_str(&s, TRUNCATE_CHARS);
-        assert_eq!(out.chars().count(), TRUNCATE_CHARS);
-        assert!(out.chars().all(|c| c == '𝄞'));
-    }
-
-    #[test]
-    fn realtime_datapoint_serializes_scores_as_passthrough_string() {
-        let row = CHEvaluationDatapoint {
-            id: Uuid::nil(),
-            evaluation_id: Uuid::nil(),
-            project_id: Uuid::nil(),
-            trace_id: Uuid::nil(),
-            updated_at: 0,
-            data: "{}".into(),
-            target: "{}".into(),
-            metadata: "{}".into(),
-            executor_output: String::new(),
-            index: 0,
-            dataset_id: Uuid::nil(),
-            dataset_datapoint_id: Uuid::nil(),
-            dataset_datapoint_created_at: 0,
-            group_id: "default".into(),
-            scores: r#"{"accuracy":0.9}"#.into(),
-        };
-        let dp = RealtimeDatapoint::from_ch_insert(&row);
-        let v = serde_json::to_value(&dp).unwrap();
-        // Scores arrive as a single string field — frontend handles flattening.
-        assert_eq!(v["scores"], json!(r#"{"accuracy":0.9}"#));
-    }
 }

--- a/app-server/src/api/v1/evals.rs
+++ b/app-server/src/api/v1/evals.rs
@@ -1,11 +1,14 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
+    cache::Cache,
     db::{self, DB, project_api_keys::ProjectApiKey},
     evaluations::{
         EvaluationDatapointResult, UpdatedDatapointStrings,
         insert_evaluation_datapoints,
-        realtime::{RealtimeDatapoint, publish_datapoint_upsert, publish_inserted_datapoints},
+        realtime::{
+            RealtimeDatapoint, cache_inserted_datapoint_trace_ids, send_datapoint_updates,
+        },
         update_evaluation_datapoint,
     },
     names::NameGenerator,
@@ -66,6 +69,7 @@ pub async fn save_eval_datapoints(
     req: Json<SaveEvalDatapointsRequest>,
     db: web::Data<DB>,
     clickhouse: web::Data<clickhouse::Client>,
+    cache: web::Data<Cache>,
     pubsub: web::Data<Arc<PubSub>>,
     project_api_key: ProjectApiKey,
 ) -> ResponseResult {
@@ -86,7 +90,18 @@ pub async fn save_eval_datapoints(
     )
     .await?;
 
-    publish_inserted_datapoints(pubsub.get_ref().as_ref(), &project_id, &eval_id, &ch_rows).await;
+    cache_inserted_datapoint_trace_ids(cache.into_inner(), &project_id, &eval_id, &ch_rows).await;
+
+    let realtime_points: Vec<RealtimeDatapoint<'_>> =
+        ch_rows.iter().map(RealtimeDatapoint::from_ch_insert).collect();
+
+    send_datapoint_updates(
+        pubsub.get_ref().as_ref(),
+        &project_id,
+        &eval_id,
+        &realtime_points,
+    )
+    .await;
 
     Ok(HttpResponse::Ok().json(eval_id))
 }
@@ -138,7 +153,7 @@ pub async fn update_eval_datapoint(
         &ch_executor_output,
         &ch_scores,
     );
-    publish_datapoint_upsert(
+    send_datapoint_updates(
         pubsub.get_ref().as_ref(),
         &project_id,
         &eval_id,

--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -22,3 +22,4 @@ pub const WORKSPACE_USAGE_WARNINGS_CACHE_KEY: &str = "workspace_usage_warnings";
 pub const USAGE_WARNING_SEND_LOCK_KEY: &str = "usage_warning_send_lock";
 pub const SYS_PROMPT_SUMMARY_CACHE_KEY: &str = "sys_prompt_summary";
 pub const SPAN_DROP_RULES_CACHE_KEY: &str = "span_drop_rules_v3";
+pub const TRACE_EVALUATION_ID_CACHE_KEY: &str = "trace_evaluation_id";

--- a/app-server/src/ch/evaluation_datapoints.rs
+++ b/app-server/src/ch/evaluation_datapoints.rs
@@ -97,31 +97,6 @@ impl CHEvaluationDatapoint {
     }
 }
 
-#[derive(Row, Serialize, Deserialize)]
-struct EvaluationIdRow {
-    #[serde(with = "clickhouse::serde::uuid")]
-    evaluation_id: Uuid,
-}
-
-pub async fn get_evaluation_id_by_trace_id(
-    clickhouse: clickhouse::Client,
-    project_id: Uuid,
-    trace_id: Uuid,
-) -> Result<Option<Uuid>> {
-    let row = clickhouse
-        .query(
-            "SELECT evaluation_id FROM evaluation_datapoints
-             PREWHERE trace_id = ?
-             WHERE project_id = ?
-             LIMIT 1",
-        )
-        .bind(trace_id)
-        .bind(project_id)
-        .fetch_optional::<EvaluationIdRow>()
-        .await?;
-    Ok(row.map(|r| r.evaluation_id))
-}
-
 pub async fn ch_insert_evaluation_datapoints(
     clickhouse: clickhouse::Client,
     eval_dps: &[CHEvaluationDatapoint],

--- a/app-server/src/ch/evaluation_datapoints.rs
+++ b/app-server/src/ch/evaluation_datapoints.rs
@@ -97,6 +97,31 @@ impl CHEvaluationDatapoint {
     }
 }
 
+#[derive(Row, Serialize, Deserialize)]
+struct EvaluationIdRow {
+    #[serde(with = "clickhouse::serde::uuid")]
+    evaluation_id: Uuid,
+}
+
+pub async fn get_evaluation_id_by_trace_id(
+    clickhouse: clickhouse::Client,
+    project_id: Uuid,
+    trace_id: Uuid,
+) -> Result<Option<Uuid>> {
+    let row = clickhouse
+        .query(
+            "SELECT evaluation_id FROM evaluation_datapoints
+             PREWHERE trace_id = ?
+             WHERE project_id = ?
+             LIMIT 1",
+        )
+        .bind(trace_id)
+        .bind(project_id)
+        .fetch_optional::<EvaluationIdRow>()
+        .await?;
+    Ok(row.map(|r| r.evaluation_id))
+}
+
 pub async fn ch_insert_evaluation_datapoints(
     clickhouse: clickhouse::Client,
     eval_dps: &[CHEvaluationDatapoint],

--- a/app-server/src/evaluations/mod.rs
+++ b/app-server/src/evaluations/mod.rs
@@ -112,9 +112,9 @@ pub async fn insert_evaluation_datapoints(
     evaluation_id: Uuid,
     project_id: Uuid,
     group_name: &String,
-) -> Result<()> {
+) -> Result<Vec<CHEvaluationDatapoint>> {
     if evaluation_datapoints.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     if is_shared_evaluation(pool, project_id, evaluation_id).await? {
@@ -130,24 +130,21 @@ pub async fn insert_evaluation_datapoints(
         .await?;
     }
 
-    ch_insert_evaluation_datapoints(
-        clickhouse,
-        evaluation_datapoints
-            .into_iter()
-            .map(|dp| {
-                CHEvaluationDatapoint::from_evaluation_datapoint_result(
-                    dp,
-                    evaluation_id,
-                    project_id,
-                    group_name,
-                )
-            })
-            .collect::<Vec<_>>()
-            .as_slice(),
-    )
-    .await?;
+    let ch_rows: Vec<CHEvaluationDatapoint> = evaluation_datapoints
+        .into_iter()
+        .map(|dp| {
+            CHEvaluationDatapoint::from_evaluation_datapoint_result(
+                dp,
+                evaluation_id,
+                project_id,
+                group_name,
+            )
+        })
+        .collect();
 
-    Ok(())
+    ch_insert_evaluation_datapoints(clickhouse, ch_rows.as_slice()).await?;
+
+    Ok(ch_rows)
 }
 
 /// Update a single evaluation datapoint using INSERT...SELECT pattern.
@@ -163,7 +160,7 @@ pub async fn update_evaluation_datapoint(
     executor_output: Option<Value>,
     scores: HashMap<String, Option<f64>>,
     trace_id: Option<Uuid>,
-) -> Result<()> {
+) -> Result<UpdatedDatapointStrings> {
     // Verify the datapoint exists and get its trace_id for shared evaluation handling.
     // We use prewhere id here, so that we hit the bloom_filter skip index on the
     // project_id, evaluation_id, id BEFORE we execute FINAL
@@ -273,5 +270,13 @@ pub async fn update_evaluation_datapoint(
         .await
         .map_err(|e| anyhow::anyhow!("Clickhouse evaluation datapoint update failed: {:?}", e))?;
 
-    Ok(())
+    Ok(UpdatedDatapointStrings {
+        executor_output: new_executor_output,
+        scores: new_scores,
+    })
+}
+
+pub struct UpdatedDatapointStrings {
+    pub executor_output: String,
+    pub scores: String,
 }

--- a/app-server/src/evaluations/mod.rs
+++ b/app-server/src/evaluations/mod.rs
@@ -1,3 +1,5 @@
+pub mod realtime;
+
 use std::collections::HashMap;
 
 use anyhow::Result;

--- a/app-server/src/evaluations/realtime.rs
+++ b/app-server/src/evaluations/realtime.rs
@@ -1,13 +1,62 @@
+use std::sync::Arc;
+
 use serde::Serialize;
 use uuid::Uuid;
 
 use crate::{
+    cache::{Cache, CacheTrait, keys::TRACE_EVALUATION_ID_CACHE_KEY},
     ch::evaluation_datapoints::CHEvaluationDatapoint,
     pubsub::PubSub,
     realtime::{SseMessage, send_to_key},
 };
 
 const TRUNCATE_CHARS: usize = 200;
+const TRACE_EVALUATION_ID_TTL_SECONDS: u64 = 86_400;
+
+async fn cache_trace_evaluation_id(
+    cache: &Cache,
+    project_id: &Uuid,
+    trace_id: &Uuid,
+    evaluation_id: &Uuid,
+) {
+    let key = format!("{}:{}:{}", TRACE_EVALUATION_ID_CACHE_KEY, project_id, trace_id);
+    if let Err(e) = cache
+        .insert_with_ttl(&key, *evaluation_id, TRACE_EVALUATION_ID_TTL_SECONDS)
+        .await
+    {
+        log::warn!("Failed to cache evaluation_id for {}: {:?}", key, e);
+    }
+}
+
+pub async fn lookup_trace_evaluation_id(
+    cache: &Cache,
+    project_id: &Uuid,
+    trace_id: &Uuid,
+) -> Option<Uuid> {
+    let key = format!("{}:{}:{}", TRACE_EVALUATION_ID_CACHE_KEY, project_id, trace_id);
+    match cache.get::<Uuid>(&key).await {
+        Ok(Some(eval_id)) => Some(eval_id),
+        Ok(None) => None,
+        Err(e) => {
+            log::warn!("Failed to read evaluation_id cache for {}: {:?}", key, e);
+            None
+        }
+    }
+}
+
+pub async fn cache_inserted_datapoint_trace_ids(
+    cache: Arc<Cache>,
+    project_id: &Uuid,
+    evaluation_id: &Uuid,
+    rows: &[CHEvaluationDatapoint],
+) {
+    for row in rows {
+        if row.trace_id.is_nil() {
+            continue;
+        }
+        cache_trace_evaluation_id(&cache, project_id, &row.trace_id, evaluation_id).await;
+    }
+}
 
 /// Lightweight datapoint payload sent over SSE.
 #[derive(Serialize)]
@@ -65,7 +114,7 @@ impl<'a> RealtimeDatapoint<'a> {
     }
 }
 
-pub async fn publish_datapoint_upsert(
+pub async fn send_datapoint_updates(
     pubsub: &PubSub,
     project_id: &Uuid,
     evaluation_id: &Uuid,
@@ -80,20 +129,6 @@ pub async fn publish_datapoint_upsert(
     };
     let key = format!("evaluation_{}", evaluation_id);
     send_to_key(pubsub, project_id, &key, message).await;
-}
-
-pub async fn publish_inserted_datapoints(
-    pubsub: &PubSub,
-    project_id: &Uuid,
-    evaluation_id: &Uuid,
-    rows: &[CHEvaluationDatapoint],
-) {
-    if rows.is_empty() {
-        return;
-    }
-    let payloads: Vec<RealtimeDatapoint<'_>> =
-        rows.iter().map(RealtimeDatapoint::from_ch_insert).collect();
-    publish_datapoint_upsert(pubsub, project_id, evaluation_id, &payloads).await;
 }
 
 fn clip_str(s: &str, max_chars: usize) -> &str {

--- a/app-server/src/evaluations/realtime.rs
+++ b/app-server/src/evaluations/realtime.rs
@@ -1,0 +1,241 @@
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::{
+    ch::evaluation_datapoints::CHEvaluationDatapoint,
+    pubsub::PubSub,
+    realtime::{SseMessage, send_to_key},
+};
+
+const TRUNCATE_CHARS: usize = 200;
+
+/// Lightweight datapoint payload sent over SSE.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RealtimeDatapoint<'a> {
+    id: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trace_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scores: Option<&'a str>,
+}
+
+impl<'a> RealtimeDatapoint<'a> {
+    pub fn from_ch_insert(row: &'a CHEvaluationDatapoint) -> Self {
+        let trace_id = (!row.trace_id.is_nil()).then_some(row.trace_id);
+        Self {
+            id: row.id,
+            index: Some(row.index),
+            trace_id,
+            data: non_empty(&row.data).map(|s| clip_str(s, TRUNCATE_CHARS)),
+            target: non_empty(&row.target).map(|s| clip_str(s, TRUNCATE_CHARS)),
+            metadata: non_empty(&row.metadata),
+            output: non_empty(&row.executor_output).map(|s| clip_str(s, TRUNCATE_CHARS)),
+            scores: non_empty(&row.scores),
+        }
+    }
+
+    pub fn from_update_strings(
+        datapoint_id: Uuid,
+        trace_id: Option<Uuid>,
+        executor_output: &'a str,
+        scores: &'a str,
+    ) -> Self {
+        let trace_id = trace_id.filter(|t| !t.is_nil());
+        Self {
+            id: datapoint_id,
+            index: None,
+            trace_id,
+            data: None,
+            target: None,
+            metadata: None,
+            output: non_empty(executor_output).map(|s| clip_str(s, TRUNCATE_CHARS)),
+            scores: non_empty(scores),
+        }
+    }
+}
+
+pub async fn publish_datapoint_upsert(
+    pubsub: &PubSub,
+    project_id: &Uuid,
+    evaluation_id: &Uuid,
+    datapoints: &[RealtimeDatapoint<'_>],
+) {
+    if datapoints.is_empty() {
+        return;
+    }
+    let message = SseMessage {
+        event_type: "datapoint_upsert".to_string(),
+        data: serde_json::json!({ "datapoints": datapoints }),
+    };
+    let key = format!("evaluation_{}", evaluation_id);
+    send_to_key(pubsub, project_id, &key, message).await;
+}
+
+pub async fn publish_inserted_datapoints(
+    pubsub: &PubSub,
+    project_id: &Uuid,
+    evaluation_id: &Uuid,
+    rows: &[CHEvaluationDatapoint],
+) {
+    if rows.is_empty() {
+        return;
+    }
+    let payloads: Vec<RealtimeDatapoint<'_>> =
+        rows.iter().map(RealtimeDatapoint::from_ch_insert).collect();
+    publish_datapoint_upsert(pubsub, project_id, evaluation_id, &payloads).await;
+}
+
+fn clip_str(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((byte_idx, _)) => &s[..byte_idx],
+        None => s,
+    }
+}
+
+fn non_empty(s: &str) -> Option<&str> {
+    match s.trim() {
+        "" | "{}" | "[]" | "null" => None,
+        _ => Some(s),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn clip_str_short_unchanged() {
+        assert_eq!(clip_str("hello", TRUNCATE_CHARS), "hello");
+    }
+
+    #[test]
+    fn clip_str_long_clips_to_max() {
+        let s: String = "a".repeat(500);
+        assert_eq!(clip_str(&s, TRUNCATE_CHARS).chars().count(), TRUNCATE_CHARS);
+    }
+
+    #[test]
+    fn clip_str_multibyte_clips_on_char_boundary() {
+        // 4-byte char × 250 = 250 chars / 1000 bytes. Clip to 200 chars.
+        let s: String = "𝄞".repeat(250);
+        let out = clip_str(&s, TRUNCATE_CHARS);
+        assert_eq!(out.chars().count(), TRUNCATE_CHARS);
+        assert!(out.chars().all(|c| c == '𝄞'));
+    }
+
+    #[test]
+    fn non_empty_filters_blank_and_empty_json() {
+        assert_eq!(non_empty(""), None);
+        assert_eq!(non_empty("   "), None);
+        assert_eq!(non_empty("{}"), None);
+        assert_eq!(non_empty("[]"), None);
+        assert_eq!(non_empty("null"), None);
+        assert_eq!(non_empty(r#"{"a":1}"#), Some(r#"{"a":1}"#));
+    }
+
+    fn sample_row() -> CHEvaluationDatapoint {
+        CHEvaluationDatapoint {
+            id: Uuid::nil(),
+            evaluation_id: Uuid::nil(),
+            project_id: Uuid::nil(),
+            trace_id: Uuid::nil(),
+            updated_at: 0,
+            data: "{}".into(),
+            target: "{}".into(),
+            metadata: "{}".into(),
+            executor_output: String::new(),
+            index: 0,
+            dataset_id: Uuid::nil(),
+            dataset_datapoint_id: Uuid::nil(),
+            dataset_datapoint_created_at: 0,
+            group_id: "default".into(),
+            scores: r#"{"accuracy":0.9}"#.into(),
+        }
+    }
+
+    #[test]
+    fn realtime_datapoint_serializes_scores_as_passthrough_string() {
+        let row = sample_row();
+        let dp = RealtimeDatapoint::from_ch_insert(&row);
+        let v = serde_json::to_value(&dp).unwrap();
+        // Scores arrive as a single string field — frontend handles flattening.
+        assert_eq!(v["scores"], json!(r#"{"accuracy":0.9}"#));
+    }
+
+    #[test]
+    fn from_ch_insert_omits_nil_trace_id_and_empty_jsonish_fields() {
+        let row = sample_row();
+        let dp = RealtimeDatapoint::from_ch_insert(&row);
+        let v = serde_json::to_value(&dp).unwrap();
+        // Nil trace_id is skipped, empty `{}` data/target/metadata are skipped,
+        // empty executor_output is skipped.
+        assert!(v.get("traceId").is_none());
+        assert!(v.get("data").is_none());
+        assert!(v.get("target").is_none());
+        assert!(v.get("metadata").is_none());
+        assert!(v.get("output").is_none());
+        // index always present on inserts.
+        assert_eq!(v["index"], json!(0));
+    }
+
+    #[test]
+    fn from_ch_insert_keeps_non_empty_trace_id_and_clips_long_data() {
+        let trace_id = Uuid::new_v4();
+        let long: String = "a".repeat(500);
+        let row = CHEvaluationDatapoint {
+            trace_id,
+            data: long.clone(),
+            target: long.clone(),
+            executor_output: long,
+            ..sample_row()
+        };
+        let dp = RealtimeDatapoint::from_ch_insert(&row);
+        let v = serde_json::to_value(&dp).unwrap();
+        assert_eq!(v["traceId"], json!(trace_id.to_string()));
+        assert_eq!(v["data"].as_str().unwrap().chars().count(), TRUNCATE_CHARS);
+        assert_eq!(v["target"].as_str().unwrap().chars().count(), TRUNCATE_CHARS);
+        assert_eq!(v["output"].as_str().unwrap().chars().count(), TRUNCATE_CHARS);
+    }
+
+    #[test]
+    fn from_update_strings_omits_index_and_static_fields() {
+        let id = Uuid::new_v4();
+        let dp = RealtimeDatapoint::from_update_strings(id, None, "", "{}");
+        let v = serde_json::to_value(&dp).unwrap();
+        assert_eq!(v["id"], json!(id.to_string()));
+        assert!(v.get("index").is_none());
+        assert!(v.get("traceId").is_none());
+        assert!(v.get("data").is_none());
+        assert!(v.get("target").is_none());
+        assert!(v.get("metadata").is_none());
+        assert!(v.get("output").is_none());
+        assert!(v.get("scores").is_none());
+    }
+
+    #[test]
+    fn from_update_strings_filters_nil_trace_id_and_passes_through_scores() {
+        let id = Uuid::new_v4();
+        let dp = RealtimeDatapoint::from_update_strings(
+            id,
+            Some(Uuid::nil()),
+            r#"{"x":1}"#,
+            r#"{"a":0.5}"#,
+        );
+        let v = serde_json::to_value(&dp).unwrap();
+        assert!(v.get("traceId").is_none());
+        assert_eq!(v["output"], json!(r#"{"x":1}"#));
+        assert_eq!(v["scores"], json!(r#"{"a":0.5}"#));
+    }
+}

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -34,7 +34,10 @@ use crate::{
     },
     traces::{
         provider::convert_span_to_provider_format,
-        realtime::{send_span_updates, send_trace_updates},
+        realtime::{
+            RealtimeDebuggerTrace, RealtimeTrace, TraceChannel, channels_for_trace,
+            send_span_updates, send_trace_updates,
+        },
         utils::{get_llm_usage_for_span, group_traces_by_project, prepare_span_for_recording},
     },
     utils::limits::{get_workspace_signal_runs_limit_exceeded, update_workspace_bytes_ingested},
@@ -104,14 +107,7 @@ pub async fn process_span_messages(
                 );
             }
 
-            send_trace_updates(
-                &updated_traces,
-                &spans,
-                cache.clone(),
-                clickhouse.clone(),
-                &pubsub,
-            )
-            .await;
+            dispatch_trace_realtime_updates(&updated_traces, cache.clone(), &pubsub).await;
 
             Some(updated_traces)
         }
@@ -251,6 +247,57 @@ pub async fn process_span_messages(
     }
 
     Ok(())
+}
+
+async fn dispatch_trace_realtime_updates(
+    traces: &[Trace],
+    cache: Arc<Cache>,
+    pubsub: &PubSub,
+) {
+    if traces.is_empty() {
+        return;
+    }
+
+    let mut project_buckets: HashMap<Uuid, Vec<RealtimeTrace>> = HashMap::new();
+    let mut evaluation_buckets: HashMap<(Uuid, Uuid), Vec<RealtimeTrace>> = HashMap::new();
+    let mut debugger_buckets: HashMap<(Uuid, String), Vec<RealtimeDebuggerTrace>> = HashMap::new();
+
+    for trace in traces {
+        for channel in channels_for_trace(trace, cache.as_ref()).await {
+            match channel {
+                TraceChannel::Project => {
+                    project_buckets
+                        .entry(trace.project_id())
+                        .or_default()
+                        .push(RealtimeTrace::from_trace(trace));
+                }
+                TraceChannel::Evaluation(evaluation_id) => {
+                    evaluation_buckets
+                        .entry((trace.project_id(), evaluation_id))
+                        .or_default()
+                        .push(RealtimeTrace::from_trace(trace));
+                }
+                TraceChannel::RolloutDebugger(rollout_session_id) => {
+                    debugger_buckets
+                        .entry((trace.project_id(), rollout_session_id))
+                        .or_default()
+                        .push(RealtimeDebuggerTrace::from_trace(trace));
+                }
+            }
+        }
+    }
+
+    for (project_id, traces_data) in project_buckets {
+        send_trace_updates(&project_id, "traces", &traces_data, pubsub).await;
+    }
+    for ((project_id, evaluation_id), traces_data) in evaluation_buckets {
+        let key = format!("evaluation_{}", evaluation_id);
+        send_trace_updates(&project_id, &key, &traces_data, pubsub).await;
+    }
+    for ((project_id, rollout_session_id), traces_data) in debugger_buckets {
+        let key = format!("rollout_session_{}", rollout_session_id);
+        send_trace_updates(&project_id, &key, &traces_data, pubsub).await;
+    }
 }
 
 async fn check_and_push_signals(

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -104,7 +104,14 @@ pub async fn process_span_messages(
                 );
             }
 
-            send_trace_updates(&updated_traces, &pubsub).await;
+            send_trace_updates(
+                &updated_traces,
+                &spans,
+                cache.clone(),
+                clickhouse.clone(),
+                &pubsub,
+            )
+            .await;
 
             Some(updated_traces)
         }

--- a/app-server/src/traces/realtime.rs
+++ b/app-server/src/traces/realtime.rs
@@ -1,6 +1,7 @@
 //! Realtime updates for traces and spans via SSE
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde::Serialize;
@@ -8,10 +9,17 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::{
+    cache::{Cache, CacheTrait, keys::TRACE_EVALUATION_ID_CACHE_KEY},
+    ch::evaluation_datapoints::get_evaluation_id_by_trace_id,
     db::{spans::Span, spans::SpanType, trace::Trace},
     pubsub::PubSub,
     realtime::{SseMessage, send_to_key},
+    traces::span_attributes::ASSOCIATION_PROPERTIES_PREFIX,
 };
+
+const TRACE_EVALUATION_ID_TTL_SECONDS: u64 = 86_400;
+const EVALUATION_TOP_SPAN_NAME: &str = "evaluation";
+const EVALUATION_ID_ATTRIBUTE_SUFFIX: &str = "evaluation_id";
 
 /// Realtime trace data for frontend consumption
 #[derive(Debug, Serialize)]
@@ -119,29 +127,45 @@ pub async fn send_span_updates(spans: &[Span], pubsub: &PubSub) {
     }
 }
 
-/// Send trace update events to SSE connections for the traces table
-pub async fn send_trace_updates(traces: &[Trace], pubsub: &PubSub) {
+pub async fn send_trace_updates(
+    traces: &[Trace],
+    spans: &[Span],
+    cache: Arc<Cache>,
+    clickhouse: clickhouse::Client,
+    pubsub: &PubSub,
+) {
     if traces.is_empty() {
         return;
     }
 
-    // Group traces by project_id
+    let trace_to_evaluation = resolve_trace_to_evaluation(traces, spans, cache, clickhouse).await;
+
     let mut traces_by_project: HashMap<Uuid, Vec<RealtimeTrace>> = HashMap::new();
+    let mut traces_by_evaluation: HashMap<(Uuid, Uuid), Vec<RealtimeTrace>> = HashMap::new();
     let mut traces_by_rollout_session: HashMap<(Uuid, String), Vec<RealtimeDebuggerTrace>> =
         HashMap::new();
 
     for trace in traces {
-        // Very rudimentary filter to exclude evaluation traces
-        if let Some(top_span_name) = trace.top_span_name() {
-            if top_span_name == "evaluation" {
-                continue;
-            }
-        }
+        let realtime_trace = RealtimeTrace::from_trace(trace);
 
-        traces_by_project
-            .entry(trace.project_id())
-            .or_default()
-            .push(RealtimeTrace::from_trace(trace));
+        if let Some(evaluation_id) = trace_to_evaluation.get(&trace.id()) {
+            traces_by_evaluation
+                .entry((trace.project_id(), *evaluation_id))
+                .or_default()
+                .push(realtime_trace);
+        } else if trace
+            .top_span_name()
+            .as_deref()
+            .is_some_and(|name| name == EVALUATION_TOP_SPAN_NAME)
+        {
+            // Unresolved evaluation trace — keep it out of the global feed.
+            continue;
+        } else {
+            traces_by_project
+                .entry(trace.project_id())
+                .or_default()
+                .push(realtime_trace);
+        }
 
         if let Some(rollout_session_id) = trace
             .metadata()
@@ -168,6 +192,18 @@ pub async fn send_trace_updates(traces: &[Trace], pubsub: &PubSub) {
         };
 
         send_to_key(pubsub, &project_id, "traces", trace_message).await;
+    }
+
+    for ((project_id, evaluation_id), traces_data) in traces_by_evaluation {
+        let trace_message = SseMessage {
+            event_type: "trace_update".to_string(),
+            data: serde_json::json!({
+                "traces": traces_data
+            }),
+        };
+
+        let evaluation_key = format!("evaluation_{}", evaluation_id);
+        send_to_key(pubsub, &project_id, &evaluation_key, trace_message).await;
     }
 
     for ((project_id, rollout_session_id), traces_data) in traces_by_rollout_session {
@@ -209,6 +245,119 @@ impl RealtimeTrace {
             tags: trace.tags().clone(),
             root_span_input: trace.root_span_input(),
             root_span_output: trace.root_span_output(),
+        }
+    }
+}
+
+/// Build a `trace_id -> evaluation_id` map for evaluation traces in this batch.
+async fn resolve_trace_to_evaluation(
+    traces: &[Trace],
+    spans: &[Span],
+    cache: Arc<Cache>,
+    clickhouse: clickhouse::Client,
+) -> HashMap<Uuid, Uuid> {
+    let evaluation_traces: Vec<(Uuid, Uuid)> = traces
+        .iter()
+        .filter(|t| {
+            t.top_span_name()
+                .as_deref()
+                .is_some_and(|name| name == EVALUATION_TOP_SPAN_NAME)
+        })
+        .map(|t| (t.id(), t.project_id()))
+        .collect();
+
+    if evaluation_traces.is_empty() {
+        return HashMap::new();
+    }
+
+    let from_spans = evaluation_ids_from_spans(spans);
+
+    let mut resolved: HashMap<Uuid, Uuid> = HashMap::new();
+    let mut needs_lookup: Vec<(Uuid, Uuid)> = Vec::new();
+
+    for (trace_id, project_id) in evaluation_traces {
+        if let Some(eval_id) = from_spans.get(&trace_id).copied() {
+            resolved.insert(trace_id, eval_id);
+        } else {
+            needs_lookup.push((trace_id, project_id));
+        }
+    }
+
+    if needs_lookup.is_empty() {
+        return resolved;
+    }
+
+    let lookups = needs_lookup.into_iter().map(|(trace_id, project_id)| {
+        let cache = cache.clone();
+        let clickhouse = clickhouse.clone();
+        async move {
+            let eval_id = resolve_one(trace_id, project_id, cache, clickhouse).await?;
+            Some((trace_id, eval_id))
+        }
+    });
+
+    for (trace_id, eval_id) in futures_util::future::join_all(lookups)
+        .await
+        .into_iter()
+        .flatten()
+    {
+        resolved.insert(trace_id, eval_id);
+    }
+
+    resolved
+}
+
+fn evaluation_ids_from_spans(spans: &[Span]) -> HashMap<Uuid, Uuid> {
+    let key = format!("{ASSOCIATION_PROPERTIES_PREFIX}.{EVALUATION_ID_ATTRIBUTE_SUFFIX}");
+    let mut out: HashMap<Uuid, Uuid> = HashMap::new();
+    for span in spans {
+        if out.contains_key(&span.trace_id) {
+            continue;
+        }
+        if let Some(eval_id) = span
+            .attributes
+            .raw_attributes
+            .get(&key)
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+        {
+            out.insert(span.trace_id, eval_id);
+        }
+    }
+    out
+}
+
+async fn resolve_one(
+    trace_id: Uuid,
+    project_id: Uuid,
+    cache: Arc<Cache>,
+    clickhouse: clickhouse::Client,
+) -> Option<Uuid> {
+    let key = format!(
+        "{}:{}:{}",
+        TRACE_EVALUATION_ID_CACHE_KEY, project_id, trace_id
+    );
+
+    match cache.get::<Uuid>(&key).await {
+        Ok(Some(eval_id)) => return Some(eval_id),
+        Ok(None) => {}
+        Err(e) => log::warn!("Failed to read evaluation_id cache for {}: {:?}", key, e),
+    }
+
+    match get_evaluation_id_by_trace_id(clickhouse, project_id, trace_id).await {
+        Ok(Some(eval_id)) => {
+            if let Err(e) = cache
+                .insert_with_ttl(&key, eval_id, TRACE_EVALUATION_ID_TTL_SECONDS)
+                .await
+            {
+                log::warn!("Failed to cache evaluation_id for {}: {:?}", key, e);
+            }
+            Some(eval_id)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            log::warn!("Failed to look up evaluation_id for {}: {:?}", trace_id, e);
+            None
         }
     }
 }

--- a/app-server/src/traces/realtime.rs
+++ b/app-server/src/traces/realtime.rs
@@ -1,7 +1,6 @@
 //! Realtime updates for traces and spans via SSE
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde::Serialize;
@@ -9,22 +8,21 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::{
-    cache::{Cache, CacheTrait, keys::TRACE_EVALUATION_ID_CACHE_KEY},
-    ch::evaluation_datapoints::get_evaluation_id_by_trace_id,
+    cache::Cache,
     db::{spans::Span, spans::SpanType, trace::Trace},
+    evaluations::realtime::lookup_trace_evaluation_id,
     pubsub::PubSub,
     realtime::{SseMessage, send_to_key},
-    traces::span_attributes::ASSOCIATION_PROPERTIES_PREFIX,
 };
 
-const TRACE_EVALUATION_ID_TTL_SECONDS: u64 = 86_400;
 const EVALUATION_TOP_SPAN_NAME: &str = "evaluation";
-const EVALUATION_ID_ATTRIBUTE_SUFFIX: &str = "evaluation_id";
+const ROLLOUT_SESSION_METADATA_KEY: &str = "rollout.session_id";
+const EVALUATION_ID_METADATA_KEY: &str = "evaluation_id";
 
 /// Realtime trace data for frontend consumption
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct RealtimeTrace {
+pub struct RealtimeTrace {
     id: Uuid,
     start_time: Option<DateTime<Utc>>,
     end_time: Option<DateTime<Utc>>,
@@ -49,7 +47,7 @@ struct RealtimeTrace {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct RealtimeDebuggerTrace {
+pub struct RealtimeDebuggerTrace {
     trace_id: Uuid,
     metadata: Option<Value>,
     has_browser_session: Option<bool>,
@@ -127,101 +125,76 @@ pub async fn send_span_updates(spans: &[Span], pubsub: &PubSub) {
     }
 }
 
-pub async fn send_trace_updates(
-    traces: &[Trace],
-    spans: &[Span],
-    cache: Arc<Cache>,
-    clickhouse: clickhouse::Client,
+pub async fn send_trace_updates<T: Serialize>(
+    project_id: &Uuid,
+    channel_key: &str,
+    traces: &[T],
     pubsub: &PubSub,
 ) {
     if traces.is_empty() {
         return;
     }
+    let message = SseMessage {
+        event_type: "trace_update".to_string(),
+        data: serde_json::json!({ "traces": traces }),
+    };
+    send_to_key(pubsub, project_id, channel_key, message).await;
+}
 
-    let trace_to_evaluation = resolve_trace_to_evaluation(traces, spans, cache, clickhouse).await;
+#[derive(Debug, Clone)]
+pub enum TraceChannel {
+    Project,
+    Evaluation(Uuid),
+    RolloutDebugger(String),
+}
 
-    let mut traces_by_project: HashMap<Uuid, Vec<RealtimeTrace>> = HashMap::new();
-    let mut traces_by_evaluation: HashMap<(Uuid, Uuid), Vec<RealtimeTrace>> = HashMap::new();
-    let mut traces_by_rollout_session: HashMap<(Uuid, String), Vec<RealtimeDebuggerTrace>> =
-        HashMap::new();
+pub async fn channels_for_trace(trace: &Trace, cache: &Cache) -> Vec<TraceChannel> {
+    let mut channels = Vec::with_capacity(2);
 
-    for trace in traces {
-        let realtime_trace = RealtimeTrace::from_trace(trace);
+    let is_evaluation_trace = trace
+        .top_span_name()
+        .as_deref()
+        .is_some_and(|name| name == EVALUATION_TOP_SPAN_NAME);
 
-        if let Some(evaluation_id) = trace_to_evaluation.get(&trace.id()) {
-            traces_by_evaluation
-                .entry((trace.project_id(), *evaluation_id))
-                .or_default()
-                .push(realtime_trace);
-        } else if trace
-            .top_span_name()
-            .as_deref()
-            .is_some_and(|name| name == EVALUATION_TOP_SPAN_NAME)
-        {
-            // Unresolved evaluation trace — keep it out of the global feed.
-            continue;
-        } else {
-            traces_by_project
-                .entry(trace.project_id())
-                .or_default()
-                .push(realtime_trace);
+    if is_evaluation_trace {
+        let eval_id = match evaluation_id_from_metadata(trace) {
+            Some(id) => Some(id),
+            None => lookup_trace_evaluation_id(cache, &trace.project_id(), &trace.id()).await,
+        };
+
+        if let Some(id) = eval_id {
+            channels.push(TraceChannel::Evaluation(id));
         }
-
-        if let Some(rollout_session_id) = trace
-            .metadata()
-            .and_then(|m| m.get("rollout.session_id"))
-            .and_then(|v| v.as_str())
-        {
-            traces_by_rollout_session
-                .entry((trace.project_id(), rollout_session_id.to_string()))
-                .or_default()
-                .push(RealtimeDebuggerTrace {
-                    trace_id: trace.id(),
-                    metadata: trace.metadata().cloned(),
-                    has_browser_session: trace.has_browser_session(),
-                });
-        }
+    } else {
+        channels.push(TraceChannel::Project);
     }
 
-    for (project_id, traces_data) in traces_by_project {
-        let trace_message = SseMessage {
-            event_type: "trace_update".to_string(),
-            data: serde_json::json!({
-                "traces": traces_data
-            }),
-        };
-
-        send_to_key(pubsub, &project_id, "traces", trace_message).await;
+    if let Some(rollout_session_id) = rollout_session_id_from_metadata(trace) {
+        channels.push(TraceChannel::RolloutDebugger(rollout_session_id));
     }
 
-    for ((project_id, evaluation_id), traces_data) in traces_by_evaluation {
-        let trace_message = SseMessage {
-            event_type: "trace_update".to_string(),
-            data: serde_json::json!({
-                "traces": traces_data
-            }),
-        };
+    channels
+}
 
-        let evaluation_key = format!("evaluation_{}", evaluation_id);
-        send_to_key(pubsub, &project_id, &evaluation_key, trace_message).await;
-    }
+fn evaluation_id_from_metadata(trace: &Trace) -> Option<Uuid> {
+    trace
+        .metadata()
+        .and_then(|m| m.get(EVALUATION_ID_METADATA_KEY))
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s).ok())
+}
 
-    for ((project_id, rollout_session_id), traces_data) in traces_by_rollout_session {
-        let trace_message = SseMessage {
-            event_type: "trace_update".to_string(),
-            data: serde_json::json!({
-                "traces": traces_data
-            }),
-        };
-
-        let rollout_session_key = format!("rollout_session_{}", rollout_session_id);
-        send_to_key(pubsub, &project_id, &rollout_session_key, trace_message).await;
-    }
+fn rollout_session_id_from_metadata(trace: &Trace) -> Option<String> {
+    trace
+        .metadata()
+        .and_then(|m| m.get(ROLLOUT_SESSION_METADATA_KEY))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
 }
 
 impl RealtimeTrace {
     /// Convert database trace to realtime format
-    fn from_trace(trace: &Trace) -> Self {
+    pub fn from_trace(trace: &Trace) -> Self {
         Self {
             id: trace.id(),
             start_time: trace.start_time(),
@@ -249,115 +222,12 @@ impl RealtimeTrace {
     }
 }
 
-/// Build a `trace_id -> evaluation_id` map for evaluation traces in this batch.
-async fn resolve_trace_to_evaluation(
-    traces: &[Trace],
-    spans: &[Span],
-    cache: Arc<Cache>,
-    clickhouse: clickhouse::Client,
-) -> HashMap<Uuid, Uuid> {
-    let evaluation_traces: Vec<(Uuid, Uuid)> = traces
-        .iter()
-        .filter(|t| {
-            t.top_span_name()
-                .as_deref()
-                .is_some_and(|name| name == EVALUATION_TOP_SPAN_NAME)
-        })
-        .map(|t| (t.id(), t.project_id()))
-        .collect();
-
-    if evaluation_traces.is_empty() {
-        return HashMap::new();
-    }
-
-    let from_spans = evaluation_ids_from_spans(spans);
-
-    let mut resolved: HashMap<Uuid, Uuid> = HashMap::new();
-    let mut needs_lookup: Vec<(Uuid, Uuid)> = Vec::new();
-
-    for (trace_id, project_id) in evaluation_traces {
-        if let Some(eval_id) = from_spans.get(&trace_id).copied() {
-            resolved.insert(trace_id, eval_id);
-        } else {
-            needs_lookup.push((trace_id, project_id));
-        }
-    }
-
-    if needs_lookup.is_empty() {
-        return resolved;
-    }
-
-    let lookups = needs_lookup.into_iter().map(|(trace_id, project_id)| {
-        let cache = cache.clone();
-        let clickhouse = clickhouse.clone();
-        async move {
-            let eval_id = resolve_one(trace_id, project_id, cache, clickhouse).await?;
-            Some((trace_id, eval_id))
-        }
-    });
-
-    for (trace_id, eval_id) in futures_util::future::join_all(lookups)
-        .await
-        .into_iter()
-        .flatten()
-    {
-        resolved.insert(trace_id, eval_id);
-    }
-
-    resolved
-}
-
-fn evaluation_ids_from_spans(spans: &[Span]) -> HashMap<Uuid, Uuid> {
-    let key = format!("{ASSOCIATION_PROPERTIES_PREFIX}.{EVALUATION_ID_ATTRIBUTE_SUFFIX}");
-    let mut out: HashMap<Uuid, Uuid> = HashMap::new();
-    for span in spans {
-        if out.contains_key(&span.trace_id) {
-            continue;
-        }
-        if let Some(eval_id) = span
-            .attributes
-            .raw_attributes
-            .get(&key)
-            .and_then(|v| v.as_str())
-            .and_then(|s| Uuid::parse_str(s).ok())
-        {
-            out.insert(span.trace_id, eval_id);
-        }
-    }
-    out
-}
-
-async fn resolve_one(
-    trace_id: Uuid,
-    project_id: Uuid,
-    cache: Arc<Cache>,
-    clickhouse: clickhouse::Client,
-) -> Option<Uuid> {
-    let key = format!(
-        "{}:{}:{}",
-        TRACE_EVALUATION_ID_CACHE_KEY, project_id, trace_id
-    );
-
-    match cache.get::<Uuid>(&key).await {
-        Ok(Some(eval_id)) => return Some(eval_id),
-        Ok(None) => {}
-        Err(e) => log::warn!("Failed to read evaluation_id cache for {}: {:?}", key, e),
-    }
-
-    match get_evaluation_id_by_trace_id(clickhouse, project_id, trace_id).await {
-        Ok(Some(eval_id)) => {
-            if let Err(e) = cache
-                .insert_with_ttl(&key, eval_id, TRACE_EVALUATION_ID_TTL_SECONDS)
-                .await
-            {
-                log::warn!("Failed to cache evaluation_id for {}: {:?}", key, e);
-            }
-            Some(eval_id)
-        }
-        Ok(None) => None,
-        Err(e) => {
-            log::warn!("Failed to look up evaluation_id for {}: {:?}", trace_id, e);
-            None
+impl RealtimeDebuggerTrace {
+    pub fn from_trace(trace: &Trace) -> Self {
+        Self {
+            trace_id: trace.id(),
+            metadata: trace.metadata().cloned(),
+            has_browser_session: trace.has_browser_session(),
         }
     }
 }

--- a/frontend/components/evaluation/columns/index.ts
+++ b/frontend/components/evaluation/columns/index.ts
@@ -32,7 +32,12 @@ export const STATIC_COLUMNS: ColumnDef<EvalRow>[] = [
     header: "Status",
     size: 70,
     enableSorting: false,
-    meta: { sql: "trace_status", dataType: "string", filterable: false, comparable: false },
+    meta: {
+      sql: "multiIf(trace_status = 'error', 'error', notEmpty(scores) AND top_span_id != '00000000-0000-0000-0000-000000000000', 'success', 'pending')",
+      dataType: "string",
+      filterable: false,
+      comparable: false,
+    },
   },
   {
     id: "index",

--- a/frontend/components/evaluation/columns/index.ts
+++ b/frontend/components/evaluation/columns/index.ts
@@ -1,5 +1,6 @@
 import { type ColumnDef } from "@tanstack/react-table";
 
+import { deriveStatus } from "@/components/evaluation/utils";
 import { type EvalRow } from "@/lib/evaluation/types";
 
 import { CostCell } from "./cost-cell";
@@ -27,17 +28,12 @@ export const STATIC_COLUMNS: ColumnDef<EvalRow>[] = [
   },
   {
     id: "status",
-    accessorFn: (row) => row["status"],
+    accessorFn: (row) => deriveStatus(row),
     cell: StatusCell,
     header: "Status",
     size: 70,
     enableSorting: false,
-    meta: {
-      sql: "multiIf(trace_status = 'error', 'error', notEmpty(scores) AND top_span_id != '00000000-0000-0000-0000-000000000000', 'success', 'pending')",
-      dataType: "string",
-      filterable: false,
-      comparable: false,
-    },
+    meta: { dataType: "string", filterable: false, comparable: false },
   },
   {
     id: "index",
@@ -209,6 +205,20 @@ export const STATIC_COLUMNS: ColumnDef<EvalRow>[] = [
       comparable: false,
       hidden: true,
     },
+  },
+  {
+    id: "traceStatus",
+    accessorFn: (row) => row["traceStatus"],
+    header: "Trace Status",
+    enableSorting: false,
+    meta: { sql: "trace_status", dataType: "string", filterable: false, comparable: false, hidden: true },
+  },
+  {
+    id: "topSpanId",
+    accessorFn: (row) => row["topSpanId"],
+    header: "Top Span ID",
+    enableSorting: false,
+    meta: { sql: "top_span_id", dataType: "string", filterable: false, comparable: false, hidden: true },
   },
 ];
 

--- a/frontend/components/evaluation/columns/status-cell.tsx
+++ b/frontend/components/evaluation/columns/status-cell.tsx
@@ -1,9 +1,10 @@
 import { Check, Loader2, X } from "lucide-react";
 
+import { deriveStatus } from "@/components/evaluation/utils";
 import { type EvalRow } from "@/lib/evaluation/types";
 
 export const StatusCell = ({ row }: { row: { original: EvalRow } }) => {
-  const status = row.original["status"];
+  const status = deriveStatus(row.original);
 
   if (status === "error") {
     return (

--- a/frontend/components/evaluation/columns/status-cell.tsx
+++ b/frontend/components/evaluation/columns/status-cell.tsx
@@ -1,13 +1,27 @@
-import { Check, X } from "lucide-react";
+import { Check, Loader2, X } from "lucide-react";
 
 import { type EvalRow } from "@/lib/evaluation/types";
 
-export const StatusCell = ({ row }: { row: { original: EvalRow } }) => (
-  <div className="flex h-full justify-center items-center w-10">
-    {row.original["status"] === "error" ? (
-      <X className="self-center text-destructive" size={18} />
-    ) : (
-      <Check className="text-success" size={18} />
-    )}
-  </div>
-);
+export const StatusCell = ({ row }: { row: { original: EvalRow } }) => {
+  const status = row.original["status"];
+
+  if (status === "error") {
+    return (
+      <div className="flex h-full justify-center items-center w-10">
+        <X className="self-center text-destructive" size={18} />
+      </div>
+    );
+  }
+  if (status === "success") {
+    return (
+      <div className="flex h-full justify-center items-center w-10">
+        <Check className="text-success" size={18} />
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-full justify-center items-center w-10">
+      <Loader2 className="text-muted-foreground animate-spin" size={18} />
+    </div>
+  );
+};

--- a/frontend/components/evaluation/evaluation.tsx
+++ b/frontend/components/evaluation/evaluation.tsx
@@ -14,7 +14,9 @@ import { useEvalStore } from "@/components/evaluation/store";
 import {
   applyScoresToStats,
   type EvaluationStatsPayload,
+  extractFlattenedScores,
   flattenScores,
+  hasOutOfRangeScore,
   mergeDatapointUpsertIntoRows,
   mergeTraceUpdateIntoRows,
 } from "@/components/evaluation/utils";
@@ -219,12 +221,23 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
     (incoming: EvalRow & { id: string }) => {
       if (targetId) return;
       const flattened = flattenScores(incoming["scores"]);
-      updateData((rows) => mergeDatapointUpsertIntoRows(rows, incoming, flattened));
-      // SWR cache is the single source of truth for chart data — mutating it
-      mutateStats((current) => applyScoresToStats(current, flattened), { revalidate: false });
+      let previous: Record<string, number> = {};
+      updateData((rows) => {
+        const existing = rows.find((r) => r["id"] === incoming.id);
+        previous = extractFlattenedScores(existing);
+        return mergeDatapointUpsertIntoRows(rows, incoming, flattened);
+      });
+      if (Object.keys(flattened).length === 0) return;
+      // If any score would clamp into an edge bucket (i.e. it's outside the
+      // existing distribution bounds), trigger a SWR revalidation
+      if (hasOutOfRangeScore(statsData, flattened)) {
+        mutateStats();
+      } else {
+        mutateStats((current) => applyScoresToStats(current, flattened, previous), { revalidate: false });
+      }
     },
 
-    [updateData, targetId, mutateStats]
+    [updateData, targetId, mutateStats, statsData]
   );
 
   // Realtime merge of trace stats (cost/duration/status/tokens) onto the row

--- a/frontend/components/evaluation/evaluation.tsx
+++ b/frontend/components/evaluation/evaluation.tsx
@@ -228,16 +228,23 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
         return mergeDatapointUpsertIntoRows(rows, incoming, flattened);
       });
       if (Object.keys(flattened).length === 0) return;
-      // If any score would clamp into an edge bucket (i.e. it's outside the
-      // existing distribution bounds), trigger a SWR revalidation
-      if (hasOutOfRangeScore(statsData, flattened)) {
+
+      let needsRevalidate = false;
+      mutateStats(
+        (current) => {
+          if (hasOutOfRangeScore(current, flattened)) {
+            needsRevalidate = true;
+            return current;
+          }
+          return applyScoresToStats(current, flattened, previous);
+        },
+        { revalidate: false }
+      );
+      if (needsRevalidate) {
         mutateStats();
-      } else {
-        mutateStats((current) => applyScoresToStats(current, flattened, previous), { revalidate: false });
       }
     },
-
-    [updateData, targetId, mutateStats, statsData]
+    [updateData, targetId, mutateStats]
   );
 
   // Realtime merge of trace stats (cost/duration/status/tokens) onto the row

--- a/frontend/components/evaluation/evaluation.tsx
+++ b/frontend/components/evaluation/evaluation.tsx
@@ -11,10 +11,18 @@ import EvaluationDatapointsTable from "@/components/evaluation/evaluation-datapo
 import EvaluationHeader from "@/components/evaluation/evaluation-header";
 import ScoreCard from "@/components/evaluation/score-card";
 import { useEvalStore } from "@/components/evaluation/store";
+import {
+  applyScoresToStats,
+  type EvaluationStatsPayload,
+  flattenScores,
+  mergeDatapointUpsertIntoRows,
+  mergeTraceUpdateIntoRows,
+} from "@/components/evaluation/utils";
 import { useInfiniteScroll } from "@/components/ui/infinite-datatable/hooks";
 import { DataTableStateProvider } from "@/components/ui/infinite-datatable/model/datatable-store";
 import { Skeleton } from "@/components/ui/skeleton";
 import { type EvalRow, type Evaluation as EvaluationType, type EvaluationResultsInfo } from "@/lib/evaluation/types";
+import { useRealtime } from "@/lib/hooks/use-realtime.ts";
 import { formatTimestamp, swrFetcher } from "@/lib/utils";
 
 import { TraceViewSidePanel } from "../traces/trace-view";
@@ -31,7 +39,7 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
   const { push } = useRouter();
   const pathName = usePathname();
   const searchParams = useSearchParams();
-  const params = useParams();
+  const params = useParams<{ projectId: string }>();
   const targetId = searchParams.get("targetId");
   const search = searchParams.get("search");
   const filter = searchParams.getAll("filter");
@@ -65,12 +73,13 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
     // columnDefs used internally in buildStatParams via store
   }, [params?.projectId, evaluationId, search, searchIn, filter, sortBy, sortDirection, buildStatsParams, columnDefs]);
 
-  const { data: statsData, isLoading: isStatsLoading } = useSWR<{
-    evaluation: EvaluationType;
-    allStatistics: Record<string, any>;
-    allDistributions: Record<string, any>;
-    scores: string[];
-  }>(statsUrl, swrFetcher);
+  const {
+    data: statsData,
+    isLoading: isStatsLoading,
+    mutate: mutateStats,
+  } = useSWR<EvaluationStatsPayload>(statsUrl, swrFetcher, {
+    revalidateOnFocus: false,
+  });
 
   // Target statistics URL (if comparing)
   const targetStatsUrl = useMemo(() => {
@@ -82,12 +91,9 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
     // columnDefs used internally in buildStatParams via store
   }, [params.projectId, targetId, search, searchIn, filter, sortBy, sortDirection, buildStatsParams, columnDefs]);
 
-  const { data: targetStatsData } = useSWR<{
-    evaluation: EvaluationType;
-    allStatistics: Record<string, any>;
-    allDistributions: Record<string, any>;
-    scores: string[];
-  }>(targetStatsUrl, swrFetcher);
+  const { data: targetStatsData } = useSWR<EvaluationStatsPayload>(targetStatsUrl, swrFetcher, {
+    revalidateOnFocus: false,
+  });
 
   const scores = useMemo(() => statsData?.scores ?? [], [statsData?.scores]);
 
@@ -166,6 +172,7 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
     isFetching: isFetchingPage,
     isLoading: isLoadingDatapoints,
     fetchNextPage,
+    updateData,
   } = useInfiniteScroll<EvalRow>({
     fetchFn: fetchDatapoints,
     enabled: !isStatsLoading,
@@ -206,6 +213,59 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
       setSelectedScore(scores[0]);
     }
   }
+
+  // Realtime merge by datapoint id. `targetId` (comparison view) disables
+  const mergeDatapointUpsert = useCallback(
+    (incoming: EvalRow & { id: string }) => {
+      if (targetId) return;
+      const flattened = flattenScores(incoming["scores"]);
+      updateData((rows) => mergeDatapointUpsertIntoRows(rows, incoming, flattened));
+      // SWR cache is the single source of truth for chart data — mutating it
+      mutateStats((current) => applyScoresToStats(current, flattened), { revalidate: false });
+    },
+
+    [updateData, targetId, mutateStats]
+  );
+
+  // Realtime merge of trace stats (cost/duration/status/tokens) onto the row
+  const mergeTraceUpdate = useCallback(
+    (trace: Record<string, unknown> & { id: string }) => {
+      if (targetId) return;
+      updateData((rows) => mergeTraceUpdateIntoRows(rows, trace));
+    },
+    [updateData, targetId]
+  );
+
+  const realtimeHandlers = useMemo(
+    () => ({
+      datapoint_upsert: (event: MessageEvent) => {
+        try {
+          const payload = JSON.parse(event.data) as { datapoints?: Array<EvalRow & { id: string }> };
+          payload.datapoints?.forEach(mergeDatapointUpsert);
+        } catch (e) {
+          console.warn("Failed to parse realtime datapoint_upsert:", e);
+        }
+      },
+      trace_update: (event: MessageEvent) => {
+        try {
+          const payload = JSON.parse(event.data) as {
+            traces?: Array<Record<string, unknown> & { id: string }>;
+          };
+          payload.traces?.forEach(mergeTraceUpdate);
+        } catch (e) {
+          console.warn("Failed to parse realtime trace_update:", e);
+        }
+      },
+    }),
+    [mergeDatapointUpsert, mergeTraceUpdate]
+  );
+
+  useRealtime({
+    key: `evaluation_${evaluationId}`,
+    projectId: params.projectId,
+    enabled: !targetId,
+    eventHandlers: realtimeHandlers,
+  });
 
   return (
     <>

--- a/frontend/components/evaluation/utils.ts
+++ b/frontend/components/evaluation/utils.ts
@@ -1,6 +1,128 @@
 import { flow, isNumber, mean, round } from "lodash";
 
 import { getOptimalTextColor, interpolateColor, normalizeValue, type RGBColor, type ScoreRange } from "@/lib/colors";
+import {
+  type EvalRow,
+  type Evaluation,
+  type EvaluationScoreDistributionBucket,
+  type EvaluationScoreStatistics,
+} from "@/lib/evaluation/types";
+
+/**
+ * Mirrors the `multiIf` formula in the `status` column SQL so realtime patches
+ */
+export type EvalDatapointStatus = "error" | "pending" | "success";
+
+export const deriveStatus = (row: EvalRow): EvalDatapointStatus => {
+  if (row["traceStatus"] === "error") return "error";
+
+  const scores = row["scores"];
+  const hasScoresString = typeof scores === "string" && scores.length > 0;
+  const hasFlattenedScores = Object.keys(row).some((k) => k.startsWith("score:") && row[k] != null);
+  return hasScoresString || hasFlattenedScores ? "success" : "pending";
+};
+
+/**
+ * Explode a `{name: number}` JSON string into `{score:<name>: number}` keys.
+ */
+export const flattenScores = (scores: unknown): Record<string, number> => {
+  if (typeof scores !== "string" || scores.length === 0) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(scores);
+  } catch {
+    return {};
+  }
+  if (parsed == null || typeof parsed !== "object") return {};
+  const out: Record<string, number> = {};
+  for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out[`score:${name}`] = value;
+    }
+  }
+  return out;
+};
+
+/**
+ * Server-computed stats payload returned by `/api/.../evaluations/[id]/stats`.
+ */
+export type EvaluationStatsPayload = {
+  evaluation: Evaluation;
+  allStatistics: Record<string, EvaluationScoreStatistics>;
+  allDistributions: Record<string, EvaluationScoreDistributionBucket[]>;
+  scores: string[];
+};
+
+const sumBucketHeights = (buckets: EvaluationScoreDistributionBucket[]): number =>
+  buckets.reduce((acc, b) => acc + (b.heights[0] ?? 0), 0);
+
+const incrementBucket = (
+  buckets: EvaluationScoreDistributionBucket[],
+  value: number
+): EvaluationScoreDistributionBucket[] => {
+  if (buckets.length === 0) return buckets;
+  let idx = buckets.findIndex((b, i) =>
+    i === buckets.length - 1
+      ? value >= b.lowerBound && value <= b.upperBound
+      : value >= b.lowerBound && value < b.upperBound
+  );
+  if (idx === -1) {
+    idx = value < buckets[0].lowerBound ? 0 : buckets.length - 1;
+  }
+  const next = [...buckets];
+  const heights = [...next[idx].heights];
+  heights[0] = (heights[0] ?? 0) + 1;
+  next[idx] = { ...next[idx], heights };
+  return next;
+};
+
+/**
+ * Apply a batch of realtime score values to a server stats payload, returning
+ * a new payload. Bucket bounds are NOT re-derived — out-of-range values clamp
+ * into edge buckets and self-heal on the next full refetch (mount / SWR
+ * revalidation). Used as an SWR `mutate` updater so the cache stays the single
+ * source of truth.
+
+ */
+export const applyScoresToStats = (
+  current: EvaluationStatsPayload | undefined,
+  flattened: Record<string, number>
+): EvaluationStatsPayload | undefined => {
+  if (!current) return current;
+  const entries = Object.entries(flattened);
+  if (entries.length === 0) return current;
+
+  const allStatistics = { ...current.allStatistics };
+  const allDistributions = { ...current.allDistributions };
+  const knownScores = new Set(current.scores);
+  const newNames: string[] = [];
+
+  for (const [key, value] of entries) {
+    const name = key.slice("score:".length);
+    const buckets = allDistributions[name];
+
+    if (!buckets || buckets.length === 0) {
+      if (!knownScores.has(name)) {
+        knownScores.add(name);
+        newNames.push(name);
+      }
+      continue;
+    }
+
+    const seedCount = sumBucketHeights(buckets);
+    const seedAvg = allStatistics[name]?.averageValue ?? 0;
+    const nextCount = seedCount + 1;
+
+    allDistributions[name] = incrementBucket(buckets, value);
+    allStatistics[name] = {
+      averageValue: (seedAvg * seedCount + value) / nextCount,
+    };
+  }
+
+  const scores = newNames.length > 0 ? [...current.scores, ...newNames] : current.scores;
+
+  return { ...current, scores, allStatistics, allDistributions };
+};
 
 export type ScoreRanges = Record<string, ScoreRange>;
 export type ScoreValue = number | undefined;
@@ -63,6 +185,75 @@ const hasSignificantRange = ({ min, max }: ScoreRange): boolean => {
 };
 
 export const shouldShowHeatmap = (range: ScoreRange): boolean => hasSignificantRange(range);
+
+/**
+ * Merge a realtime `datapoint_upsert` payload into the existing rows array.
+ *
+ * Updates an existing row in place if it matches by id; otherwise inserts the
+ * new row at the position implied by `index` (datapoints are conventionally
+ * rendered ascending by index).
+ */
+export const mergeDatapointUpsertIntoRows = (
+  rows: EvalRow[],
+  incoming: EvalRow & { id: string },
+  flattened: Record<string, number>
+): EvalRow[] => {
+  const idx = rows.findIndex((r) => r["id"] === incoming.id);
+  if (idx !== -1) {
+    const next = [...rows];
+    const merged = { ...next[idx], ...incoming, ...flattened };
+    merged["status"] = deriveStatus(merged);
+    next[idx] = merged;
+    return next;
+  }
+  const seeded: EvalRow = { ...incoming, ...flattened, status: deriveStatus(incoming) };
+  const incomingIndex = Number(seeded["index"] ?? Number.POSITIVE_INFINITY);
+  const insertAt = rows.findIndex((r) => Number(r["index"] ?? -1) > incomingIndex);
+  if (insertAt === -1) return [...rows, seeded];
+  const next = [...rows];
+  next.splice(insertAt, 0, seeded);
+  return next;
+};
+
+/**
+ * Merge a realtime `trace_update` payload into the row whose `traceId`
+ * matches. No-op for rows that haven't been fetched yet.
+ */
+export const mergeTraceUpdateIntoRows = (
+  rows: EvalRow[],
+  trace: Record<string, unknown> & { id: string }
+): EvalRow[] => {
+  const idx = rows.findIndex((r) => r["traceId"] === trace.id);
+  if (idx === -1) return rows;
+
+  const totalCost = Number(trace["totalCost"] ?? 0);
+  const inputCost = Number(trace["inputCost"] ?? 0);
+  const outputCost = Number(trace["outputCost"] ?? 0);
+  const sumCost = inputCost + outputCost;
+  const cost = totalCost > 0 ? Math.max(sumCost, totalCost) : sumCost;
+  const startTime = trace["startTime"] as string | undefined;
+  const endTime = trace["endTime"] as string | undefined;
+  const duration = startTime && endTime ? (Date.parse(endTime) - Date.parse(startTime)) / 1000 : undefined;
+
+  const next = [...rows];
+  const merged: EvalRow = {
+    ...next[idx],
+    cost,
+    inputCost,
+    outputCost,
+    totalCost,
+    inputTokens: trace["inputTokens"],
+    outputTokens: trace["outputTokens"],
+    totalTokens: trace["totalTokens"],
+    traceStatus: trace["status"],
+    startTime,
+    endTime,
+    ...(duration != null ? { duration } : {}),
+  };
+  merged["status"] = deriveStatus(merged);
+  next[idx] = merged;
+  return next;
+};
 
 export const createHeatmapStyle = (value: number, { min, max }: ScoreRange) => {
   if (!shouldShowHeatmap({ min, max })) {

--- a/frontend/components/evaluation/utils.ts
+++ b/frontend/components/evaluation/utils.ts
@@ -1,5 +1,6 @@
-import { flow, isNumber, mean, round } from "lodash";
+import { flow, get, isNumber, mean, round } from "lodash";
 
+import { calculateScoreDistribution } from "@/lib/actions/evaluation/utils";
 import { getOptimalTextColor, interpolateColor, normalizeValue, type RGBColor, type ScoreRange } from "@/lib/colors";
 import {
   type EvalRow,
@@ -8,18 +9,23 @@ import {
   type EvaluationScoreStatistics,
 } from "@/lib/evaluation/types";
 
-/**
- * Mirrors the `multiIf` formula in the `status` column SQL so realtime patches
- */
 export type EvalDatapointStatus = "error" | "pending" | "success";
+
+const NIL_UUID = "00000000-0000-0000-0000-000000000000";
 
 export const deriveStatus = (row: EvalRow): EvalDatapointStatus => {
   if (row["traceStatus"] === "error") return "error";
 
-  const scores = row["scores"];
-  const hasScoresString = typeof scores === "string" && scores.length > 0;
+  const scores = get(row, "scores");
+  const hasScoresString = typeof scores === "string" && scores.length > 0 && scores !== "{}";
   const hasFlattenedScores = Object.keys(row).some((k) => k.startsWith("score:") && row[k] != null);
-  return hasScoresString || hasFlattenedScores ? "success" : "pending";
+  if (!hasScoresString && !hasFlattenedScores) return "pending";
+
+  const topSpanId = get(row, "topSpanId");
+  if (typeof topSpanId !== "string" || topSpanId === "" || topSpanId === NIL_UUID) {
+    return "pending";
+  }
+  return "success";
 };
 
 /**
@@ -56,11 +62,7 @@ export type EvaluationStatsPayload = {
 const sumBucketHeights = (buckets: EvaluationScoreDistributionBucket[]): number =>
   buckets.reduce((acc, b) => acc + (b.heights[0] ?? 0), 0);
 
-const incrementBucket = (
-  buckets: EvaluationScoreDistributionBucket[],
-  value: number
-): EvaluationScoreDistributionBucket[] => {
-  if (buckets.length === 0) return buckets;
+const findBucketIdx = (buckets: EvaluationScoreDistributionBucket[], value: number): number => {
   let idx = buckets.findIndex((b, i) =>
     i === buckets.length - 1
       ? value >= b.lowerBound && value <= b.upperBound
@@ -69,11 +71,42 @@ const incrementBucket = (
   if (idx === -1) {
     idx = value < buckets[0].lowerBound ? 0 : buckets.length - 1;
   }
+  return idx;
+};
+
+const adjustBucket = (
+  buckets: EvaluationScoreDistributionBucket[],
+  value: number,
+  delta: number
+): EvaluationScoreDistributionBucket[] => {
+  if (buckets.length === 0) return buckets;
+  const idx = findBucketIdx(buckets, value);
   const next = [...buckets];
   const heights = [...next[idx].heights];
-  heights[0] = (heights[0] ?? 0) + 1;
+  heights[0] = Math.max(0, (heights[0] ?? 0) + delta);
   next[idx] = { ...next[idx], heights };
   return next;
+};
+
+/**
+ * Returns true if any of the supplied score values would fall outside the
+ * existing bucket bounds for that score
+ */
+export const hasOutOfRangeScore = (
+  current: EvaluationStatsPayload | undefined,
+  flattened: Record<string, number>
+): boolean => {
+  if (!current) return false;
+  for (const [key, value] of Object.entries(flattened)) {
+    const name = key.slice("score:".length);
+    const buckets = current.allDistributions[name];
+    if (!buckets || buckets.length === 0) continue;
+    if (sumBucketHeights(buckets) === 0) continue;
+    const lo = buckets[0].lowerBound;
+    const hi = buckets[buckets.length - 1].upperBound;
+    if (value < lo || value > hi) return true;
+  }
+  return false;
 };
 
 /**
@@ -82,11 +115,11 @@ const incrementBucket = (
  * into edge buckets and self-heal on the next full refetch (mount / SWR
  * revalidation). Used as an SWR `mutate` updater so the cache stays the single
  * source of truth.
-
  */
 export const applyScoresToStats = (
   current: EvaluationStatsPayload | undefined,
-  flattened: Record<string, number>
+  flattened: Record<string, number>,
+  previous: Record<string, number> = {}
 ): EvaluationStatsPayload | undefined => {
   if (!current) return current;
   const entries = Object.entries(flattened);
@@ -94,34 +127,58 @@ export const applyScoresToStats = (
 
   const allStatistics = { ...current.allStatistics };
   const allDistributions = { ...current.allDistributions };
-  const knownScores = new Set(current.scores);
   const newNames: string[] = [];
 
   for (const [key, value] of entries) {
     const name = key.slice("score:".length);
-    const buckets = allDistributions[name];
+    const existingBuckets = allDistributions[name];
+    const prevValue = previous[key];
+    const isUpdate = typeof prevValue === "number" && Number.isFinite(prevValue);
 
-    if (!buckets || buckets.length === 0) {
-      if (!knownScores.has(name)) {
-        knownScores.add(name);
-        newNames.push(name);
-      }
+    // First time we see this score (no buckets yet, or seed buckets are empty
+    // because the server had nothing to bucket): seed via the same routine the
+    // server uses, then continue. Bounds will self-heal on revalidation.
+    if (!existingBuckets || sumBucketHeights(existingBuckets) === 0) {
+      allDistributions[name] = calculateScoreDistribution([{ scores: { [name]: value } }], name);
+      allStatistics[name] = { averageValue: value };
+      if (!current.scores.includes(name)) newNames.push(name);
       continue;
     }
 
-    const seedCount = sumBucketHeights(buckets);
+    const seedCount = sumBucketHeights(existingBuckets);
     const seedAvg = allStatistics[name]?.averageValue ?? 0;
-    const nextCount = seedCount + 1;
 
-    allDistributions[name] = incrementBucket(buckets, value);
-    allStatistics[name] = {
-      averageValue: (seedAvg * seedCount + value) / nextCount,
-    };
+    if (isUpdate) {
+      // Subtract old contribution, add new — count stays the same.
+      let nextBuckets = adjustBucket(existingBuckets, prevValue, -1);
+      nextBuckets = adjustBucket(nextBuckets, value, +1);
+      allDistributions[name] = nextBuckets;
+      allStatistics[name] = {
+        averageValue: (seedAvg * seedCount - prevValue + value) / seedCount,
+      };
+    } else {
+      const nextCount = seedCount + 1;
+      allDistributions[name] = adjustBucket(existingBuckets, value, +1);
+      allStatistics[name] = {
+        averageValue: (seedAvg * seedCount + value) / nextCount,
+      };
+    }
   }
 
   const scores = newNames.length > 0 ? [...current.scores, ...newNames] : current.scores;
 
   return { ...current, scores, allStatistics, allDistributions };
+};
+
+export const extractFlattenedScores = (row: EvalRow | undefined): Record<string, number> => {
+  if (!row) return {};
+  const out: Record<string, number> = {};
+  for (const [k, v] of Object.entries(row)) {
+    if (k.startsWith("score:") && typeof v === "number" && Number.isFinite(v)) {
+      out[k] = v;
+    }
+  }
+  return out;
 };
 
 export type ScoreRanges = Record<string, ScoreRange>;
@@ -201,12 +258,10 @@ export const mergeDatapointUpsertIntoRows = (
   const idx = rows.findIndex((r) => r["id"] === incoming.id);
   if (idx !== -1) {
     const next = [...rows];
-    const merged = { ...next[idx], ...incoming, ...flattened };
-    merged["status"] = deriveStatus(merged);
-    next[idx] = merged;
+    next[idx] = { ...next[idx], ...incoming, ...flattened };
     return next;
   }
-  const seeded: EvalRow = { ...incoming, ...flattened, status: deriveStatus(incoming) };
+  const seeded: EvalRow = { ...incoming, ...flattened };
   const incomingIndex = Number(seeded["index"] ?? Number.POSITIVE_INFINITY);
   const insertAt = rows.findIndex((r) => Number(r["index"] ?? -1) > incomingIndex);
   if (insertAt === -1) return [...rows, seeded];
@@ -236,7 +291,7 @@ export const mergeTraceUpdateIntoRows = (
   const duration = startTime && endTime ? (Date.parse(endTime) - Date.parse(startTime)) / 1000 : undefined;
 
   const next = [...rows];
-  const merged: EvalRow = {
+  next[idx] = {
     ...next[idx],
     cost,
     inputCost,
@@ -246,12 +301,11 @@ export const mergeTraceUpdateIntoRows = (
     outputTokens: trace["outputTokens"],
     totalTokens: trace["totalTokens"],
     traceStatus: trace["status"],
+    topSpanId: trace["topSpanId"],
     startTime,
     endTime,
     ...(duration != null ? { duration } : {}),
   };
-  merged["status"] = deriveStatus(merged);
-  next[idx] = merged;
   return next;
 };
 

--- a/frontend/components/sql/utils.ts
+++ b/frontend/components/sql/utils.ts
@@ -197,6 +197,7 @@ export const tableSchemas: Record<string, TableSchema> = {
       { name: "trace_status", type: "String", description: "Status of the associated trace" },
       { name: "trace_metadata", type: "String", description: "Metadata from the associated trace as stringified JSON" },
       { name: "trace_tags", type: "Array(String)", description: "Tags from the associated trace" },
+      { name: "top_span_id", type: "UUID", description: "ID of the top-level span of the associated trace" },
       {
         name: "trace_spans",
         type: "Array(Tuple(name String, duration Float64, type String))",

--- a/frontend/lib/clickhouse/migrations/41_evaluation_datapoints_view_top_span_id.sql
+++ b/frontend/lib/clickhouse/migrations/41_evaluation_datapoints_view_top_span_id.sql
@@ -1,0 +1,52 @@
+DROP VIEW IF EXISTS evaluation_datapoints_v0;
+CREATE VIEW IF NOT EXISTS evaluation_datapoints_v0
+SQL SECURITY INVOKER
+AS SELECT
+    edp.id id,
+    edp.evaluation_id evaluation_id,
+    edp.data data,
+    edp.target target,
+    edp.metadata metadata,
+    edp.executor_output executor_output,
+    edp.index `index`,
+    edp.trace_id trace_id,
+    edp.group_id group_id,
+    edp.scores scores,
+    edp.updated_at updated_at,
+    edp.updated_at created_at,
+    edp.dataset_id dataset_id,
+    edp.dataset_datapoint_id dataset_datapoint_id,
+    edp.dataset_datapoint_created_at dataset_datapoint_created_at,
+    end_time - start_time duration,
+    t.input_cost input_cost,
+    t.output_cost output_cost,
+    t.total_cost total_cost,
+    t.start_time start_time,
+    t.end_time end_time,
+    t.input_tokens input_tokens,
+    t.output_tokens output_tokens,
+    t.total_tokens total_tokens,
+    t.status trace_status,
+    t.metadata trace_metadata,
+    t.tags trace_tags,
+    t.top_span_id top_span_id,
+    s.spans trace_spans
+FROM evaluation_datapoints edp FINAL
+LEFT JOIN traces_replacing t FINAL ON (t.project_id = edp.project_id) AND (t.id = edp.trace_id)
+LEFT JOIN
+(
+    SELECT
+        trace_id,
+        project_id,
+        groupArray(
+            CAST(
+                tuple(name, duration, span_type)
+                AS
+                Tuple(name String, duration Float64, type String)
+            )
+        ) AS spans
+    FROM spans
+    WHERE project_id = {project_id:UUID}
+    GROUP BY project_id, trace_id
+) AS s ON (s.project_id = edp.project_id) AND (s.trace_id = edp.trace_id)
+WHERE edp.project_id = {project_id:UUID};

--- a/query-engine/src/query_validator.py
+++ b/query-engine/src/query_validator.py
@@ -216,6 +216,7 @@ class TableRegistry:
             "trace_status",
             "trace_metadata",
             "trace_tags",
+            "top_span_id",
             "trace_spans",
         }
         self.tables["evaluation_datapoints"] = TableSchema(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new SSE event flows and cache-backed ClickHouse lookups that affect both evaluation and trace realtime streams; issues could surface as missed/duplicated UI updates or extra query/load under high throughput.
> 
> **Overview**
> Adds realtime evaluation updates by publishing `datapoint_upsert` SSE events when evaluation datapoints are inserted/updated, including a new lightweight `RealtimeDatapoint` payload and wiring `PubSub` into the eval datapoint API endpoints.
> 
> Extends trace realtime publishing to route evaluation traces to per-evaluation SSE channels (`evaluation_<id>`) by resolving `trace_id -> evaluation_id` via span attributes or a cached ClickHouse lookup, and updates the ClickHouse `evaluation_datapoints_v0` view/schema to expose `top_span_id` for status derivation.
> 
> On the frontend, subscribes the evaluation page to `evaluation_<id>` realtime events and incrementally merges incoming datapoint and trace updates into the table and SWR stats cache (including new pending/success/error status handling and hidden `traceStatus`/`topSpanId` columns).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 128b9d73847e16e391689a02a39d15465ca7f133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->