### PR TITLE
remove unnecessary tracing from ingestion pipeline

### DIFF
--- a/app-server/src/cache/autocomplete.rs
+++ b/app-server/src/cache/autocomplete.rs
@@ -5,7 +5,6 @@ use chrono::{Duration, Utc};
 use clickhouse::Row;
 use serde::Deserialize;
 use serde_json::Value;
-use tracing::instrument;
 use uuid::Uuid;
 
 use crate::cache::keys::{AUTOCOMPLETE_CACHE_KEY, AUTOCOMPLETE_LOCK_CACHE_KEY};
@@ -101,7 +100,6 @@ async fn prefill_autocomplete_key_if_missing(
     Ok(())
 }
 
-#[instrument(skip_all)]
 pub async fn populate_autocomplete_cache(
     project_id: Uuid,
     spans: &[Span],

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use rayon::prelude::*;
 use serde_json::Value;
-use tracing::{Instrument, instrument};
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -73,31 +73,26 @@ pub async fn process_span_messages(
     // Enrich spans with usage info
     let mut span_usage_vec = Vec::with_capacity(messages.len());
 
-    let usage_span = tracing::info_span!("preprocess.usage_lookup", span_count = messages.len());
-    async {
-        for m in &mut messages {
-            let span_usage = get_llm_usage_for_span(
-                &mut m.span.attributes,
-                db.clone(),
-                cache.clone(),
-                &m.span.name,
-                &m.span.project_id,
-            )
-            .await;
+    for m in &mut messages {
+        let span_usage = get_llm_usage_for_span(
+            &mut m.span.attributes,
+            db.clone(),
+            cache.clone(),
+            &m.span.name,
+            &m.span.project_id,
+        )
+        .await;
 
-            prepare_span_for_recording(&mut m.span, &span_usage);
-            if !m.pre_processed {
-                convert_span_to_provider_format(&mut m.span);
-            }
-            // `estimate_size_bytes` is deferred until AFTER PII redaction
-            // (post-dedup loop below) so the recorded size reflects the
-            // redacted output.
-
-            span_usage_vec.push(span_usage);
+        prepare_span_for_recording(&mut m.span, &span_usage);
+        if !m.pre_processed {
+            convert_span_to_provider_format(&mut m.span);
         }
+        // `estimate_size_bytes` is deferred until AFTER PII redaction
+        // (post-dedup loop below) so the recorded size reflects the
+        // redacted output.
+
+        span_usage_vec.push(span_usage);
     }
-    .instrument(usage_span)
-    .await;
 
     // Split into parallel `Vec`s — downstream code reads `spans` and
     // `dedups` as separate slices keyed by index.
@@ -106,11 +101,7 @@ pub async fn process_span_messages(
         .map(|m| (m.span, m.input_dedup))
         .unzip();
 
-    // Process trace aggregations
-    let trace_aggregations = {
-        let _g = tracing::info_span!("preprocess.trace_agg", span_count = spans.len()).entered();
-        TraceAggregation::from_spans(&spans, &span_usage_vec)
-    };
+    let trace_aggregations = TraceAggregation::from_spans(&spans, &span_usage_vec);
 
     // Build the dedup batch up front so the size-bytes loop and CHSpans build
     // can run before we kick off the parallel inserts.
@@ -121,11 +112,6 @@ pub async fn process_span_messages(
         .map(|(i, _)| i)
         .collect();
     let mut dedup = {
-        let _g = tracing::info_span!(
-            "preprocess.dedup_batch",
-            recordable = recordable_indices.len()
-        )
-        .entered();
         let dedup_input: Vec<&Span> = recordable_indices.iter().map(|&i| &spans[i]).collect();
         let recordable_dedups: Vec<Option<LlmInputDedup>> = recordable_indices
             .iter()
@@ -210,37 +196,30 @@ pub async fn process_span_messages(
     }
 
     // Build CHSpans with embedded events to insert to ClickHouse
-    let ch_spans: Vec<CHSpan> = {
-        let _g: tracing::span::EnteredSpan = tracing::info_span!(
-            "preprocess.ch_span_build",
-            recordable = recordable_indices.len()
-        )
-        .entered();
-        recordable_indices
-            .iter()
-            .enumerate()
-            .map(|(dedup_idx, &span_idx)| {
-                let span = &spans[span_idx];
-                let usage = &span_usage_vec[span_idx];
-                let mut ch_span = CHSpan::from_db_span(span, usage, span.project_id);
-                let hashes = dedup
-                    .span_hashes
+    let ch_spans: Vec<CHSpan> = recordable_indices
+        .iter()
+        .enumerate()
+        .map(|(dedup_idx, &span_idx)| {
+            let span = &spans[span_idx];
+            let usage = &span_usage_vec[span_idx];
+            let mut ch_span = CHSpan::from_db_span(span, usage, span.project_id);
+            let hashes = dedup
+                .span_hashes
+                .get(dedup_idx)
+                .cloned()
+                .unwrap_or_default();
+            if !hashes.is_empty() {
+                ch_span.input = String::new();
+                ch_span.input_message_hashes = hashes;
+                ch_span.input_new_message_indices = dedup
+                    .span_new_indices
                     .get(dedup_idx)
                     .cloned()
                     .unwrap_or_default();
-                if !hashes.is_empty() {
-                    ch_span.input = String::new();
-                    ch_span.input_message_hashes = hashes;
-                    ch_span.input_new_message_indices = dedup
-                        .span_new_indices
-                        .get(dedup_idx)
-                        .cloned()
-                        .unwrap_or_default();
-                }
-                ch_span
-            })
-            .collect()
-    };
+            }
+            ch_span
+        })
+        .collect();
 
     // Parallelize trace upsert against the span path. Within the span path
     // the strict order llm_messages -> mark_seen -> spans must be preserved

--- a/app-server/src/traces/realtime.rs
+++ b/app-server/src/traces/realtime.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Value;
-use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -73,7 +72,6 @@ struct RealtimeSpan {
 
 /// Send realtime span update events to SSE connections for specific traces
 /// lmnr.rollout.session_id
-#[instrument(skip_all)]
 pub async fn send_span_updates(spans: &[Span], pubsub: &PubSub) {
     // Group spans by (project_id, trace_id)
     let mut spans_by_trace: HashMap<(Uuid, Uuid), Vec<RealtimeSpan>> = HashMap::new();

--- a/app-server/src/utils/limits.rs
+++ b/app-server/src/utils/limits.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use chrono::{DateTime, Months, Utc};
-use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -205,7 +204,6 @@ pub async fn get_workspace_signal_runs_limit_exceeded(
     Ok(signal_runs >= effective_limit)
 }
 
-#[instrument(skip_all)]
 pub async fn update_workspace_bytes_ingested(
     db: Arc<DB>,
     clickhouse: clickhouse::Client,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change; no business logic, storage order, or API behavior is modified.
> 
> **Overview**
> Removes **nested tracing instrumentation** from the span ingestion path so work stays under the existing top-level `process_span_messages` span instead of emitting many child spans per batch.
> 
> In **`processor.rs`**, drops `preprocess.usage_lookup`, `preprocess.trace_agg`, `preprocess.dedup_batch`, and `preprocess.ch_span_build` (`info_span` / `Instrument` wrappers) while keeping the same sequential logic for usage lookup, trace aggregation, dedup, and `CHSpan` construction. Also drops the unused `Instrument` import.
> 
> Removes **`#[instrument(skip_all)]`** from **`populate_autocomplete_cache`**, **`send_span_updates`**, and **`update_workspace_bytes_ingested`** (and the related `tracing::instrument` imports where no longer needed). **`process_span_messages`** still uses `#[instrument(...)]` at the entry point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3abbdedfa5b9970d203c3898bbdfaa5ed9499840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->