### PR TITLE
feat: fix subagent detections

### DIFF
--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -268,14 +268,19 @@ const pathHashKey = (parentSpanPath: string, promptHash: string): string => `${p
 
 /**
  * For each cluster of LLMs sharing `(parentSpanPath, promptHash)`, return
- * each LLM's invocation root: the ancestor span ID that distinguishes its
- * invocation from other invocations of the same subagent. `""` means the
- * cluster is one invocation.
+ * each LLM's invocation root key: a string identifying the unique ancestor
+ * chain that distinguishes its invocation from other invocations of the same
+ * subagent. `""` means every member shares the same chain (one invocation).
  *
- * We find the first `ids_path` index where cluster members disagree, but
- * ignore the last two positions (the LLM itself and its direct parent —
- * some SDKs reuse one loop body across iterations, others spawn a fresh
- * one per iteration; both are still one invocation).
+ * The key is the full structural portion of `ids_path` — every ancestor
+ * except the last two positions (the LLM itself and its direct parent), which
+ * are iteration noise: some SDKs reuse one loop body across iterations,
+ * others spawn a fresh one per iteration; both are still one invocation.
+ *
+ * Using the full structural prefix (rather than a single divergence-index
+ * value) correctly partitions a cluster with multiple divergence depths —
+ * e.g. two invocations sharing depth-1 but diverging at depth-2 stay
+ * separate even when a third invocation diverges from them at depth-1.
  */
 const computeInvocationRoots = (cluster: LlmSpanInfo[]): Map<string, string> => {
   const out = new Map<string, string>();
@@ -284,27 +289,16 @@ const computeInvocationRoots = (cluster: LlmSpanInfo[]): Map<string, string> => 
     return out;
   }
 
-  const minLen = Math.min(...cluster.map((s) => s.idsPath.length));
-  const structuralLen = Math.max(0, minLen - 2);
+  const structuralPrefix = (s: LlmSpanInfo): string => (s.idsPath.length <= 2 ? "" : s.idsPath.slice(0, -2).join("\0"));
 
-  let divergenceIdx = -1;
-  for (let i = 0; i < structuralLen; i++) {
-    const expected = cluster[0].idsPath[i];
-    for (let j = 1; j < cluster.length; j++) {
-      if (cluster[j].idsPath[i] !== expected) {
-        divergenceIdx = i;
-        break;
-      }
-    }
-    if (divergenceIdx !== -1) break;
-  }
-
-  if (divergenceIdx === -1) {
+  const keys = cluster.map(structuralPrefix);
+  const firstKey = keys[0];
+  if (keys.every((k) => k === firstKey)) {
     for (const s of cluster) out.set(s.spanId, "");
     return out;
   }
-  for (const s of cluster) {
-    out.set(s.spanId, s.idsPath[divergenceIdx] ?? "");
+  for (let i = 0; i < cluster.length; i++) {
+    out.set(cluster[i].spanId, keys[i]);
   }
   return out;
 };

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -397,8 +397,19 @@ const computeSubagentBoundaries = (spans: TraceViewSpan[]): SubagentLlmGrouping 
           return best;
         })
       : null;
+  // No reliably-identifiable main agent → skip subagent grouping entirely.
+  // Otherwise hashless LLMs would all hash-key to "<path>|" (never === null) and
+  // be promoted into spurious subagent groups.
+  if (mainSpan === null) {
+    return {
+      llmToAnchor: new Map(),
+      mainAgentAncestors: new Set(),
+      subagentAncestors: new Map(),
+      anchorLlmTimes: new Map(),
+    };
+  }
   // Keyed by (path, hash) only so every main-agent invocation is suppressed.
-  const mainPathHashKey = mainSpan ? pathHashKey(mainSpan.spanPath, mainSpan.promptHash) : null;
+  const mainPathHashKey = pathHashKey(mainSpan.spanPath, mainSpan.promptHash);
   const pathHashKeyOf = (s: LlmSpanInfo) => pathHashKey(s.spanPath, s.promptHash);
 
   // Anchor = first LLM (by start time) per full composite key, excluding main.

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -275,52 +275,102 @@ type LlmSpanInfo = {
   spanPath: string;
   spanPathLength: number;
   promptHash: string;
+  /** Ancestor span ID distinguishing this invocation from other invocations of the same (path, hash). Filled by `computeInvocationRoots`. */
+  invocationRoot: string;
   idsPath: string[];
   inputTokens: number;
   startTime: string;
 };
 
-// Shared with TOP_PATH_QUERY in lib/actions/sessions/trace-io.ts and useTraceUserInput.
-// The parent-path keying (drop trailing leaf segment) used here must also stay
-// in sync with the `arrayPopBack(splitByChar('.', path))` expression in those
-// SQL queries — both pick the same "main agent" identity.
 export const MAIN_AGENT_SEARCH_WINDOW = 5;
 
+const compositeKey = (parentSpanPath: string, promptHash: string, invocationRoot: string): string =>
+  `${parentSpanPath}\0${promptHash}\0${invocationRoot}`;
+
+const pathHashKey = (parentSpanPath: string, promptHash: string): string => `${parentSpanPath}\0${promptHash}`;
+
 /**
- * Detect sub-agent boundary span IDs from in-memory spans.
+ * For each cluster of LLMs sharing `(parentSpanPath, promptHash)`, return
+ * each LLM's invocation root: the ancestor span ID that distinguishes its
+ * invocation from other invocations of the same subagent. `""` means the
+ * cluster is one invocation.
  *
- * Collects individual LLM/CACHED spans (no grouping). Picks the main agent
- * as the shallowest (shortest span path) among the earliest few LLM calls,
- * breaking ties by highest input tokens. Splits spans into main vs non-main
- * via the composite (spanPath, promptHash) key, then walks each non-main
- * candidate's idsPath to find the first ancestor not in the main agent's
- * span IDs — that's the boundary. Dedup via Set collapses sibling/loop
- * iterations sharing a boundary while preserving separate invocations of
- * the same agent type under different parents.
- *
- * Runs on every span arrival (via the transcript's useMemo on `spans`).
- * The search window is the first MAIN_AGENT_SEARCH_WINDOW LLM spans by
- * start time, so once that many have arrived the main agent pick is
- * stable — later arrivals go to indices beyond the window and don't
- * affect identification.
+ * We find the first `ids_path` index where cluster members disagree, but
+ * ignore the last two positions (the LLM itself and its direct parent —
+ * some SDKs reuse one loop body across iterations, others spawn a fresh
+ * one per iteration; both are still one invocation).
  */
-export const computeSubagentBoundaries = (spans: TraceViewSpan[]): Set<string> => {
+const computeInvocationRoots = (cluster: LlmSpanInfo[]): Map<string, string> => {
+  const out = new Map<string, string>();
+  if (cluster.length <= 1) {
+    if (cluster[0]) out.set(cluster[0].spanId, "");
+    return out;
+  }
+
+  const minLen = Math.min(...cluster.map((s) => s.idsPath.length));
+  const structuralLen = Math.max(0, minLen - 2);
+
+  let divergenceIdx = -1;
+  for (let i = 0; i < structuralLen; i++) {
+    const expected = cluster[0].idsPath[i];
+    for (let j = 1; j < cluster.length; j++) {
+      if (cluster[j].idsPath[i] !== expected) {
+        divergenceIdx = i;
+        break;
+      }
+    }
+    if (divergenceIdx !== -1) break;
+  }
+
+  if (divergenceIdx === -1) {
+    for (const s of cluster) out.set(s.spanId, "");
+    return out;
+  }
+  for (const s of cluster) {
+    out.set(s.spanId, s.idsPath[divergenceIdx] ?? "");
+  }
+  return out;
+};
+
+/**
+ * Subagent grouping output.
+ *
+ * Each non-main LLM/CACHED span is keyed by `(parentSpanPath, promptHash, invocationRoot)`
+ * and mapped to an anchor (the first LLM with that key by start time). The
+ * main agent is picked by shortest `spanPath` among the first
+ * `MAIN_AGENT_SEARCH_WINDOW` hashed LLMs (ties broken by highest input tokens)
+ * and its (path, hash) is excluded across every invocation so it stays inline.
+ *
+ * `mainAgentAncestors` / `subagentAncestors` record every strict ancestor of
+ * each LLM's `ids_path`, used by `buildSpanToAnchorMap` to place non-LLM spans
+ * by their deepest claimed ancestor (main wins ties → standalone).
+ */
+export interface SubagentLlmGrouping {
+  /** LLM/CACHED spanId -> its anchor spanId. Main-agent LLMs are absent. */
+  llmToAnchor: Map<string, string>;
+  /** Span IDs claimed by the main agent (strict ancestors of main-agent LLMs). */
+  mainAgentAncestors: Set<string>;
+  /** Span ID -> anchor IDs of subagents whose LLM has that ID as a strict ancestor. */
+  subagentAncestors: Map<string, Set<string>>;
+  /** Anchor -> sorted LLM start times, for nearest-preceding-LLM tie-breaks. */
+  anchorLlmTimes: Map<string, string[]>;
+}
+
+export const computeSubagentBoundaries = (spans: TraceViewSpan[]): SubagentLlmGrouping => {
   const llmSpans: LlmSpanInfo[] = [];
 
   for (const span of spans) {
     if (span.spanType !== "LLM" && span.spanType !== "CACHED") continue;
 
-    const promptHash = span.attributes?.["lmnr.span.prompt_hash"] as string | undefined;
-    const idsPath = span.attributes?.["lmnr.span.ids_path"] as string[] | undefined;
-
-    if (!promptHash || !Array.isArray(idsPath) || idsPath.length === 0) continue;
+    const promptHash = (span.attributes?.["lmnr.span.prompt_hash"] as string | undefined) ?? "";
+    const idsPathRaw = span.attributes?.["lmnr.span.ids_path"] as string[] | undefined;
+    const idsPath = Array.isArray(idsPathRaw) ? idsPathRaw.filter((id) => id !== NULL_SPAN_ID) : [];
 
     const spanPathAttr = span.attributes?.["lmnr.span.path"];
     const spanPathArr = Array.isArray(spanPathAttr) ? spanPathAttr : [];
-    // Drop the trailing segment (the current span's own name) when keying
-    // subagent identity. The current span name can be dynamic (e.g. tool
-    // names parameterised per call) while still being the same agent step,
-    // so we group by the parent path which is the stable subagent location.
+    // Drop the trailing leaf — it can be dynamic (e.g. tool name per call) while
+    // still being the same agent step. Must stay in sync with `arrayPopBack(splitByChar('.', path))`
+    // in lib/actions/sessions/trace-io.ts (TOP_PATH_QUERY) and useTraceUserInput.
     const parentSpanPath = spanPathArr.slice(0, -1).join(".");
 
     llmSpans.push({
@@ -329,45 +379,104 @@ export const computeSubagentBoundaries = (spans: TraceViewSpan[]): Set<string> =
       spanPath: parentSpanPath,
       spanPathLength: spanPathArr.length,
       promptHash,
-      idsPath: idsPath.filter((id) => id !== NULL_SPAN_ID),
+      invocationRoot: "", // filled in after path+hash clustering below
+      idsPath,
       inputTokens: span.inputTokens ?? 0,
       startTime: span.startTime,
     });
   }
 
-  if (llmSpans.length <= 1) return new Set();
+  if (llmSpans.length === 0) {
+    return {
+      llmToAnchor: new Map(),
+      mainAgentAncestors: new Set(),
+      subagentAncestors: new Map(),
+      anchorLlmTimes: new Map(),
+    };
+  }
 
   llmSpans.sort((a, b) => a.startTime.localeCompare(b.startTime));
 
-  const searchWindow = llmSpans.slice(0, MAIN_AGENT_SEARCH_WINDOW);
-  const mainSpan = searchWindow.reduce((best, s) => {
-    if (s.spanPathLength < best.spanPathLength) return s;
-    if (s.spanPathLength === best.spanPathLength && s.inputTokens > best.inputTokens) return s;
-    return best;
-  });
-
-  const mainCompositeKey = `${mainSpan.spanPath}\0${mainSpan.promptHash}`;
-  const compositeKeyOf = (s: LlmSpanInfo) => `${s.spanPath}\0${s.promptHash}`;
-
-  const mainSpans = llmSpans.filter((s) => compositeKeyOf(s) === mainCompositeKey);
-  const nonMainSpans = llmSpans.filter((s) => compositeKeyOf(s) !== mainCompositeKey);
-  if (nonMainSpans.length === 0) return new Set();
-
-  const mainSpanIds = new Set(mainSpans.flatMap((s) => s.idsPath));
-
-  const candidates = nonMainSpans;
-
-  const boundaryIds = new Set<string>();
-  for (const c of candidates) {
-    for (const id of c.idsPath) {
-      if (!mainSpanIds.has(id)) {
-        boundaryIds.add(id);
-        break;
-      }
+  // Cluster by (path, hash) and fill each LLM's invocation root.
+  const clusters = new Map<string, LlmSpanInfo[]>();
+  for (const s of llmSpans) {
+    const key = pathHashKey(s.spanPath, s.promptHash);
+    let bucket = clusters.get(key);
+    if (!bucket) {
+      bucket = [];
+      clusters.set(key, bucket);
+    }
+    bucket.push(s);
+  }
+  for (const bucket of clusters.values()) {
+    const roots = computeInvocationRoots(bucket);
+    for (const s of bucket) {
+      s.invocationRoot = roots.get(s.spanId) ?? "";
     }
   }
 
-  return boundaryIds;
+  // Main agent: shortest path among the first N hashed LLMs, ties by input tokens.
+  // Hashless spans are never main (unhashed prompts aren't a reliable identity).
+  const hashedSearchWindow = llmSpans.filter((s) => s.promptHash !== "").slice(0, MAIN_AGENT_SEARCH_WINDOW);
+  const mainSpan =
+    hashedSearchWindow.length > 0
+      ? hashedSearchWindow.reduce((best, s) => {
+          if (s.spanPathLength < best.spanPathLength) return s;
+          if (s.spanPathLength === best.spanPathLength && s.inputTokens > best.inputTokens) return s;
+          return best;
+        })
+      : null;
+  // Keyed by (path, hash) only so every main-agent invocation is suppressed.
+  const mainPathHashKey = mainSpan ? pathHashKey(mainSpan.spanPath, mainSpan.promptHash) : null;
+  const pathHashKeyOf = (s: LlmSpanInfo) => pathHashKey(s.spanPath, s.promptHash);
+
+  // Anchor = first LLM (by start time) per full composite key, excluding main.
+  const keyToAnchor = new Map<string, string>();
+  for (const s of llmSpans) {
+    if (pathHashKeyOf(s) === mainPathHashKey) continue;
+    const key = compositeKey(s.spanPath, s.promptHash, s.invocationRoot);
+    if (!keyToAnchor.has(key)) keyToAnchor.set(key, s.spanId);
+  }
+
+  // Record each LLM's strict ancestors against its agent (main or sub) so
+  // `buildSpanToAnchorMap` can place non-LLM spans by deepest claimed ancestor.
+  const llmToAnchor = new Map<string, string>();
+  const mainAgentAncestors = new Set<string>();
+  const subagentAncestors = new Map<string, Set<string>>();
+  const anchorLlmTimes = new Map<string, string[]>();
+
+  for (const s of llmSpans) {
+    if (pathHashKeyOf(s) === mainPathHashKey) {
+      for (let i = 0; i < s.idsPath.length - 1; i++) {
+        mainAgentAncestors.add(s.idsPath[i]);
+      }
+      continue;
+    }
+
+    const key = compositeKey(s.spanPath, s.promptHash, s.invocationRoot);
+    const anchor = keyToAnchor.get(key);
+    if (!anchor) continue;
+    llmToAnchor.set(s.spanId, anchor);
+
+    for (let i = 0; i < s.idsPath.length - 1; i++) {
+      const ancestorId = s.idsPath[i];
+      let anchors = subagentAncestors.get(ancestorId);
+      if (!anchors) {
+        anchors = new Set();
+        subagentAncestors.set(ancestorId, anchors);
+      }
+      anchors.add(anchor);
+    }
+
+    let times = anchorLlmTimes.get(anchor);
+    if (!times) {
+      times = [];
+      anchorLlmTimes.set(anchor, times);
+    }
+    times.push(s.startTime);
+  }
+
+  return { llmToAnchor, mainAgentAncestors, subagentAncestors, anchorLlmTimes };
 };
 
 export interface CondensedSubagentGroup {
@@ -378,64 +487,105 @@ export interface CondensedSubagentGroup {
 }
 
 /**
- * Groups every span under its nearest subagent boundary ancestor, returning
- * `{groupId, spanIds}` per subagent. Shares `group-<boundary>` naming with
- * `buildTranscriptListEntries` so the condensed timeline can sync its
- * collapsed/expanded state with the transcript via `transcriptExpandedGroups`.
+ * Returns `{groupId, spanIds}` per subagent. LLM spans map via
+ * `computeSubagentBoundaries`; non-LLM spans are placed by their deepest
+ * claimed `ids_path` ancestor (see `buildSpanToAnchorMap`). Shares
+ * `group-<anchorSpanId>` naming with `buildTranscriptListEntries` so the
+ * condensed timeline can sync collapsed/expanded state.
  */
 export const computeSubagentGroups = (allSpans: TraceViewSpan[]): CondensedSubagentGroup[] => {
-  const groupBoundarySet = computeSubagentBoundaries(allSpans);
-  if (groupBoundarySet.size === 0) return [];
+  const grouping = computeSubagentBoundaries(allSpans);
+  if (grouping.llmToAnchor.size === 0) return [];
 
-  const parentMap = new Map<string, string | undefined>();
-  for (const s of allSpans) parentMap.set(s.spanId, s.parentSpanId);
-
-  const spanGroupCache = new Map<string, string | null>();
-  const findGroupBoundary = (spanId: string): string | null => {
-    if (spanGroupCache.has(spanId)) return spanGroupCache.get(spanId)!;
-    const visited: string[] = [spanId];
-    let current: string | undefined = spanId;
-    let result: string | null = null;
-    while (current) {
-      if (groupBoundarySet.has(current)) {
-        result = current;
-        break;
-      }
-      const parent = parentMap.get(current);
-      if (!parent) break;
-      if (spanGroupCache.has(parent)) {
-        result = spanGroupCache.get(parent)!;
-        break;
-      }
-      visited.push(parent);
-      current = parent;
-    }
-    for (const id of visited) spanGroupCache.set(id, result);
-    return result;
-  };
+  const spanToAnchor = buildSpanToAnchorMap(allSpans, grouping);
 
   const groupSpansMap = new Map<string, string[]>();
   for (const span of allSpans) {
-    const boundary = findGroupBoundary(span.spanId);
-    if (!boundary) continue;
-    let bucket = groupSpansMap.get(boundary);
+    const anchor = spanToAnchor.get(span.spanId);
+    if (!anchor) continue;
+    let bucket = groupSpansMap.get(anchor);
     if (!bucket) {
       bucket = [];
-      groupSpansMap.set(boundary, bucket);
+      groupSpansMap.set(anchor, bucket);
     }
     bucket.push(span.spanId);
   }
 
-  return Array.from(groupSpansMap.entries()).map(([boundary, spanIds]) => ({
-    groupId: `group-${boundary}`,
+  return Array.from(groupSpansMap.entries()).map(([anchor, spanIds]) => ({
+    groupId: `group-${anchor}`,
     spanIds,
   }));
 };
 
 /**
- * Builds the flat list of transcript entries from spans.
- * Handles subagent grouping: spans under a subagent boundary are collapsed
- * into group headers with expandable children.
+ * Maps every span to its subagent anchor (or `undefined` for standalone).
+ *
+ * LLM/CACHED spans use `grouping.llmToAnchor` directly. Non-LLM spans walk
+ * their `ids_path` strict ancestors (skipping the span's own ID, so a TOOL
+ * that wraps a subagent doesn't claim itself) deepest-first and stop at the
+ * first claimed ancestor. Main-agent claim wins ties → standalone. Multiple
+ * subagent claims at one depth → nearest preceding LLM by start time.
+ */
+const buildSpanToAnchorMap = (allSpans: TraceViewSpan[], grouping: SubagentLlmGrouping): Map<string, string> => {
+  const result = new Map<string, string>();
+  for (const span of allSpans) {
+    const anchor = grouping.llmToAnchor.get(span.spanId);
+    if (anchor) result.set(span.spanId, anchor);
+  }
+
+  if (grouping.subagentAncestors.size === 0) return result;
+
+  const resolveSubagent = (idsPath: string[], spanStartTime: string): string | null => {
+    for (let i = idsPath.length - 2; i >= 0; i--) {
+      const ancestorId = idsPath[i];
+      if (grouping.mainAgentAncestors.has(ancestorId)) return null;
+
+      const subClaims = grouping.subagentAncestors.get(ancestorId);
+      if (!subClaims) continue;
+
+      if (subClaims.size === 1) return subClaims.values().next().value!;
+
+      // Multiple subagents claim this ancestor — pick the one whose most
+      // recent LLM iteration started at or before this span.
+      let chosen: string | null = null;
+      let chosenTime = "";
+      for (const anchor of subClaims) {
+        const times = grouping.anchorLlmTimes.get(anchor);
+        if (!times) continue;
+        for (let j = times.length - 1; j >= 0; j--) {
+          if (times[j] <= spanStartTime) {
+            if (times[j] > chosenTime) {
+              chosenTime = times[j];
+              chosen = anchor;
+            }
+            break;
+          }
+        }
+      }
+      return chosen;
+    }
+    return null;
+  };
+
+  for (const span of allSpans) {
+    if (result.has(span.spanId)) continue;
+    if (span.spanType === "LLM" || span.spanType === "CACHED") continue;
+
+    const idsPathAttr = span.attributes?.["lmnr.span.ids_path"] as string[] | undefined;
+    const idsPath = Array.isArray(idsPathAttr) ? idsPathAttr.filter((id) => id !== NULL_SPAN_ID) : [];
+    if (idsPath.length === 0) continue;
+
+    const anchor = resolveSubagent(idsPath, span.startTime);
+    if (anchor) result.set(span.spanId, anchor);
+  }
+
+  return result;
+};
+
+/**
+ * Builds the flat list of transcript entries. Non-main LLM/CACHED spans anchor
+ * subagent group blocks; non-LLM spans bundle in or stay standalone per
+ * `buildSpanToAnchorMap`. Main-agent LLMs render inline.
  */
 export const buildTranscriptListEntries = (
   allSpans: TraceViewSpan[],
@@ -446,71 +596,30 @@ export const buildTranscriptListEntries = (
 
   const listSpans = selectionFilteredSpans.filter((span) => span.spanType !== "DEFAULT");
 
-  const groupBoundarySet = computeSubagentBoundaries(allSpans);
-  if (groupBoundarySet.size === 0) {
+  const grouping = computeSubagentBoundaries(allSpans);
+  if (grouping.llmToAnchor.size === 0) {
     return listSpans.map((span): TranscriptListEntry => ({ type: "span", span: toLightweight(span) }));
   }
 
-  const parentMap = new Map<string, string | undefined>();
+  const spanToAnchor = buildSpanToAnchorMap(allSpans, grouping);
   const spanMap = new Map<string, TraceViewSpan>();
-  for (const s of allSpans) {
-    parentMap.set(s.spanId, s.parentSpanId);
-    spanMap.set(s.spanId, s);
-  }
+  for (const s of allSpans) spanMap.set(s.spanId, s);
 
-  const spanGroupCache = new Map<string, string | null>();
-  const findGroupBoundary = (spanId: string): string | null => {
-    if (spanGroupCache.has(spanId)) return spanGroupCache.get(spanId)!;
-
-    const visited: string[] = [spanId];
-    let current = spanId;
-    let result: string | null = null;
-
-    while (current) {
-      if (groupBoundarySet.has(current)) {
-        result = current;
-        break;
-      }
-      const parent = parentMap.get(current);
-      if (!parent) break;
-      if (spanGroupCache.has(parent)) {
-        result = spanGroupCache.get(parent)!;
-        break;
-      }
-      visited.push(parent);
-      current = parent;
-    }
-
-    for (const id of visited) {
-      spanGroupCache.set(id, result);
-    }
-    return result;
-  };
-
-  // Pass 1: collect all spans per boundary, preserving time order.
-  //
-  // Boundary spans are excluded from their own group UNLESS the boundary
-  // itself is an LLM/CACHED span. In the latter case (a leaf subagent that
-  // consists of a single LLM call), the boundary span IS the subagent's
-  // inference and must be included so `groupMeta` has a `firstLlmSpanId`
-  // to render in the group header. Non-LLM boundary spans (e.g. TOOL/DEFAULT
-  // parents that bracket the subagent loop) are kept out and emitted as a
-  // standalone span above the group block in Pass 3.
+  // Pass 1: bucket list-visible spans by anchor, preserving listSpans order
+  // (typically start-time from getTranscriptData).
   const groupSpansMap = new Map<string, TraceViewSpan[]>();
   for (const span of listSpans) {
-    const isBoundary = groupBoundarySet.has(span.spanId);
-    const isLlm = span.spanType === "LLM" || span.spanType === "CACHED";
-    if (isBoundary && !isLlm) continue;
-
-    const boundary = isBoundary ? span.spanId : findGroupBoundary(span.spanId);
-    if (!boundary) continue;
-    if (!groupSpansMap.has(boundary)) {
-      groupSpansMap.set(boundary, []);
+    const anchor = spanToAnchor.get(span.spanId);
+    if (!anchor) continue;
+    let bucket = groupSpansMap.get(anchor);
+    if (!bucket) {
+      bucket = [];
+      groupSpansMap.set(anchor, bucket);
     }
-    groupSpansMap.get(boundary)!.push(span);
+    bucket.push(span);
   }
 
-  // Pass 2: pre-compute group metadata
+  // Pass 2: pre-compute group metadata.
   const groupMeta = new Map<
     string,
     {
@@ -530,13 +639,13 @@ export const buildTranscriptListEntries = (
     }
   >();
 
-  for (const [boundary, groupSpans] of groupSpansMap) {
+  for (const [anchor, groupSpans] of groupSpansMap) {
     const firstLlm = groupSpans.find((s) => s.spanType === "LLM" || s.spanType === "CACHED");
     const lastLlm = groupSpans.findLast((s) => s.spanType === "LLM" || s.spanType === "CACHED");
 
     if (!firstLlm) continue;
 
-    const boundarySpan = spanMap.get(boundary);
+    const anchorSpan = spanMap.get(anchor);
     const lightSpans = groupSpans.map((s) => toLightweight(s));
 
     let inputTokens = 0;
@@ -550,10 +659,10 @@ export const buildTranscriptListEntries = (
       totalCost += s.totalCost;
     }
 
-    groupMeta.set(boundary, {
-      groupId: `group-${boundary}`,
-      name: boundarySpan?.name ?? groupSpans[0].name,
-      path: boundarySpan?.path ?? "",
+    groupMeta.set(anchor, {
+      groupId: `group-${anchor}`,
+      name: anchorSpan?.name ?? groupSpans[0].name,
+      path: anchorSpan?.path ?? "",
       firstSpan: lightSpans[0],
       firstLlmSpanId: firstLlm.spanId,
       lastLlmSpanId: lastLlm && lastLlm.spanId !== firstLlm.spanId ? lastLlm.spanId : null,
@@ -567,27 +676,10 @@ export const buildTranscriptListEntries = (
     });
   }
 
-  // Pass 3: emit flat entries — standalone spans, group headers + child spans.
-  //
-  // Only non-LLM boundary spans get emitted as a standalone entry above the
-  // group block. LLM/CACHED boundaries are already represented inside the
-  // group header (as firstSpan / firstLlmSpanId) and must NOT be duplicated.
-  const boundarySpanMap = new Map<string, TraceViewSpan>();
-  for (const span of listSpans) {
-    if (groupBoundarySet.has(span.spanId) && span.spanType !== "LLM" && span.spanType !== "CACHED") {
-      boundarySpanMap.set(span.spanId, span);
-    }
-  }
-
-  const emitBoundaryBlock = (boundary: string, entries: TranscriptListEntry[]) => {
-    const boundarySpan = boundarySpanMap.get(boundary);
-    if (boundarySpan) {
-      entries.push({ type: "span", span: toLightweight(boundarySpan) });
-    }
-
-    const meta = groupMeta.get(boundary);
+  const emitGroupBlock = (anchor: string, entries: TranscriptListEntry[]) => {
+    const meta = groupMeta.get(anchor);
     if (!meta) {
-      const groupSpans = groupSpansMap.get(boundary);
+      const groupSpans = groupSpansMap.get(anchor);
       if (groupSpans) {
         for (const s of groupSpans) {
           entries.push({ type: "span", span: toLightweight(s) });
@@ -617,27 +709,21 @@ export const buildTranscriptListEntries = (
     }
   };
 
+  // Pass 3: emit entries in listSpans order. Each group's block is emitted at
+  // the position of its first member; subsequent members of the same group are
+  // skipped. Anchorless spans render standalone.
   const emittedGroups = new Set<string>();
   const entries: TranscriptListEntry[] = [];
 
   for (const span of listSpans) {
-    if (groupBoundarySet.has(span.spanId)) {
-      if (emittedGroups.has(span.spanId)) continue;
-      emittedGroups.add(span.spanId);
-      emitBoundaryBlock(span.spanId, entries);
-      continue;
-    }
-
-    const boundary = findGroupBoundary(span.spanId);
-
-    if (!boundary) {
+    const anchor = spanToAnchor.get(span.spanId);
+    if (!anchor) {
       entries.push({ type: "span", span: toLightweight(span) });
       continue;
     }
-
-    if (emittedGroups.has(boundary)) continue;
-    emittedGroups.add(boundary);
-    emitBoundaryBlock(boundary, entries);
+    if (emittedGroups.has(anchor)) continue;
+    emittedGroups.add(anchor);
+    emitGroupBlock(anchor, entries);
   }
 
   return entries;

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -37,15 +37,32 @@ export const computePathInfoMap = (spans: TraceViewSpan[]): Map<string, PathInfo
     spans.map((span) => [span.spanId, { spanId: span.spanId, name: span.name, parentSpanId: span.parentSpanId }])
   );
 
-  // Sections needed for display counts
+  // Memoize parent chains so siblings reuse one walk and the two consumers
+  // below (buildSpanNameMap + the pathInfo loop) don't each pay the full cost.
+  const parentChainCache = new Map<string, string[]>();
+  const getParentIds = (spanId: string): string[] => {
+    const cached = parentChainCache.get(spanId);
+    if (cached) return cached;
+    const span = spanMap.get(spanId);
+    const parent = span?.parentSpanId ? spanMap.get(span.parentSpanId) : undefined;
+    const result = parent ? [...getParentIds(parent.spanId), parent.spanId] : [];
+    parentChainCache.set(spanId, result);
+    return result;
+  };
+
   const nonDefaultSpans = spans.filter((span) => span.spanType !== "DEFAULT");
   const sections = groupIntoSections(nonDefaultSpans);
-  const spanNameMap = buildSpanNameMap(sections, spanMap);
+  const spanNameMap = buildSpanNameMap(sections, spanMap, getParentIds);
 
-  // Compute pathInfo for each span
   const pathInfoMap = new Map<string, PathInfo>();
   for (const span of spans) {
-    const parentChain = buildParentChain(span, spanMap);
+    const parentIds = getParentIds(span.spanId);
+    const parentChain = parentIds
+      .map((id) => {
+        const parent = spanMap.get(id);
+        return parent ? { spanId: parent.spanId, name: parent.name } : null;
+      })
+      .filter((ref): ref is { spanId: string; name: string } => ref !== null);
     pathInfoMap.set(span.spanId, buildPathInfo(parentChain, spanNameMap));
   }
 
@@ -131,40 +148,19 @@ const groupIntoSections = (listSpans: TraceViewSpan[]): TraceViewSpan[][] =>
     return sections;
   }, []);
 
-const buildParentChainRecursive = (
-  spanId: string,
-  spanMap: Map<string, Pick<TraceViewSpan, "spanId" | "name" | "parentSpanId">>,
-  chain: string[] = []
-): string[] => {
-  const span = spanMap.get(spanId);
-  if (!span?.parentSpanId) {
-    return chain;
-  }
-
-  const parentSpan = spanMap.get(span.parentSpanId);
-  if (!parentSpan) {
-    return chain;
-  }
-
-  return buildParentChainRecursive(parentSpan.spanId, spanMap, [parentSpan.spanId, ...chain]);
-};
-
 /**
- * Calculate occurrence counts [2], [3] for duplicate names within sections
- * Returns a Map of spanId -> structured data with name and optional count
+ * Calculate occurrence counts [2], [3] for duplicate names within sections.
+ * Returns a Map of spanId -> structured data with name and optional count.
  */
 const buildSpanNameMap = (
   sections: TraceViewSpan[][],
-  spanMap: Map<string, Pick<TraceViewSpan, "spanId" | "name" | "parentSpanId">>
+  spanMap: Map<string, Pick<TraceViewSpan, "spanId" | "name" | "parentSpanId">>,
+  getParentIds: (spanId: string) => string[]
 ): Map<string, { name: string; count?: number }> => {
   const map = new Map<string, { name: string; count?: number }>();
 
   sections.forEach((section) => {
-    const parentChains: string[][] = section.map((listSpan) => {
-      const chain = [listSpan.spanId];
-      const parentChain = buildParentChainRecursive(listSpan.spanId, spanMap);
-      return [...parentChain, ...chain];
-    });
+    const parentChains: string[][] = section.map((listSpan) => [...getParentIds(listSpan.spanId), listSpan.spanId]);
 
     const commonParentIndex =
       parentChains.length > 0
@@ -177,35 +173,16 @@ const buildSpanNameMap = (
     const spansInContext = new Set<string>(parentChains.flatMap((chain) => chain.slice(commonParentIndex)));
 
     const nameCounter = new Map<string, number>();
-    const sortedSpans = Array.from(spansInContext)
-      .map((id) => spanMap.get(id))
-      .filter((span): span is Pick<TraceViewSpan, "spanId" | "name" | "parentSpanId"> => span !== undefined);
-
-    sortedSpans.forEach((span) => {
-      const name = span.name;
-      const currentCount = nameCounter.get(name) || 0;
-      const count = currentCount + 1;
-      nameCounter.set(name, count);
-
-      map.set(span.spanId, count > 1 ? { name, count } : { name });
-    });
+    for (const id of spansInContext) {
+      const span = spanMap.get(id);
+      if (!span) continue;
+      const count = (nameCounter.get(span.name) ?? 0) + 1;
+      nameCounter.set(span.name, count);
+      map.set(span.spanId, count > 1 ? { name: span.name, count } : { name: span.name });
+    }
   });
 
   return map;
-};
-
-const buildParentChain = (
-  span: TraceViewSpan,
-  spanMap: Map<string, Pick<TraceViewSpan, "spanId" | "name" | "parentSpanId">>
-): Array<{ spanId: string; name: string }> => {
-  const parentChainIds = buildParentChainRecursive(span.spanId, spanMap);
-
-  return parentChainIds
-    .map((spanId) => {
-      const parentSpan = spanMap.get(spanId);
-      return parentSpan ? { spanId: parentSpan.spanId, name: parentSpan.name } : null;
-    })
-    .filter((ref): ref is { spanId: string; name: string } => ref !== null);
 };
 
 const buildPathInfo = (
@@ -345,7 +322,7 @@ const computeInvocationRoots = (cluster: LlmSpanInfo[]): Map<string, string> => 
  * each LLM's `ids_path`, used by `buildSpanToAnchorMap` to place non-LLM spans
  * by their deepest claimed ancestor (main wins ties → standalone).
  */
-export interface SubagentLlmGrouping {
+interface SubagentLlmGrouping {
   /** LLM/CACHED spanId -> its anchor spanId. Main-agent LLMs are absent. */
   llmToAnchor: Map<string, string>;
   /** Span IDs claimed by the main agent (strict ancestors of main-agent LLMs). */
@@ -356,7 +333,7 @@ export interface SubagentLlmGrouping {
   anchorLlmTimes: Map<string, string[]>;
 }
 
-export const computeSubagentBoundaries = (spans: TraceViewSpan[]): SubagentLlmGrouping => {
+const computeSubagentBoundaries = (spans: TraceViewSpan[]): SubagentLlmGrouping => {
   const llmSpans: LlmSpanInfo[] = [];
 
   for (const span of spans) {
@@ -605,8 +582,8 @@ export const buildTranscriptListEntries = (
   const spanMap = new Map<string, TraceViewSpan>();
   for (const s of allSpans) spanMap.set(s.spanId, s);
 
-  // Pass 1: bucket list-visible spans by anchor, preserving listSpans order
-  // (typically start-time from getTranscriptData).
+  // Bucket order matters: first/last-LLM detection below assumes start-time
+  // order (the order spans arrive in `listSpans`).
   const groupSpansMap = new Map<string, TraceViewSpan[]>();
   for (const span of listSpans) {
     const anchor = spanToAnchor.get(span.spanId);
@@ -619,48 +596,46 @@ export const buildTranscriptListEntries = (
     bucket.push(span);
   }
 
-  // Pass 2: pre-compute group metadata.
-  const groupMeta = new Map<
-    string,
-    {
-      groupId: string;
-      name: string;
-      path: string;
-      firstSpan: TraceViewListSpan;
-      firstLlmSpanId: string | null;
-      lastLlmSpanId: string | null;
-      startTime: string;
-      endTime: string;
-      inputTokens: number;
-      outputTokens: number;
-      cacheReadInputTokens: number;
-      totalCost: number;
-      childSpans: TraceViewListSpan[];
-    }
-  >();
+  const emittedGroups = new Set<string>();
+  const entries: TranscriptListEntry[] = [];
 
-  for (const [anchor, groupSpans] of groupSpansMap) {
-    const firstLlm = groupSpans.find((s) => s.spanType === "LLM" || s.spanType === "CACHED");
-    const lastLlm = groupSpans.findLast((s) => s.spanType === "LLM" || s.spanType === "CACHED");
+  const emitGroupBlock = (anchor: string) => {
+    const groupSpans = groupSpansMap.get(anchor);
+    if (!groupSpans || groupSpans.length === 0) return;
 
-    if (!firstLlm) continue;
-
-    const anchorSpan = spanMap.get(anchor);
-    const lightSpans = groupSpans.map((s) => toLightweight(s));
-
+    let firstLlm: TraceViewSpan | undefined;
+    let lastLlm: TraceViewSpan | undefined;
     let inputTokens = 0;
     let outputTokens = 0;
     let cacheReadInputTokens = 0;
     let totalCost = 0;
     for (const s of groupSpans) {
+      if (s.spanType === "LLM" || s.spanType === "CACHED") {
+        firstLlm ??= s;
+        lastLlm = s;
+      }
       inputTokens += s.inputTokens;
       outputTokens += s.outputTokens;
       cacheReadInputTokens += s.cacheReadInputTokens ?? 0;
       totalCost += s.totalCost;
     }
 
-    groupMeta.set(anchor, {
-      groupId: `group-${anchor}`,
+    // No LLM/CACHED left after visibility filtering — degrade to standalone
+    // rows so the user still sees the spans.
+    if (!firstLlm) {
+      for (const s of groupSpans) {
+        entries.push({ type: "span", span: toLightweight(s) });
+      }
+      return;
+    }
+
+    const anchorSpan = spanMap.get(anchor);
+    const lightSpans = groupSpans.map((s) => toLightweight(s));
+    const groupId = `group-${anchor}`;
+
+    entries.push({
+      type: "group",
+      groupId,
       name: anchorSpan?.name ?? groupSpans[0].name,
       path: anchorSpan?.path ?? "",
       firstSpan: lightSpans[0],
@@ -672,48 +647,19 @@ export const buildTranscriptListEntries = (
       outputTokens,
       cacheReadInputTokens,
       totalCost,
-      childSpans: lightSpans,
     });
-  }
 
-  const emitGroupBlock = (anchor: string, entries: TranscriptListEntry[]) => {
-    const meta = groupMeta.get(anchor);
-    if (!meta) {
-      const groupSpans = groupSpansMap.get(anchor);
-      if (groupSpans) {
-        for (const s of groupSpans) {
-          entries.push({ type: "span", span: toLightweight(s) });
-        }
-      }
-      return;
-    }
+    entries.push({ type: "group-input", groupId, firstLlmSpanId: firstLlm.spanId });
 
-    const { childSpans, ...groupHeader } = meta;
-    entries.push({ ...groupHeader, type: "group" });
-
-    if (meta.firstLlmSpanId) {
-      entries.push({
-        type: "group-input",
-        groupId: meta.groupId,
-        firstLlmSpanId: meta.firstLlmSpanId,
-      });
-    }
-
-    for (let i = 0; i < childSpans.length; i++) {
+    for (let i = 0; i < lightSpans.length; i++) {
       entries.push({
         type: "group-span",
-        span: childSpans[i],
-        groupId: meta.groupId,
-        isLast: i === childSpans.length - 1,
+        span: lightSpans[i],
+        groupId,
+        isLast: i === lightSpans.length - 1,
       });
     }
   };
-
-  // Pass 3: emit entries in listSpans order. Each group's block is emitted at
-  // the position of its first member; subsequent members of the same group are
-  // skipped. Anchorless spans render standalone.
-  const emittedGroups = new Set<string>();
-  const entries: TranscriptListEntry[] = [];
 
   for (const span of listSpans) {
     const anchor = spanToAnchor.get(span.spanId);
@@ -723,7 +669,7 @@ export const buildTranscriptListEntries = (
     }
     if (emittedGroups.has(anchor)) continue;
     emittedGroups.add(anchor);
-    emitGroupBlock(anchor, entries);
+    emitGroupBlock(anchor);
   }
 
   return entries;
@@ -822,16 +768,17 @@ export const transformSpansToCondensedTimeline = (spans: TraceViewSpan[]): Conde
     computeDepth(span.spanId, 0);
   }
 
-  // Calculate positions for each span
-  const spansWithPosition: Array<{
+  type SpanWithPosition = {
     span: TraceViewSpan;
     left: number;
     width: number;
     originalDepth: number;
     startMs: number;
     endMs: number;
-  }> = [];
+  };
 
+  // spanId -> position map keeps the DFS-ordering pass below O(N).
+  const positionById = new Map<string, SpanWithPosition>();
   for (const span of spans) {
     const spanStartMs = new Date(span.startTime).getTime();
     const spanEndMs = new Date(span.endTime).getTime();
@@ -840,7 +787,7 @@ export const transformSpansToCondensedTimeline = (spans: TraceViewSpan[]): Conde
     const left = ((spanStartMs - startTime) / upperIntervalInMilliseconds) * 100;
     const width = (spanDuration / upperIntervalInMilliseconds) * 100;
 
-    spansWithPosition.push({
+    positionById.set(span.spanId, {
       span,
       left,
       width,
@@ -850,27 +797,24 @@ export const transformSpansToCondensedTimeline = (spans: TraceViewSpan[]): Conde
     });
   }
 
-  // Use DFS order to process spans (parent before children) instead of sorting by start time
-  const orderedSpans: typeof spansWithPosition = [];
+  const orderedSpans: SpanWithPosition[] = [];
   const visited = new Set<string>();
 
   const dfsOrder = (spanId: string) => {
     if (visited.has(spanId)) return;
     visited.add(spanId);
 
-    const spanWithPos = spansWithPosition.find((s) => s.span.spanId === spanId);
+    const spanWithPos = positionById.get(spanId);
     if (spanWithPos) {
       orderedSpans.push(spanWithPos);
     }
 
-    // Process children in order
     const children = childSpansMap[spanId] || [];
     for (const child of children) {
       dfsOrder(child.spanId);
     }
   };
 
-  // Start from top-level spans
   for (const span of topLevelSpans) {
     dfsOrder(span.spanId);
   }

--- a/frontend/lib/spans/providers/anthropic.ts
+++ b/frontend/lib/spans/providers/anthropic.ts
@@ -54,13 +54,20 @@ const extractFirstUserMessage = (messages: AnthropicMessage[]): TextPart[] => {
 const renderAnthropicMessage = (msg: { content: unknown }): string => {
   if (typeof msg.content === "string") return msg.content;
   if (!Array.isArray(msg.content)) return "";
-  return joinNonEmpty(
-    msg.content.map(
-      (block) =>
-        AnthropicThinkingBlockSchema.safeParse(block).data?.thinking ??
-        AnthropicTextBlockSchema.safeParse(block).data?.text
-    )
-  );
+
+  const textParts: (string | undefined)[] = [];
+  const thinkingParts: (string | undefined)[] = [];
+  for (const block of msg.content) {
+    const text = AnthropicTextBlockSchema.safeParse(block).data?.text;
+    if (text) {
+      textParts.push(text);
+      continue;
+    }
+    const thinking = AnthropicThinkingBlockSchema.safeParse(block).data?.thinking;
+    if (thinking) thinkingParts.push(thinking);
+  }
+
+  return joinNonEmpty(textParts.length > 0 ? textParts : thinkingParts);
 };
 
 const renderOutputTextAnthropic = (data: unknown): string | null => {

--- a/frontend/lib/spans/providers/gemini.ts
+++ b/frontend/lib/spans/providers/gemini.ts
@@ -43,8 +43,16 @@ const extractFirstUserMessage = (contents: z.infer<typeof GeminiContentsSchema>)
   return [];
 };
 
-const renderGeminiMessage = (msg: GeminiContent): string =>
-  joinNonEmpty(msg.parts.map((part) => ("text" in part ? part.text : null)));
+const renderGeminiMessage = (msg: GeminiContent): string => {
+  const textParts: (string | undefined)[] = [];
+  const thoughtParts: (string | undefined)[] = [];
+  for (const part of msg.parts) {
+    if (!("text" in part)) continue;
+    if (part.thought) thoughtParts.push(part.text);
+    else textParts.push(part.text);
+  }
+  return joinNonEmpty(textParts.length > 0 ? textParts : thoughtParts);
+};
 
 const renderOutputTextGemini = (data: unknown): string | null => {
   const messages = parseGeminiOutput(data);

--- a/frontend/lib/spans/providers/gen-ai.ts
+++ b/frontend/lib/spans/providers/gen-ai.ts
@@ -4,6 +4,7 @@ import { type ParsedInput, type TextPart } from "@/lib/actions/sessions/parse-in
 import { GenAIMessagesSchema, looksLikeGenAIMessages } from "@/lib/spans/types/gen-ai";
 
 import { type ProviderAdapter } from "./types";
+import { joinNonEmpty } from "./utils";
 
 type GenAIMessage = z.infer<typeof GenAIMessagesSchema>[number];
 type GenAIPart = GenAIMessage["parts"][number];
@@ -53,8 +54,32 @@ const parseSystemAndUserGenAI = (data: unknown): ParsedInput | null => {
   return { systemText, userParts: extractFirstUserMessage(messages) };
 };
 
+const renderGenAIMessage = (message: GenAIMessage): string => {
+  const textParts: string[] = [];
+  const thinkingParts: string[] = [];
+  for (const part of message.parts) {
+    if (typeof part === "string") {
+      if (part.length > 0) textParts.push(part);
+      continue;
+    }
+    const obj = part as { type?: string; content?: unknown };
+    if (typeof obj.content !== "string" || obj.content.length === 0) continue;
+    if (obj.type === "text") textParts.push(obj.content);
+    else if (obj.type === "thinking") thinkingParts.push(obj.content);
+  }
+  return joinNonEmpty(textParts.length > 0 ? textParts : thinkingParts);
+};
+
+const renderOutputTextGenAI = (data: unknown): string | null => {
+  if (!looksLikeGenAIMessages(data)) return null;
+  const result = GenAIMessagesSchema.safeParse(data);
+  if (!result.success) return null;
+  return joinNonEmpty(result.data.map(renderGenAIMessage));
+};
+
 export const genAIAdapter: ProviderAdapter = {
   id: "gen-ai",
   detect: (data) => looksLikeGenAIMessages(data),
   parseSystemAndUser: parseSystemAndUserGenAI,
+  renderOutputText: renderOutputTextGenAI,
 };

--- a/frontend/lib/spans/providers/gen-ai.ts
+++ b/frontend/lib/spans/providers/gen-ai.ts
@@ -54,20 +54,25 @@ const parseSystemAndUserGenAI = (data: unknown): ParsedInput | null => {
   return { systemText, userParts: extractFirstUserMessage(messages) };
 };
 
-const renderGenAIMessage = (message: GenAIMessage): string => {
-  const textParts: string[] = [];
-  const thinkingParts: string[] = [];
-  for (const part of message.parts) {
+const collectGenAIParts = (parts: GenAIPart[]): { text: string[]; thinking: string[] } => {
+  const text: string[] = [];
+  const thinking: string[] = [];
+  for (const part of parts) {
     if (typeof part === "string") {
-      if (part.length > 0) textParts.push(part);
+      if (part.length > 0) text.push(part);
       continue;
     }
     const obj = part as { type?: string; content?: unknown };
     if (typeof obj.content !== "string" || obj.content.length === 0) continue;
-    if (obj.type === "text") textParts.push(obj.content);
-    else if (obj.type === "thinking") thinkingParts.push(obj.content);
+    if (obj.type === "text") text.push(obj.content);
+    else if (obj.type === "thinking") thinking.push(obj.content);
   }
-  return joinNonEmpty(textParts.length > 0 ? textParts : thinkingParts);
+  return { text, thinking };
+};
+
+const renderGenAIMessage = (message: GenAIMessage): string => {
+  const { text, thinking } = collectGenAIParts(message.parts);
+  return joinNonEmpty(text.length > 0 ? text : thinking);
 };
 
 const renderOutputTextGenAI = (data: unknown): string | null => {

--- a/frontend/tests/test-provider-registry.test.ts
+++ b/frontend/tests/test-provider-registry.test.ts
@@ -75,11 +75,86 @@ describe("provider registry: matchProviderKey rendering", () => {
     assert.strictEqual(m!.rendered, "one\n\ntwo");
   });
 
+  it("renders only text from Anthropic mix of thinking + text, ignoring thinking", () => {
+    const data = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "let me reason about this...", signature: "sig" },
+        { type: "text", text: "the answer is 42" },
+      ],
+    };
+    const m = matchProviderKey(data, "anthropic");
+    assert.ok(m);
+    assert.strictEqual(m!.rendered, "the answer is 42");
+  });
+
+  it("falls back to Anthropic thinking when no text block is present", () => {
+    const data = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "internal monologue", signature: "sig" }],
+    };
+    const m = matchProviderKey(data, "anthropic");
+    assert.ok(m);
+    assert.strictEqual(m!.rendered, "internal monologue");
+  });
+
   it("renders Gemini candidate text", () => {
     const data = { content: { role: "model", parts: [{ text: "g-hello" }] } };
     const m = matchProviderKey(data);
     assert.ok(m);
     assert.strictEqual(m!.rendered, "g-hello");
+  });
+
+  it("ignores Gemini thought parts when a non-thought text part is present", () => {
+    const data = {
+      content: {
+        role: "model",
+        parts: [{ text: "thinking step by step...", thought: true }, { text: "final answer" }],
+      },
+    };
+    const m = matchProviderKey(data, "gemini");
+    assert.ok(m);
+    assert.strictEqual(m!.rendered, "final answer");
+  });
+
+  it("falls back to Gemini thought parts when no plain text is present", () => {
+    const data = {
+      content: {
+        role: "model",
+        parts: [{ text: "all I have is reasoning", thought: true }],
+      },
+    };
+    const m = matchProviderKey(data, "gemini");
+    assert.ok(m);
+    assert.strictEqual(m!.rendered, "all I have is reasoning");
+  });
+
+  it("renders gen-ai (OTel) output preferring text over thinking", () => {
+    const data = [
+      {
+        role: "assistant",
+        parts: [
+          { type: "thinking", content: "This is a straightforward math problem..." },
+          { type: "text", content: "# Answer: 9 sheep" },
+        ],
+        finish_reason: "stop",
+      },
+    ];
+    const m = matchProviderKey(data);
+    assert.ok(m);
+    assert.strictEqual(m!.rendered, "# Answer: 9 sheep");
+  });
+
+  it("falls back to gen-ai thinking when no text part is present", () => {
+    const data = [
+      {
+        role: "assistant",
+        parts: [{ type: "thinking", content: "internal monologue" }],
+      },
+    ];
+    const m = matchProviderKey(data);
+    assert.ok(m);
+    assert.strictEqual(m!.rendered, "internal monologue");
   });
 
   it("renders OpenAI Responses assistant output_text", () => {

--- a/frontend/tests/test-subagent-grouping.test.ts
+++ b/frontend/tests/test-subagent-grouping.test.ts
@@ -1,0 +1,862 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { type TraceViewSpan } from "@/components/traces/trace-view/store/base";
+import { computeSubagentGroups } from "@/components/traces/trace-view/store/utils";
+
+type FixtureSpanType = "LLM" | "CACHED" | "TOOL" | "DEFAULT";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+interface SpanInput {
+  id: string;
+  parentId?: string;
+  type: FixtureSpanType;
+  /**
+   * Path of ancestor segments (leaf last). Used for both `lmnr.span.path` and
+   * `path`. The leaf must be unique enough to identify the span by name; the
+   * preceding segments name its ancestors.
+   */
+  path: string[];
+  /**
+   * Span IDs of ancestors at each path position. MUST be the same length as
+   * `path`, and `idsPath[idsPath.length - 1]` MUST equal `id`. This is what
+   * the algorithm reads to figure out invocation roots.
+   */
+  idsPath: string[];
+  promptHash?: string;
+  /** ISO time string. Defaults are auto-assigned in document order. */
+  startTime?: string;
+  inputTokens?: number;
+}
+
+const T0 = new Date("2025-01-01T00:00:00.000Z").getTime();
+const toTime = (offsetSeconds: number) => new Date(T0 + offsetSeconds * 1000).toISOString();
+
+const makeSpan = (input: SpanInput, autoStartOffset: number): TraceViewSpan => {
+  const last = input.idsPath[input.idsPath.length - 1];
+  assert.strictEqual(last, input.id, `idsPath must end with span id for ${input.id}`);
+  assert.strictEqual(input.idsPath.length, input.path.length, `idsPath/path length mismatch for ${input.id}`);
+
+  const startTime = input.startTime ?? toTime(autoStartOffset);
+  const endTime = toTime((input.startTime ? Date.parse(input.startTime) / 1000 - T0 / 1000 : autoStartOffset) + 1);
+
+  return {
+    spanId: input.id,
+    parentSpanId: input.parentId,
+    traceId: "trace-1",
+    name: input.path[input.path.length - 1],
+    startTime,
+    endTime,
+    attributes: {
+      "lmnr.span.path": input.path,
+      "lmnr.span.ids_path": input.idsPath,
+      "lmnr.span.prompt_hash": input.promptHash ?? "",
+    },
+    spanType: input.type as TraceViewSpan["spanType"],
+    path: input.path.join("."),
+    events: [],
+    collapsed: false,
+    inputTokens: input.inputTokens ?? 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    inputCost: 0,
+    outputCost: 0,
+    totalCost: 0,
+  };
+};
+
+const buildSpans = (inputs: SpanInput[]): TraceViewSpan[] => inputs.map((s, i) => makeSpan(s, i));
+
+/**
+ * Convenience: get an unordered, set-style snapshot of subagent groups
+ * keyed by their first member's span ID for easy assertions.
+ */
+const groupsBySpanIds = (spans: TraceViewSpan[]): Set<string>[] =>
+  computeSubagentGroups(spans).map((g) => new Set(g.spanIds));
+
+const groupContaining = (spans: TraceViewSpan[], spanId: string): Set<string> | null => {
+  for (const g of groupsBySpanIds(spans)) {
+    if (g.has(spanId)) return g;
+  }
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Cases
+// ---------------------------------------------------------------------------
+
+describe("computeSubagentGroups", () => {
+  it("returns no groups when only one LLM span exists", () => {
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main_llm"],
+        idsPath: ["root", "llm"],
+        promptHash: "h1",
+      },
+    ]);
+    assert.deepStrictEqual(computeSubagentGroups(spans), []);
+  });
+
+  it("groups multiple iterations of one subagent into a single group", () => {
+    // One subagent invocation with three LLM iterations sharing one loop body.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      // Main agent LLM (shortest path among hashed LLMs => suppressed).
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      // Subagent invocation root (a TOOL span wrapping the inner loop).
+      { id: "sub_call", parentId: "root", type: "TOOL", path: ["root", "sub_call"], idsPath: ["root", "sub_call"] },
+      // Loop body for the subagent (reused across iterations).
+      {
+        id: "sub_loop",
+        parentId: "sub_call",
+        type: "DEFAULT",
+        path: ["root", "sub_call", "sub_loop"],
+        idsPath: ["root", "sub_call", "sub_loop"],
+      },
+      // Three LLM iterations under one shared loop body.
+      {
+        id: "iter_1",
+        parentId: "sub_loop",
+        type: "LLM",
+        path: ["root", "sub_call", "sub_loop", "iter"],
+        idsPath: ["root", "sub_call", "sub_loop", "iter_1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "iter_2",
+        parentId: "sub_loop",
+        type: "LLM",
+        path: ["root", "sub_call", "sub_loop", "iter"],
+        idsPath: ["root", "sub_call", "sub_loop", "iter_2"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "iter_3",
+        parentId: "sub_loop",
+        type: "LLM",
+        path: ["root", "sub_call", "sub_loop", "iter"],
+        idsPath: ["root", "sub_call", "sub_loop", "iter_3"],
+        promptHash: "sub_hash",
+      },
+    ]);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 1, "expected exactly one subagent group");
+    // `sub_loop` is inside the invocation and joins. `sub_call` wraps the
+    // invocation (its own ID is an ancestor of the LLMs) and stays out.
+    assert.deepStrictEqual(groups[0], new Set(["iter_1", "iter_2", "iter_3", "sub_loop"]));
+    assert.ok(!groupContaining(spans, "main_llm"));
+    assert.ok(!groupContaining(spans, "sub_call"));
+  });
+
+  it("splits two separate invocations of the same subagent into separate groups", () => {
+    // Two calls of the same (path, hash); only the wrapping invocation span differs.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      // Invocation A.
+      { id: "call_a", parentId: "root", type: "TOOL", path: ["root", "task"], idsPath: ["root", "call_a"] },
+      {
+        id: "loop_a",
+        parentId: "call_a",
+        type: "DEFAULT",
+        path: ["root", "task", "loop"],
+        idsPath: ["root", "call_a", "loop_a"],
+      },
+      {
+        id: "a_iter_1",
+        parentId: "loop_a",
+        type: "LLM",
+        path: ["root", "task", "loop", "iter"],
+        idsPath: ["root", "call_a", "loop_a", "a_iter_1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "a_iter_2",
+        parentId: "loop_a",
+        type: "LLM",
+        path: ["root", "task", "loop", "iter"],
+        idsPath: ["root", "call_a", "loop_a", "a_iter_2"],
+        promptHash: "sub_hash",
+      },
+      // Invocation B (same path + hash, different invocation root).
+      { id: "call_b", parentId: "root", type: "TOOL", path: ["root", "task"], idsPath: ["root", "call_b"] },
+      {
+        id: "loop_b",
+        parentId: "call_b",
+        type: "DEFAULT",
+        path: ["root", "task", "loop"],
+        idsPath: ["root", "call_b", "loop_b"],
+      },
+      {
+        id: "b_iter_1",
+        parentId: "loop_b",
+        type: "LLM",
+        path: ["root", "task", "loop", "iter"],
+        idsPath: ["root", "call_b", "loop_b", "b_iter_1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "b_iter_2",
+        parentId: "loop_b",
+        type: "LLM",
+        path: ["root", "task", "loop", "iter"],
+        idsPath: ["root", "call_b", "loop_b", "b_iter_2"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "b_iter_3",
+        parentId: "loop_b",
+        type: "LLM",
+        path: ["root", "task", "loop", "iter"],
+        idsPath: ["root", "call_b", "loop_b", "b_iter_3"],
+        promptHash: "sub_hash",
+      },
+    ]);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 2, "expected two subagent groups (one per invocation)");
+
+    const groupA = groupContaining(spans, "a_iter_1");
+    const groupB = groupContaining(spans, "b_iter_1");
+    assert.ok(groupA && groupB);
+    assert.notStrictEqual(groupA, groupB);
+    // A's iterations are all in A; B's are all in B.
+    assert.ok(groupA.has("a_iter_2"));
+    assert.ok(!groupA.has("b_iter_1"));
+    assert.ok(groupB.has("b_iter_2"));
+    assert.ok(groupB.has("b_iter_3"));
+  });
+
+  it("treats different prompt hashes at the same code location as different subagents", () => {
+    // Same parentSpanPath, three prompt hashes → three subagents.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      {
+        id: "wrap",
+        parentId: "root",
+        type: "DEFAULT",
+        path: ["root", "wrap"],
+        idsPath: ["root", "wrap"],
+      },
+      {
+        id: "llm_a",
+        parentId: "wrap",
+        type: "LLM",
+        path: ["root", "wrap", "step"],
+        idsPath: ["root", "wrap", "llm_a"],
+        promptHash: "hash_A",
+      },
+      {
+        id: "llm_b",
+        parentId: "wrap",
+        type: "LLM",
+        path: ["root", "wrap", "step"],
+        idsPath: ["root", "wrap", "llm_b"],
+        promptHash: "hash_B",
+      },
+      {
+        id: "llm_c",
+        parentId: "wrap",
+        type: "LLM",
+        path: ["root", "wrap", "step"],
+        idsPath: ["root", "wrap", "llm_c"],
+        promptHash: "hash_C",
+      },
+    ]);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 3);
+    for (const id of ["llm_a", "llm_b", "llm_c"]) {
+      const g = groupContaining(spans, id);
+      assert.ok(g, `${id} should be in a group`);
+      assert.strictEqual(g!.size, 1, `${id}'s group should contain only itself (different hashes)`);
+    }
+  });
+
+  it("bundles a non-LLM tool span into the right subagent via parent-id walk", () => {
+    // Two subagents; each has an inner TOOL — each must join its own subagent.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      // Subagent A.
+      { id: "call_a", parentId: "root", type: "TOOL", path: ["root", "a"], idsPath: ["root", "call_a"] },
+      {
+        id: "loop_a",
+        parentId: "call_a",
+        type: "DEFAULT",
+        path: ["root", "a", "loop"],
+        idsPath: ["root", "call_a", "loop_a"],
+      },
+      {
+        id: "a_llm",
+        parentId: "loop_a",
+        type: "LLM",
+        path: ["root", "a", "loop", "call"],
+        idsPath: ["root", "call_a", "loop_a", "a_llm"],
+        promptHash: "a_hash",
+      },
+      {
+        id: "a_tool",
+        parentId: "loop_a",
+        type: "TOOL",
+        path: ["root", "a", "loop", "search"],
+        idsPath: ["root", "call_a", "loop_a", "a_tool"],
+      },
+      // Subagent B.
+      { id: "call_b", parentId: "root", type: "TOOL", path: ["root", "b"], idsPath: ["root", "call_b"] },
+      {
+        id: "loop_b",
+        parentId: "call_b",
+        type: "DEFAULT",
+        path: ["root", "b", "loop"],
+        idsPath: ["root", "call_b", "loop_b"],
+      },
+      {
+        id: "b_llm",
+        parentId: "loop_b",
+        type: "LLM",
+        path: ["root", "b", "loop", "call"],
+        idsPath: ["root", "call_b", "loop_b", "b_llm"],
+        promptHash: "b_hash",
+      },
+      {
+        id: "b_tool",
+        parentId: "loop_b",
+        type: "TOOL",
+        path: ["root", "b", "loop", "search"],
+        idsPath: ["root", "call_b", "loop_b", "b_tool"],
+      },
+    ]);
+
+    const groupA = groupContaining(spans, "a_llm");
+    const groupB = groupContaining(spans, "b_llm");
+    assert.ok(groupA && groupB);
+    assert.ok(groupA.has("a_tool"));
+    assert.ok(!groupA.has("b_tool"));
+    assert.ok(groupB.has("b_tool"));
+    assert.ok(!groupB.has("a_tool"));
+  });
+
+  it("resolves a subagent even when chained through many default ancestor spans", () => {
+    // Subagent invocations diverge only at one deep ancestor; everything
+    // above is shared. Divergence detection must work without a hardcoded depth.
+    const deepPath = (...tail: string[]) => ["root", "a", "b", "c", "d", ...tail];
+    const deepIds = (...tail: string[]) => ["root", "a", "b", "c", "d", ...tail];
+
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      { id: "a", parentId: "root", type: "DEFAULT", path: ["root", "a"], idsPath: ["root", "a"] },
+      { id: "b", parentId: "a", type: "DEFAULT", path: ["root", "a", "b"], idsPath: ["root", "a", "b"] },
+      { id: "c", parentId: "b", type: "DEFAULT", path: ["root", "a", "b", "c"], idsPath: ["root", "a", "b", "c"] },
+      {
+        id: "d",
+        parentId: "c",
+        type: "DEFAULT",
+        path: ["root", "a", "b", "c", "d"],
+        idsPath: ["root", "a", "b", "c", "d"],
+      },
+      {
+        id: "main_llm",
+        parentId: "d",
+        type: "LLM",
+        path: deepPath("main"),
+        idsPath: deepIds("main_llm"),
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      // Invocation 1 of the subagent: enclosure_1 -> loop_1 -> llm_1.
+      {
+        id: "enclosure_1",
+        parentId: "d",
+        type: "TOOL",
+        path: deepPath("task"),
+        idsPath: deepIds("enclosure_1"),
+      },
+      {
+        id: "loop_1",
+        parentId: "enclosure_1",
+        type: "DEFAULT",
+        path: deepPath("task", "loop"),
+        idsPath: deepIds("enclosure_1", "loop_1"),
+      },
+      {
+        id: "iter_1a",
+        parentId: "loop_1",
+        type: "LLM",
+        path: deepPath("task", "loop", "call"),
+        idsPath: deepIds("enclosure_1", "loop_1", "iter_1a"),
+        promptHash: "sub_hash",
+      },
+      {
+        id: "iter_1b",
+        parentId: "loop_1",
+        type: "LLM",
+        path: deepPath("task", "loop", "call"),
+        idsPath: deepIds("enclosure_1", "loop_1", "iter_1b"),
+        promptHash: "sub_hash",
+      },
+      // Invocation 2 of the same subagent: enclosure_2 -> loop_2 -> llm_2.
+      {
+        id: "enclosure_2",
+        parentId: "d",
+        type: "TOOL",
+        path: deepPath("task"),
+        idsPath: deepIds("enclosure_2"),
+      },
+      {
+        id: "loop_2",
+        parentId: "enclosure_2",
+        type: "DEFAULT",
+        path: deepPath("task", "loop"),
+        idsPath: deepIds("enclosure_2", "loop_2"),
+      },
+      {
+        id: "iter_2a",
+        parentId: "loop_2",
+        type: "LLM",
+        path: deepPath("task", "loop", "call"),
+        idsPath: deepIds("enclosure_2", "loop_2", "iter_2a"),
+        promptHash: "sub_hash",
+      },
+    ]);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 2, "two invocations => two subagent groups");
+
+    const g1 = groupContaining(spans, "iter_1a");
+    const g2 = groupContaining(spans, "iter_2a");
+    assert.ok(g1 && g2);
+    assert.notStrictEqual(g1, g2);
+    assert.ok(g1.has("iter_1b"), "both iterations of invocation 1 stay together");
+    assert.ok(!g1.has("iter_2a"), "invocation 2 must not leak into invocation 1");
+  });
+
+  it("renders the main agent inline across multiple top-level invocations", () => {
+    // Two main-agent calls (same path + hash) must not form a subagent group.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_call_1",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_call_1"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      {
+        id: "main_call_2",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_call_2"],
+        promptHash: "main_hash",
+        inputTokens: 80,
+      },
+      // A subagent to anchor the main-agent detection.
+      {
+        id: "sub_wrap",
+        parentId: "root",
+        type: "DEFAULT",
+        path: ["root", "sub"],
+        idsPath: ["root", "sub_wrap"],
+      },
+      {
+        id: "sub_loop",
+        parentId: "sub_wrap",
+        type: "DEFAULT",
+        path: ["root", "sub", "loop"],
+        idsPath: ["root", "sub_wrap", "sub_loop"],
+      },
+      {
+        id: "sub_llm",
+        parentId: "sub_loop",
+        type: "LLM",
+        path: ["root", "sub", "loop", "call"],
+        idsPath: ["root", "sub_wrap", "sub_loop", "sub_llm"],
+        promptHash: "sub_hash",
+      },
+    ]);
+
+    assert.ok(!groupContaining(spans, "main_call_1"));
+    assert.ok(!groupContaining(spans, "main_call_2"));
+    assert.ok(groupContaining(spans, "sub_llm"));
+  });
+
+  it("gives LLM spans with no prompt hash their own group instead of dropping them", () => {
+    // A hashless LLM next to a hashed sibling under the same parent: gets its own group.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      {
+        id: "wrap",
+        parentId: "root",
+        type: "DEFAULT",
+        path: ["root", "wrap"],
+        idsPath: ["root", "wrap"],
+      },
+      {
+        id: "hashless_llm",
+        parentId: "wrap",
+        type: "LLM",
+        path: ["root", "wrap", "step"],
+        idsPath: ["root", "wrap", "hashless_llm"],
+      },
+      {
+        id: "hashed_llm",
+        parentId: "wrap",
+        type: "LLM",
+        path: ["root", "wrap", "step"],
+        idsPath: ["root", "wrap", "hashed_llm"],
+        promptHash: "some_hash",
+      },
+    ]);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 2);
+    const gHashless = groupContaining(spans, "hashless_llm");
+    const gHashed = groupContaining(spans, "hashed_llm");
+    assert.ok(gHashless && gHashed);
+    assert.notStrictEqual(gHashless, gHashed);
+    assert.ok(!gHashless!.has("hashed_llm"));
+    assert.ok(!gHashed!.has("hashless_llm"));
+  });
+
+  it("collapses iterations even when each iteration spawns a fresh loop-body span", () => {
+    // Divergence at length-2 (each LLM's direct parent) is iteration-level
+    // noise and must not split the subagent.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      { id: "call", parentId: "root", type: "TOOL", path: ["root", "task"], idsPath: ["root", "call"] },
+      // Each iteration has its OWN loop body span.
+      {
+        id: "loop_i1",
+        parentId: "call",
+        type: "DEFAULT",
+        path: ["root", "task", "loop"],
+        idsPath: ["root", "call", "loop_i1"],
+      },
+      {
+        id: "llm_i1",
+        parentId: "loop_i1",
+        type: "LLM",
+        path: ["root", "task", "loop", "call"],
+        idsPath: ["root", "call", "loop_i1", "llm_i1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "loop_i2",
+        parentId: "call",
+        type: "DEFAULT",
+        path: ["root", "task", "loop"],
+        idsPath: ["root", "call", "loop_i2"],
+      },
+      {
+        id: "llm_i2",
+        parentId: "loop_i2",
+        type: "LLM",
+        path: ["root", "task", "loop", "call"],
+        idsPath: ["root", "call", "loop_i2", "llm_i2"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "loop_i3",
+        parentId: "call",
+        type: "DEFAULT",
+        path: ["root", "task", "loop"],
+        idsPath: ["root", "call", "loop_i3"],
+      },
+      {
+        id: "llm_i3",
+        parentId: "loop_i3",
+        type: "LLM",
+        path: ["root", "task", "loop", "call"],
+        idsPath: ["root", "call", "loop_i3", "llm_i3"],
+        promptHash: "sub_hash",
+      },
+    ]);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 1, "iterations under fresh-per-step loop bodies still collapse to one subagent");
+    assert.ok(groups[0].has("llm_i1"));
+    assert.ok(groups[0].has("llm_i2"));
+    assert.ok(groups[0].has("llm_i3"));
+  });
+
+  it("tie-breaks tool assignment by nearest preceding LLM when multiple subagents share a parent", () => {
+    // Two subagent LLMs are siblings under one orchestrator span. A TOOL between
+    // them joins whichever LLM most recently preceded it.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+        startTime: toTime(0),
+      },
+      {
+        id: "orchestrator",
+        parentId: "root",
+        type: "DEFAULT",
+        path: ["root", "orchestrator"],
+        idsPath: ["root", "orchestrator"],
+        startTime: toTime(1),
+      },
+      {
+        id: "step0_llm",
+        parentId: "orchestrator",
+        type: "LLM",
+        path: ["root", "orchestrator", "step_0", "call"],
+        idsPath: ["root", "orchestrator", "step0_loop", "step0_llm"],
+        promptHash: "step_hash",
+        startTime: toTime(2),
+      },
+      // Tool fired between the two subagent LLM calls.
+      {
+        id: "between_tool",
+        parentId: "orchestrator",
+        type: "TOOL",
+        path: ["root", "orchestrator", "fetch"],
+        idsPath: ["root", "orchestrator", "between_tool"],
+        startTime: toTime(3),
+      },
+      {
+        id: "step1_llm",
+        parentId: "orchestrator",
+        type: "LLM",
+        path: ["root", "orchestrator", "step_1", "call"],
+        idsPath: ["root", "orchestrator", "step1_loop", "step1_llm"],
+        promptHash: "step_hash",
+        startTime: toTime(4),
+      },
+      // Tool fired after the second subagent LLM call.
+      {
+        id: "after_tool",
+        parentId: "orchestrator",
+        type: "TOOL",
+        path: ["root", "orchestrator", "fetch"],
+        idsPath: ["root", "orchestrator", "after_tool"],
+        startTime: toTime(5),
+      },
+    ]);
+
+    const g0 = groupContaining(spans, "step0_llm");
+    const g1 = groupContaining(spans, "step1_llm");
+    assert.ok(g0 && g1);
+    assert.notStrictEqual(g0, g1);
+    assert.ok(g0.has("between_tool"), "between_tool should follow the nearest preceding LLM (step_0)");
+    assert.ok(!g1.has("between_tool"));
+    assert.ok(g1.has("after_tool"), "after_tool should follow the nearest preceding LLM (step_1)");
+    assert.ok(!g0.has("after_tool"));
+  });
+
+  it("keeps a tool standalone when its deepest claimed ancestor is also a main-agent ancestor", () => {
+    // Main agent and subagents share the `orchestrator` ancestor. A TOOL whose
+    // deepest claimed ancestor is `orchestrator` stays standalone (main wins ties).
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "orchestrator",
+        parentId: "root",
+        type: "DEFAULT",
+        path: ["root", "orchestrator"],
+        idsPath: ["root", "orchestrator"],
+      },
+      // Main agent LLM lives directly under `orchestrator`.
+      {
+        id: "main_llm",
+        parentId: "orchestrator",
+        type: "LLM",
+        path: ["root", "orchestrator", "main"],
+        idsPath: ["root", "orchestrator", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 200,
+      },
+      // Sibling tool of the main LLM — same parent, shouldn't join any subagent.
+      {
+        id: "main_tool",
+        parentId: "orchestrator",
+        type: "TOOL",
+        path: ["root", "orchestrator", "fetch"],
+        idsPath: ["root", "orchestrator", "main_tool"],
+      },
+      // Subagent 1 — its LLM is also under `orchestrator` but the path differs.
+      {
+        id: "sub1_llm",
+        parentId: "orchestrator",
+        type: "LLM",
+        path: ["root", "orchestrator", "sub_a"],
+        idsPath: ["root", "orchestrator", "sub1_llm"],
+        promptHash: "sub_a_hash",
+      },
+      // Subagent 2 — same scope sibling.
+      {
+        id: "sub2_llm",
+        parentId: "orchestrator",
+        type: "LLM",
+        path: ["root", "orchestrator", "sub_b"],
+        idsPath: ["root", "orchestrator", "sub2_llm"],
+        promptHash: "sub_b_hash",
+      },
+    ]);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 2);
+    assert.ok(!groupContaining(spans, "main_tool"));
+    assert.ok(!groupContaining(spans, "main_llm"));
+  });
+
+  it("leaves spans without an ids_path attribute standalone instead of crashing", () => {
+    // Older instrumentation may emit spans missing `lmnr.span.ids_path`.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      {
+        id: "sub_wrap",
+        parentId: "root",
+        type: "DEFAULT",
+        path: ["root", "sub"],
+        idsPath: ["root", "sub_wrap"],
+      },
+      {
+        id: "sub_llm",
+        parentId: "sub_wrap",
+        type: "LLM",
+        path: ["root", "sub", "call"],
+        idsPath: ["root", "sub_wrap", "sub_llm"],
+        promptHash: "sub_hash",
+      },
+    ]);
+    // Strip ids_path from a tool span to simulate missing attribute.
+    const orphanTool: TraceViewSpan = {
+      ...makeSpan(
+        {
+          id: "orphan",
+          parentId: "root",
+          type: "TOOL",
+          path: ["root", "orphan"],
+          idsPath: ["root", "orphan"],
+        },
+        spans.length
+      ),
+      attributes: { "lmnr.span.path": ["root", "orphan"], "lmnr.span.prompt_hash": "" },
+    };
+    spans.push(orphanTool);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 1);
+    assert.ok(groups[0].has("sub_llm"));
+    assert.ok(!groupContaining(spans, "orphan"), "orphan tool with no ids_path must stay standalone");
+  });
+
+  it("excludes the wrapping TOOL/DEFAULT span from the subagent group it encloses", () => {
+    // The span whose own ID appears as an ancestor of the subagent's LLM is the
+    // call-site from the parent agent and must render OUTSIDE the group.
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      // The wrapping TOOL — the subagent's invocation starts here.
+      { id: "wrap", parentId: "root", type: "TOOL", path: ["root", "wrap"], idsPath: ["root", "wrap"] },
+      // An intermediate DEFAULT span between the wrapper and the LLM.
+      {
+        id: "inner",
+        parentId: "wrap",
+        type: "DEFAULT",
+        path: ["root", "wrap", "inner"],
+        idsPath: ["root", "wrap", "inner"],
+      },
+      {
+        id: "sub_llm",
+        parentId: "inner",
+        type: "LLM",
+        path: ["root", "wrap", "inner", "call"],
+        idsPath: ["root", "wrap", "inner", "sub_llm"],
+        promptHash: "sub_hash",
+      },
+    ]);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 1);
+    assert.ok(groups[0].has("sub_llm"));
+    assert.ok(groups[0].has("inner")); // inside the invocation
+    assert.ok(!groups[0].has("wrap")); // the call-site stays out
+  });
+});

