### PR TITLE
log error on invalid llm default headers

### DIFF
--- a/frontend/lib/ai/model.ts
+++ b/frontend/lib/ai/model.ts
@@ -92,7 +92,9 @@ function hasValidLlmDefaultHeaders(): boolean {
   try {
     parseLlmDefaultHeaders();
     return true;
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`AI provider failed to configure: ${message}`);
     return false;
   }
 }

--- a/frontend/lib/ai/model.ts
+++ b/frontend/lib/ai/model.ts
@@ -88,13 +88,18 @@ export function parseLlmDefaultHeaders(value = process.env.LLM_DEFAULT_HEADERS_J
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
+let hasWarnedAboutHeaders = false;
+
 function hasValidLlmDefaultHeaders(): boolean {
   try {
     parseLlmDefaultHeaders();
     return true;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`AI provider failed to configure: ${message}`);
+    if (!hasWarnedAboutHeaders) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`AI provider failed to configure: ${message}`);
+      hasWarnedAboutHeaders = true;
+    }
     return false;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change; configuration gating behavior is unchanged aside from a single warn log.
> 
> **Overview**
> When **`LLM_DEFAULT_HEADERS_JSON`** fails validation, **`hasValidLlmDefaultHeaders()`** still treats the AI provider as unconfigured (same behavior for **`isAiProviderConfigured()`**), but it now emits a **one-time** **`console.warn`** with the parse/validation error instead of failing silently.
> 
> A module-level flag prevents repeated warnings on every check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ca6fc5fdf74142dce1e56e74b2b39fc6b25d07a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->