### PR TITLE
increase rabbitmq connection timeout

### DIFF
--- a/app-server/src/mq/rabbit.rs
+++ b/app-server/src/mq/rabbit.rs
@@ -304,7 +304,7 @@ impl MessageQueueTrait for RabbitMQ {
             anyhow::Ok(consumer)
         };
 
-        let consumer = match tokio::time::timeout(std::time::Duration::from_secs(15), setup).await {
+        let consumer = match tokio::time::timeout(std::time::Duration::from_secs(60), setup).await {
             Ok(Ok(consumer)) => consumer,
             Ok(Err(e)) => return Err(e),
             Err(_) => {

--- a/app-server/src/mq/rabbit.rs
+++ b/app-server/src/mq/rabbit.rs
@@ -6,12 +6,24 @@ use lapin::{
     options::{BasicConsumeOptions, BasicPublishOptions, BasicQosOptions, QueueBindOptions},
     types::{FieldTable, ShortString},
 };
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
 
 use super::{
     MessageQueueAcker, MessageQueueDelivery, MessageQueueDeliveryTrait, MessageQueueReceiver,
     MessageQueueReceiverTrait, MessageQueueTrait, connection::ResilientConnection,
 };
+
+/// Whole-chain timeout for consumer setup (`create_channel` → `basic_qos` →
+/// `queue_bind` → `basic_consume`). Tunable because a memory-pressured broker
+/// can leave channel ops stalled for tens of seconds before the alarm clears.
+static CONSUMER_SETUP_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
+    let secs = std::env::var("RABBITMQ_CONSUMER_SETUP_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(60);
+    Duration::from_secs(secs)
+});
 
 struct RabbitChannelManager {
     connection: Arc<ResilientConnection>,
@@ -304,7 +316,7 @@ impl MessageQueueTrait for RabbitMQ {
             anyhow::Ok(consumer)
         };
 
-        let consumer = match tokio::time::timeout(std::time::Duration::from_secs(60), setup).await {
+        let consumer = match tokio::time::timeout(*CONSUMER_SETUP_TIMEOUT, setup).await {
             Ok(Ok(consumer)) => consumer,
             Ok(Err(e)) => return Err(e),
             Err(_) => {

--- a/app-server/src/worker/mod.rs
+++ b/app-server/src/worker/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use backoff::ExponentialBackoffBuilder;
 use serde::{Serialize, de::DeserializeOwned};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -11,6 +11,16 @@ use crate::mq::{
 };
 
 const DEFAULT_PREFETCH_COUNT: u16 = 128;
+
+/// Cap on the backoff between worker connect retries. Tunable so operators can
+/// slow the retry cadence when the broker is recovering from memory pressure.
+static CONNECT_BACKOFF_MAX_INTERVAL: LazyLock<Duration> = LazyLock::new(|| {
+    let secs = std::env::var("WORKER_CONNECT_BACKOFF_MAX_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(10);
+    Duration::from_secs(secs)
+});
 
 /// Message handler trait - implement this to process messages
 #[async_trait]
@@ -212,7 +222,7 @@ impl<H: MessageHandler> QueueWorker<H> {
     async fn connect(&self) -> anyhow::Result<MessageQueueReceiver> {
         let backoff = ExponentialBackoffBuilder::new()
             .with_initial_interval(Duration::from_secs(1))
-            .with_max_interval(Duration::from_secs(20))
+            .with_max_interval(*CONNECT_BACKOFF_MAX_INTERVAL)
             .with_max_elapsed_time(Some(Duration::from_secs(300)))
             .build();
 

--- a/app-server/src/worker/mod.rs
+++ b/app-server/src/worker/mod.rs
@@ -212,7 +212,7 @@ impl<H: MessageHandler> QueueWorker<H> {
     async fn connect(&self) -> anyhow::Result<MessageQueueReceiver> {
         let backoff = ExponentialBackoffBuilder::new()
             .with_initial_interval(Duration::from_secs(1))
-            .with_max_interval(Duration::from_secs(5))
+            .with_max_interval(Duration::from_secs(20))
             .with_max_elapsed_time(Some(Duration::from_secs(300)))
             .build();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust RabbitMQ consumer setup timeout and worker reconnect backoff via env vars, with conservative defaults; main risk is misconfiguration causing slower reconnects or longer hangs before retry.
> 
> **Overview**
> Makes RabbitMQ worker connectivity more resilient under broker stalls by **tuning timeouts/backoff via env vars**.
> 
> `RabbitMQ::get_receiver` now uses a configurable whole-chain consumer setup timeout (`RABBITMQ_CONSUMER_SETUP_TIMEOUT_SECS`, default 60s) instead of a fixed 15s, and worker connection retry backoff max interval is now configurable (`WORKER_CONNECT_BACKOFF_MAX_INTERVAL_SECS`, default 10s) instead of a fixed 5s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c758e6af525060a5de274520c95ee4865b29f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->