### PR TITLE
fix: cover case of direct parent being subagent

### DIFF
--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -271,9 +271,10 @@ const pathHashKey = (parentSpanPath: string, promptHash: string): string => `${p
  * LLM's invocation root key: a string distinguishing its invocation from other
  * invocations of the same subagent. `""` means one invocation.
  *
- * The key is a structural prefix of `ids_path`; how deep depends on whether the
- * LLM's direct parent is a real subagent container or per-iteration noise:
- *  - If a single direct parent holds 2+ of the cluster's LLMs, that parent ran
+ * The key is a structural prefix of `ids_path`; how deep is decided per-span
+ * by whether *that span's own* direct parent is a real subagent container or
+ * per-iteration noise:
+ *  - If the LLM's direct parent holds 2+ of the cluster's LLMs, that parent ran
  *    the subagent (looping internally), so it stays in the key (`ids_path`
  *    minus the LLM itself). This separates sibling subagents that share a name
  *    — hence a `parentSpanPath` — but directly parent their own LLM calls (e.g.
@@ -282,6 +283,12 @@ const pathHashKey = (parentSpanPath: string, promptHash: string): string => `${p
  *    loop body per iteration), so it's dropped with the LLM (`ids_path` minus
  *    the last two); iterations then collapse while divergence higher up still
  *    separates distinct invocations.
+ *
+ * The decision is per-span, not per-cluster: a cluster can mix container
+ * parents and per-iteration wrappers (when they share a name), and each must
+ * be trimmed by its own rule. Within a cluster all members share one
+ * `parentSpanPath`, hence one `ids_path` length, so container keys (length-1
+ * trim) and noise keys (length-2 trim) never collide.
  *
  * Using the full structural prefix (not a single divergence index) correctly
  * partitions a cluster with multiple divergence depths. Falls back to
@@ -297,19 +304,20 @@ const computeInvocationRoots = (cluster: LlmSpanInfo[]): Map<string, string> => 
   const directParentId = (s: LlmSpanInfo): string =>
     s.idsPath.length >= 2 ? s.idsPath[s.idsPath.length - 2] : s.parentSpanId;
 
-  // A direct parent shared by 2+ cluster LLMs is a real container, not
-  // per-iteration noise — keep it in the key instead of trimming it as noise.
+  // Count how many of the cluster's LLMs sit under each direct parent.
   const llmsPerParent = new Map<string, number>();
   for (const s of cluster) {
     const p = directParentId(s);
     llmsPerParent.set(p, (llmsPerParent.get(p) ?? 0) + 1);
   }
