### PR TITLE
hotfix tmp rollback all connection settings

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -26,7 +26,7 @@ use clustering::queue::{
 };
 use features::{Feature, is_feature_enabled};
 use lapin::{
-    ExchangeKind,
+    Connection, ConnectionProperties, ExchangeKind,
     options::{ExchangeDeclareOptions, QueueDeclareOptions},
     types::FieldTable,
 };
@@ -281,44 +281,38 @@ fn main() -> anyhow::Result<()> {
     let db = Arc::new(inner_db);
 
     // === 3. Message queues ===
-    // Only enable RabbitMQ if it is a full build and RabbitMQ Feature (URL) is set.
-    // Connections are wrapped in ResilientConnection: lapin's Connection has no
-    // auto-reconnect, so we register an on_error handler and a supervisor task
-    // that redials with exponential backoff and atomically swaps the live
-    // connection in. Callers (channel pool, get_receiver, is_healthy) read the
-    // current connection through `ResilientConnection::current()` and never see
-    // the swap.
-    let (publisher_connection, consumer_connection) = if is_feature_enabled(Feature::RabbitMQ)
-        && is_feature_enabled(Feature::FullBuild)
-    {
-        let rabbitmq_url = env::var("RABBITMQ_URL").expect("RABBITMQ_URL must be set");
-        runtime_handle.block_on(async {
-            let publisher_conn = ResilientConnection::connect(rabbitmq_url.clone(), "publisher")
-                .await
-                .unwrap();
-
-            // Only create consumer connection if consumer mode is enabled
-            let consumer_conn = if enable_consumer() {
-                log::info!("Consumer mode enabled - creating consumer connection");
-                Some(
-                    ResilientConnection::connect(rabbitmq_url.clone(), "consumer")
+    let (publisher_connection, consumer_connection) =
+        if is_feature_enabled(Feature::RabbitMQ) && is_feature_enabled(Feature::FullBuild) {
+            let rabbitmq_url = env::var("RABBITMQ_URL").expect("RABBITMQ_URL must be set");
+            runtime_handle.block_on(async {
+                let publisher_conn = Arc::new(
+                    Connection::connect(&rabbitmq_url, ConnectionProperties::default())
                         .await
                         .unwrap(),
-                )
-            } else {
-                log::info!("Producer-only mode - skipping consumer connection");
-                None
-            };
+                );
 
-            (Some(publisher_conn), consumer_conn)
-        })
-    } else {
-        (None, None)
-    };
+                // Only create consumer connection if consumer mode is enabled
+                let consumer_conn = if enable_consumer() {
+                    log::info!("Consumer mode enabled - creating consumer connection");
+                    Some(Arc::new(
+                        Connection::connect(&rabbitmq_url, ConnectionProperties::default())
+                            .await
+                            .unwrap(),
+                    ))
+                } else {
+                    log::info!("Producer-only mode - skipping consumer connection");
+                    None
+                };
+
+                (Some(publisher_conn), consumer_conn)
+            })
+        } else {
+            (None, None)
+        };
 
     let queue: Arc<MessageQueue> = if let Some(publisher_conn) = publisher_connection.as_ref() {
         runtime_handle.block_on(async {
-            let channel = publisher_conn.current().create_channel().await.unwrap();
+            let channel = publisher_conn.create_channel().await.unwrap();
 
             // Create quorum queue arguments (reused for all queues)
             let mut quorum_queue_args = FieldTable::default();

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -34,7 +34,7 @@ use logs::{
     LOGS_EXCHANGE, LOGS_QUEUE, LOGS_ROUTING_KEY, consumer::LogsHandler,
     grpc_service::ProcessLogsService,
 };
-use mq::{MessageQueue, connection::ResilientConnection};
+use mq::MessageQueue;
 use names::NameGenerator;
 use notifications::{
     NOTIFICATIONS_EXCHANGE, NOTIFICATIONS_QUEUE, NOTIFICATIONS_ROUTING_KEY, NotificationHandler,

--- a/app-server/src/mq/mod.rs
+++ b/app-server/src/mq/mod.rs
@@ -3,7 +3,7 @@ use lapin::{
     Acker,
     options::{BasicAckOptions, BasicNackOptions, BasicRejectOptions},
 };
-pub mod connection;
+// pub mod connection;
 pub mod rabbit;
 pub mod tokio_mpsc;
 pub mod utils;

--- a/app-server/src/mq/rabbit.rs
+++ b/app-server/src/mq/rabbit.rs
@@ -2,7 +2,7 @@ use backoff::ExponentialBackoffBuilder;
 use deadpool::managed::{Manager, Pool, PoolError, RecycleError};
 use futures_util::StreamExt;
 use lapin::{
-    Acker, BasicProperties, Channel, ConnectionStatus, Consumer,
+    Acker, BasicProperties, Channel, Connection, ConnectionStatus, Consumer,
     options::{BasicConsumeOptions, BasicPublishOptions, BasicQosOptions, QueueBindOptions},
     types::{FieldTable, ShortString},
 };
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use super::{
     MessageQueueAcker, MessageQueueDelivery, MessageQueueDeliveryTrait, MessageQueueReceiver,
-    MessageQueueReceiverTrait, MessageQueueTrait, connection::ResilientConnection,
+    MessageQueueReceiverTrait, MessageQueueTrait,
 };
 
 /// Whole-chain timeout for consumer setup (`create_channel` → `basic_qos` →
@@ -26,7 +26,7 @@ static CONSUMER_SETUP_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
 });
 
 struct RabbitChannelManager {
-    connection: Arc<ResilientConnection>,
+    connection: Arc<Connection>,
 }
 
 impl Manager for RabbitChannelManager {
@@ -35,27 +35,11 @@ impl Manager for RabbitChannelManager {
 
     async fn create(&self) -> Result<Channel, Self::Error> {
         let create_channel = || async {
-            // Read the connection handle on every attempt; lapin auto-recover
-            // keeps it alive across broker blips so the same Arc is always current.
-            let connection = self.connection.current();
-            let attempt = connection.create_channel();
-            match tokio::time::timeout(std::time::Duration::from_secs(10), attempt).await {
-                Ok(Ok(channel)) => Ok(channel),
-                Ok(Err(e)) => {
-                    log::warn!("Failed to create channel: {:?}", e);
-                    self.connection.notify_error();
-                    Err(backoff::Error::transient(anyhow::Error::from(e)))
-                }
-                Err(_) => {
-                    log::warn!("create_channel timed out");
-                    self.connection.notify_error();
-                    Err(backoff::Error::transient(anyhow::anyhow!(
-                        "create_channel timed out"
-                    )))
-                }
-            }
+            self.connection.create_channel().await.map_err(|e| {
+                log::warn!("Failed to create channel: {:?}", e);
+                backoff::Error::transient(anyhow::Error::from(e))
+            })
         };
-
         let backoff = ExponentialBackoffBuilder::new()
             .with_initial_interval(std::time::Duration::from_millis(100))
             .with_max_interval(std::time::Duration::from_secs(5))
@@ -94,8 +78,8 @@ impl Manager for RabbitChannelManager {
 }
 
 pub struct RabbitMQ {
-    publisher_connection: Arc<ResilientConnection>,
-    consumer_connection: Option<Arc<ResilientConnection>>,
+    publisher_connection: Arc<Connection>,
+    consumer_connection: Option<Arc<Connection>>,
     publisher_channel_pool: Pool<RabbitChannelManager>,
 }
 
@@ -145,8 +129,8 @@ impl MessageQueueReceiverTrait for RabbitMQReceiver {
 
 impl RabbitMQ {
     pub fn new(
-        publisher_connection: Arc<ResilientConnection>,
-        consumer_connection: Option<Arc<ResilientConnection>>,
+        publisher_connection: Arc<Connection>,
+        consumer_connection: Option<Arc<Connection>>,
         max_channel_pool_size: usize,
     ) -> Self {
         let manager = RabbitChannelManager {
@@ -189,7 +173,6 @@ impl MessageQueueTrait for RabbitMQ {
                 Ok(channel) => channel,
                 Err(PoolError::Backend(e)) => {
                     log::warn!("Failed to get channel from pool: {}", e);
-                    self.publisher_connection.notify_error();
                     return Err(backoff::Error::transient(anyhow::anyhow!(
                         "Failed to get channel from pool: {}",
                         e
@@ -207,7 +190,6 @@ impl MessageQueueTrait for RabbitMQ {
             // Check if channel is still connected before using it
             if !channel.status().connected() {
                 log::warn!("Channel is not connected, retrying...");
-                self.publisher_connection.notify_error();
                 return Err(backoff::Error::transient(anyhow::anyhow!(
                     "Channel is not connected"
                 )));
@@ -227,13 +209,11 @@ impl MessageQueueTrait for RabbitMQ {
                     Ok(_confirmation) => Ok(()),
                     Err(e) => {
                         log::warn!("Failed to publish message promise: {:?}", e);
-                        self.publisher_connection.notify_error();
                         Err(backoff::Error::transient(anyhow::Error::from(e)))
                     }
                 },
                 Err(e) => {
                     log::warn!("Failed to get call promise from basic_publish: {:?}", e);
-                    self.publisher_connection.notify_error();
                     Err(backoff::Error::transient(anyhow::Error::from(e)))
                 }
             }
@@ -272,12 +252,10 @@ impl MessageQueueTrait for RabbitMQ {
             )
         })?;
 
-        let connection = consumer_conn.current();
-        if !connection.status().connected() {
-            consumer_conn.notify_error();
+        if !consumer_conn.status().connected() {
             return Err(anyhow::anyhow!(
                 "Consumer connection is not in connected state: {:?}",
-                connection_state(connection.status())
+                connection_state(consumer_conn.status())
             ));
         }
 
@@ -285,10 +263,10 @@ impl MessageQueueTrait for RabbitMQ {
         // `create_channel` against a half-dead connection; without this the
         // worker's outer backoff retry never fires another attempt.
         let setup = async {
-            let channel = connection.create_channel().await.map_err(|e| {
-                consumer_conn.notify_error();
-                anyhow::Error::from(e)
-            })?;
+            let channel = consumer_conn
+                .create_channel()
+                .await
+                .map_err(|e| anyhow::Error::from(e))?;
 
             channel
                 .basic_qos(prefetch_count, BasicQosOptions::default())
@@ -320,7 +298,6 @@ impl MessageQueueTrait for RabbitMQ {
             Ok(Ok(consumer)) => consumer,
             Ok(Err(e)) => return Err(e),
             Err(_) => {
-                consumer_conn.notify_error();
                 return Err(anyhow::anyhow!(
                     "Timed out setting up RabbitMQ consumer for queue '{}'",
                     queue_name
@@ -332,11 +309,11 @@ impl MessageQueueTrait for RabbitMQ {
     }
 
     fn is_healthy(&self) -> bool {
-        let publisher_ok = self.publisher_connection.is_connected();
+        let publisher_ok = self.publisher_connection.status().connected();
         if !publisher_ok {
             log::error!(
                 "RabbitMQ readiness: publisher connection is not connected (state: {:?})",
-                connection_state(self.publisher_connection.current().status())
+                connection_state(self.publisher_connection.status())
             );
         }
 
@@ -344,11 +321,11 @@ impl MessageQueueTrait for RabbitMQ {
             .consumer_connection
             .as_ref()
             .map(|c| {
-                let connected = c.is_connected();
+                let connected = c.status().connected();
                 if !connected {
                     log::error!(
                         "RabbitMQ readiness: consumer connection is not connected (state: {:?})",
-                        connection_state(c.current().status())
+                        connection_state(c.status())
                     );
                 }
                 connected


### PR DESCRIPTION
Rolls back most of #1765 temporarily as a hotfix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RabbitMQ connectivity behavior by removing the `ResilientConnection` wrapper/auto-recovery hooks and using raw `lapin::Connection` in both startup and channel pooling, which could impact reliability during broker blips. Scope is limited to message-queue connection management and health checks.
> 
> **Overview**
> Replaces the custom `ResilientConnection`-based RabbitMQ setup with direct `lapin::Connection` usage in `main.rs` and `mq/rabbit.rs`, including channel creation, consumer setup, and readiness checks.
> 
> Disables the `mq::connection` module export and removes the error-notification/reconnect signaling paths (`notify_error`, `current()`) from publishing/consumer logic, keeping retry/backoff only at the channel/publish level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5781a6fad8bb744524321643a34c74600471eee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->