### PR TITLE
feat: capture cache hits, fix models

### DIFF
--- a/app-server/src/llm/mod.rs
+++ b/app-server/src/llm/mod.rs
@@ -212,9 +212,9 @@ pub fn model_for_size(provider: &str, size: ModelSize) -> String {
     }
 
     match (provider, size) {
-        ("gemini", ModelSize::Small) => "gemini-3-flash-preview".to_string(),
+        ("gemini", ModelSize::Small) => "gemini-3.1-flash-lite".to_string(),
         ("gemini", ModelSize::Medium) => "gemini-3-flash-preview".to_string(),
-        ("gemini", ModelSize::Large) => "gemini-3-pro-preview".to_string(),
+        ("gemini", ModelSize::Large) => "gemini-3.1-pro-preview".to_string(),
         ("bedrock", ModelSize::Small) => "us.anthropic.claude-haiku-4-5-20251001-v1:0".to_string(),
         ("bedrock", ModelSize::Medium) => "us.anthropic.claude-sonnet-4-6".to_string(),
         ("bedrock", ModelSize::Large) => "us.anthropic.claude-opus-4-7".to_string(),

--- a/frontend/lib/actions/sessions/extract-input.ts
+++ b/frontend/lib/actions/sessions/extract-input.ts
@@ -24,7 +24,7 @@ export function joinUserParts(parts: TextPart[]): string | null {
   return text.length > 0 ? text : null;
 }
 
-// Structural fingerprint of a user message: sequence of top-level XML-like tags (nested tags ignored), or "plain" for messages with no tags.
+// Sequence of top-level XML-like tags, or "plain" for tag-free messages.
 export function fingerprintUserMessage(input: string): string {
   const TOP_LEVEL_TAG = /<([a-zA-Z_][\w-]*)\b[^>]*>([\s\S]*?)<\/\1\s*>/;
   const parts: string[] = [];
@@ -53,113 +53,273 @@ interface TraceForExtraction {
   parsed: ParsedInput | null;
 }
 
-/**
- * For a group of traces sharing the same system prompt, generate or
- * retrieve a cached regex, then apply it to extract each trace's input.
- */
+type ExtractionPath =
+  | "no-samples"
+  | "cache-hit"
+  | "cache-stale-regenerated"
+  | "cache-miss-regenerated"
+  | "llm-no-regex";
+
+type TraceResult = { inputPreview: string | null; outputPreview: string | null; outputSpan: unknown };
+type ResultsMap = Record<string, TraceResult>;
+
+// For a group of traces sharing a system prompt, retrieve or generate a regex
+// and apply it to extract each trace's input. `results` is mutated in place;
+// trace-io.ts hydrates the full Span afterwards.
 export async function extractInputsForGroup(
   systemHash: string,
   projectId: string,
   traces: TraceForExtraction[],
-  // Accepts any result shape with text preview fields + a nullable outputSpan;
-  // trace-io.ts hydrates the full Span afterwards, this layer only writes text.
-  results: Record<string, { inputPreview: string | null; outputPreview: string | null; outputSpan: unknown }>,
+  results: ResultsMap,
   fingerprint: string = "plain"
 ): Promise<void> {
   const cacheKey = `${REGEX_CACHE_PREFIX}${projectId}:${systemHash}:${fingerprint}`;
 
-  try {
-    const cachedRegex = await cache.get<string>(cacheKey);
-    if (cachedRegex) {
-      let allMatched = true;
-      for (const trace of traces) {
-        const joinedText = joinUserParts(trace.parsed?.userParts ?? []);
-        if (!joinedText) {
-          results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
-          continue;
-        }
-        const result = applyRegex(cachedRegex, joinedText);
-        if (result.kind === "extracted") {
-          results[trace.traceId] = { inputPreview: result.text, outputPreview: trace.output, outputSpan: null };
-        } else if (result.kind === "no-user-request") {
-          results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
-        } else {
-          allMatched = false;
-          break;
-        }
+  await observe(
+    {
+      name: "traces:extract-inputs",
+      input: { projectId, systemHash, fingerprint, traceCount: traces.length, cacheKey },
+    },
+    async () => {
+      const cacheOutcome = await tryCachedRegex(cacheKey, traces, results);
+      if (cacheOutcome.cacheHitFullyApplied) {
+        return {
+          path: "cache-hit" satisfies ExtractionPath,
+          extractedFromCache: cacheOutcome.extractedCount,
+          tracesFulfilled: traces.length,
+        };
       }
-      if (allMatched) {
-        await cache.expire(cacheKey, SEVEN_DAYS_SECONDS).catch(() => {});
-        return;
-      }
-      await cache.remove(cacheKey).catch(() => {});
-    }
-  } catch {
-    // ignore cache errors
-  }
 
-  const samples = traces.slice(0, BATCH_SIZE).filter((t) => t.parsed && t.parsed.userParts.length > 0);
-  if (samples.length === 0) {
-    for (const trace of traces) {
-      results[trace.traceId] = {
-        inputPreview: joinUserParts(trace.parsed?.userParts ?? []),
-        outputPreview: trace.output,
-        outputSpan: null,
-      };
-    }
-    return;
-  }
-
-  await observe({ name: "trace-io:extract-trace-inputs", input: { projectId } }, async () => {
-    const allUserParts = samples.map((s) => s.parsed!.userParts);
-    const llmInput = buildDeduplicatedLLMInput(allUserParts);
-    const regex = await generateExtractionRegex(llmInput);
-
-    if (!regex) {
-      for (const trace of traces) {
-        if (!(trace.traceId in results)) {
+      const samples = traces.slice(0, BATCH_SIZE).filter((t) => t.parsed && t.parsed.userParts.length > 0);
+      if (samples.length === 0) {
+        for (const trace of traces) {
           results[trace.traceId] = {
             inputPreview: joinUserParts(trace.parsed?.userParts ?? []),
             outputPreview: trace.output,
             outputSpan: null,
           };
         }
+        return {
+          path: "no-samples" satisfies ExtractionPath,
+          tracesFulfilled: traces.length,
+          previousCacheState: cacheOutcome.cacheState,
+        };
       }
-      return;
+
+      const llmOutcome = await runRegexExtraction(cacheKey, traces, samples, results);
+
+      const path: ExtractionPath = !llmOutcome.regexGenerated
+        ? "llm-no-regex"
+        : cacheOutcome.cacheState === "stale"
+          ? "cache-stale-regenerated"
+          : "cache-miss-regenerated";
+
+      return {
+        path,
+        sampleCount: samples.length,
+        regexGenerated: llmOutcome.regexGenerated,
+        extractedFromLlm: llmOutcome.extractedCount,
+        cachedAfterLlm: llmOutcome.cached,
+        tracesFulfilled: traces.length,
+        previousCacheState: cacheOutcome.cacheState,
+      };
+    }
+  );
+}
+
+interface CacheOutcome {
+  cacheState: "miss" | "hit" | "stale" | "error";
+  cacheHitFullyApplied: boolean;
+  extractedCount: number;
+}
+
+// Cached regex must match EVERY trace; one failure invalidates it and stages
+// are discarded so the regenerated regex owns the whole batch.
+async function tryCachedRegex(
+  cacheKey: string,
+  traces: TraceForExtraction[],
+  results: ResultsMap
+): Promise<CacheOutcome> {
+  return observe({ name: "traces:cache-lookup", input: { cacheKey, traceCount: traces.length } }, async () => {
+    let cachedRegex: string | null = null;
+    let cacheError: string | null = null;
+    try {
+      cachedRegex = await cache.get<string>(cacheKey);
+    } catch (error) {
+      cacheError = error instanceof Error ? error.message : String(error);
     }
 
-    let anyMatch = false;
+    if (cacheError) {
+      return {
+        outcome: { cacheState: "error" as const, cacheHitFullyApplied: false, extractedCount: 0 },
+        error: cacheError,
+      };
+    }
+
+    if (!cachedRegex) {
+      return {
+        outcome: { cacheState: "miss" as const, cacheHitFullyApplied: false, extractedCount: 0 },
+        hit: false,
+      };
+    }
+
+    const stagedResults: ResultsMap = {};
+    let allMatched = true;
+    let extractedCount = 0;
+    let noUserRequestCount = 0;
+    let firstFailureTraceId: string | null = null;
+
     for (const trace of traces) {
       const joinedText = joinUserParts(trace.parsed?.userParts ?? []);
       if (!joinedText) {
-        results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
+        stagedResults[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
         continue;
       }
-      const result = observe({ name: "apply-regex", input: { pattern: regex, text: joinedText } }, () =>
-        applyRegex(regex, joinedText)
-      );
+      const result = applyRegex(cachedRegex, joinedText);
       if (result.kind === "extracted") {
-        results[trace.traceId] = { inputPreview: result.text, outputPreview: trace.output, outputSpan: null };
-        anyMatch = true;
+        stagedResults[trace.traceId] = {
+          inputPreview: result.text,
+          outputPreview: trace.output,
+          outputSpan: null,
+        };
+        extractedCount++;
       } else if (result.kind === "no-user-request") {
-        results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
-        anyMatch = true;
+        stagedResults[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
+        noUserRequestCount++;
       } else {
-        results[trace.traceId] = { inputPreview: joinedText, outputPreview: trace.output, outputSpan: null };
+        allMatched = false;
+        firstFailureTraceId = trace.traceId;
+        break;
       }
     }
 
-    if (anyMatch) {
-      await cache.set(cacheKey, regex, { expireAfterSeconds: SEVEN_DAYS_SECONDS }).catch(() => {});
+    if (allMatched) {
+      Object.assign(results, stagedResults);
+      await cache.expire(cacheKey, SEVEN_DAYS_SECONDS).catch(() => {});
+      return {
+        outcome: {
+          cacheState: "hit" as const,
+          cacheHitFullyApplied: true,
+          extractedCount,
+        },
+        hit: true,
+        ttlRefreshed: true,
+        extractedCount,
+        noUserRequestCount,
+        cachedRegex,
+      };
     }
-  });
+
+    await cache.remove(cacheKey).catch(() => {});
+    return {
+      outcome: {
+        cacheState: "stale" as const,
+        cacheHitFullyApplied: false,
+        extractedCount: 0,
+      },
+      hit: true,
+      invalidated: true,
+      firstFailureTraceId,
+      cachedRegex,
+    };
+  }).then(({ outcome }) => outcome);
 }
 
-/**
- * Build the LLM prompt from multiple traces' user message parts,
- * deduplicating parts that are identical across samples by index
- * and detecting scaffolding structurally for single-sample cases.
- */
+interface LlmOutcome {
+  regexGenerated: boolean;
+  extractedCount: number;
+  cached: boolean;
+}
+
+async function runRegexExtraction(
+  cacheKey: string,
+  traces: TraceForExtraction[],
+  samples: TraceForExtraction[],
+  results: ResultsMap
+): Promise<LlmOutcome> {
+  return observe(
+    {
+      name: "traces:generate-regex",
+      input: { cacheKey, sampleCount: samples.length, traceCount: traces.length },
+    },
+    async () => {
+      const allUserParts = samples.map((s) => s.parsed!.userParts);
+      const llmInput = buildDeduplicatedLLMInput(allUserParts);
+      const regex = await generateExtractionRegex(llmInput);
+
+      if (!regex) {
+        for (const trace of traces) {
+          if (!(trace.traceId in results)) {
+            results[trace.traceId] = {
+              inputPreview: joinUserParts(trace.parsed?.userParts ?? []),
+              outputPreview: trace.output,
+              outputSpan: null,
+            };
+          }
+        }
+        return {
+          outcome: { regexGenerated: false, extractedCount: 0, cached: false },
+          reason: "llm-returned-null",
+        };
+      }
+
+      let anyMatch = false;
+      let extractedCount = 0;
+      let noUserRequestCount = 0;
+      let fallbackToJoinedCount = 0;
+
+      for (const trace of traces) {
+        const joinedText = joinUserParts(trace.parsed?.userParts ?? []);
+        if (!joinedText) {
+          results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
+          continue;
+        }
+        const result = applyRegex(regex, joinedText);
+        if (result.kind === "extracted") {
+          results[trace.traceId] = { inputPreview: result.text, outputPreview: trace.output, outputSpan: null };
+          extractedCount++;
+          anyMatch = true;
+        } else if (result.kind === "no-user-request") {
+          results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
+          noUserRequestCount++;
+          anyMatch = true;
+        } else {
+          results[trace.traceId] = { inputPreview: joinedText, outputPreview: trace.output, outputSpan: null };
+          fallbackToJoinedCount++;
+        }
+      }
+
+      let cached = false;
+      if (anyMatch) {
+        cached = await persistRegex(cacheKey, regex);
+      }
+
+      return {
+        outcome: { regexGenerated: true, extractedCount, cached },
+        regex,
+        extractedCount,
+        noUserRequestCount,
+        fallbackToJoinedCount,
+        anyMatch,
+      };
+    }
+  ).then(({ outcome }) => outcome);
+}
+
+// Persist failure is non-fatal; extractions are returned regardless.
+async function persistRegex(cacheKey: string, regex: string): Promise<boolean> {
+  return observe({ name: "traces:cache-save", input: { cacheKey, regex } }, async () => {
+    try {
+      await cache.set(cacheKey, regex, { expireAfterSeconds: SEVEN_DAYS_SECONDS });
+      return { saved: true };
+    } catch (error) {
+      return { saved: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }).then(({ saved }) => saved);
+}
+
+// Dedupes parts identical across samples by index; for a single sample,
+// detects scaffolding structurally so the LLM can ignore it.
 function buildDeduplicatedLLMInput(allParts: TextPart[][]): string {
   if (allParts.length === 1) {
     return buildSingleSampleInput(allParts[0]);

--- a/frontend/lib/actions/sessions/prompts.ts
+++ b/frontend/lib/actions/sessions/prompts.ts
@@ -148,7 +148,8 @@ export async function generateExtractionRegex(userMessage: string): Promise<stri
     });
 
     return object.regex?.trim() || null;
-  } catch {
+  } catch (error) {
+    console.error("[traces:generate-extraction-regex] LLM call failed:", error);
     return null;
   }
 }

--- a/frontend/lib/actions/spans/previews/prompts.ts
+++ b/frontend/lib/actions/spans/previews/prompts.ts
@@ -128,7 +128,7 @@ export const generatePreviewKeys = async (structures: SpanStructure[]): Promise<
   if (structures.length === 0) return [];
 
   try {
-    const { text } = await observe({ name: "generate-preview-keys" }, async () =>
+    const { text } = await observe({ name: "previews:generate-preview-keys" }, async () =>
       generateText({
         model: getLanguageModel("small"),
         system: PREVIEW_KEY_SYSTEM_PROMPT,
@@ -144,7 +144,8 @@ export const generatePreviewKeys = async (structures: SpanStructure[]): Promise<
     );
 
     return parsePreviewKeysResponse(text, structures.length);
-  } catch {
+  } catch (error) {
+    console.error("[previews:generate-preview-keys] LLM call failed:", error);
     return new Array(structures.length).fill(null);
   }
 };

--- a/frontend/lib/actions/spans/previews/resolve.ts
+++ b/frontend/lib/actions/spans/previews/resolve.ts
@@ -26,15 +26,9 @@ interface ParsedSpan {
   toolName?: string;
 }
 
-/**
- * Classify raw span payloads. Non-generation spans are resolved directly to a
- * truncated string; generation spans with object payloads are returned for
- * further processing by the resolution pipeline.
- *
- * Tool-only LLM outputs are split into one `ParsedSpan` entry per tool so
- * each tool's arguments get their own fingerprint (enabling cache reuse
- * across different tool mixes) and their own preview rendering.
- */
+// Non-generation spans resolve to a truncated string; generation spans go to
+// the pipeline. Tool-only LLM outputs split into one entry per tool so each
+// tool gets its own fingerprint and preview.
 function classifyRawSpans(
   rawSpans: Array<{ spanId: string; data: string; name: string }>,
   spanTypes: Record<string, string>
@@ -64,16 +58,13 @@ function classifyRawSpans(
       case "object": {
         const hint = detectOutputStructure(classification.data);
 
-        // Happy path: provider schema extracts non-empty text/thinking → done.
         const match = matchProviderKey(classification.data, hint);
         if (match && match.rendered.trim() !== "") {
           resolved[raw.spanId] = match.rendered;
           break;
         }
 
-        // No visible text. For LLM outputs, surface every tool block so each
-        // tool's descriptive fields (e.g. input.description) flow through the
-        // pipeline independently instead of rendering nothing.
+        // No visible text — surface each tool block so descriptive fields render.
         const tools =
           spanType === "LLM" || spanType === "CACHED" ? extractToolsIfToolOnly(classification.data, hint) : null;
 
@@ -118,77 +109,96 @@ function fillMissing(previews: SpanPreviewResult, spanIds: string[]): SpanPrevie
   return result;
 }
 
-/**
- * Look up cached LLM-generated Mustache keys by structural fingerprint.
- * Indexed by each ParsedSpan's `key` (not `spanId`) so tool-only entries
- * stay separate.
- */
+// Indexed by ParsedSpan.key (not spanId) so tool-only entries stay separate.
 async function applyCachedKeys(
   projectId: string,
   parsedSpans: ParsedSpan[]
 ): Promise<{ resolved: Record<string, string | null>; uncached: ParsedSpan[] }> {
   const uniqueFingerprints = [...new Set(parsedSpans.map((s) => s.fingerprint))];
 
-  const cachedEntries = await Promise.all(
-    uniqueFingerprints.map(async (fingerprint) => {
-      try {
-        const key = await cache.get<string>(SPAN_RENDERING_KEY_CACHE_KEY(projectId, fingerprint));
-        return [fingerprint, key] as const;
-      } catch {
-        return [fingerprint, null] as const;
+  return observe(
+    {
+      name: "previews:cache-lookup",
+      input: {
+        projectId,
+        spanCount: parsedSpans.length,
+        uniqueFingerprintCount: uniqueFingerprints.length,
+        fingerprints: uniqueFingerprints,
+      },
+    },
+    async () => {
+      const cachedEntries = await Promise.all(
+        uniqueFingerprints.map(async (fingerprint) => {
+          try {
+            const key = await cache.get<string>(SPAN_RENDERING_KEY_CACHE_KEY(projectId, fingerprint));
+            return [fingerprint, key] as const;
+          } catch {
+            return [fingerprint, null] as const;
+          }
+        })
+      );
+
+      const fingerprintToKey = new Map<string, string>();
+      for (const [fingerprint, key] of cachedEntries) {
+        if (key) fingerprintToKey.set(fingerprint, key);
       }
-    })
-  );
 
-  const fingerprintToKey = new Map<string, string>();
-  for (const [fingerprint, key] of cachedEntries) {
-    if (key) fingerprintToKey.set(fingerprint, key);
-  }
+      const resolved: Record<string, string | null> = {};
+      const uncached: ParsedSpan[] = [];
+      const hitFingerprints = new Set<string>();
+      const staleCachedKeys: Array<{ spanId: string; fingerprint: string; key: string }> = [];
 
-  const resolved: Record<string, string | null> = {};
-  const uncached: ParsedSpan[] = [];
-  const hitFingerprints = new Set<string>();
+      for (const span of parsedSpans) {
+        const cachedKey = fingerprintToKey.get(span.fingerprint);
+        if (!cachedKey) {
+          uncached.push(span);
+          continue;
+        }
 
-  for (const span of parsedSpans) {
-    const cachedKey = fingerprintToKey.get(span.fingerprint);
-    if (!cachedKey) {
-      uncached.push(span);
-      continue;
+        const rendered = validateMustacheKey(cachedKey, span.parsedData);
+        if (rendered) {
+          resolved[span.key] = rendered;
+          hitFingerprints.add(span.fingerprint);
+        } else {
+          staleCachedKeys.push({ spanId: span.spanId, fingerprint: span.fingerprint, key: cachedKey });
+          uncached.push(span);
+        }
+      }
+
+      await Promise.all(
+        [...hitFingerprints].map((fingerprint) =>
+          cache
+            .expire(SPAN_RENDERING_KEY_CACHE_KEY(projectId, fingerprint), RENDERING_KEY_TTL_SECONDS)
+            .catch(() => false)
+        )
+      );
+
+      return {
+        resolved,
+        uncached,
+        cacheHitFingerprints: hitFingerprints.size,
+        cacheMissFingerprints: uniqueFingerprints.length - fingerprintToKey.size,
+        spansResolvedFromCache: Object.keys(resolved).length,
+        spansUncached: uncached.length,
+        staleCachedKeys,
+        ttlRefreshed: hitFingerprints.size,
+      };
     }
-
-    const rendered = validateMustacheKey(cachedKey, span.parsedData);
-    if (rendered) {
-      resolved[span.key] = rendered;
-      hitFingerprints.add(span.fingerprint);
-    } else {
-      uncached.push(span);
-    }
-  }
-
-  // Refresh TTL on successful hits so active schemas don't expire.
-  await Promise.all(
-    [...hitFingerprints].map((fingerprint) =>
-      cache.expire(SPAN_RENDERING_KEY_CACHE_KEY(projectId, fingerprint), RENDERING_KEY_TTL_SECONDS).catch(() => false)
-    )
   );
-
-  return { resolved, uncached };
 }
 
-/**
- * Ask the LLM to generate Mustache keys for remaining structures.
- * Keys that render successfully are persisted back to the cache.
- */
 async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
   resolved: Record<string, string | null>;
   unresolved: ParsedSpan[];
   keysToSave: Array<{ fingerprint: string; key: string }>;
 }> {
-  return observe({ name: "transcript:generate-mustache-keys", input: { spans } }, async () => {
+  return observe({ name: "previews:generate-mustache-keys", input: { spans } }, async () => {
     const resolved: Record<string, string | null> = {};
     const keysToSave: Array<{ fingerprint: string; key: string }> = [];
 
-    if (spans.length === 0) return { resolved, unresolved: [], keysToSave };
+    if (spans.length === 0) {
+      return { resolved, unresolved: [], keysToSave, llmCalled: false, generatedKeys: [] };
+    }
 
     const seen = new Set<string>();
     const dedupedFingerprints: string[] = [];
@@ -210,14 +220,16 @@ async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
     }
 
     let generatedKeys: Array<string | null> = [];
+    let llmError: string | null = null;
     try {
       const raw = await generatePreviewKeys(structures);
       generatedKeys = raw.slice(0, dedupedFingerprints.length);
     } catch (error) {
-      console.error("Preview key generation failed:", error);
+      llmError = error instanceof Error ? error.message : String(error);
     }
 
     const unresolved: ParsedSpan[] = [];
+    const skippedKeys: Array<{ fingerprint: string; key: string; groupSize: number }> = [];
 
     for (let i = 0; i < dedupedFingerprints.length; i++) {
       const fingerprint = dedupedFingerprints[i];
@@ -232,9 +244,7 @@ async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
       let keyProducedValidRender = false;
 
       for (const span of groupSpans) {
-        const rendered = observe({ name: "validate-mustache-key", input: { key, data: span.parsedData } }, () =>
-          validateMustacheKey(key, span.parsedData)
-        );
+        const rendered = validateMustacheKey(key, span.parsedData);
         if (rendered) {
           resolved[span.key] = rendered;
           keyProducedValidRender = true;
@@ -245,19 +255,28 @@ async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
 
       if (keyProducedValidRender) {
         keysToSave.push({ fingerprint, key });
+      } else {
+        skippedKeys.push({ fingerprint, key, groupSize: groupSpans.length });
       }
     }
 
-    return { resolved, unresolved, keysToSave };
+    return {
+      resolved,
+      unresolved,
+      keysToSave,
+      llmCalled: true,
+      llmError,
+      uniqueFingerprints: dedupedFingerprints.length,
+      generatedNonNullKeys: generatedKeys.filter((k) => !!k).length,
+      keysSkippedNoValidRender: skippedKeys,
+      spansResolved: Object.keys(resolved).length,
+      spansUnresolved: unresolved.length,
+    };
   });
 }
 
-/**
- * Last-resort fallback used when the LLM path is unavailable or produced no
- * valid key for a span. Dispatches based on variant: tool-only LLM entries
- * use the strictly descriptive-only heuristic (description/summary/title or
- * null), while generic spans use the full priority-key search.
- */
+// Tool-only entries use the descriptive-only heuristic; generic spans use
+// the full priority-key search.
 function applyHeuristicFallback(spans: ParsedSpan[]): Record<string, string | null> {
   const resolved: Record<string, string | null> = {};
   for (const span of spans) {
@@ -275,16 +294,35 @@ async function saveRenderingKeys(
 ): Promise<void> {
   if (keysToSave.length === 0) return;
 
-  await Promise.all(
-    keysToSave.map(({ fingerprint, key }) =>
-      cache
-        .set(SPAN_RENDERING_KEY_CACHE_KEY(projectId, fingerprint), key, {
-          expireAfterSeconds: RENDERING_KEY_TTL_SECONDS,
+  await observe(
+    {
+      name: "previews:cache-save",
+      input: { projectId, count: keysToSave.length, entries: keysToSave },
+    },
+    async () => {
+      const failures: Array<{ fingerprint: string; error: string }> = [];
+
+      await Promise.all(
+        keysToSave.map(async ({ fingerprint, key }) => {
+          try {
+            await cache.set(SPAN_RENDERING_KEY_CACHE_KEY(projectId, fingerprint), key, {
+              expireAfterSeconds: RENDERING_KEY_TTL_SECONDS,
+            });
+          } catch (error) {
+            failures.push({
+              fingerprint,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
         })
-        .catch((error) => {
-          console.error("Failed to save rendering key:", error);
-        })
-    )
+      );
+
+      return {
+        succeeded: keysToSave.length - failures.length,
+        failed: failures.length,
+        failures,
+      };
+    }
   );
 }
 
@@ -303,7 +341,6 @@ function assembleFinalPreviews(
 ): SpanPreviewResult {
   const result: SpanPreviewResult = {};
 
-  // Group tool-only entries by their real spanId.
   const toolOnlyBySpanId = new Map<string, ParsedSpan[]>();
   for (const span of parsedSpans) {
     if (span.variant === "llm_tool_only") {
@@ -329,17 +366,8 @@ export interface ResolveOptions {
   skipGeneration?: boolean;
 }
 
-/**
- * Run the full preview resolution pipeline on pre-fetched span data:
- *   1. classify raw payloads; resolve inline when a provider schema (OpenAI /
- *      Anthropic / Gemini / LangChain) yields non-empty text/thinking, and
- *      split tool-only LLM outputs into per-tool entries
- *   2. look up cached LLM-generated Mustache keys by fingerprint
- *   3. generate new keys via LLM (when a provider is configured) and persist them
- *   4. fall back to priority-key heuristic for anything still unresolved
- *      (this is the only path for tool spans when no LLM provider is configured)
- *   5. group per-tool results back into one preview string per span
- */
+// Pipeline: classify → cache lookup → LLM generation (if configured) →
+// heuristic fallback → assemble per-tool results back into per-span previews.
 export async function resolvePreviews(
   rawSpans: Array<{ spanId: string; data: string; name: string }>,
   spanIds: string[],
@@ -348,27 +376,69 @@ export async function resolvePreviews(
   options: ResolveOptions = {}
 ): Promise<SpanPreviewResult> {
   const { skipGeneration = false } = options;
-  const { resolved: classified, needsProcessing } = classifyRawSpans(rawSpans, spanTypes);
 
-  if (needsProcessing.length === 0) {
-    return fillMissing(classified, spanIds);
-  }
+  return observe(
+    {
+      name: "previews:resolve",
+      input: { projectId, spanCount: spanIds.length, rawSpanCount: rawSpans.length, skipGeneration },
+    },
+    async () => {
+      const { resolved: classified, needsProcessing } = classifyRawSpans(rawSpans, spanTypes);
+      const inlineResolvedCount = Object.keys(classified).length;
 
-  const { resolved: cacheResolved, uncached } = await applyCachedKeys(projectId, needsProcessing);
-  let keyResolved: Record<string, string | null> = { ...cacheResolved };
+      if (needsProcessing.length === 0) {
+        return {
+          previews: fillMissing(classified, spanIds),
+          inlineResolved: inlineResolvedCount,
+          needsProcessing: 0,
+          cacheResolved: 0,
+          llmResolved: 0,
+          heuristicResolved: 0,
+          unresolved: 0,
+          path: "inline-only",
+        };
+      }
 
-  if (uncached.length > 0) {
-    const llmAvailable = !skipGeneration && isAiProviderConfigured();
+      const { resolved: cacheResolved, uncached } = await applyCachedKeys(projectId, needsProcessing);
+      let keyResolved: Record<string, string | null> = { ...cacheResolved };
+      const cacheResolvedCount = Object.keys(cacheResolved).length;
+      let llmResolvedCount = 0;
+      let heuristicResolvedCount = 0;
+      let path: "cache-only" | "llm" | "heuristic-fallback" = "cache-only";
 
-    if (!llmAvailable) {
-      keyResolved = { ...keyResolved, ...applyHeuristicFallback(uncached) };
-    } else {
-      const { resolved: llmResolved, unresolved, keysToSave } = await generateKeysViaLlm(uncached);
-      await saveRenderingKeys(projectId, keysToSave);
-      keyResolved = { ...keyResolved, ...llmResolved, ...applyHeuristicFallback(unresolved) };
+      if (uncached.length > 0) {
+        const aiConfigured = isAiProviderConfigured();
+        const llmAvailable = !skipGeneration && aiConfigured;
+
+        if (!llmAvailable) {
+          path = "heuristic-fallback";
+          const heuristic = applyHeuristicFallback(uncached);
+          heuristicResolvedCount = Object.values(heuristic).filter((v) => v !== null).length;
+          keyResolved = { ...keyResolved, ...heuristic };
+        } else {
+          path = "llm";
+          const { resolved: llmResolved, unresolved, keysToSave } = await generateKeysViaLlm(uncached);
+          llmResolvedCount = Object.keys(llmResolved).length;
+          await saveRenderingKeys(projectId, keysToSave);
+          const heuristic = applyHeuristicFallback(unresolved);
+          heuristicResolvedCount = Object.values(heuristic).filter((v) => v !== null).length;
+          keyResolved = { ...keyResolved, ...llmResolved, ...heuristic };
+        }
+      }
+
+      const assembled = assembleFinalPreviews(keyResolved, needsProcessing);
+      const previews = fillMissing({ ...classified, ...assembled }, spanIds);
+
+      return {
+        previews,
+        path,
+        inlineResolved: inlineResolvedCount,
+        needsProcessing: needsProcessing.length,
+        cacheResolved: cacheResolvedCount,
+        llmResolved: llmResolvedCount,
+        heuristicResolved: heuristicResolvedCount,
+        unresolved: Object.values(previews).filter((v) => v === null).length,
+      };
     }
-  }
-
-  const assembled = assembleFinalPreviews(keyResolved, needsProcessing);
-  return fillMissing({ ...classified, ...assembled }, spanIds);
+  ).then((result) => result.previews);
 }

--- a/frontend/lib/ai/model.ts
+++ b/frontend/lib/ai/model.ts
@@ -14,9 +14,9 @@ type LLMProvider = "openai" | "gemini" | "bedrock";
 // Per-provider defaults. Used when LLM_MODEL_<TIER> is not set.
 const DEFAULT_MODELS: Record<LLMProvider, Record<ModelTier, string>> = {
   gemini: {
-    small: "gemini-3-flash-preview",
+    small: "gemini-3.1-flash-lite",
     medium: "gemini-3-flash-preview",
-    large: "gemini-3-pro-preview",
+    large: "gemini-3.1-pro-preview",
   },
   bedrock: {
     small: "us.anthropic.claude-haiku-4-5-20251001-v1:0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes input-extraction and span-preview caching/LLM pipelines, which can alter what users see and how often regeneration occurs if cache validation is wrong. Model default updates may also change output quality/cost characteristics for Gemini deployments.
> 
> **Overview**
> Updates default Gemini model fallbacks on both backend (`model_for_size`) and frontend (`DEFAULT_MODELS`) to `gemini-3.1-flash-lite` (small) and `gemini-3.1-pro-preview` (large).
> 
> Refactors trace input extraction to **record cache/LLM path outcomes** and make cached regex usage all-or-nothing: cached regex must match *every* trace or it is invalidated and the batch is regenerated, with TTL refresh/persist wrapped in new `observe` spans.
> 
> Enhances span preview resolution with **more detailed `observe` instrumentation**, stricter cached Mustache-key validation (treat invalid renders as stale and regenerate), explicit error logging on LLM failures, and metrics around cache hits/misses, LLM vs heuristic resolution, and cache-save failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 386415becea73e390525aef9e6fb4347093bfd0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->