### PR TITLE
explicitly install yarn (not shipped in 26 alpine)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* pnpm-workspace.yaml* ./
-RUN npm i -g yarn
-RUN yarn global add pnpm && pnpm i --frozen-lockfile
+RUN npm i -g pnpm@latest-11
+RUN pnpm i --frozen-lockfile
 
 
 # Rebuild the source code only when needed

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* pnpm-workspace.yaml* ./
+RUN npm i -g yarn
 RUN yarn global add pnpm && pnpm i --frozen-lockfile
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docker build-only change with no runtime app logic; low risk aside from verifying the image still builds and installs dependencies correctly.
> 
> **Overview**
> Updates the **frontend** Docker **deps** stage so **pnpm** is installed with **npm** instead of **yarn**, which is no longer available on **Node 26 Alpine**.
> 
> The previous one-liner `yarn global add pnpm && pnpm i --frozen-lockfile` is split into `npm i -g pnpm@latest-11` followed by `pnpm i --frozen-lockfile`, pinning the **pnpm** major line while keeping a frozen lockfile install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1899933593ffe1eb796aaa854059a26d3e32a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->