### PR TITLE
separate rate limit for grpc

### DIFF
--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -31,3 +31,5 @@ pub const SPAN_KEEP_DEFAULT_RULES_CACHE_KEY: &str = "signals_span_keep_default_r
 pub const TRACE_EVALUATION_ID_CACHE_KEY: &str = "trace_evaluation_id";
 #[cfg_attr(not(feature = "signals"), allow(dead_code))]
 pub const TRACE_INPUT_REGEX_CACHE_KEY: &str = "signals_trace_input_regex";
+
+pub const INGESTION_RATE_LIMIT_PROJECT_IDS_CACHE_KEY: &str = "ingestion_rate_limit_project_ids";

--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -32,4 +32,4 @@ pub const TRACE_EVALUATION_ID_CACHE_KEY: &str = "trace_evaluation_id";
 #[cfg_attr(not(feature = "signals"), allow(dead_code))]
 pub const TRACE_INPUT_REGEX_CACHE_KEY: &str = "signals_trace_input_regex";
 
-pub const INGESTION_RATE_LIMIT_PROJECT_IDS_CACHE_KEY: &str = "ingestion_rate_limit_project_ids";
+pub const INGESTION_RATE_LIMIT_PROJECT_ID_CACHE_KEY: &str = "ingestion_rate_limit_project_id";