--- a/frontend/tests/test-subagent-grouping.test.ts
+++ b/frontend/tests/test-subagent-grouping.test.ts
@@ -104,6 +104,45 @@ describe("computeSubagentGroups", () => {
     assert.deepStrictEqual(computeSubagentGroups(spans), []);
   });
 
+  it("returns no groups when every LLM span is hashless", () => {
+    // No hashed LLMs → no reliably-identifiable main agent → grouping must be
+    // suppressed entirely. Without the early return, every hashless LLM would
+    // be promoted into a spurious group because pathHashKeyOf(s) (a string)
+    // never equals mainPathHashKey (null).
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "llm_a",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "llm_a"],
+        idsPath: ["root", "llm_a"],
+      },
+      {
+        id: "llm_b",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "llm_b"],
+        idsPath: ["root", "llm_b"],
+      },
+    ]);
+    assert.deepStrictEqual(computeSubagentGroups(spans), []);
+  });
+
+  it("returns no groups for a single hashless LLM span", () => {
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main_llm"],
+        idsPath: ["root", "llm"],
+      },
+    ]);
+    assert.deepStrictEqual(computeSubagentGroups(spans), []);
+  });
+
   it("groups multiple iterations of one subagent into a single group", () => {
     // One subagent invocation with three LLM iterations sharing one loop body.
     const spans = buildSpans([

--- a/frontend/tests/test-subagent-grouping.test.ts
+++ b/frontend/tests/test-subagent-grouping.test.ts
@@ -819,6 +819,96 @@ describe("computeSubagentGroups", () => {
     assert.ok(!groupContaining(spans, "orphan"), "orphan tool with no ids_path must stay standalone");
   });
 
+  it("splits three invocations correctly when their divergence depths differ", () => {
+    // Pathological cluster: three subagent invocations of the same (path, hash)
+    // where the structural divergences happen at TWO different depths.
+    //
+    //   root
+    //   ├── X
+    //   │   ├── inv_A -> loop_A -> llm_A
+    //   │   └── inv_B -> loop_B -> llm_B    (A vs B diverge at idx=2)
+    //   └── Y
+    //       └── inv_C -> loop_C -> llm_C    (A vs C diverge at idx=1)
+    //
+    // A naive "first index where any member differs from cluster[0]" picks
+    // idx=1 and keys A and B with the same root (X), incorrectly merging
+    // two independent invocations. Using the full structural prefix as the
+    // key separates them.
+    const sharedPath = ["root", "branch", "task", "loop", "call"];
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      { id: "X", parentId: "root", type: "DEFAULT", path: ["root", "branch"], idsPath: ["root", "X"] },
+      { id: "inv_A", parentId: "X", type: "TOOL", path: ["root", "branch", "task"], idsPath: ["root", "X", "inv_A"] },
+      {
+        id: "loop_A",
+        parentId: "inv_A",
+        type: "DEFAULT",
+        path: ["root", "branch", "task", "loop"],
+        idsPath: ["root", "X", "inv_A", "loop_A"],
+      },
+      {
+        id: "llm_A",
+        parentId: "loop_A",
+        type: "LLM",
+        path: sharedPath,
+        idsPath: ["root", "X", "inv_A", "loop_A", "llm_A"],
+        promptHash: "sub_hash",
+      },
+      { id: "inv_B", parentId: "X", type: "TOOL", path: ["root", "branch", "task"], idsPath: ["root", "X", "inv_B"] },
+      {
+        id: "loop_B",
+        parentId: "inv_B",
+        type: "DEFAULT",
+        path: ["root", "branch", "task", "loop"],
+        idsPath: ["root", "X", "inv_B", "loop_B"],
+      },
+      {
+        id: "llm_B",
+        parentId: "loop_B",
+        type: "LLM",
+        path: sharedPath,
+        idsPath: ["root", "X", "inv_B", "loop_B", "llm_B"],
+        promptHash: "sub_hash",
+      },
+      { id: "Y", parentId: "root", type: "DEFAULT", path: ["root", "branch"], idsPath: ["root", "Y"] },
+      { id: "inv_C", parentId: "Y", type: "TOOL", path: ["root", "branch", "task"], idsPath: ["root", "Y", "inv_C"] },
+      {
+        id: "loop_C",
+        parentId: "inv_C",
+        type: "DEFAULT",
+        path: ["root", "branch", "task", "loop"],
+        idsPath: ["root", "Y", "inv_C", "loop_C"],
+      },
+      {
+        id: "llm_C",
+        parentId: "loop_C",
+        type: "LLM",
+        path: sharedPath,
+        idsPath: ["root", "Y", "inv_C", "loop_C", "llm_C"],
+        promptHash: "sub_hash",
+      },
+    ]);
+
+    const groups = groupsBySpanIds(spans);
+    assert.strictEqual(groups.length, 3, "three invocations => three subagent groups");
+    const gA = groupContaining(spans, "llm_A");
+    const gB = groupContaining(spans, "llm_B");
+    const gC = groupContaining(spans, "llm_C");
+    assert.ok(gA && gB && gC);
+    assert.notStrictEqual(gA, gB, "A and B share branch X but are distinct invocations");
+    assert.notStrictEqual(gA, gC);
+    assert.notStrictEqual(gB, gC);
+  });
+
   it("excludes the wrapping TOOL/DEFAULT span from the subagent group it encloses", () => {
     // The span whose own ID appears as an ancestor of the subagent's LLM is the
     // call-site from the parent agent and must render OUTSIDE the group.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core trace transcript grouping logic (subagent anchoring, main-agent detection, non-LLM assignment) which can affect what users see and how spans are clustered. Also tweaks provider output rendering and timeline/path computations; covered by new targeted tests but behavior is user-facing.
> 
> **Overview**
> **Trace UI grouping is reworked to fix subagent detection.** Subagent grouping now keys LLM/CACHED spans by `(parentSpanPath, promptHash, invocationRoot)` (derived from structural `ids_path` prefixes), selects anchors per key, suppresses *all* main-agent invocations via `(path, hash)`, and assigns non-LLM spans to groups via a new `buildSpanToAnchorMap` with main-agent tie-breaking and nearest-preceding-LLM disambiguation.
> 
> **Provider output rendering now prefers final text over reasoning.** Anthropic and Gemini renderers ignore thinking/thought parts when any normal text exists (but fall back to thinking when text is absent), and the `gen-ai` provider gains `renderOutputText` with the same preference; tests are added/expanded to lock this behavior.
> 
> **Performance/robustness tweaks.** `computePathInfoMap` memoizes parent chains, condensed timeline DFS ordering is made O(N) via a `spanId -> position` map, and a comprehensive `test-subagent-grouping` suite is added to cover iteration collapsing, multi-invocation splits, hashless spans, missing `ids_path`, and divergence-depth edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b53f9b1022e833d5956e67cb757ef238289ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->