-  const directParentIsContainer = Array.from(llmsPerParent.values()).some((n) => n >= 2);
 
   const structuralPrefix = (s: LlmSpanInfo): string => {
-    if (directParentIsContainer) {
-      return s.idsPath.length >= 2 ? s.idsPath.slice(0, -1).join("\0") : directParentId(s);
+    const p = directParentId(s);
+    // This span's own parent is a real container (2+ cluster LLMs) → keep it.
+    if ((llmsPerParent.get(p) ?? 0) >= 2) {
+      return s.idsPath.length >= 2 ? s.idsPath.slice(0, -1).join("\0") : p;
     }
+    // Per-iteration wrapper → drop it (and the LLM) as noise.
     return s.idsPath.length <= 2 ? "" : s.idsPath.slice(0, -2).join("\0");
   };
 

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -267,20 +267,25 @@ const compositeKey = (parentSpanPath: string, promptHash: string, invocationRoot
 const pathHashKey = (parentSpanPath: string, promptHash: string): string => `${parentSpanPath}\0${promptHash}`;
 
 /**
- * For each cluster of LLMs sharing `(parentSpanPath, promptHash)`, return
- * each LLM's invocation root key: a string identifying the unique ancestor
- * chain that distinguishes its invocation from other invocations of the same
- * subagent. `""` means every member shares the same chain (one invocation).
+ * For each cluster of LLMs sharing `(parentSpanPath, promptHash)`, return each
+ * LLM's invocation root key: a string distinguishing its invocation from other
+ * invocations of the same subagent. `""` means one invocation.
  *
- * The key is the full structural portion of `ids_path` — every ancestor
- * except the last two positions (the LLM itself and its direct parent), which
- * are iteration noise: some SDKs reuse one loop body across iterations,
- * others spawn a fresh one per iteration; both are still one invocation.
+ * The key is a structural prefix of `ids_path`; how deep depends on whether the
+ * LLM's direct parent is a real subagent container or per-iteration noise:
+ *  - If a single direct parent holds 2+ of the cluster's LLMs, that parent ran
+ *    the subagent (looping internally), so it stays in the key (`ids_path`
+ *    minus the LLM itself). This separates sibling subagents that share a name
+ *    — hence a `parentSpanPath` — but directly parent their own LLM calls (e.g.
+ *    two Claude Code "Agent" tool spans, each making several calls).
+ *  - Otherwise the direct parent is a per-call wrapper (some SDKs spawn a fresh
+ *    loop body per iteration), so it's dropped with the LLM (`ids_path` minus
+ *    the last two); iterations then collapse while divergence higher up still
+ *    separates distinct invocations.
  *
- * Using the full structural prefix (rather than a single divergence-index
- * value) correctly partitions a cluster with multiple divergence depths —
- * e.g. two invocations sharing depth-1 but diverging at depth-2 stay
- * separate even when a third invocation diverges from them at depth-1.
+ * Using the full structural prefix (not a single divergence index) correctly
+ * partitions a cluster with multiple divergence depths. Falls back to
+ * `parent_span_id` when `ids_path` is absent (older instrumentation).
  */
 const computeInvocationRoots = (cluster: LlmSpanInfo[]): Map<string, string> => {
   const out = new Map<string, string>();
@@ -289,7 +294,24 @@ const computeInvocationRoots = (cluster: LlmSpanInfo[]): Map<string, string> => 
     return out;
   }
 
-  const structuralPrefix = (s: LlmSpanInfo): string => (s.idsPath.length <= 2 ? "" : s.idsPath.slice(0, -2).join("\0"));
+  const directParentId = (s: LlmSpanInfo): string =>
+    s.idsPath.length >= 2 ? s.idsPath[s.idsPath.length - 2] : s.parentSpanId;
+
+  // A direct parent shared by 2+ cluster LLMs is a real container, not
+  // per-iteration noise — keep it in the key instead of trimming it as noise.
+  const llmsPerParent = new Map<string, number>();
+  for (const s of cluster) {
+    const p = directParentId(s);
+    llmsPerParent.set(p, (llmsPerParent.get(p) ?? 0) + 1);
+  }
+  const directParentIsContainer = Array.from(llmsPerParent.values()).some((n) => n >= 2);
+
+  const structuralPrefix = (s: LlmSpanInfo): string => {
+    if (directParentIsContainer) {
+      return s.idsPath.length >= 2 ? s.idsPath.slice(0, -1).join("\0") : directParentId(s);
+    }
+    return s.idsPath.length <= 2 ? "" : s.idsPath.slice(0, -2).join("\0");
+  };
 
   const keys = cluster.map(structuralPrefix);
   const firstKey = keys[0];

--- a/frontend/tests/test-subagent-grouping.test.ts
+++ b/frontend/tests/test-subagent-grouping.test.ts
@@ -786,6 +786,100 @@ describe("computeSubagentGroups", () => {
     assert.ok(gB.has("b_llm2") && !gB.has("a_llm1") && !gB.has("a_llm2"));
   });
 
+  it("collapses per-iteration wrappers even when a container subagent shares the cluster", () => {
+    // Mixed cluster: under one parent, three spans share the name "iter" (so all
+    // four LLMs share parentSpanPath + hash => one cluster). Two of them are
+    // per-iteration loop bodies (1 LLM each, one looping subagent) and one is a
+    // container (2 LLMs directly). The per-span trim must collapse the two
+    // iterations together while keeping the container as its own group; a
+    // cluster-global "is container?" flag would wrongly split the iterations.
+    const iterCallPath = ["root", "superloop", "iter", "call"];
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      {
+        id: "main_llm",
+        parentId: "root",
+        type: "LLM",
+        path: ["root", "main"],
+        idsPath: ["root", "main_llm"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      {
+        id: "superloop",
+        parentId: "root",
+        type: "DEFAULT",
+        path: ["root", "superloop"],
+        idsPath: ["root", "superloop"],
+      },
+      // Two per-iteration loop bodies (fresh span per iteration, 1 LLM each).
+      {
+        id: "loop_i1",
+        parentId: "superloop",
+        type: "DEFAULT",
+        path: ["root", "superloop", "iter"],
+        idsPath: ["root", "superloop", "loop_i1"],
+      },
+      {
+        id: "llm_x1",
+        parentId: "loop_i1",
+        type: "LLM",
+        path: iterCallPath,
+        idsPath: ["root", "superloop", "loop_i1", "llm_x1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "loop_i2",
+        parentId: "superloop",
+        type: "DEFAULT",
+        path: ["root", "superloop", "iter"],
+        idsPath: ["root", "superloop", "loop_i2"],
+      },
+      {
+        id: "llm_x2",
+        parentId: "loop_i2",
+        type: "LLM",
+        path: iterCallPath,
+        idsPath: ["root", "superloop", "loop_i2", "llm_x2"],
+        promptHash: "sub_hash",
+      },
+      // A container with the SAME name "iter" that directly parents 2 LLMs.
+      {
+        id: "agent_a",
+        parentId: "superloop",
+        type: "TOOL",
+        path: ["root", "superloop", "iter"],
+        idsPath: ["root", "superloop", "agent_a"],
+      },
+      {
+        id: "llm_a1",
+        parentId: "agent_a",
+        type: "LLM",
+        path: iterCallPath,
+        idsPath: ["root", "superloop", "agent_a", "llm_a1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "llm_a2",
+        parentId: "agent_a",
+        type: "LLM",
+        path: iterCallPath,
+        idsPath: ["root", "superloop", "agent_a", "llm_a2"],
+        promptHash: "sub_hash",
+      },
+    ]);
+
+    const gx1 = groupContaining(spans, "llm_x1");
+    const ga = groupContaining(spans, "llm_a1");
+    assert.ok(gx1 && ga);
+    // The two per-iteration LLMs collapse into one group...
+    assert.ok(gx1.has("llm_x2"), "per-iteration wrappers must collapse together");
+    assert.ok(!gx1.has("llm_a1") && !gx1.has("llm_a2"), "container LLMs stay out of the iteration group");
+    // ...separate from the container subagent, whose two calls group together.
+    assert.ok(ga.has("llm_a2"), "the container's own calls group together");
+    assert.ok(!ga.has("llm_x1") && !ga.has("llm_x2"), "iteration LLMs stay out of the container group");
+  });
+
   it("tie-breaks tool assignment by nearest preceding LLM when multiple subagents share a parent", () => {
     // Two subagent LLMs are siblings under one orchestrator span. A TOOL between
     // them joins whichever LLM most recently preceded it.

--- a/frontend/tests/test-subagent-grouping.test.ts
+++ b/frontend/tests/test-subagent-grouping.test.ts
@@ -680,6 +680,112 @@ describe("computeSubagentGroups", () => {
     assert.ok(groups[0].has("llm_i3"));
   });
 
+  it("splits two same-named subagents that each directly parent multiple LLMs", () => {
+    // Reproduces a real Claude Code trace: two TOOL spans both literally named
+    // "Agent" under the same parent, each DIRECTLY parenting several same-hash
+    // LLM calls (no intermediate loop-body span). Same name => same
+    // parentSpanPath + same hash => one cluster; the only distinguishing signal
+    // is the direct parent id. A naive `slice(0, -2)` drops exactly that id and
+    // merges both invocations into one subagent.
+    const agentLlmPath = ["root", "query", "Agent", "anthropic.messages"];
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      { id: "query", parentId: "root", type: "DEFAULT", path: ["root", "query"], idsPath: ["root", "query"] },
+      // Main agent (shortest path among hashed LLMs => suppressed).
+      {
+        id: "main_1",
+        parentId: "query",
+        type: "LLM",
+        path: ["root", "query", "anthropic.messages"],
+        idsPath: ["root", "query", "main_1"],
+        promptHash: "main_hash",
+        inputTokens: 100,
+      },
+      // Two top-level same-hash LLMs under `query` (subagent-1: a separate
+      // cluster because their parentSpanPath has no "Agent" segment).
+      {
+        id: "top_1",
+        parentId: "query",
+        type: "LLM",
+        path: ["root", "query", "anthropic.messages"],
+        idsPath: ["root", "query", "top_1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "top_2",
+        parentId: "query",
+        type: "LLM",
+        path: ["root", "query", "anthropic.messages"],
+        idsPath: ["root", "query", "top_2"],
+        promptHash: "sub_hash",
+      },
+      // Agent #1 — directly parents two same-hash LLMs.
+      {
+        id: "agent_a",
+        parentId: "query",
+        type: "TOOL",
+        path: ["root", "query", "Agent"],
+        idsPath: ["root", "query", "agent_a"],
+      },
+      {
+        id: "a_llm1",
+        parentId: "agent_a",
+        type: "LLM",
+        path: agentLlmPath,
+        idsPath: ["root", "query", "agent_a", "a_llm1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "a_llm2",
+        parentId: "agent_a",
+        type: "LLM",
+        path: agentLlmPath,
+        idsPath: ["root", "query", "agent_a", "a_llm2"],
+        promptHash: "sub_hash",
+      },
+      // Agent #2 — same name + hash, different invocation (different parent id).
+      {
+        id: "agent_b",
+        parentId: "query",
+        type: "TOOL",
+        path: ["root", "query", "Agent"],
+        idsPath: ["root", "query", "agent_b"],
+      },
+      {
+        id: "b_llm1",
+        parentId: "agent_b",
+        type: "LLM",
+        path: agentLlmPath,
+        idsPath: ["root", "query", "agent_b", "b_llm1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "b_llm2",
+        parentId: "agent_b",
+        type: "LLM",
+        path: agentLlmPath,
+        idsPath: ["root", "query", "agent_b", "b_llm2"],
+        promptHash: "sub_hash",
+      },
+    ]);
+
+    assert.ok(!groupContaining(spans, "main_1"), "main agent stays inline");
+
+    const gTop = groupContaining(spans, "top_1");
+    const gA = groupContaining(spans, "a_llm1");
+    const gB = groupContaining(spans, "b_llm1");
+    assert.ok(gTop && gA && gB);
+
+    // Three distinct subagents: the top-level pair, Agent #1, Agent #2.
+    assert.notStrictEqual(gA, gB, "the two Agent invocations must be separate subagents");
+    assert.notStrictEqual(gTop, gA);
+    assert.notStrictEqual(gTop, gB);
+
+    assert.ok(gTop.has("top_2") && !gTop.has("a_llm1") && !gTop.has("b_llm1"));
+    assert.ok(gA.has("a_llm2") && !gA.has("b_llm1") && !gA.has("b_llm2"));
+    assert.ok(gB.has("b_llm2") && !gB.has("a_llm1") && !gB.has("a_llm2"));
+  });
+
   it("tie-breaks tool assignment by nearest preceding LLM when multiple subagents share a parent", () => {
     // Two subagent LLMs are siblings under one orchestrator span. A TOOL between
     // them joins whichever LLM most recently preceded it.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes heuristics for transcript/condensed subagent grouping only; wrong keys could mis-group LLMs in complex traces, but scope is localized and covered by new tests.
> 
> **Overview**
> **Subagent invocation grouping** in the trace view now decides per LLM whether its direct parent is a real subagent container (two or more cluster LLMs under that parent) or a per-iteration wrapper. Container parents stay in the `ids_path` prefix so sibling same-named agents (e.g. two Claude Code **Agent** tools each parenting several LLM calls) split into separate groups; wrappers still use the shorter trim so loop iterations collapse.
> 
> Comments on `computeInvocationRoots` were updated to match. **Two regression tests** cover the dual-Agent case and a mixed cluster where iteration bodies and a container share the same path/hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac2acdb87fb2362dc555b58a04e1a2285b76e93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->