--- a/app-server/src/features/mod.rs
+++ b/app-server/src/features/mod.rs
@@ -22,6 +22,7 @@ pub enum Feature {
     Signals,
     Reports,
     RateLimiter,
+    GrpcRateLimiter,
 }
 
 pub fn is_feature_enabled(feature: Feature) -> bool {
@@ -75,6 +76,11 @@ pub fn is_feature_enabled(feature: Feature) -> bool {
             env::var("REDIS_URL").is_ok()
                 && env::var("RATE_LIMIT").is_ok()
                 && env::var("RATE_LIMIT_PERIOD_SECS").is_ok()
+        }
+        Feature::GrpcRateLimiter => {
+            env::var("REDIS_URL").is_ok()
+                && env::var("GRPC_RATE_LIMIT").is_ok()
+                && env::var("GRPC_RATE_LIMIT_PERIOD_SECS").is_ok()
         }
     }
 }

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1560,8 +1560,10 @@ fn main() -> anyhow::Result<()> {
         // === Rate limiter ===
         let rate_limiter = if is_feature_enabled(Feature::RateLimiter) {
             let redis_url = env::var("REDIS_URL").unwrap();
-            let limit: usize = env::var("RATE_LIMIT").unwrap().parse().unwrap();
-            let period_secs: u64 = env::var("RATE_LIMIT_PERIOD_SECS").unwrap().parse().unwrap();
+
+            let http_limit: usize = env::var("RATE_LIMIT").unwrap().parse().unwrap();
+            let http_period_secs: u64 =
+                env::var("RATE_LIMIT_PERIOD_SECS").unwrap().parse().unwrap();
             // project_auth middleware populates ProjectApiKey in request extensions
             match Limiter::builder(&redis_url)
                 .key_by(|req: &dev::ServiceRequest| {
@@ -1569,15 +1571,15 @@ fn main() -> anyhow::Result<()> {
                         .get::<db::project_api_keys::ProjectApiKey>()
                         .map(|k| format!("ratelimit:{}", k.project_id))
                 })
-                .limit(limit)
-                .period(Duration::from_secs(period_secs))
+                .limit(http_limit)
+                .period(Duration::from_secs(http_period_secs))
                 .build()
             {
                 Ok(limiter) => {
                     log::info!(
                         "Rate limiter initialized ({} req/{} s per project)",
-                        limit,
-                        period_secs
+                        http_limit,
+                        http_period_secs
                     );
                     Some(limiter)
                 }
@@ -1591,10 +1593,37 @@ fn main() -> anyhow::Result<()> {
             None
         };
 
-        // gRPC ingestion shares the same Redis-backed quota as HTTP via
-        // `ratelimit:<project_id>`. Limiter is Clone (inner redis::Client +
-        // Arc'd key fn), so cloning once for the gRPC thread is cheap.
-        let grpc_rate_limiter = rate_limiter.as_ref().map(|l| Arc::new(l.clone()));
+        let grpc_rate_limiter = if is_feature_enabled(Feature::GrpcRateLimiter) {
+            let redis_url = env::var("REDIS_URL").unwrap();
+
+            let grpc_limit: usize = env::var("GRPC_RATE_LIMIT").unwrap().parse().unwrap();
+            let grpc_period_secs: u64 = env::var("GRPC_RATE_LIMIT_PERIOD_SECS")
+                .unwrap()
+                .parse()
+                .unwrap();
+            // no key_by. .count() is called explicitly with a key manually
+            match Limiter::builder(&redis_url)
+                .limit(grpc_limit)
+                .period(Duration::from_secs(grpc_period_secs))
+                .build()
+            {
+                Ok(limiter) => {
+                    log::info!(
+                        "gRPC Rate limiter initialized ({} req/{} s per project)",
+                        grpc_limit,
+                        grpc_period_secs
+                    );
+                    Some(limiter)
+                }
+                Err(e) => {
+                    log::warn!("Failed to initialize gRPC rate limiter: {:?}", e);
+                    None
+                }
+            }
+        } else {
+            log::info!("gRPC rate limiter is disabled");
+            None
+        };
 
         // == HTTP server and listener workers ==
         let http_server_handle = thread::Builder::new()
@@ -1764,7 +1793,7 @@ fn main() -> anyhow::Result<()> {
                         cache.clone(),
                         clickhouse.clone(),
                         queue.clone(),
-                        grpc_rate_limiter.clone(),
+                        grpc_rate_limiter,
                     );
 
                     let process_logs_service = ProcessLogsService::new(

--- a/app-server/src/traces/grpc_service.rs
+++ b/app-server/src/traces/grpc_service.rs
@@ -63,7 +63,7 @@ impl TraceService for ProcessTracesService {
         // blip doesn't black-hole ingestion.
         if let Some(ref limiter) = self.rate_limiter {
             if is_project_id_rate_limited(self.cache.clone(), project_id).await {
-                let key = format!("ratelimit:{}", project_id);
+                let key = format!("grpc_ratelimit:{}", project_id);
                 match limiter.count(key).await {
                     Ok(_) => {}
                     Err(LimiterError::LimitExceeded(_)) => {

--- a/app-server/src/traces/grpc_service.rs
+++ b/app-server/src/traces/grpc_service.rs
@@ -128,7 +128,7 @@ async fn get_limited_project_ids(cache: Arc<Cache>) -> Vec<Uuid> {
         Ok(Some(v)) => v,
         Ok(None) => vec![],
         Err(e) => {
-            log::error!("Error getting rate limited project ids");
+            log::error!("Error getting rate limited project ids: {:?}", e);
             vec![]
         }
     }

--- a/app-server/src/traces/grpc_service.rs
+++ b/app-server/src/traces/grpc_service.rs
@@ -70,10 +70,6 @@ impl TraceService for ProcessTracesService {
                 match limiter.count(key).await {
                     Ok(_) => {}
                     Err(LimiterError::LimitExceeded(_)) => {
-                        // `cancelled` rather than `resource_exhausted`: OTel SDK
-                        // retry policies treat `resource_exhausted` as retriable
-                        // only when the server attaches `RetryInfo`, so legitimate
-                        // exporters would otherwise drop the batch on the floor.
                         return Err(Status::resource_exhausted("Rate limit exceeded"));
                     }
                     Err(e) => {

--- a/app-server/src/traces/grpc_service.rs
+++ b/app-server/src/traces/grpc_service.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{
     auth::authenticate_request,
-    cache::{Cache, CacheTrait, keys::INGESTION_RATE_LIMIT_PROJECT_IDS_CACHE_KEY},
+    cache::{Cache, CacheTrait, keys::INGESTION_RATE_LIMIT_PROJECT_ID_CACHE_KEY},
     db::DB,
     features::{Feature, is_feature_enabled},
     mq::MessageQueue,
@@ -62,10 +62,7 @@ impl TraceService for ProcessTracesService {
         // errors — same posture as the bytes-limit check below — so a Redis
         // blip doesn't black-hole ingestion.
         if let Some(ref limiter) = self.rate_limiter {
-            if get_limited_project_ids(self.cache.clone())
-                .await
-                .contains(&project_id)
-            {
+            if is_project_id_rate_limited(self.cache.clone(), project_id).await {
                 let key = format!("ratelimit:{}", project_id);
                 match limiter.count(key).await {
                     Ok(_) => {}
@@ -116,16 +113,19 @@ impl TraceService for ProcessTracesService {
     }
 }
 
-async fn get_limited_project_ids(cache: Arc<Cache>) -> Vec<Uuid> {
+async fn is_project_id_rate_limited(cache: Arc<Cache>, project_id: Uuid) -> bool {
     match cache
-        .get::<Vec<Uuid>>(INGESTION_RATE_LIMIT_PROJECT_IDS_CACHE_KEY)
+        .get::<i8>(&format!(
+            "{INGESTION_RATE_LIMIT_PROJECT_ID_CACHE_KEY}:{}",
+            project_id.to_string()
+        ))
         .await
     {
-        Ok(Some(v)) => v,
-        Ok(None) => vec![],
+        Ok(Some(v)) => v != 0,
+        Ok(None) => false,
         Err(e) => {
             log::error!("Error getting rate limited project ids: {:?}", e);
-            vec![]
+            false
         }
     }
 }

--- a/app-server/src/traces/grpc_service.rs
+++ b/app-server/src/traces/grpc_service.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
 use actix_limitation::{Error as LimiterError, Limiter};
+use uuid::Uuid;
 
 use crate::{
     auth::authenticate_request,
-    cache::Cache,
+    cache::{Cache, CacheTrait, keys::INGESTION_RATE_LIMIT_PROJECT_IDS_CACHE_KEY},
     db::DB,
     features::{Feature, is_feature_enabled},
     mq::MessageQueue,
@@ -22,7 +23,7 @@ pub struct ProcessTracesService {
     cache: Arc<Cache>,
     clickhouse: clickhouse::Client,
     queue: Arc<MessageQueue>,
-    rate_limiter: Option<Arc<Limiter>>,
+    rate_limiter: Option<Limiter>,
 }
 
 impl ProcessTracesService {
@@ -31,7 +32,7 @@ impl ProcessTracesService {
         cache: Arc<Cache>,
         clickhouse: clickhouse::Client,
         queue: Arc<MessageQueue>,
-        rate_limiter: Option<Arc<Limiter>>,
+        rate_limiter: Option<Limiter>,
     ) -> Self {
         Self {
             db,
@@ -61,18 +62,23 @@ impl TraceService for ProcessTracesService {
         // errors — same posture as the bytes-limit check below — so a Redis
         // blip doesn't black-hole ingestion.
         if let Some(ref limiter) = self.rate_limiter {
-            let key = format!("ratelimit:{}", project_id);
-            match limiter.count(key).await {
-                Ok(_) => {}
-                Err(LimiterError::LimitExceeded(_)) => {
-                    // `cancelled` rather than `resource_exhausted`: OTel SDK
-                    // retry policies treat `resource_exhausted` as retriable
-                    // only when the server attaches `RetryInfo`, so legitimate
-                    // exporters would otherwise drop the batch on the floor.
-                    return Err(Status::resource_exhausted("Rate limit exceeded"));
-                }
-                Err(e) => {
-                    log::error!("Rate limiter error, allowing request: {:?}", e);
+            if get_limited_project_ids(self.cache.clone())
+                .await
+                .contains(&project_id)
+            {
+                let key = format!("ratelimit:{}", project_id);
+                match limiter.count(key).await {
+                    Ok(_) => {}
+                    Err(LimiterError::LimitExceeded(_)) => {
+                        // `cancelled` rather than `resource_exhausted`: OTel SDK
+                        // retry policies treat `resource_exhausted` as retriable
+                        // only when the server attaches `RetryInfo`, so legitimate
+                        // exporters would otherwise drop the batch on the floor.
+                        return Err(Status::resource_exhausted("Rate limit exceeded"));
+                    }
+                    Err(e) => {
+                        log::error!("Rate limiter error, allowing request: {:?}", e);
+                    }
                 }
             }
         }
@@ -111,5 +117,19 @@ impl TraceService for ProcessTracesService {
         })?;
 
         Ok(Response::new(response))
+    }
+}
+
+async fn get_limited_project_ids(cache: Arc<Cache>) -> Vec<Uuid> {
+    match cache
+        .get::<Vec<Uuid>>(INGESTION_RATE_LIMIT_PROJECT_IDS_CACHE_KEY)
+        .await
+    {
+        Ok(Some(v)) => v,
+        Ok(None) => vec![],
+        Err(e) => {
+            log::error!("Error getting rate limited project ids");
+            vec![]
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches ingestion throttling on the gRPC trace export path and introduces new env-driven limiter behavior, which could accidentally over/under-limit traffic if misconfigured. Changes are localized and fail-open on Redis/cache errors.
> 
> **Overview**
> Adds a new `GrpcRateLimiter` feature flag and separate env vars (`GRPC_RATE_LIMIT`, `GRPC_RATE_LIMIT_PERIOD_SECS`) so gRPC ingestion can be rate-limited independently from HTTP.
> 
> Updates trace gRPC export to optionally enforce limits using a distinct Redis key prefix (`grpc_ratelimit:<project_id>`) and gates enforcement per project via a cache flag stored under `ingestion_rate_limit_project_id:<project_id>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb3d9f7174034459ab99cbb0e5a050e9be8c1c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->