### PR TITLE
feat: guard posthog more strictly

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -75,24 +75,33 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: PropsWithChildren) {
   const featureFlags = Object.fromEntries(Object.values(Feature).map((f) => [f, isFeatureEnabled(f)])) as FeatureFlags;
 
-  const session = await getServerSession(authOptions).catch(() => null);
+  const posthogEnabled = featureFlags[Feature.POSTHOG];
+  const session = posthogEnabled ? await getServerSession(authOptions).catch(() => null) : null;
   const email = session?.user?.email ?? undefined;
+
+  const body = (
+    <body className="flex flex-col h-full">
+      <NuqsAdapter>
+        <div className="flex">
+          <div className="flex flex-col grow max-w-full min-h-screen">
+            <main className="z-10 flex flex-col grow">{children}</main>
+            <Toaster />
+          </div>
+        </div>
+      </NuqsAdapter>
+    </body>
+  );
 
   return (
     <html lang="en" className={cn("h-full antialiased", sans.variable, manrope.variable, spaceGrotesk.variable)}>
       <FeatureFlagsProvider flags={featureFlags}>
-        <PostHogProvider telemetryEnabled={featureFlags[Feature.POSTHOG]} email={email}>
-          <body className="flex flex-col h-full">
-            <NuqsAdapter>
-              <div className="flex">
-                <div className="flex flex-col grow max-w-full min-h-screen">
-                  <main className="z-10 flex flex-col grow">{children}</main>
-                  <Toaster />
-                </div>
-              </div>
-            </NuqsAdapter>
-          </body>
-        </PostHogProvider>
+        {posthogEnabled ? (
+          <PostHogProvider telemetryEnabled email={email}>
+            {body}
+          </PostHogProvider>
+        ) : (
+          body
+        )}
       </FeatureFlagsProvider>
     </html>
   );

--- a/frontend/app/project/[projectId]/layout.tsx
+++ b/frontend/app/project/[projectId]/layout.tsx
@@ -40,8 +40,8 @@ export default async function ProjectIdLayout(props: { children: ReactNode; para
 
   const posthog = PostHogClient();
 
-  if (posthog) {
-    posthog.identify({ distinctId: user.email ?? "" });
+  if (isFeatureEnabled(Feature.POSTHOG) && posthog && user.email) {
+    posthog.identify({ distinctId: user.email });
   }
 
   const cookieStore = await cookies();

--- a/frontend/app/project/[projectId]/layout.tsx
+++ b/frontend/app/project/[projectId]/layout.tsx
@@ -15,7 +15,6 @@ import { getProjectsByWorkspace } from "@/lib/actions/projects";
 import { getWorkspaceInfo } from "@/lib/actions/workspace";
 import { requireProjectAccess } from "@/lib/authorization";
 import { Feature, isFeatureEnabled } from "@/lib/features/features";
-import { PostHogIdentifier } from "@/lib/posthog";
 import PostHogClient from "@/lib/posthog/server";
 
 const projectSidebarCookieName = "project-sidebar-state";
@@ -52,7 +51,6 @@ export default async function ProjectIdLayout(props: { children: ReactNode; para
   return (
     <UserContextProvider user={user}>
       <SessionSyncProvider>
-        <PostHogIdentifier email={user.email} />
         <ProjectContextProvider workspace={workspace} projects={projects} project={projectDetails}>
           <div className="fixed inset-0 flex overflow-clip md:pt-2 bg-sidebar">
             <SidebarProvider cookieName={projectSidebarCookieName} className="bg-sidebar" defaultOpen={defaultOpen}>

--- a/frontend/app/workspace/[workspaceId]/layout.tsx
+++ b/frontend/app/workspace/[workspaceId]/layout.tsx
@@ -4,6 +4,8 @@ import { type PropsWithChildren } from "react";
 import SessionSyncProvider from "@/components/auth/session-sync-provider";
 import { UserContextProvider } from "@/contexts/user-context";
 import { requireWorkspaceAccess } from "@/lib/authorization";
+import { Feature, isFeatureEnabled } from "@/lib/features/features";
+import PostHogClient from "@/lib/posthog/server";
 
 export const metadata: Metadata = {
   title: "Workspace",
@@ -12,6 +14,12 @@ export const metadata: Metadata = {
 export default async function WorkspaceLayout(props: PropsWithChildren<{ params: Promise<{ workspaceId: string }> }>) {
   const params = await props.params;
   const session = await requireWorkspaceAccess(params.workspaceId);
+
+  const posthog = PostHogClient();
+
+  if (isFeatureEnabled(Feature.POSTHOG) && posthog && session.user.email) {
+    posthog.identify({ distinctId: session.user.email });
+  }
 
   return (
     <UserContextProvider user={session.user}>

--- a/frontend/lib/posthog/index.ts
+++ b/frontend/lib/posthog/index.ts
@@ -1,2 +1,2 @@
 export { type Feature, identify, track } from "./client";
-export { PostHogIdentifier, PostHogProvider } from "./provider";
+export { PostHogProvider } from "./provider";

--- a/frontend/lib/posthog/provider.tsx
+++ b/frontend/lib/posthog/provider.tsx
@@ -23,14 +23,3 @@ export function PostHogProvider({ children, telemetryEnabled, email }: PropsWith
 
   return <PHProvider client={posthog}>{children}</PHProvider>;
 }
-
-/** Lightweight component that only identifies the user without adding another PHProvider layer. */
-export function PostHogIdentifier({ email }: { email?: string }) {
-  useEffect(() => {
-    if (email) {
-      identify(email, { email });
-    }
-  }, [email]);
-
-  return null;
-}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to telemetry initialization/identification and avoid unnecessary session lookups when PostHog is disabled.
> 
> **Overview**
> PostHog is now **more strictly guarded** behind `Feature.POSTHOG`: `RootLayout` only calls `getServerSession` and mounts `PostHogProvider` when telemetry is enabled.
> 
> Server-side `posthog.identify` calls in project/workspace layouts now require both the feature flag and a non-empty user email, and the standalone `PostHogIdentifier` component/export has been removed in favor of provider/server identification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88a5569c9e400164a0f1e8b41d78c4faeaa130b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->