### PR TITLE
feat: flip condition

### DIFF
--- a/frontend/components/projects/sidebar-footer.tsx
+++ b/frontend/components/projects/sidebar-footer.tsx
@@ -29,7 +29,7 @@ const SidebarFooterComponent = () => {
 
   return (
     <SidebarFooter className="px-0 mb-2">
-      {!features.LAMINAR_CLOUD && (
+      {features.LAMINAR_CLOUD && (
         <SidebarGroup className={cn((open || openMobile) && showStarCard ? "text-sm" : "hidden")}>
           <SidebarGroupContent>
             <div className={cn("flex flex-col rounded-lg border bg-muted relative p-2")}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI behavior change gated by `LAMINAR_CLOUD`; risk is limited to potentially displaying/hiding the sidebar promo card in the wrong environment if the flag is mis-set.
> 
> **Overview**
> Flips the `LAMINAR_CLOUD` feature-flag condition in `sidebar-footer.tsx` so the GitHub stars “Laminar is fully open source” promo card is shown *only* when `LAMINAR_CLOUD` is enabled (instead of when it’s disabled).
> 
> No other sidebar footer links or the non-cloud `VersionBadge` gating are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a48333ce3dbc33bf6b26e699a51c7e4fb1d84c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->