### PR TITLE
feat(analytics): expand posthog tracking + fix signals:page_viewed

### DIFF
--- a/frontend/components/signals/create-signal-drawer/signal-form-fields.tsx
+++ b/frontend/components/signals/create-signal-drawer/signal-form-fields.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { track } from "@/lib/posthog";
 import { cn, tryParseJson } from "@/lib/utils";
 
 import { type ManageSignalContentVariant } from "./manage-signal-content";
@@ -41,6 +42,7 @@ export default function SignalFormFields({
   const applyTemplate = useCallback(
     (templateIndex: number) => {
       const template = templates[templateIndex];
+      track("signals", "template_applied", { template: template.name });
       setValue("prompt", template.prompt, { shouldValidate: true });
       const parsedSchema = tryParseJson(template.structuredOutputSchema);
       if (parsedSchema) {
@@ -52,6 +54,7 @@ export default function SignalFormFields({
   );
 
   const clearToBlank = useCallback(() => {
+    track("signals", "template_applied", { template: "Blank" });
     setValue("prompt", "", { shouldValidate: true });
     setValue("schemaFields", getDefaultSchemaFields(), { shouldValidate: true });
   }, [setValue]);

--- a/frontend/components/signals/index.tsx
+++ b/frontend/components/signals/index.tsx
@@ -42,6 +42,10 @@ function SignalsContent() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { toast } = useToast();
 
+  useEffect(() => {
+    track("signals", "page_viewed");
+  }, []);
+
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
   const [sparklineData, setSparklineData] = useState<SignalSparklineData>({});
   const [dateRange, setDateRange] = useState<DateRangeValue>({ pastHours: "168" });

--- a/frontend/components/traces/add-to-labeling-queue-popover.tsx
+++ b/frontend/components/traces/add-to-labeling-queue-popover.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/lib/hooks/use-toast";
+import { track } from "@/lib/posthog";
 import { type LabelingQueue } from "@/lib/queue/types";
 import { type PaginatedResponse } from "@/lib/types";
 import { swrFetcher } from "@/lib/utils";
@@ -97,6 +98,9 @@ export default function AddToLabelingQueuePopover({
       })();
 
       if (response.ok) {
+        track("labeling_queues", "added", {
+          source: isSpanMode ? "span" : isDatapointMode ? "datapoint" : "queue",
+        });
         toast({
           title: "Success",
           description: (

--- a/frontend/components/traces/export-spans-popover.tsx
+++ b/frontend/components/traces/export-spans-popover.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { type Dataset } from "@/lib/dataset/types";
 import { useToast } from "@/lib/hooks/use-toast";
+import { track } from "@/lib/posthog";
 import { type Span } from "@/lib/traces/types";
 
 import DatasetSelect from "../ui/dataset-select";
@@ -44,6 +45,7 @@ export default function ExportSpansPopover({ children, span }: PropsWithChildren
           variant: "destructive",
         });
       } else {
+        track("datasets", "span_added", { source: "span_view" });
         toast({
           title: `Added span to dataset`,
           description: (

--- a/frontend/components/traces/span-controls.tsx
+++ b/frontend/components/traces/span-controls.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/lib/hooks/use-toast";
+import { track } from "@/lib/posthog";
 import { type Span, SpanType } from "@/lib/traces/types";
 import { type ErrorEventAttributes } from "@/lib/types";
 
@@ -82,6 +83,7 @@ export function SpanControls({ children, span, onClose, isAlwaysSelectSpan }: Pr
             <Link
               href={{ pathname: `/project/${projectId}/playgrounds/create`, query: { spanId: span.spanId } }}
               passHref
+              onClick={() => track("playgrounds", "experiment_clicked", { source: "span_view" })}
             >
               <Button variant="outlinePrimary" className="px-1.5 text-xs h-6 font-mono bg-primary/10">
                 <PlayCircle className="mr-1" size={14} />

--- a/frontend/components/traces/span-view/index.tsx
+++ b/frontend/components/traces/span-view/index.tsx
@@ -13,6 +13,7 @@ import { SpanSearchProvider } from "@/components/traces/span-view/span-search-co
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert.tsx";
 import ContentRenderer from "@/components/ui/content-renderer/index";
 import { spanViewTheme } from "@/components/ui/content-renderer/utils";
+import { track } from "@/lib/posthog";
 import { type Span, SpanType } from "@/lib/traces/types";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/tabs";
@@ -59,7 +60,13 @@ const SpanViewTabs = ({
   const defaultTab = initialTab ?? (isLLM ? "overview" : "span-input");
 
   return (
-    <Tabs key={initialTab} className="flex flex-col grow overflow-hidden gap-0" defaultValue={defaultTab} tabIndex={0}>
+    <Tabs
+      key={initialTab}
+      className="flex flex-col grow overflow-hidden gap-0"
+      defaultValue={defaultTab}
+      onValueChange={(value) => track("traces", "span_tab_selected", { tab: value })}
+      tabIndex={0}
+    >
       <div className="px-2 pb-2 mt-2 border-b w-full">
         <TabsList className="border-none text-xs h-7">
           {isLLM && (

--- a/frontend/components/traces/trace-view/chat.tsx
+++ b/frontend/components/traces/trace-view/chat.tsx
@@ -12,6 +12,7 @@ import { renderSpanReferences } from "@/components/traces/trace-view/span-refere
 import { useTraceViewBaseStore } from "@/components/traces/trace-view/store/base";
 import { Button } from "@/components/ui/button";
 import DefaultTextarea from "@/components/ui/default-textarea";
+import { track } from "@/lib/posthog";
 import { cn } from "@/lib/utils";
 
 /**
@@ -75,6 +76,7 @@ export default function Chat({ traceId, onSetSpanId, onClose }: ChatProps) {
   );
 
   const handleExampleClick = (question: string) => {
+    track("traces", "chat_message_sent", { source: "example" });
     sendMessage({
       role: "user",
       parts: [{ type: "text", text: question }],
@@ -313,6 +315,7 @@ export default function Chat({ traceId, onSetSpanId, onClose }: ChatProps) {
             onSubmit={(e) => {
               e.preventDefault();
               if (input.trim()) {
+                track("traces", "chat_message_sent", { source: "input" });
                 sendMessage({
                   role: "user",
                   parts: [{ type: "text", text: input }],
@@ -329,6 +332,7 @@ export default function Chat({ traceId, onSetSpanId, onClose }: ChatProps) {
                   if (e.key === "Enter" && !e.shiftKey) {
                     e.preventDefault();
                     if (input.trim()) {
+                      track("traces", "chat_message_sent", { source: "input" });
                       sendMessage({
                         role: "user",
                         parts: [{ type: "text", text: input }],
@@ -348,15 +352,6 @@ export default function Chat({ traceId, onSetSpanId, onClose }: ChatProps) {
                 className="h-7 w-7 rounded-full border bg-primary flex-shrink-0 mr-1 mb-1"
                 variant="ghost"
                 disabled={input.trim() === "" || status === "streaming"}
-                onClick={() => {
-                  if (input.trim()) {
-                    sendMessage({
-                      role: "user",
-                      parts: [{ type: "text", text: input }],
-                    });
-                    setInput("");
-                  }
-                }}
               >
                 <ArrowUp className="w-4 h-4" />
               </Button>

--- a/frontend/components/traces/trace-view/header/index.tsx
+++ b/frontend/components/traces/trace-view/header/index.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { type Filter } from "@/lib/actions/common/filters";
 import { type EventRow } from "@/lib/events/types";
+import { track } from "@/lib/posthog";
 import { cn } from "@/lib/utils";
 
 import Metadata from "../metadata";
@@ -132,6 +133,7 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
 
   const handleOpenSession = useCallback(() => {
     if (!hasSession) return;
+    track("sessions", "detail_opened", { source: "trace_header" });
     const encodedSessionId = sessionId.split("/").map(encodeURIComponent).join("/");
     window.open(`/project/${projectId}/sessions/${encodedSessionId}`, "_blank");
   }, [hasSession, sessionId, projectId]);
@@ -261,7 +263,14 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
         </div>
       )}
       {signalsPanelOpen && (
-        <ResizableSignalCard traceId={traceId} onClose={() => setSignalsPanelOpen(false)} className="mt-2" />
+        <ResizableSignalCard
+          traceId={traceId}
+          onClose={() => {
+            track("traces", "signals_panel_closed");
+            setSignalsPanelOpen(false);
+          }}
+          className="mt-2"
+        />
       )}
       <div className="flex items-center gap-2 mt-2">
         <TraceViewSearch


### PR DESCRIPTION
## Summary
- Add tracking for previously-untracked surfaces: Ask AI chat sends, signal events panel close, signal preset templates, open session from trace header, Experiment-in-playground, add-to-labeling-queue, add-to-dataset, span-view tab selection.
- Fix `signals:page_viewed` reporting 0 — the call was missing on `frontend/components/signals/index.tsx`. Other index pages (evaluations, dashboards, playgrounds) all use `useEffect(() => track("X", "page_viewed"), [])` on mount; signals didn't.
- Drop redundant `onClick` on the Ask AI submit button. It had both `type="submit"` and an `onClick` calling `sendMessage`, so button clicks fired `sendMessage` twice (onClick + form `onSubmit`). Pre-existing bug; would also have inflated the new `chat_message_sent` metric 2x on button clicks.

## New events
| Event | Properties |
|---|---|
| `traces:chat_message_sent` | `source: "input" \| "example"` |
| `traces:signals_panel_closed` | — |
| `traces:span_tab_selected` | `tab: "overview" \| "span-input" \| "span-output" \| "attributes" \| "events"` |
| `signals:template_applied` | `template: <preset name> \| "Blank"` |
| `signals:page_viewed` | — (was missing) |
| `sessions:detail_opened` | `source: "trace_header"` (existing event, new source value) |
| `playgrounds:experiment_clicked` | `source: "span_view"` |
| `labeling_queues:added` | `source: "span" \| "datapoint" \| "queue"` |
| `datasets:span_added` | `source: "span_view"` |

Subagent expansion was already tracked at `transcript/index.tsx:392` as `traces:subagent_group_toggled` with an `expanded` flag — filter `expanded=true` to count expansions only. No code change.

## Test plan
- [ ] Open a trace, send a message in Ask AI via Enter and via button; both fire `traces:chat_message_sent` once with `source: "input"`.
- [ ] Click an example question in Ask AI; fires once with `source: "example"`.
- [ ] Close the signal events panel from the trace header X; fires `traces:signals_panel_closed`.
- [ ] Open the create-signal drawer, click each template + Blank; fires `signals:template_applied` with the right `template` name.
- [ ] Click the session pill in the trace header; fires `sessions:detail_opened` with `source: "trace_header"`.
- [ ] In an LLM span, click "Experiment in playground"; fires `playgrounds:experiment_clicked`.
- [ ] In a span view, switch tabs; fires `traces:span_tab_selected` with the new tab id.
- [ ] Add a span to a labeling queue and to a dataset; both events fire on success only.
- [ ] Visit `/project/<id>/signals`; `signals:page_viewed` fires once on mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to client-side analytics calls plus removing a redundant chat submit handler that could double-send messages and inflate metrics.
> 
> **Overview**
> Adds **new PostHog tracking events** for key UI interactions: applying/clearing signal templates, viewing the Signals page, sending trace-chat messages (example vs input), selecting span-view tabs, closing the trace signals panel, opening a session from the trace header, clicking “Experiment in playground”, and successfully adding spans to labeling queues/datasets.
> 
> Fixes analytics/data correctness by firing `signals:page_viewed` on Signals page mount and removing the chat submit button’s redundant `onClick` (preventing duplicate `sendMessage` calls and double-counted `traces:chat_message_sent`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 389142fd6cc013543fe24d677ca5dc54912e2df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->