### PR TITLE
limit sql query memory to 256 mb

### DIFF
--- a/app-server/src/sql/ch.rs
+++ b/app-server/src/sql/ch.rs
@@ -14,6 +14,7 @@ use crate::sql::{ClickhouseReadonlyClient, SqlQueryError};
 
 const DEFAULT_SQL_QUERY_MAX_EXECUTION_TIME: &str = "120";
 const DEFAULT_SQL_QUERY_MAX_RESULT_BYTES: &str = "536870912"; // 512MB
+const DEFAULT_SQL_QUERY_MAX_MEMORY_USAGE: &str = "268435456"; // 256MB
 
 #[derive(Deserialize)]
 pub struct ClickhouseBadResponseError {
@@ -49,6 +50,13 @@ pub async fn query(
                 .as_ref()
                 .map(|s| s.as_str())
                 .unwrap_or(DEFAULT_SQL_QUERY_MAX_RESULT_BYTES),
+        )
+        .with_option(
+            "max_memory_usage",
+            env::var("SQL_QUERY_MAX_MEMORY_USAGE")
+                .as_ref()
+                .map(|s| s.as_str())
+                .unwrap_or(DEFAULT_SQL_QUERY_MAX_MEMORY_USAGE),
         );
 
     for (key, value) in parameters {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new ClickHouse `max_memory_usage` setting (default 256MB) for user SQL queries, which could cause previously-working heavy queries to fail or be terminated under load.
> 
> **Overview**
> Adds an explicit ClickHouse memory cap for SQL execution by setting `max_memory_usage` on each query, defaulting to **256MB** and allowing override via `SQL_QUERY_MAX_MEMORY_USAGE`.
> 
> This complements the existing execution time and result-size limits to better bound resource usage for user-triggered queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c31049bdc9b85d6a01820860ba77ccae51ba3cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->