### PR TITLE
better tracing for ingestion pipeline

### DIFF
--- a/app-server/src/cache/autocomplete.rs
+++ b/app-server/src/cache/autocomplete.rs
@@ -5,6 +5,7 @@ use chrono::{Duration, Utc};
 use clickhouse::Row;
 use serde::Deserialize;
 use serde_json::Value;
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::cache::keys::{AUTOCOMPLETE_CACHE_KEY, AUTOCOMPLETE_LOCK_CACHE_KEY};
@@ -100,6 +101,7 @@ async fn prefill_autocomplete_key_if_missing(
     Ok(())
 }
 
+#[instrument(skip_all)]
 pub async fn populate_autocomplete_cache(
     project_id: Uuid,
     spans: &[Span],

--- a/app-server/src/traces/realtime.rs
+++ b/app-server/src/traces/realtime.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Value;
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -72,6 +73,7 @@ struct RealtimeSpan {
 
 /// Send realtime span update events to SSE connections for specific traces
 /// lmnr.rollout.session_id
+#[instrument(skip_all)]
 pub async fn send_span_updates(spans: &[Span], pubsub: &PubSub) {
     // Group spans by (project_id, trace_id)
     let mut spans_by_trace: HashMap<(Uuid, Uuid), Vec<RealtimeSpan>> = HashMap::new();

--- a/app-server/src/utils/limits.rs
+++ b/app-server/src/utils/limits.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use chrono::{DateTime, Months, Utc};
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -204,6 +205,7 @@ pub async fn get_workspace_signal_runs_limit_exceeded(
     Ok(signal_runs >= effective_limit)
 }
 
+#[instrument(skip_all)]
 pub async fn update_workspace_bytes_ingested(
     db: Arc<DB>,
     clickhouse: clickhouse::Client,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds `tracing::instrument` spans around a few ingestion-path async functions for better observability, without changing business logic. Low risk aside from minor overhead/log volume changes if tracing is enabled.
> 
> **Overview**
> Improves observability of the ingestion pipeline by adding `tracing::instrument(skip_all)` to key async entry points: `populate_autocomplete_cache`, `send_span_updates`, and `update_workspace_bytes_ingested`.
> 
> These changes primarily enhance structured tracing/span correlation (and avoid capturing large args via `skip_all`) without altering runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8930e85e8c8f2c3c7b523bdd92182bedde57f7d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->