### PR TITLE
enable configurable rabbit auto-reconnect

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -284,9 +284,15 @@ fn main() -> anyhow::Result<()> {
     let (publisher_connection, consumer_connection) =
         if is_feature_enabled(Feature::RabbitMQ) && is_feature_enabled(Feature::FullBuild) {
             let rabbitmq_url = env::var("RABBITMQ_URL").expect("RABBITMQ_URL must be set");
+            let auto_reconnect =
+                env::var("RABBITMQ_AUTO_RECONNECT").is_ok_and(|v| v.to_lowercase() == "true");
+            let mut props = ConnectionProperties::default();
+            if auto_reconnect {
+                props = props.enable_auto_recover();
+            }
             runtime_handle.block_on(async {
                 let publisher_conn = Arc::new(
-                    Connection::connect(&rabbitmq_url, ConnectionProperties::default())
+                    Connection::connect(&rabbitmq_url, props.clone())
                         .await
                         .unwrap(),
                 );
@@ -295,9 +301,7 @@ fn main() -> anyhow::Result<()> {
                 let consumer_conn = if enable_consumer() {
                     log::info!("Consumer mode enabled - creating consumer connection");
                     Some(Arc::new(
-                        Connection::connect(&rabbitmq_url, ConnectionProperties::default())
-                            .await
-                            .unwrap(),
+                        Connection::connect(&rabbitmq_url, props).await.unwrap(),
                     ))
                 } else {
                     log::info!("Producer-only mode - skipping consumer connection");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches RabbitMQ connection setup and can change runtime behavior of message publishing/consuming when `RABBITMQ_AUTO_RECONNECT=true`, which could affect delivery semantics and failure modes. Default behavior remains unchanged when the env var is unset/false.
> 
> **Overview**
> Adds an opt-in `RABBITMQ_AUTO_RECONNECT` environment flag to enable Lapin connection auto-recovery for RabbitMQ.
> 
> When enabled, both the publisher and (if consumer mode is on) consumer connections are created with `ConnectionProperties::enable_auto_recover()` instead of the default connection properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a21a4a21e3486740ca3c1315e18a1d2a37c09a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->