### PR TITLE
fix: propagate callback-url

### DIFF
--- a/frontend/app/(auth)/invitations/page.tsx
+++ b/frontend/app/(auth)/invitations/page.tsx
@@ -7,6 +7,7 @@ import { getServerSession } from "next-auth";
 
 import InvitationActions from "@/components/invitations/invitation-actions";
 import { LaminarLogo } from "@/components/ui/icons";
+import { clearOnboardingState } from "@/lib/actions/onboarding";
 import { authOptions } from "@/lib/auth";
 import { db } from "@/lib/db/drizzle";
 import { membersOfWorkspaces, workspaceInvitations, workspaces } from "@/lib/db/migrations/schema";
@@ -42,6 +43,10 @@ const handleInvitation = async (action: "accept" | "decline", id: string, worksp
 
         await tx.insert(membersOfWorkspaces).values({ userId, memberRole: "member", workspaceId });
       });
+
+      // Joining a real team workspace supersedes any in-progress wizard — without
+      // this clear, the (app) layout would bounce /workspace/<id> back to /onboarding.
+      await clearOnboardingState();
 
       revalidatePath(`/workspace/${workspaceId}`);
       redirect(`/workspace/${workspaceId}`);

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -93,5 +93,16 @@ export const config = {
     "/api/workspaces/:path+",
     "/api/shared/traces/:path+",
     "/uploads/:path+",
+    // Authenticated app routes: withAuth redirects unauthenticated requests to
+    // `/sign-in?callbackUrl=<original URL with query>`, preserving deep links
+    // like `/invitations?token=...`. A Server Component layout can't read the
+    // request pathname on its own, so the middleware is the only place that
+    // can preserve the callback URL.
+    "/projects",
+    "/project/:path+",
+    "/workspace/:path+",
+    "/invitations",
+    "/onboarding",
+    "/checkout",
   ],
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands auth middleware coverage to additional app routes and alters post-invitation state handling, which can affect sign-in redirects and navigation flow. Risk is moderate due to potential unintended route matching/redirect behavior changes.
> 
> **Overview**
> **Fixes deep-link redirect behavior for authenticated pages.** The middleware `matcher` now includes key app routes (e.g. `/projects`, `/workspace/:path+`, `/invitations`, `/onboarding`, `/checkout`) so `withAuth` can consistently redirect to `/sign-in?callbackUrl=<original URL + query>`, preserving links like `/invitations?token=...`.
> 
> **Prevents onboarding from overriding invitation acceptance.** When an invitation is accepted, `invitations/page.tsx` now calls `clearOnboardingState()` before redirecting to the joined workspace to avoid being bounced back into the onboarding flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8612cb7c9592a7c125985f54e38b87c333308214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->