### PR TITLE
fix(trace-view): sync trace shrink with span panel enter

### DIFF
--- a/frontend/components/traces/trace-view/dynamic-width-layout.tsx
+++ b/frontend/components/traces/trace-view/dynamic-width-layout.tsx
@@ -9,7 +9,7 @@ import { usePanelResize } from "@/components/traces/trace-view/use-panel-resize"
 
 import { type TraceViewPanels } from "./trace-view-content";
 
-const enterExitTransition = { type: "spring", stiffness: 300, damping: 30 } as const;
+const enterExitTransition = { duration: 0.25, ease: "easeOut" } as const;
 const instantTransition = { duration: 0 } as const;
 
 interface DynamicWidthLayoutProps {
@@ -67,17 +67,16 @@ export default function DynamicWidthLayout({ panels, sidePanelRef }: DynamicWidt
   return (
     <div ref={containerRef} className="h-full w-full overflow-hidden">
       <div className="flex flex-row h-full">
-        {/* Trace Panel — always visible */}
+        {/* Trace has no inner-abs wrapper because it never animates from 0 — content reflows
+            with the flex item. Span/chat keep the inner-abs pinned-at-target slide-in pattern. */}
         <motion.div
-          className="relative flex h-full flex-shrink-0 overflow-hidden"
+          className="relative flex h-full flex-shrink-0"
           initial={false}
           animate={{ width: widths.trace }}
           transition={transition}
         >
-          <div className="absolute inset-y-0 left-0 flex" style={{ width: widths.trace }}>
-            <LeftEdgeResizeHandle onMouseDown={traceResize.handleMouseDown} />
-            {panels.tracePanel}
-          </div>
+          <LeftEdgeResizeHandle onMouseDown={traceResize.handleMouseDown} />
+          {panels.tracePanel}
         </motion.div>
 
         <AnimatePresence initial={false}>

--- a/frontend/components/traces/trace-view/dynamic-width-layout.tsx
+++ b/frontend/components/traces/trace-view/dynamic-width-layout.tsx
@@ -1,8 +1,9 @@
 import { AnimatePresence, motion } from "framer-motion";
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { shallow } from "zustand/shallow";
 
 import { LeftEdgeResizeHandle } from "@/components/traces/trace-view/left-edge-resize-handle";
+import { computeLayout, type ResizablePanel, type Visible } from "@/components/traces/trace-view/panel-layout";
 import { useTraceViewStore } from "@/components/traces/trace-view/store";
 import { usePanelResize } from "@/components/traces/trace-view/use-panel-resize";
 
@@ -17,11 +18,11 @@ interface DynamicWidthLayoutProps {
 }
 
 export default function DynamicWidthLayout({ panels, sidePanelRef }: DynamicWidthLayoutProps) {
-  const { tracePanelWidth, spanPanelWidth, chatPanelWidth, resizePanel, setMaxWidth } = useTraceViewStore(
+  const { targets, maxWidth, layoutChangeSource, resizePanel, setMaxWidth } = useTraceViewStore(
     (state) => ({
-      tracePanelWidth: state.tracePanelWidth,
-      spanPanelWidth: state.spanPanelWidth,
-      chatPanelWidth: state.chatPanelWidth,
+      targets: state.targets,
+      maxWidth: state.maxWidth,
+      layoutChangeSource: state.layoutChangeSource,
       resizePanel: state.resizePanel,
       setMaxWidth: state.setMaxWidth,
     }),
@@ -44,21 +45,40 @@ export default function DynamicWidthLayout({ panels, sidePanelRef }: DynamicWidt
     return () => observer.disconnect();
   }, [sidePanelRef, setMaxWidth]);
 
-  const traceResize = usePanelResize("trace", resizePanel);
-  const spanResize = usePanelResize("span", resizePanel);
-  const chatResize = usePanelResize("chat", resizePanel);
+  const visible = useMemo<Visible>(
+    () => ({ span: panels.showSpan, chat: panels.showChat }),
+    [panels.showSpan, panels.showChat]
+  );
+
+  const widths = useMemo(() => computeLayout(targets, visible, maxWidth), [targets, visible, maxWidth]);
+
+  const dragPanel = useCallback(
+    (panel: ResizablePanel, delta: number) => resizePanel(panel, delta, visible),
+    [resizePanel, visible]
+  );
+
+  const traceResize = usePanelResize("trace", dragPanel);
+  const spanResize = usePanelResize("span", dragPanel);
+  const chatResize = usePanelResize("chat", dragPanel);
 
   const isResizing = traceResize.isResizing || spanResize.isResizing || chatResize.isResizing;
-  const transition = isResizing ? instantTransition : enterExitTransition;
+  const transition = !isResizing && layoutChangeSource === "visibility" ? enterExitTransition : instantTransition;
 
   return (
     <div ref={containerRef} className="h-full w-full overflow-hidden">
       <div className="flex flex-row h-full">
         {/* Trace Panel — always visible */}
-        <div className="relative flex h-full flex-shrink-0" style={{ width: tracePanelWidth }}>
-          <LeftEdgeResizeHandle onMouseDown={traceResize.handleMouseDown} />
-          {panels.tracePanel}
-        </div>
+        <motion.div
+          className="relative flex h-full flex-shrink-0 overflow-hidden"
+          initial={false}
+          animate={{ width: widths.trace }}
+          transition={transition}
+        >
+          <div className="absolute inset-y-0 left-0 flex" style={{ width: widths.trace }}>
+            <LeftEdgeResizeHandle onMouseDown={traceResize.handleMouseDown} />
+            {panels.tracePanel}
+          </div>
+        </motion.div>
 
         <AnimatePresence initial={false}>
           {/* Span Panel */}
@@ -67,11 +87,11 @@ export default function DynamicWidthLayout({ panels, sidePanelRef }: DynamicWidt
               key="span-panel"
               className="relative h-full flex-shrink-0 overflow-hidden"
               initial={{ width: 0, opacity: 0.5 }}
-              animate={{ width: spanPanelWidth, opacity: 1 }}
+              animate={{ width: widths.span, opacity: 1 }}
               exit={{ width: 0, opacity: 0.5 }}
               transition={transition}
             >
-              <div className="absolute inset-y-0 left-0 flex" style={{ width: spanPanelWidth }}>
+              <div className="absolute inset-y-0 left-0 flex" style={{ width: widths.span }}>
                 <LeftEdgeResizeHandle onMouseDown={spanResize.handleMouseDown} />
                 {panels.spanPanel}
               </div>
@@ -84,11 +104,11 @@ export default function DynamicWidthLayout({ panels, sidePanelRef }: DynamicWidt
               key="chat-panel"
               className="relative h-full flex-shrink-0 overflow-hidden"
               initial={{ width: 0, opacity: 0.5 }}
-              animate={{ width: chatPanelWidth, opacity: 1 }}
+              animate={{ width: widths.chat, opacity: 1 }}
               exit={{ width: 0, opacity: 0.5 }}
               transition={transition}
             >
-              <div className="absolute inset-y-0 left-0 flex" style={{ width: chatPanelWidth }}>
+              <div className="absolute inset-y-0 left-0 flex" style={{ width: widths.chat }}>
                 <LeftEdgeResizeHandle onMouseDown={chatResize.handleMouseDown} />
                 {panels.chatPanel}
               </div>

--- a/frontend/components/traces/trace-view/panel-layout.ts
+++ b/frontend/components/traces/trace-view/panel-layout.ts
@@ -20,8 +20,6 @@ export const PANELS: Readonly<Record<ResizablePanel, { min: number; default: num
   chat: { min: 375, default: 385 },
 };
 
-const ORDER: readonly ResizablePanel[] = ["trace", "span", "chat"];
-
 export const DEFAULT_TARGETS: Targets = {
   trace: PANELS.trace.default,
   span: PANELS.span.default,
@@ -111,7 +109,10 @@ export function computeLayout(targets: Targets, visible: Visible, maxWidth: numb
  * - delta < 0 (shrink): clamp target to its min; propagate any leftover shrink RIGHTWARD,
  *   each panel clamping at its min.
  *
- * Only visible panels participate; hidden panels' targets are unchanged.
+ * Operates on the *currently rendered* widths, not raw targets — otherwise after a fit
+ * (container resize / panel becoming visible) targets can exceed maxWidth and the drag
+ * delta desynchronises from cursor movement. Only visible panels participate; hidden
+ * panels' targets are unchanged.
  */
 export function applyDrag(
   targets: Targets,
@@ -124,10 +125,11 @@ export function applyDrag(
   const idx = order.indexOf(panel);
   if (idx === -1 || delta === 0) return targets;
 
-  const next: Record<ResizablePanel, number> = { ...targets };
+  const start = computeLayout(targets, visible, maxWidth);
+  const next: Record<ResizablePanel, number> = { ...start };
 
   if (delta > 0) {
-    next[panel] = targets[panel] + delta;
+    next[panel] = start[panel] + delta;
 
     if (Number.isFinite(maxWidth)) {
       const total = order.reduce((s, k) => s + next[k], 0);

--- a/frontend/components/traces/trace-view/panel-layout.ts
+++ b/frontend/components/traces/trace-view/panel-layout.ts
@@ -1,0 +1,158 @@
+/**
+ * Pure functions for the trace-view panel layout.
+ *
+ * Single source of truth: `targets` = the user's drag intent for each panel.
+ * `applyDrag` updates targets in response to a drag delta. `computeLayout`
+ * derives the rendered widths from targets + visibility + container width.
+ *
+ * Targets are persisted; rendered widths are not.
+ */
+
+export type ResizablePanel = "trace" | "span" | "chat";
+
+export type Targets = Readonly<Record<ResizablePanel, number>>;
+export type Widths = Targets;
+export type Visible = Readonly<{ span: boolean; chat: boolean }>;
+
+export const PANELS: Readonly<Record<ResizablePanel, { min: number; default: number }>> = {
+  trace: { min: 488, default: 500 },
+  span: { min: 400, default: 405 },
+  chat: { min: 375, default: 385 },
+};
+
+const ORDER: readonly ResizablePanel[] = ["trace", "span", "chat"];
+
+export const DEFAULT_TARGETS: Targets = {
+  trace: PANELS.trace.default,
+  span: PANELS.span.default,
+  chat: PANELS.chat.default,
+};
+
+function visibleOrder(visible: Visible): ResizablePanel[] {
+  const out: ResizablePanel[] = ["trace"];
+  if (visible.span) out.push("span");
+  if (visible.chat) out.push("chat");
+  return out;
+}
+
+/**
+ * Derive rendered widths from targets, visibility, and container width.
+ *
+ * - Hidden panels' output equals their target (irrelevant; not rendered).
+ * - Visible panels are clamped to at-least-min before fitting.
+ * - If Σ visible widths ≤ maxWidth: render at clamped target; gap is absorbed by the container.
+ * - If Σ > maxWidth: shrink proportionally using above-min slack.
+ *   If slack is exhausted (overflow policy), shrink visible panels proportionally below their mins.
+ * - If maxWidth is not finite (not yet measured), return clamped targets.
+ */
+export function computeLayout(targets: Targets, visible: Visible, maxWidth: number): Widths {
+  const order = visibleOrder(visible);
+  const widths: Record<ResizablePanel, number> = { ...targets };
+
+  for (const k of order) widths[k] = Math.max(widths[k], PANELS[k].min);
+
+  if (!Number.isFinite(maxWidth)) return widths;
+
+  const sum = order.reduce((s, k) => s + widths[k], 0);
+  if (sum <= maxWidth) return widths;
+
+  let deficit = sum - maxWidth;
+
+  const slack: Record<ResizablePanel, number> = { trace: 0, span: 0, chat: 0 };
+  let totalSlack = 0;
+  for (const k of order) {
+    slack[k] = Math.max(0, widths[k] - PANELS[k].min);
+    totalSlack += slack[k];
+  }
+
+  if (totalSlack > 0) {
+    let remaining = deficit;
+    for (const k of order) {
+      const share = Math.min(slack[k], Math.round(deficit * (slack[k] / totalSlack)));
+      const actual = Math.min(share, remaining);
+      widths[k] -= actual;
+      remaining -= actual;
+    }
+    if (remaining > 0) {
+      for (let i = order.length - 1; i >= 0 && remaining > 0; i--) {
+        const k = order[i];
+        const absorb = Math.min(remaining, widths[k] - PANELS[k].min);
+        widths[k] -= absorb;
+        remaining -= absorb;
+      }
+    }
+    deficit = remaining;
+    if (deficit <= 0) return widths;
+  }
+
+  const totalWidth = order.reduce((s, k) => s + widths[k], 0);
+  if (totalWidth <= 0) return widths;
+
+  let remaining2 = deficit;
+  for (const k of order) {
+    const share = Math.round(deficit * (widths[k] / totalWidth));
+    const actual = Math.min(share, remaining2);
+    widths[k] -= actual;
+    remaining2 -= actual;
+  }
+  if (remaining2 > 0) {
+    const last = order[order.length - 1];
+    widths[last] -= remaining2;
+  }
+
+  return widths;
+}
+
+/**
+ * Update drag targets in response to a left-edge drag on `panel`.
+ *
+ * - delta > 0 (grow): add to target. If total exceeds maxWidth, cascade-shrink LEFT
+ *   visible neighbors down to their mins; if still over, cap the target's growth.
+ * - delta < 0 (shrink): clamp target to its min; propagate any leftover shrink RIGHTWARD,
+ *   each panel clamping at its min.
+ *
+ * Only visible panels participate; hidden panels' targets are unchanged.
+ */
+export function applyDrag(
+  targets: Targets,
+  visible: Visible,
+  panel: ResizablePanel,
+  delta: number,
+  maxWidth: number
+): Targets {
+  const order = visibleOrder(visible);
+  const idx = order.indexOf(panel);
+  if (idx === -1 || delta === 0) return targets;
+
+  const next: Record<ResizablePanel, number> = { ...targets };
+
+  if (delta > 0) {
+    next[panel] = targets[panel] + delta;
+
+    if (Number.isFinite(maxWidth)) {
+      const total = order.reduce((s, k) => s + next[k], 0);
+      let overflow = total - maxWidth;
+      if (overflow > 0) {
+        for (let i = idx - 1; i >= 0 && overflow > 0; i--) {
+          const k = order[i];
+          const shrinkable = Math.max(0, next[k] - PANELS[k].min);
+          const amt = Math.min(shrinkable, overflow);
+          next[k] -= amt;
+          overflow -= amt;
+        }
+        if (overflow > 0) next[panel] -= overflow;
+      }
+    }
+  } else {
+    let remaining = delta;
+    for (let i = idx; i < order.length && remaining < 0; i++) {
+      const k = order[i];
+      const cur = next[k];
+      const newW = Math.max(PANELS[k].min, cur + remaining);
+      next[k] = newW;
+      remaining -= newW - cur;
+    }
+  }
+
+  return next;
+}

--- a/frontend/components/traces/trace-view/store/index.tsx
+++ b/frontend/components/traces/trace-view/store/index.tsx
@@ -3,6 +3,14 @@ import { createStore, type StoreApi } from "zustand";
 import { persist } from "zustand/middleware";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 
+import {
+  applyDrag,
+  DEFAULT_TARGETS,
+  type ResizablePanel,
+  type Targets,
+  type Visible,
+} from "@/components/traces/trace-view/panel-layout";
+
 import { type BaseTraceViewStore, createBaseTraceViewSlice, TraceViewContext, type TraceViewTrace } from "./base";
 
 export {
@@ -14,99 +22,26 @@ export {
   type TraceViewTrace,
   ZOOM_INCREMENT,
 } from "./base";
+export type { ResizablePanel } from "@/components/traces/trace-view/panel-layout";
 
-export type ResizablePanel = "trace" | "span" | "chat";
-
-type PanelWidthKey = "tracePanelWidth" | "spanPanelWidth" | "chatPanelWidth";
-type PanelDef = { key: PanelWidthKey; min: number; default: number };
-
-const ALL_PANELS: PanelDef[] = [
-  { key: "tracePanelWidth", min: 488, default: 500 },
-  { key: "spanPanelWidth", min: 400, default: 405 },
-  { key: "chatPanelWidth", min: 375, default: 385 },
-];
+/**
+ * What kind of state change last affected layout. Drives transition selection
+ * in the layout component (drag/container = instant, visibility = spring).
+ */
+export type LayoutChangeSource = "initial" | "drag" | "container" | "visibility";
 
 interface TraceViewStoreState {
-  tracePanelWidth: number;
-  spanPanelWidth: number;
-  chatPanelWidth: number;
+  targets: Targets;
   maxWidth: number;
+  layoutChangeSource: LayoutChangeSource;
 }
 
 interface TraceViewStoreActions {
-  resizePanel: (panel: ResizablePanel, delta: number) => void;
+  resizePanel: (panel: ResizablePanel, delta: number, visible: Visible) => void;
   setMaxWidth: (maxWidth: number) => void;
-  fitPanelsToMaxWidth: () => void;
 }
 
 type TraceViewStore = BaseTraceViewStore & TraceViewStoreState & TraceViewStoreActions;
-
-/** Determine which panels are currently visible based on store state. */
-function getVisiblePanels(state: TraceViewStore): PanelDef[] {
-  const result: PanelDef[] = [ALL_PANELS[0]]; // trace always visible
-
-  if (state.spanPanelOpen || (state.isAlwaysSelectSpan && state.spans.length > 0)) result.push(ALL_PANELS[1]);
-
-  if (state.tracesAgentOpen) result.push(ALL_PANELS[2]);
-
-  return result;
-}
-
-/** Distribute a deficit proportionally across panels based on their budget above minimum.
- *  If all panels are at minimum, falls back to proportional shrinking below minimums. */
-function distributeDeficit(
-  state: TraceViewStore,
-  visiblePanels: PanelDef[],
-  deficit: number
-): Partial<TraceViewStoreState> {
-  const updates: Partial<TraceViewStoreState> = {};
-  const budgets = visiblePanels.map((p) => ({
-    key: p.key,
-    min: p.min,
-    width: state[p.key],
-    budget: state[p.key] - p.min,
-  }));
-  const totalBudget = budgets.reduce((sum, b) => sum + b.budget, 0);
-
-  if (totalBudget > 0) {
-    // Preferred: shrink panels proportionally to their budget above minimum
-    let remaining = deficit;
-    for (const b of budgets) {
-      const share = Math.min(b.budget, Math.round(deficit * (b.budget / totalBudget)));
-      const actual = Math.min(share, remaining);
-      updates[b.key] = b.width - actual;
-      remaining -= actual;
-    }
-    // Absorb rounding remainder
-    if (remaining > 0) {
-      for (let i = budgets.length - 1; i >= 0 && remaining > 0; i--) {
-        const b = budgets[i];
-        const current = (updates[b.key] as number) ?? b.width;
-        const absorb = Math.min(remaining, current - b.min);
-        updates[b.key] = current - absorb;
-        remaining -= absorb;
-      }
-    }
-  } else {
-    // Fallback: all at minimum, shrink proportionally below minimums
-    const totalWidth = budgets.reduce((sum, b) => sum + b.width, 0);
-    if (totalWidth <= 0) return updates;
-    let remaining = deficit;
-    for (const b of budgets) {
-      const share = Math.round(deficit * (b.width / totalWidth));
-      const actual = Math.min(share, remaining);
-      updates[b.key] = b.width - actual;
-      remaining -= actual;
-    }
-    // Absorb rounding remainder from last panel
-    if (remaining > 0) {
-      const last = budgets[budgets.length - 1];
-      updates[last.key] = ((updates[last.key] as number) ?? last.width) - remaining;
-    }
-  }
-
-  return updates;
-}
 
 const createTraceViewStore = (options?: {
   initialTrace?: TraceViewTrace;
@@ -128,111 +63,60 @@ const createTraceViewStore = (options?: {
         return {
           ...baseSlice,
 
-          tracePanelWidth: ALL_PANELS[0].default,
-          spanPanelWidth: ALL_PANELS[1].default,
-          chatPanelWidth: ALL_PANELS[2].default,
+          targets: DEFAULT_TARGETS,
           maxWidth: Infinity,
+          layoutChangeSource: "initial",
 
           setMaxWidth: (maxWidth: number) => {
             const current = get().maxWidth;
-            if (Math.abs(maxWidth - current) < 1) return; // guard against loops
-            set({ maxWidth } as Partial<TraceViewStore>);
-            get().fitPanelsToMaxWidth();
+            if (Math.abs(maxWidth - current) < 1) return;
+            set({ maxWidth, layoutChangeSource: "container" } as Partial<TraceViewStore>);
           },
 
-          fitPanelsToMaxWidth: () => {
+          resizePanel: (panel, delta, visible) => {
             const state = get();
-            if (state.maxWidth === Infinity) return;
-
-            const visible = getVisiblePanels(state);
-            const total = visible.reduce((sum, p) => sum + state[p.key], 0);
-            if (total <= state.maxWidth) return;
-
-            const deficit = total - state.maxWidth;
-            const updates = distributeDeficit(state, visible, deficit);
-            set(updates as Partial<TraceViewStore>);
+            const next = applyDrag(state.targets, visible, panel, delta, state.maxWidth);
+            if (next === state.targets) return;
+            set({ targets: next, layoutChangeSource: "drag" } as Partial<TraceViewStore>);
           },
 
-          resizePanel: (panel: ResizablePanel, delta: number) => {
-            const state = get();
-            const visible = getVisiblePanels(state);
-
-            const targetKey = `${panel}PanelWidth` as PanelWidthKey;
-            const startIndex = visible.findIndex((p) => p.key === targetKey);
-            if (startIndex === -1) {
-              return;
-            }
-
-            const updates: Partial<TraceViewStoreState> = {};
-
-            if (delta > 0) {
-              // GROW: apply delta to target, then cascade-shrink LEFT to fit maxWidth
-              const newTargetWidth = state[targetKey] + delta;
-              updates[targetKey] = newTargetWidth;
-
-              // Compute total with the update applied
-              let total = 0;
-              for (const p of visible) {
-                total += (updates[p.key] as number) ?? state[p.key];
-              }
-
-              let overflow = total - state.maxWidth;
-              if (overflow > 0) {
-                // Walk LEFT from target, shrinking each panel to its minimum
-                for (let i = startIndex - 1; i >= 0 && overflow > 0; i--) {
-                  const { key, min } = visible[i];
-                  const current = (updates[key] as number) ?? state[key];
-                  const shrinkable = Math.max(0, current - min);
-                  const shrinkAmount = Math.min(shrinkable, overflow);
-                  updates[key] = current - shrinkAmount;
-                  overflow -= shrinkAmount;
-                }
-
-                // If still overflow, cap the target's growth
-                if (overflow > 0) {
-                  updates[targetKey] = (updates[targetKey] as number) - overflow;
-                }
-              }
-            } else if (delta < 0) {
-              // SHRINK: clamp to min, propagate overflow RIGHTWARD
-              let remaining = delta;
-              for (let i = startIndex; i < visible.length && remaining < 0; i++) {
-                const { key, min } = visible[i];
-                const current = state[key];
-                const newWidth = Math.max(min, current + remaining);
-                updates[key] = newWidth;
-                remaining -= newWidth - current;
-              }
-            }
-
-            set(updates as Partial<TraceViewStore>);
-          },
-
-          // Override visibility-changing actions to auto-fit after
           setSelectedSpan: (span) => {
             baseSlice.setSelectedSpan(span);
-            get().fitPanelsToMaxWidth();
+            set({ layoutChangeSource: "visibility" } as Partial<TraceViewStore>);
           },
 
           setSpanPanelOpen: (open) => {
             baseSlice.setSpanPanelOpen(open);
-            get().fitPanelsToMaxWidth();
+            set({ layoutChangeSource: "visibility" } as Partial<TraceViewStore>);
           },
 
           setTracesAgentOpen: (open) => {
             baseSlice.setTracesAgentOpen(open);
-            get().fitPanelsToMaxWidth();
+            set({ layoutChangeSource: "visibility" } as Partial<TraceViewStore>);
           },
         };
       },
       {
         name: options?.storeKey ?? "trace-view-state",
-        version: 1,
+        version: 2,
         migrate: (persistedState, version) => {
-          // v0 -> v1: transcript is the new default tab; move legacy users off "tree" once.
-          if (version < 1 && persistedState && typeof persistedState === "object") {
-            (persistedState as Record<string, unknown>).tab = "transcript";
+          if (!persistedState || typeof persistedState !== "object") return persistedState as TraceViewStore;
+          const s = persistedState as Record<string, unknown>;
+
+          if (version < 1) s.tab = "transcript";
+
+          if (version < 2) {
+            const trace = s.tracePanelWidth;
+            const span = s.spanPanelWidth;
+            const chat = s.chatPanelWidth;
+            if (typeof trace === "number" && typeof span === "number" && typeof chat === "number") {
+              s.targets = { trace, span, chat };
+            }
+            delete s.tracePanelWidth;
+            delete s.spanPanelWidth;
+            delete s.chatPanelWidth;
           }
+
           return persistedState as TraceViewStore;
         },
         partialize: (state) => {
@@ -240,9 +124,7 @@ const createTraceViewStore = (options?: {
           const tabToPersist = persistentTabs.includes(state.tab as any) ? state.tab : undefined;
 
           return {
-            tracePanelWidth: state.tracePanelWidth,
-            spanPanelWidth: state.spanPanelWidth,
-            chatPanelWidth: state.chatPanelWidth,
+            targets: state.targets,
             ...(tabToPersist && { tab: tabToPersist }),
             showTreeContent: state.showTreeContent,
             condensedTimelineEnabled: state.condensedTimelineEnabled,
@@ -256,12 +138,15 @@ const createTraceViewStore = (options?: {
               ? (persisted.tab as TraceViewStore["tab"])
               : "transcript";
 
+          const t = persisted.targets as Partial<Targets> | undefined;
+          const targets: Targets =
+            t && typeof t.trace === "number" && typeof t.span === "number" && typeof t.chat === "number"
+              ? { trace: t.trace, span: t.span, chat: t.chat }
+              : currentState.targets;
+
           return {
             ...currentState,
-            // Only pick keys that partialize actually produces — never overwrite functions
-            ...(typeof persisted.tracePanelWidth === "number" && { tracePanelWidth: persisted.tracePanelWidth }),
-            ...(typeof persisted.spanPanelWidth === "number" && { spanPanelWidth: persisted.spanPanelWidth }),
-            ...(typeof persisted.chatPanelWidth === "number" && { chatPanelWidth: persisted.chatPanelWidth }),
+            targets,
             ...(typeof persisted.showTreeContent === "boolean" && { showTreeContent: persisted.showTreeContent }),
             ...(typeof persisted.condensedTimelineEnabled === "boolean" && {
               condensedTimelineEnabled: persisted.condensedTimelineEnabled,


### PR DESCRIPTION
## Summary
- Refactor trace-view panel widths to a single source of truth: `targets` + pure `computeLayout` / `applyDrag` in `panel-layout.ts`. Rendered widths derive via `useMemo`; the layout component animates trace width with framer-motion in lockstep with the entering span/chat panel, eliminating the snap where trace shrinks instantly while the span panel grows.
- Fitting and overflow policy now live in one pure function. Visible panels are clamped to min before redistribution; sub-min only happens as a documented fallback when `Σ mins > maxWidth`.
- Transition policy: spring on visibility flips; instant on drags and container-resize observer ticks (driven by a `layoutChangeSource` flag in the store).

## Test plan
- [ ] Open a trace; click a span — span panel enters smoothly while trace shrinks alongside (no instant jump).
- [ ] Open the chat panel from a wide window; close it — both transitions feel smooth.
- [ ] Drag the trace, span, and chat resize handles; widths follow cursor without lag.
- [ ] Resize browser window narrow then wide; panels redistribute without spring overshoot.
- [ ] Narrow window so `Σ mins > maxWidth`; verify panels shrink proportionally below min (no panel disappears or pushes scroll).
- [ ] Existing persisted widths from prior version load without errors (migration v1 → v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors trace-view panel sizing and persistence to a new `targets`/layout-computation model, which could introduce regressions in resize/overflow behavior and stored user settings despite being UI-scoped.
> 
> **Overview**
> Refactors trace-view panel sizing to use persisted per-panel `targets` plus new pure layout helpers (`computeLayout`/`applyDrag`) to derive rendered widths based on visibility and container `maxWidth`, replacing the prior per-panel width fields and auto-fit logic.
> 
> Updates `DynamicWidthLayout` to compute widths via `useMemo`, animate the trace panel width in sync with span/chat enter/exit, and choose transitions based on a new `layoutChangeSource` (spring only for visibility changes; instant for drags/container resizes). Adds a persisted state migration (v2) to convert legacy `*PanelWidth` values into `targets`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 491964863368498c0e93d920cf55f7aad0603aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->