### PR TITLE
fix(landing): hero z-index so CTA buttons stay clickable

### DIFF
--- a/frontend/components/landing/hero/index.tsx
+++ b/frontend/components/landing/hero/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 // all live inside the same 880px centered column. Title block is left-aligned;
 // CTA row sits below at gap-32. Logo strip is a 4-col grid below.
 const Hero = ({ className, hasSession }: Props) => (
-  <div className={cn("flex flex-col items-center w-full", className)}>
+  <div className={cn("flex flex-col items-center w-full z-10", className)}>
     <Header hasSession={hasSession} className={cn("w-full pt-4 px-6 lg:px-0", LANDING_COLUMN_MAX_W)} isIncludePadding />
 
     <div className="flex flex-col items-center w-full px-6 lg:px-0 pt-[100px] pb-2 justify-start gap-[80px] shrink-0">


### PR DESCRIPTION
## Summary
- Hero wrapper gets `z-10` so the Sign up / Book demo CTAs (and the nav header) sit above any sibling section that creates its own stacking context underneath
- Without this, an overlapping element from the next section was intercepting clicks

## Test plan
- [ ] Visit `/` and click the "Sign up" and "Book demo" CTAs in the hero — both should navigate
- [ ] Click each nav link in the header (Docs, Blog, Pricing, Book demo, GitHub) — all should respond
- [ ] Confirm no visual regression in the hero / nav layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on the hero container; no auth, data, or API changes.
> 
> **Overview**
> Adds **`z-10`** to the landing hero’s outer wrapper so the header and hero CTAs sit above the following section in the paint/stack order.
> 
> This fixes **unclickable** Sign up, Book demo, and nav links when a sibling section (e.g. **`UnderstandWhy`**) overlapped the hero without changing layout or copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594410ba229b76e5d609140f32fe7eccdd3cbe38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->