### PR TITLE
Revert "limit sql query memory to 256 mb (#1770)"

### DIFF
--- a/app-server/src/sql/ch.rs
+++ b/app-server/src/sql/ch.rs
@@ -14,7 +14,6 @@ use crate::sql::{ClickhouseReadonlyClient, SqlQueryError};
 
 const DEFAULT_SQL_QUERY_MAX_EXECUTION_TIME: &str = "120";
 const DEFAULT_SQL_QUERY_MAX_RESULT_BYTES: &str = "536870912"; // 512MB
-const DEFAULT_SQL_QUERY_MAX_MEMORY_USAGE: &str = "268435456"; // 256MB
 
 #[derive(Deserialize)]
 pub struct ClickhouseBadResponseError {
@@ -50,13 +49,6 @@ pub async fn query(
                 .as_ref()
                 .map(|s| s.as_str())
                 .unwrap_or(DEFAULT_SQL_QUERY_MAX_RESULT_BYTES),
-        )
-        .with_option(
-            "max_memory_usage",
-            env::var("SQL_QUERY_MAX_MEMORY_USAGE")
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or(DEFAULT_SQL_QUERY_MAX_MEMORY_USAGE),
         );
 
     for (key, value) in parameters {


### PR DESCRIPTION
This reverts commit 92691467ae2967765604cbb125805d8469f81d4a.

This setting fails with readonly user. Reverting while doing further investigation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a server-side guardrail on ClickHouse query memory usage, which could allow more resource-intensive queries and impact cluster stability. Change is localized to SQL query execution options but affects runtime behavior in production.
> 
> **Overview**
> Reverts the ClickHouse per-query memory cap by removing the `max_memory_usage` option (and its default/env wiring) from `app-server/src/sql/ch.rs` when executing user SQL queries.
> 
> This keeps only `max_execution_time` and `max_result_bytes` limits applied to readonly query execution, addressing failures caused by the memory setting with the readonly user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c2ff6b727f81a1998416e583ce7cc034fa07c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->