### PR TITLE
fix: fix debugger ui, realtime, small paddings fix in settings

### DIFF
--- a/frontend/components/settings/settings.tsx
+++ b/frontend/components/settings/settings.tsx
@@ -114,7 +114,7 @@ export default function Settings({ apiKeys, projectId, workspaceId, slackClientI
               </SidebarGroup>
             </SidebarContent>
           </Sidebar>
-          <div className="flex-1 overflow-y-auto">
+          <div className="flex-1 overflow-y-auto pb-24">
             <div className="flex flex-col gap-8 max-w-6xl mx-auto px-4">{renderContent()}</div>
           </div>
         </div>

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -126,10 +126,7 @@ const Transcript = ({ onSpanSelect, isShared = false }: TranscriptProps) => {
   }, [trace?.id, spans.length]);
 
   const { userInput, isLoading: isUserInputLoading } = useTraceUserInput(projectId, trace?.id, isShared, llmSpanCount);
-  // Render the user-input row whenever we know an LLM span exists (even while
-  // its content is still being fetched). This makes the input appear as soon
-  // as the first LLM span arrives over realtime.
-  const hasUserInput = llmSpanCount > 0 || isUserInputLoading || !!userInput;
+  const hasUserInput = !!userInput;
 
   const flatRows = useMemo(() => {
     const rows: FlatRow[] = [];
@@ -170,6 +167,11 @@ const Transcript = ({ onSpanSelect, isShared = false }: TranscriptProps) => {
     return types;
   }, [transcriptEntries, spans]);
 
+  // Pending spans don't have stable input/output yet — fetching previews for
+  // them returns null content (or content from a stale time window), and the
+  // hook's permanent dedup would then prevent a re-fetch once the realtime
+  // span_update flips the span to non-pending. Skip them here so the next
+  // visibility effect picks them up cleanly once they're complete.
   const { inputSpanIds, promptHashes } = useMemo(() => {
     const ids: string[] = [];
     const hashes: Record<string, string> = {};
@@ -177,8 +179,9 @@ const Transcript = ({ onSpanSelect, isShared = false }: TranscriptProps) => {
 
     for (const entry of transcriptEntries) {
       if (entry.type === "group" && entry.firstLlmSpanId) {
-        ids.push(entry.firstLlmSpanId);
         const span = spanMap.get(entry.firstLlmSpanId);
+        if (span?.pending) continue;
+        ids.push(entry.firstLlmSpanId);
         const hash = span?.attributes?.["lmnr.span.prompt_hash"] as string | undefined;
         if (hash) {
           hashes[entry.firstLlmSpanId] = hash;
@@ -298,9 +301,10 @@ const Transcript = ({ onSpanSelect, isShared = false }: TranscriptProps) => {
     () =>
       items.flatMap((item) => {
         const row = flatRows[item.index];
-        return row ? getSpanIdsForRow(row, transcriptExpandedGroups) : [];
+        if (!row) return [];
+        return getSpanIdsForRow(row, transcriptExpandedGroups).filter((id) => !spansById.get(id)?.pending);
       }),
-    [items, flatRows, transcriptExpandedGroups]
+    [items, flatRows, transcriptExpandedGroups, spansById]
   );
 
   const scrollOffset = virtualizer.scrollOffset ?? 0;

--- a/frontend/components/traces/trace-view/transcript/item/input-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/input-item.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight } from "lucide-react";
 
-import { PreviewLoadingPlaceholder } from "@/components/traces/trace-view/preview-loading-placeholder.tsx";
+import { useOptionalDebuggerStore } from "@/components/debugger-sessions/debugger-session-view/store";
 import { CollapsedTextWithMore } from "@/components/traces/trace-view/transcript/collapsed-text-with-more";
 import { cn } from "@/lib/utils.ts";
 
@@ -11,27 +11,32 @@ interface InputItemProps {
   className?: string;
 }
 
-export function InputItem({ text, isLoading, inGroup, className }: InputItemProps) {
-  if (!isLoading && !text) return null;
+export function InputItem({ text, inGroup, className }: InputItemProps) {
+  const { enabled: isDebuggerMode } = useOptionalDebuggerStore(() => null);
+
+  if (!text) return null;
 
   return (
-    <div
-      className={cn(
-        "flex flex-col flex-1 min-w-0 py-2 pl-1 pr-2 border-l-4 border-l-transparent gap-1 bg-blue-400/5",
-        {
-          "bg-muted/60": inGroup,
-        },
-        className
-      )}
-    >
-      <div className="flex gap-2 items-center min-w-0">
-        <div className="flex items-center justify-center z-10 rounded shrink-0 bg-blue-400/70 w-5 h-5 min-w-5 min-h-5">
-          <ArrowRight size={14} />
+    <div className="flex">
+      <div
+        className={cn(
+          "flex flex-col flex-1 min-w-0 py-2 pr-2 border-l-4 border-l-transparent gap-1 bg-blue-400/5",
+          {
+            "bg-muted/60": inGroup,
+          },
+          isDebuggerMode ? "pl-11" : "pl-1",
+          className
+        )}
+      >
+        <div className="flex gap-2 items-center min-w-0">
+          <div className="flex items-center justify-center z-10 rounded shrink-0 bg-blue-400/70 w-5 h-5 min-w-5 min-h-5">
+            <ArrowRight size={14} />
+          </div>
+          <span className="font-medium text-sm whitespace-nowrap shrink-0">Input</span>
         </div>
-        <span className="font-medium text-sm whitespace-nowrap shrink-0">Input</span>
-      </div>
-      <div className="pl-7">
-        {isLoading ? <PreviewLoadingPlaceholder /> : <CollapsedTextWithMore text={text!} lineHeight={17} />}
+        <div className="pl-7">
+          <CollapsedTextWithMore text={text} lineHeight={17} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/traces/trace-view/transcript/item/span-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/span-item.tsx
@@ -137,7 +137,7 @@ export default function SpanItem({
       }}
     >
       {cachingEnabled && fullSpan && (
-        <div className="flex items-start justify-center shrink-0 w-10 p-1 self-stretch pt-2.5">
+        <div className="flex items-start justify-center shrink-0 w-10 p-0.5 self-stretch">
           <DebuggerCheckpoint span={fullSpan} />
         </div>
       )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes transcript row rendering and span-preview fetching behavior, especially around pending realtime spans, which could affect what content appears (or fails to appear) during live updates. UI-only changes, but touches core trace-view interactions and virtualized list visibility logic.
> 
> **Overview**
> Fixes trace transcript realtime behavior by **excluding `pending` spans** from preview/input fetch queues and from the set of “visible” span IDs, avoiding stale/null preview caching that previously blocked re-fetching once a span completes.
> 
> Adjusts transcript rendering to only show the top-level user input row when the input is actually available (not just because LLM spans exist/loading), and tweaks debugger-related layout/padding: `InputItem` now aligns with debugger mode indentation and no longer shows a loading placeholder, `SpanItem` checkpoint padding is tightened, and Settings adds bottom padding (`pb-24`) to prevent content being obscured near the page bottom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5954daa647a02672613f47615bc19ddcd634004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->