### PR TITLE
Add LLM default headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For production environment, we recommend using our [managed platform](https://la
 
 ### Configuring LLM provider (optional)
 
-Frontend AI features (chat-with-trace, SQL-with-AI) require an LLM provider. Configure one in your `.env` file at the repo root — the vars are read by the frontend only.
+Frontend AI features (chat-with-trace, SQL-with-AI) and server-side AI workers require an LLM provider. Configure one in your `.env` file at the repo root.
 
 Pick one of the following provider setups. `LLM_MODEL_SMALL|MEDIUM|LARGE` are optional — per-provider defaults apply when unset.
 
@@ -67,6 +67,7 @@ LLM_API_KEY=your_gemini_key
 # Option B: OpenAI (or any OpenAI-compatible gateway such as LiteLLM, OpenRouter, vLLM)
 LLM_PROVIDER=openai
 # LLM_BASE_URL=http://localhost:4000   # optional, for OpenAI-compatible gateways
+# LLM_DEFAULT_HEADERS_JSON='{"X-Gateway-Tenant":"tenant"}'   # optional, for gateways that require static headers
 LLM_API_KEY=your_openai_key
 
 # Option C: AWS Bedrock (Anthropic Claude). Uses AWS credentials instead of LLM_API_KEY.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ For production environment, we recommend using our [managed platform](https://la
 
 Frontend AI features (chat-with-trace, SQL-with-AI) and server-side AI workers require an LLM provider. Configure one in your `.env` file at the repo root.
 
-Pick one of the following provider setups. `LLM_MODEL_SMALL|MEDIUM|LARGE` are optional — per-provider defaults apply when unset.
+Pick one of the following provider setups. `LLM_MODEL_SMALL|MEDIUM|LARGE` are optional — per-provider defaults apply when unset. `LLM_DEFAULT_HEADERS_JSON` is optional for any provider or gateway that requires static headers.
 
 ```sh
+# Optional for any provider/gateway that requires static headers
+# LLM_DEFAULT_HEADERS_JSON='{"X-Gateway-Tenant":"tenant"}'
+
 # Option A: Gemini
 LLM_PROVIDER=gemini
 LLM_API_KEY=your_gemini_key
@@ -67,7 +70,6 @@ LLM_API_KEY=your_gemini_key
 # Option B: OpenAI (or any OpenAI-compatible gateway such as LiteLLM, OpenRouter, vLLM)
 LLM_PROVIDER=openai
 # LLM_BASE_URL=http://localhost:4000   # optional, for OpenAI-compatible gateways
-# LLM_DEFAULT_HEADERS_JSON='{"X-Gateway-Tenant":"tenant"}'   # optional, for gateways that require static headers
 LLM_API_KEY=your_openai_key
 
 # Option C: AWS Bedrock (Anthropic Claude). Uses AWS credentials instead of LLM_API_KEY.

--- a/app-server/src/llm/gemini/client.rs
+++ b/app-server/src/llm/gemini/client.rs
@@ -5,7 +5,7 @@ use super::{
     InlineRequestItem, Operation,
 };
 use crate::llm::{
-    LanguageModelClient, ProviderResult,
+    LanguageModelClient, ProviderResult, default_headers_from_env,
     models::{ProviderBatchOperation, ProviderRequest, ProviderRequestItem, ProviderResponse},
 };
 use std::{env, time::Duration};
@@ -29,10 +29,12 @@ impl GeminiClient {
             .filter(|s| !s.trim().is_empty())
             .unwrap_or_else(|| "https://generativelanguage.googleapis.com/v1beta".to_string());
         let api_base_url = raw_base_url.trim_end_matches('/').to_string();
+        let default_headers = default_headers_from_env().map_err(GeminiError::config)?;
 
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(120))
+            .default_headers(default_headers)
             .build()
             .map_err(|e| GeminiError::config(format!("Failed to build HTTP client: {}", e)))?;
 

--- a/app-server/src/llm/mod.rs
+++ b/app-server/src/llm/mod.rs
@@ -11,6 +11,7 @@ pub use models::*;
 pub use openai::OpenAIClient;
 
 use enum_dispatch::enum_dispatch;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::collections::HashMap;
 use std::env;
 use std::sync::OnceLock;
@@ -101,6 +102,7 @@ pub(crate) enum ProviderClient {
 }
 
 static ALWAYS_USE_REALTIME: OnceLock<bool> = OnceLock::new();
+const LLM_DEFAULT_HEADERS_JSON_ENV: &str = "LLM_DEFAULT_HEADERS_JSON";
 
 #[cfg_attr(not(feature = "signals"), allow(dead_code))]
 pub fn always_use_realtime() -> bool {
@@ -140,6 +142,40 @@ fn has_bedrock_credentials() -> bool {
     env::var("AWS_ACCESS_KEY_ID").is_ok_and(|v| !v.is_empty())
         && env::var("AWS_SECRET_ACCESS_KEY").is_ok_and(|v| !v.is_empty())
         && env::var("AWS_REGION").is_ok_and(|v| !v.is_empty())
+}
+
+pub(crate) fn default_headers_from_env() -> Result<HeaderMap, String> {
+    let Some(raw_headers) = env::var(LLM_DEFAULT_HEADERS_JSON_ENV)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+    else {
+        return Ok(HeaderMap::new());
+    };
+
+    parse_default_headers_json(&raw_headers)
+        .map_err(|e| format!("{LLM_DEFAULT_HEADERS_JSON_ENV}: {e}"))
+}
+
+fn parse_default_headers_json(raw_headers: &str) -> Result<HeaderMap, String> {
+    let parsed: serde_json::Value = serde_json::from_str(raw_headers)
+        .map_err(|e| format!("must be a JSON object with string values: {e}"))?;
+    let object = parsed
+        .as_object()
+        .ok_or_else(|| "must be a JSON object with string values".to_string())?;
+
+    let mut headers = HeaderMap::new();
+    for (name, value) in object {
+        let value = value
+            .as_str()
+            .ok_or_else(|| format!("header '{name}' value must be a string"))?;
+        let name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|e| format!("invalid header name '{name}': {e}"))?;
+        let value = HeaderValue::from_str(value)
+            .map_err(|e| format!("invalid value for header '{name}': {e}"))?;
+        headers.insert(name, value);
+    }
+
+    Ok(headers)
 }
 
 /// Resolve the primary provider name from `LLM_PROVIDER`. Required —
@@ -189,6 +225,53 @@ pub fn request_to_tools_attr(request: &ProviderRequest) -> Option<serde_json::Va
         None
     } else {
         Some(serde_json::Value::Array(tool_array))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_default_headers_json_accepts_string_map() {
+        let headers = parse_default_headers_json(
+            r#"{"X-Gateway-Tenant":"brex","anthropic-version":"2023-06-01"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            headers.get("x-gateway-tenant").unwrap().to_str().unwrap(),
+            "brex"
+        );
+        assert_eq!(
+            headers.get("anthropic-version").unwrap().to_str().unwrap(),
+            "2023-06-01"
+        );
+    }
+
+    #[test]
+    fn parse_default_headers_json_rejects_non_object() {
+        let error = parse_default_headers_json(r#"["x"]"#).unwrap_err();
+        assert!(error.contains("must be a JSON object"));
+    }
+
+    #[test]
+    fn parse_default_headers_json_rejects_non_string_values() {
+        let error = parse_default_headers_json(r#"{"X-Gateway-Tenant":true}"#).unwrap_err();
+        assert!(error.contains("value must be a string"));
+    }
+
+    #[test]
+    fn parse_default_headers_json_rejects_invalid_names() {
+        let error = parse_default_headers_json(r#"{"Bad Header":"value"}"#).unwrap_err();
+        assert!(error.contains("invalid header name"));
+    }
+
+    #[test]
+    fn parse_default_headers_json_rejects_invalid_values() {
+        let error =
+            parse_default_headers_json("{\"X-Gateway-Tenant\":\"bad\\nvalue\"}").unwrap_err();
+        assert!(error.contains("invalid value"));
     }
 }
 

--- a/app-server/src/llm/openai/client.rs
+++ b/app-server/src/llm/openai/client.rs
@@ -3,7 +3,7 @@
 use super::OpenAIError;
 use super::conversions::{parse_openai_response, provider_request_to_openai_body};
 use crate::llm::{
-    LanguageModelClient, ProviderResult,
+    LanguageModelClient, ProviderResult, default_headers_from_env,
     models::{ProviderRequest, ProviderResponse},
 };
 use std::{env, time::Duration};
@@ -27,10 +27,12 @@ impl OpenAIClient {
             .filter(|s| !s.trim().is_empty())
             .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
         let api_base_url = raw_base_url.trim_end_matches('/').to_string();
+        let default_headers = default_headers_from_env().map_err(OpenAIError::config)?;
 
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(120))
+            .default_headers(default_headers)
             .build()
             .map_err(|e| OpenAIError::config(format!("Failed to build HTTP client: {}", e)))?;
 

--- a/frontend/lib/ai/model.ts
+++ b/frontend/lib/ai/model.ts
@@ -52,7 +52,7 @@ function getConfiguredLLMProvider(): LLMProvider | null {
  * features don't light up UI that will throw on first call.
  */
 export function isAiProviderConfigured(): boolean {
-  return getConfiguredLLMProvider() !== null;
+  return getConfiguredLLMProvider() !== null && hasValidLlmDefaultHeaders();
 }
 
 function resolveModelName(provider: LLMProvider, tier: ModelTier): string {
@@ -81,10 +81,29 @@ export function parseLlmDefaultHeaders(value = process.env.LLM_DEFAULT_HEADERS_J
     if (typeof headerValue !== "string") {
       throw new Error(`Invalid LLM_DEFAULT_HEADERS_JSON: header '${name}' value must be a string`);
     }
+    validateHeader(name, headerValue);
     headers[name] = headerValue;
   }
 
   return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+function hasValidLlmDefaultHeaders(): boolean {
+  try {
+    parseLlmDefaultHeaders();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function validateHeader(name: string, value: string): void {
+  try {
+    new Headers([[name, value]]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid LLM_DEFAULT_HEADERS_JSON: invalid header '${name}' (${message})`);
+  }
 }
 
 export function getLanguageModel(tier: ModelTier = "large"): LanguageModel {

--- a/frontend/lib/ai/model.ts
+++ b/frontend/lib/ai/model.ts
@@ -10,6 +10,7 @@ import type { LanguageModel } from "ai";
 type ModelTier = "small" | "medium" | "large";
 
 type LLMProvider = "openai" | "gemini" | "bedrock";
+type LlmDefaultHeaders = Record<string, string>;
 
 // Per-provider defaults. Used when LLM_MODEL_<TIER> is not set.
 const DEFAULT_MODELS: Record<LLMProvider, Record<ModelTier, string>> = {
@@ -58,6 +59,34 @@ function resolveModelName(provider: LLMProvider, tier: ModelTier): string {
   return process.env[`LLM_MODEL_${tier.toUpperCase()}`] || DEFAULT_MODELS[provider][tier];
 }
 
+export function parseLlmDefaultHeaders(value = process.env.LLM_DEFAULT_HEADERS_JSON): LlmDefaultHeaders | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid LLM_DEFAULT_HEADERS_JSON: expected a JSON object with string values (${message})`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Invalid LLM_DEFAULT_HEADERS_JSON: expected a JSON object with string values");
+  }
+
+  const headers: LlmDefaultHeaders = {};
+  for (const [name, headerValue] of Object.entries(parsed)) {
+    if (typeof headerValue !== "string") {
+      throw new Error(`Invalid LLM_DEFAULT_HEADERS_JSON: header '${name}' value must be a string`);
+    }
+    headers[name] = headerValue;
+  }
+
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
 export function getLanguageModel(tier: ModelTier = "large"): LanguageModel {
   const provider = getConfiguredLLMProvider();
   if (!provider) {
@@ -77,12 +106,13 @@ export function getLanguageModel(tier: ModelTier = "large"): LanguageModel {
 
   const apiKey = process.env.LLM_API_KEY;
   const baseURL = process.env.LLM_BASE_URL;
+  const headers = parseLlmDefaultHeaders();
 
   if (provider === "openai") {
-    const openai = createOpenAI({ apiKey, ...(baseURL ? { baseURL } : {}) });
+    const openai = createOpenAI({ apiKey, ...(baseURL ? { baseURL } : {}), ...(headers ? { headers } : {}) });
     return openai(modelName);
   }
 
-  const google = createGoogleGenerativeAI({ apiKey, ...(baseURL ? { baseURL } : {}) });
+  const google = createGoogleGenerativeAI({ apiKey, ...(baseURL ? { baseURL } : {}), ...(headers ? { headers } : {}) });
   return google(modelName);
 }

--- a/frontend/tests/test-llm-default-headers.test.ts
+++ b/frontend/tests/test-llm-default-headers.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseLlmDefaultHeaders } from "@/lib/ai/model";
+
+describe("parseLlmDefaultHeaders", () => {
+  it("returns undefined when unset or blank", () => {
+    assert.strictEqual(parseLlmDefaultHeaders(undefined), undefined);
+    assert.strictEqual(parseLlmDefaultHeaders("  "), undefined);
+  });
+
+  it("parses a JSON object with string values", () => {
+    assert.deepStrictEqual(parseLlmDefaultHeaders('{"X-Gateway-Tenant":"brex"}'), {
+      "X-Gateway-Tenant": "brex",
+    });
+  });
+
+  it("rejects non-object JSON", () => {
+    assert.throws(() => parseLlmDefaultHeaders('["x"]'), /expected a JSON object/);
+  });
+
+  it("rejects non-string header values", () => {
+    assert.throws(() => parseLlmDefaultHeaders('{"X-Gateway-Tenant":true}'), /value must be a string/);
+  });
+});

--- a/frontend/tests/test-llm-default-headers.test.ts
+++ b/frontend/tests/test-llm-default-headers.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { parseLlmDefaultHeaders } from "@/lib/ai/model";
+import { isAiProviderConfigured, parseLlmDefaultHeaders } from "@/lib/ai/model";
 
 describe("parseLlmDefaultHeaders", () => {
   it("returns undefined when unset or blank", () => {
@@ -22,4 +22,35 @@ describe("parseLlmDefaultHeaders", () => {
   it("rejects non-string header values", () => {
     assert.throws(() => parseLlmDefaultHeaders('{"X-Gateway-Tenant":true}'), /value must be a string/);
   });
+
+  it("rejects invalid header names and values", () => {
+    assert.throws(() => parseLlmDefaultHeaders('{"Bad Header":"value"}'), /invalid header/);
+    assert.throws(() => parseLlmDefaultHeaders('{"X-Gateway-Tenant":"bad\\nvalue"}'), /invalid header/);
+  });
+
+  it("does not report the provider configured when default headers are invalid", () => {
+    const previousProvider = process.env.LLM_PROVIDER;
+    const previousApiKey = process.env.LLM_API_KEY;
+    const previousHeaders = process.env.LLM_DEFAULT_HEADERS_JSON;
+
+    try {
+      process.env.LLM_PROVIDER = "openai";
+      process.env.LLM_API_KEY = "test-key";
+      process.env.LLM_DEFAULT_HEADERS_JSON = '{"Bad Header":"value"}';
+
+      assert.strictEqual(isAiProviderConfigured(), false);
+    } finally {
+      restoreEnv("LLM_PROVIDER", previousProvider);
+      restoreEnv("LLM_API_KEY", previousApiKey);
+      restoreEnv("LLM_DEFAULT_HEADERS_JSON", previousHeaders);
+    }
+  });
 });
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}


### PR DESCRIPTION
## Summary
- Parse optional `LLM_DEFAULT_HEADERS_JSON` as a JSON object of string headers
- Apply those headers to frontend Gemini/OpenAI provider factories
- Apply those headers to app-server Gemini/OpenAI reqwest clients
- Document the optional env var for OpenAI-compatible gateways

This pairs with lmnr-ai/lmnr-helm#35, which renders the same env var from `llmDefaultHeaders`.

## Verification
- `pnpm --dir frontend exec tsx --test tests/test-llm-default-headers.test.ts`
- `pnpm --dir frontend exec tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --jsx preserve --types node --skipLibCheck lib/ai/model.ts`
- `pnpm --dir frontend exec eslint lib/ai/model.ts tests/test-llm-default-headers.test.ts`
- `git diff --check`

Full frontend `pnpm --dir frontend type-check` is currently blocked by pre-existing missing asset imports under `@/assets/...`. App-server cargo verification is currently blocked locally by missing `protoc`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change with strict JSON validation; no auth or data-path changes, and Bedrock is unaffected.
> 
> **Overview**
> Adds optional **`LLM_DEFAULT_HEADERS_JSON`** so deployments can send static HTTP headers on every LLM request—mainly for **OpenAI-compatible gateways** that need tenant or version headers alongside `LLM_BASE_URL`.
> 
> **Frontend:** `parseLlmDefaultHeaders` reads the env var (JSON object of strings, validated) and passes `headers` into OpenAI and Gemini AI SDK factories in `getLanguageModel`. Bedrock is unchanged.
> 
> **App-server:** Shared `default_headers_from_env` / `parse_default_headers_json` builds a `reqwest` `HeaderMap` and attaches it via `.default_headers()` on Gemini and OpenAI HTTP clients at init. Invalid config fails client creation with clear errors; unit tests cover parsing edge cases.
> 
> **Docs:** README notes server-side AI workers use the same `.env` LLM config and documents the new variable under the OpenAI gateway example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6fea16e8c981e57cba1289eb32f86cde065ca8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->