### PR TITLE
search use spans view

### DIFF
--- a/app-server/src/search/snippets.rs
+++ b/app-server/src/search/snippets.rs
@@ -203,9 +203,8 @@ fn build_snippet_query(project_id: Uuid, context_regex: &str, key_tuples: &str) 
                 extract(input, '{context_regex}') AS input_snippet,
                 extract(output, '{context_regex}') AS output_snippet,
                 extract(attributes, '{context_regex}') AS attributes_snippet
-         FROM spans
-         WHERE project_id = '{project_id}'
-           AND (trace_id, span_id) IN ({key_tuples})
+         FROM spans_v0(project_id = '{project_id}')
+         WHERE (trace_id, span_id) IN ({key_tuples})
          ORDER BY start_time ASC"
     )
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the underlying ClickHouse source for search snippets, which could affect result correctness/performance if the view differs from the table or has different filtering semantics.
> 
> **Overview**
> Search snippet enrichment now queries ClickHouse via the `spans_v0(project_id = ...)` view rather than filtering the `spans` table by `project_id`.
> 
> The snippet query structure and `(trace_id, span_id)` key filtering remain the same, but the data source and project scoping semantics are delegated to the view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ce9816c4618097896ff0761977aaf5b8cb72acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->