### PR TITLE
exclude sql path from bad request flags

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1548,7 +1548,10 @@ fn main() -> anyhow::Result<()> {
                             .wrap(ErrorHandlers::new().handler(
                                 StatusCode::BAD_REQUEST,
                                 |res: dev::ServiceResponse| {
-                                    log::error!("Bad request: {:?}", res.response().body());
+                                    let path = res.request().path();
+                                    if !path.ends_with("/sql/query") {
+                                        log::error!("Bad request: {:?}", res.response().body());
+                                    }
                                     Ok(ErrorHandlerResponse::Response(res.map_into_left_body()))
                                 },
                             ))

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1549,7 +1549,9 @@ fn main() -> anyhow::Result<()> {
                                 StatusCode::BAD_REQUEST,
                                 |res: dev::ServiceResponse| {
                                     let path = res.request().path();
-                                    if !path.ends_with("/sql/query") {
+                                    if path.ends_with("/sql/query") {
+                                        log::warn!("Bad request: {:?}", res.response().body());
+                                    } else {
                                         log::error!("Bad request: {:?}", res.response().body());
                                     }
                                     Ok(ErrorHandlerResponse::Response(res.map_into_left_body()))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change to log severity in an existing error handler; no auth, API, or response logic changes.
> 
> **Overview**
> The HTTP server’s global **400 Bad Request** error handler now treats **`/sql/query`** paths differently: it logs at **warn** instead of **error** when the request path ends with `/sql/query`, while all other bad requests still use **error**.
> 
> This keeps routine SQL query validation failures (e.g. on `/v1/sql/query` and project-scoped SQL routes) from being elevated to error-level logs and alerting, without changing the HTTP response behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ddad1e63b2d592852e168a69ce7d89604677ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->