### PR TITLE
Fix/version badge

### DIFF
--- a/frontend/components/common/version-badge.tsx
+++ b/frontend/components/common/version-badge.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlags } from "@/contexts/feature-flags-context.tsx";
 import { cn } from "@/lib/utils";
 
 interface VersionBadgeProps {
@@ -5,7 +6,8 @@ interface VersionBadgeProps {
 }
 
 export default function VersionBadge({ className }: VersionBadgeProps) {
-  if (process.env.LAMINAR_CLOUD === "true") return null;
+  const features = useFeatureFlags();
+  if (features.LAMINAR_CLOUD) return null;
   const version = process.env.NEXT_PUBLIC_APP_VERSION;
   if (!version) return null;
 

--- a/frontend/components/common/version-badge.tsx
+++ b/frontend/components/common/version-badge.tsx
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from "@/contexts/feature-flags-context.tsx";
 import { cn } from "@/lib/utils";
 
 interface VersionBadgeProps {
@@ -6,8 +5,6 @@ interface VersionBadgeProps {
 }
 
 export default function VersionBadge({ className }: VersionBadgeProps) {
-  const features = useFeatureFlags();
-  if (features.LAMINAR_CLOUD) return null;
   const version = process.env.NEXT_PUBLIC_APP_VERSION;
   if (!version) return null;
 

--- a/frontend/components/projects/sidebar-footer.tsx
+++ b/frontend/components/projects/sidebar-footer.tsx
@@ -87,7 +87,7 @@ const SidebarFooterComponent = () => {
           </SidebarMenu>
         </SidebarGroupContent>
       </SidebarGroup>
-      {(open || openMobile) && (
+      {(open || openMobile) && !features.LAMINAR_CLOUD && (
         <div className="px-5 flex">
           <VersionBadge />
         </div>

--- a/frontend/components/projects/sidebar-footer.tsx
+++ b/frontend/components/projects/sidebar-footer.tsx
@@ -17,6 +17,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar.tsx";
+import { useFeatureFlags } from "@/contexts/feature-flags-context.tsx";
 import { useLocalStorage } from "@/hooks/use-local-storage.tsx";
 import { cn } from "@/lib/utils.ts";
 
@@ -24,9 +25,11 @@ const SidebarFooterComponent = () => {
   const { open, openMobile } = useSidebar();
   const [showStarCard, setShowStarCard] = useLocalStorage("showStarCard", true);
 
+  const features = useFeatureFlags();
+
   return (
     <SidebarFooter className="px-0 mb-2">
-      {process.env.LAMINAR_CLOUD !== "true" && (
+      {!features.LAMINAR_CLOUD && (
         <SidebarGroup className={cn((open || openMobile) && showStarCard ? "text-sm" : "hidden")}>
           <SidebarGroupContent>
             <div className={cn("flex flex-col rounded-lg border bg-muted relative p-2")}>

--- a/frontend/lib/actions/sessions/extract-input.ts
+++ b/frontend/lib/actions/sessions/extract-input.ts
@@ -175,7 +175,9 @@ async function tryCachedRegex(
         stagedResults[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
         continue;
       }
-      const result = applyRegex(cachedRegex, joinedText);
+      const result = observe({ name: "apply-regex", input: { pattern: cachedRegex, text: joinedText } }, () =>
+        applyRegex(cachedRegex, joinedText)
+      );
       if (result.kind === "extracted") {
         stagedResults[trace.traceId] = {
           inputPreview: result.text,
@@ -274,7 +276,9 @@ async function runRegexExtraction(
           results[trace.traceId] = { inputPreview: null, outputPreview: trace.output, outputSpan: null };
           continue;
         }
-        const result = applyRegex(regex, joinedText);
+        const result = observe({ name: "traces:apply-regex", input: { pattern: regex, text: joinedText } }, () =>
+          applyRegex(regex, joinedText)
+        );
         if (result.kind === "extracted") {
           results[trace.traceId] = { inputPreview: result.text, outputPreview: trace.output, outputSpan: null };
           extractedCount++;

--- a/frontend/lib/actions/spans/previews/resolve.ts
+++ b/frontend/lib/actions/spans/previews/resolve.ts
@@ -155,7 +155,10 @@ async function applyCachedKeys(
           continue;
         }
 
-        const rendered = validateMustacheKey(cachedKey, span.parsedData);
+        const rendered = observe(
+          { name: "validate-mustache-key", input: { key: cachedKey, data: span.parsedData } },
+          () => validateMustacheKey(cachedKey, span.parsedData)
+        );
         if (rendered) {
           resolved[span.key] = rendered;
           hitFingerprints.add(span.fingerprint);
@@ -244,7 +247,10 @@ async function generateKeysViaLlm(spans: ParsedSpan[]): Promise<{
       let keyProducedValidRender = false;
 
       for (const span of groupSpans) {
-        const rendered = validateMustacheKey(key, span.parsedData);
+        const rendered = observe(
+          { name: "previews:validate-mustache-key", input: { key, data: span.parsedData } },
+          () => validateMustacheKey(key, span.parsedData)
+        );
         if (rendered) {
           resolved[span.key] = rendered;
           keyProducedValidRender = true;

--- a/frontend/lib/features/features.ts
+++ b/frontend/lib/features/features.ts
@@ -18,6 +18,7 @@ export enum Feature {
   CLUSTERING = "CLUSTERING",
   SLACK = "SLACK",
   LANDING = "LANDING",
+  LAMINAR_CLOUD = "LAMINAR_CLOUD",
 }
 
 const AUTH_PROVIDER_FEATURES = [
@@ -117,6 +118,10 @@ export const isFeatureEnabled = (feature: Feature): boolean => {
 
   if (feature === Feature.POSTHOG) {
     return process.env.POSTHOG_TELEMETRY === "true";
+  }
+
+  if (feature === Feature.LAMINAR_CLOUD) {
+    return process.env.LAMINAR_CLOUD === "true";
   }
 
   return process.env.ENVIRONMENT === "PRODUCTION";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to new feature-flag path controlling sidebar UI and added `observe` wrappers that may affect performance/logging volume in hot paths for trace input extraction and span preview resolution.
> 
> **Overview**
> Fixes version badge behavior by removing the hardcoded `process.env.LAMINAR_CLOUD` early return in `VersionBadge` and instead gating sidebar footer UI (OSS star card and version badge) via a new `Feature.LAMINAR_CLOUD` flag from `useFeatureFlags`.
> 
> Adds `Feature.LAMINAR_CLOUD` to the feature system (`features.ts`) and wraps regex application and mustache-key validation in `observe(...)` spans in `extract-input.ts` and `previews/resolve.ts` for better tracing of these operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608b68b57058e9ba0e97921aa6c580a03524e412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->