### PR TITLE
add wait_for_async_insert env vars

### DIFF
--- a/app-server/src/ch/llm_messages.rs
+++ b/app-server/src/ch/llm_messages.rs
@@ -1,4 +1,7 @@
+use std::env;
+
 use clickhouse::Row;
+use clickhouse::insert::Insert;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -21,6 +24,18 @@ pub struct CHLlmMessage {
 
 impl ClickhouseInsertable for CHLlmMessage {
     const TABLE: Table = Table::LlmMessages;
+
+    fn configure_insert(insert: Insert<Self>) -> Insert<Self> {
+        let wait_for_async_insert: bool = env::var("LLM_MESSAGES_CH_WAIT_FOR_ASYNC_INSERT")
+            .unwrap_or("true".to_string())
+            .parse()
+            .unwrap_or(true);
+
+        insert.with_option(
+            "wait_for_async_insert",
+            if wait_for_async_insert { "1" } else { "0" },
+        )
+    }
 
     fn to_data_plane_batch(items: Vec<Self>) -> DataPlaneBatch {
         DataPlaneBatch::LlmMessages(items)

--- a/app-server/src/ch/spans.rs
+++ b/app-server/src/ch/spans.rs
@@ -1,5 +1,8 @@
+use std::env;
+
 use anyhow::Result;
 use clickhouse::Row;
+use clickhouse::insert::Insert;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -202,6 +205,18 @@ impl CHSpan {
 
 impl ClickhouseInsertable for CHSpan {
     const TABLE: Table = Table::Spans;
+
+    fn configure_insert(insert: Insert<Self>) -> Insert<Self> {
+        let wait_for_async_insert: bool = env::var("SPANS_CH_WAIT_FOR_ASYNC_INSERT")
+            .unwrap_or("true".to_string())
+            .parse()
+            .unwrap_or(true);
+
+        insert.with_option(
+            "wait_for_async_insert",
+            if wait_for_async_insert { "1" } else { "0" },
+        )
+    }
 
     fn to_data_plane_batch(items: Vec<Self>) -> DataPlaneBatch {
         DataPlaneBatch::Spans(items)

--- a/app-server/src/ch/traces.rs
+++ b/app-server/src/ch/traces.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
+use std::env;
 
 use chrono::{DateTime, Utc};
 use clickhouse::Row;
+use clickhouse::insert::Insert;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -101,6 +103,18 @@ impl CHTrace {
 
 impl ClickhouseInsertable for CHTrace {
     const TABLE: Table = Table::Traces;
+
+    fn configure_insert(insert: Insert<Self>) -> Insert<Self> {
+        let wait_for_async_insert: bool = env::var("TRACES_CH_WAIT_FOR_ASYNC_INSERT")
+            .unwrap_or("true".to_string())
+            .parse()
+            .unwrap_or(true);
+
+        insert.with_option(
+            "wait_for_async_insert",
+            if wait_for_async_insert { "1" } else { "0" },
+        )
+    }
 
     fn to_data_plane_batch(items: Vec<Self>) -> DataPlaneBatch {
         DataPlaneBatch::Traces(items)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes ClickHouse insert behavior for `spans`, `traces`, and `llm_messages` by wiring in environment-controlled `wait_for_async_insert`, which can affect write latency and durability/visibility timing if misconfigured.
> 
> **Overview**
> Adds per-table overrides of `ClickhouseInsertable::configure_insert` for `CHSpan`, `CHTrace`, and `CHLlmMessage` to set the ClickHouse insert option `wait_for_async_insert`.
> 
> The option is controlled via new env vars (`SPANS_CH_WAIT_FOR_ASYNC_INSERT`, `TRACES_CH_WAIT_FOR_ASYNC_INSERT`, `LLM_MESSAGES_CH_WAIT_FOR_ASYNC_INSERT`) defaulting to `true`, enabling deployments to tune async insert waiting behavior without code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8c4e159f161ef271acff7ddea4116c0323bbee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->