### PR TITLE
ignore empty llm_base_url env var

### DIFF
--- a/app-server/src/llm/gemini/client.rs
+++ b/app-server/src/llm/gemini/client.rs
@@ -25,7 +25,9 @@ impl GeminiClient {
             .map_err(|_| GeminiError::config("LLM_API_KEY environment variable not set"))?;
 
         let raw_base_url = env::var("LLM_BASE_URL")
-            .unwrap_or_else(|_| "https://generativelanguage.googleapis.com/v1beta".to_string());
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "https://generativelanguage.googleapis.com/v1beta".to_string());
         let api_base_url = raw_base_url.trim_end_matches('/').to_string();
 
         let client = reqwest::Client::builder()

--- a/app-server/src/llm/openai/client.rs
+++ b/app-server/src/llm/openai/client.rs
@@ -22,8 +22,10 @@ impl OpenAIClient {
         let api_key = env::var("LLM_API_KEY")
             .map_err(|_| OpenAIError::config("LLM_API_KEY environment variable not set"))?;
 
-        let raw_base_url =
-            env::var("LLM_BASE_URL").unwrap_or_else(|_| "https://api.openai.com/v1".to_string());
+        let raw_base_url = env::var("LLM_BASE_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
         let api_base_url = raw_base_url.trim_end_matches('/').to_string();
 
         let client = reqwest::Client::builder()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small config parsing change that only affects how the LLM base URL is derived, falling back to defaults when the env var is empty/whitespace.
> 
> **Overview**
> Updates `OpenAIClient::new` and `GeminiClient::new` to treat an empty/whitespace `LLM_BASE_URL` environment variable as unset, so the clients fall back to the provider default base URLs instead of using an invalid empty string.
> 
> The resulting `api_base_url` normalization (trailing slash trimming) and HTTP client setup remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 307e27a6b74acb96416bed722353db4ce79cc21e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->