### PR TITLE
Feat/datapoint runs chart

### DIFF
--- a/frontend/app/api/projects/[projectId]/evaluations/datapoint-comparison/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/datapoint-comparison/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest } from "next/server";
+import { prettifyError, ZodError } from "zod/v4";
+
+import { getEvaluationDatapointComparison, GetEvaluationDatapointComparisonSchema } from "@/lib/actions/evaluation";
+
+export async function GET(req: NextRequest, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
+  const { projectId } = await props.params;
+  const sp = req.nextUrl.searchParams;
+
+  const evaluationIds = sp
+    .get("evaluationIds")
+    ?.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const indexRaw = sp.get("index");
+  const indexNum = indexRaw != null ? Number(indexRaw) : NaN;
+
+  const parseResult = GetEvaluationDatapointComparisonSchema.safeParse({
+    projectId,
+    evaluationIds,
+    index: indexNum,
+  });
+
+  if (!parseResult.success) {
+    return Response.json({ error: prettifyError(parseResult.error) }, { status: 400 });
+  }
+
+  try {
+    const rows = await getEvaluationDatapointComparison(parseResult.data);
+    return Response.json({ rows });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return Response.json({ error: prettifyError(error) }, { status: 400 });
+    }
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch datapoint comparison." },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/components/evaluation/datapoint-runs-chart.tsx
+++ b/frontend/components/evaluation/datapoint-runs-chart.tsx
@@ -147,7 +147,10 @@ export default function DatapointRunsChart({
       {!collapsed && (
         <div className="h-[120px] overflow-x-auto overflow-y-hidden">
           <div className="h-full" style={{ minWidth }}>
-            <ChartContainer config={CHART_CONFIG} className="aspect-auto h-full w-full">
+            <ChartContainer
+              config={CHART_CONFIG}
+              className="aspect-auto h-full w-full [&_*:focus]:outline-none [&_*:focus-visible]:outline-none"
+            >
               <LineChart margin={{ top: 12, right: 16, bottom: 4, left: 8 }} data={points} accessibilityLayer>
                 <XAxis
                   dataKey="createdAt"

--- a/frontend/components/evaluation/datapoint-runs-chart.tsx
+++ b/frontend/components/evaluation/datapoint-runs-chart.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useMemo } from "react";
+import { Line, LineChart, Tooltip, XAxis, YAxis } from "recharts";
+import useSWR from "swr";
+
+import { Button } from "@/components/ui/button";
+import { type ChartConfig, ChartContainer } from "@/components/ui/chart";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { type EvaluationDatapointComparisonRow } from "@/lib/actions/evaluation";
+import { type Evaluation as EvaluationType } from "@/lib/evaluation/types";
+import { cn, formatTimestamp, swrFetcher } from "@/lib/utils";
+
+interface DatapointRunsChartProps {
+  projectId: string;
+  index: number;
+  evaluations: EvaluationType[];
+  currentTraceId?: string;
+  scoreNames: string[];
+  selectedScore?: string;
+  onSelectScore: (score: string) => void;
+  onSelectTrace: (traceId: string) => void;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+}
+
+type RunPoint = {
+  evaluationId: string;
+  traceId: string;
+  name: string;
+  createdAt: string;
+  value: number | null;
+  isCurrent: boolean;
+};
+
+const MIN_POINT_WIDTH = 72;
+const CHART_CONFIG: ChartConfig = { value: { color: "hsl(var(--chart-1))" } };
+
+const shortTime = (iso: string) => {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "—";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(d);
+};
+
+const formatScore = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(3));
+
+export default function DatapointRunsChart({
+  projectId,
+  index,
+  evaluations,
+  currentTraceId,
+  scoreNames,
+  selectedScore,
+  onSelectScore,
+  onSelectTrace,
+  collapsed,
+  onToggleCollapse,
+}: DatapointRunsChartProps) {
+  const activeScore = selectedScore && scoreNames.includes(selectedScore) ? selectedScore : scoreNames[0];
+
+  const url = useMemo(() => {
+    const ids = evaluations.map((e) => e.id).join(",");
+    return `/api/projects/${projectId}/evaluations/datapoint-comparison?evaluationIds=${ids}&index=${index}`;
+  }, [projectId, evaluations, index]);
+
+  const { data, isLoading, error } = useSWR<{ rows: EvaluationDatapointComparisonRow[] }>(url, swrFetcher, {
+    revalidateOnFocus: false,
+  });
+
+  const points = useMemo<RunPoint[]>(() => {
+    const evalById = new Map(evaluations.map((e) => [e.id, e]));
+    // Dedup by evaluationId (RMT may surface pre-merge duplicates); keep the last seen.
+    const byEval = new Map<string, EvaluationDatapointComparisonRow>();
+    (data?.rows ?? []).forEach((r) => byEval.set(r.evaluationId, r));
+    return Array.from(byEval.values())
+      .map((r) => {
+        const ev = evalById.get(r.evaluationId);
+        const v = activeScore ? r.scores[activeScore] : undefined;
+        return {
+          evaluationId: r.evaluationId,
+          traceId: r.traceId,
+          name: ev?.name ?? "—",
+          createdAt: ev?.createdAt ?? "",
+          value: typeof v === "number" && Number.isFinite(v) ? v : null,
+          isCurrent: !!currentTraceId && r.traceId === currentTraceId,
+        };
+      })
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  }, [data, evaluations, activeScore, currentTraceId]);
+
+  if (isLoading && !collapsed) {
+    return (
+      <div className="flex-none border-b px-5 py-4">
+        <Skeleton className="h-[120px] w-full rounded-[4px]" />
+      </div>
+    );
+  }
+
+  // Best-effort enhancement: on error or when there's nothing to compare
+  // (only the current run has this datapoint), don't take up header space.
+  if (error || points.length < 2) return null;
+
+  const minWidth = Math.max(points.length * MIN_POINT_WIDTH, 240);
+
+  return (
+    <div className={cn("flex-none border-b px-5", collapsed ? "py-2" : "py-4 space-y-2")}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-secondary-foreground truncate">
+          Row #{index} across {points.length} runs
+          {!collapsed && " — click a point to open that run's trace"}
+        </span>
+        <div className="flex flex-none items-center gap-2">
+          {!collapsed && scoreNames.length > 1 && (
+            <Select value={activeScore} onValueChange={onSelectScore}>
+              <SelectTrigger className="h-6 w-[140px] text-xs bg-secondary flex-none">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {scoreNames.map((s) => (
+                  <SelectItem key={s} value={s} className="text-xs">
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {onToggleCollapse && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 text-secondary-foreground"
+              onClick={onToggleCollapse}
+              aria-label={collapsed ? "Show run comparison" : "Hide run comparison"}
+            >
+              {collapsed ? <ChevronDown className="size-4" /> : <ChevronUp className="size-4" />}
+            </Button>
+          )}
+        </div>
+      </div>
+      {!collapsed && (
+        <div className="h-[120px] overflow-x-auto overflow-y-hidden">
+          <div className="h-full" style={{ minWidth }}>
+            <ChartContainer config={CHART_CONFIG} className="aspect-auto h-full w-full">
+              <LineChart margin={{ top: 12, right: 16, bottom: 4, left: 8 }} data={points} accessibilityLayer>
+                <XAxis
+                  dataKey="createdAt"
+                  tickFormatter={shortTime}
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={6}
+                  interval={0}
+                  height={20}
+                  tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+                />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={4}
+                  width="auto"
+                  domain={[0, "auto"]}
+                  tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+                />
+                <Tooltip
+                  cursor={{ stroke: "hsl(var(--muted-foreground))", strokeDasharray: 4 }}
+                  content={<RunTooltip score={activeScore} />}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  stroke="hsl(var(--chart-1))"
+                  strokeWidth={2}
+                  connectNulls
+                  isAnimationActive={false}
+                  activeDot={false}
+                  dot={<RunDot onSelect={onSelectTrace} />}
+                />
+              </LineChart>
+            </ChartContainer>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// recharts injects cx/cy/payload when it clones this as the Line `dot`.
+function RunDot({
+  cx,
+  cy,
+  payload,
+  onSelect,
+}: {
+  cx?: number;
+  cy?: number;
+  payload?: RunPoint;
+  onSelect: (traceId: string) => void;
+}) {
+  if (cx == null || cy == null || payload?.value == null) return null;
+  const isCurrent = !!payload.isCurrent;
+  return (
+    <g style={{ cursor: "pointer" }} onClick={() => payload.traceId && onSelect(payload.traceId)}>
+      {/* enlarged transparent hit target so the small dots are easy to click */}
+      <circle cx={cx} cy={cy} r={9} fill="transparent" />
+      <circle
+        cx={cx}
+        cy={cy}
+        r={isCurrent ? 5 : 3.5}
+        fill={isCurrent ? "hsl(var(--chart-1))" : "hsl(var(--background))"}
+        stroke="hsl(var(--chart-1))"
+        strokeWidth={isCurrent ? 2 : 1.5}
+      />
+    </g>
+  );
+}
+
+function RunTooltip({
+  active,
+  payload,
+  score,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: RunPoint }>;
+  score?: string;
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+  const point = payload[0]?.payload;
+  if (!point) return null;
+  return (
+    <div className="rounded-md border bg-background p-2 text-xs shadow-md">
+      <div className="font-medium mb-1 truncate max-w-60">
+        {point.name}
+        {point.isCurrent && <span className="ml-1 text-muted-foreground">(current)</span>}
+      </div>
+      <div className="text-muted-foreground">{point.createdAt ? formatTimestamp(point.createdAt) : "—"}</div>
+      <div className="mt-1 flex items-center gap-2">
+        <span className="size-2 rounded-sm shrink-0" style={{ background: "hsl(var(--chart-1))" }} />
+        <span className="text-muted-foreground">{score ?? "score"}</span>
+        <span className="ml-auto font-mono">{point.value === null ? "—" : formatScore(point.value)}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/evaluation/datapoint-runs-chart.tsx
+++ b/frontend/components/evaluation/datapoint-runs-chart.tsx
@@ -2,11 +2,12 @@
 
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useMemo } from "react";
-import { Line, LineChart, Tooltip, XAxis, YAxis } from "recharts";
+import { CartesianGrid, Line, LineChart, ReferenceLine, Text, XAxis, YAxis } from "recharts";
 import useSWR from "swr";
 
+import { formatScoreValue } from "@/components/evaluation/utils.ts";
 import { Button } from "@/components/ui/button";
-import { type ChartConfig, ChartContainer } from "@/components/ui/chart";
+import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { type EvaluationDatapointComparisonRow } from "@/lib/actions/evaluation";
@@ -35,7 +36,6 @@ type RunPoint = {
   isCurrent: boolean;
 };
 
-const MIN_POINT_WIDTH = 72;
 const CHART_CONFIG: ChartConfig = { value: { color: "hsl(var(--chart-1))" } };
 
 const shortTime = (iso: string) => {
@@ -48,8 +48,6 @@ const shortTime = (iso: string) => {
     minute: "2-digit",
   }).format(d);
 };
-
-const formatScore = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(3));
 
 export default function DatapointRunsChart({
   projectId,
@@ -107,14 +105,14 @@ export default function DatapointRunsChart({
   // (only the current run has this datapoint), don't take up header space.
   if (error || points.length < 2) return null;
 
-  const minWidth = Math.max(points.length * MIN_POINT_WIDTH, 240);
+  const horizontalPadding = Math.max(6 - points.length, 0) * 80;
+  const currentRun = points.find((p) => p.isCurrent);
 
   return (
-    <div className={cn("flex-none border-b px-5", collapsed ? "py-2" : "py-4 space-y-2")}>
+    <div className={cn("flex flex-col border-b px-4 py-2")}>
       <div className="flex items-center justify-between gap-2">
         <span className="text-xs text-secondary-foreground truncate">
-          Row #{index} across {points.length} runs
-          {!collapsed && " — click a point to open that run's trace"}
+          Comparing row #{index} across {points.length} runs
         </span>
         <div className="flex flex-none items-center gap-2">
           {!collapsed && scoreNames.length > 1 && (
@@ -144,20 +142,25 @@ export default function DatapointRunsChart({
           )}
         </div>
       </div>
-      {!collapsed && (
-        <div className="h-[120px] overflow-x-auto overflow-y-hidden">
-          <div className="h-full" style={{ minWidth }}>
+      <div
+        className={cn(
+          "grid transition-all duration-300 ease-in-out",
+          collapsed ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100"
+        )}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="h-44 pt-2">
             <ChartContainer config={CHART_CONFIG} className="aspect-auto h-full w-full">
               <LineChart margin={{ top: 12, right: 16, bottom: 4, left: 8 }} data={points} accessibilityLayer>
                 <XAxis
                   dataKey="createdAt"
-                  tickFormatter={shortTime}
                   tickLine={false}
                   axisLine={false}
                   tickMargin={6}
                   interval={0}
-                  height={20}
-                  tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+                  height={40}
+                  padding={{ left: horizontalPadding, right: horizontalPadding }}
+                  tick={<RunXAxisTick points={points} />}
                 />
                 <YAxis
                   tickLine={false}
@@ -165,12 +168,50 @@ export default function DatapointRunsChart({
                   tickMargin={4}
                   width="auto"
                   domain={[0, "auto"]}
-                  tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+                  tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
                 />
-                <Tooltip
+                <CartesianGrid strokeDasharray="5 5 1 5" horizontal={false} syncWithTicks />
+                {currentRun && (
+                  <ReferenceLine
+                    x={currentRun.createdAt}
+                    stroke="hsl(var(--chart-1))"
+                    strokeDasharray="4 4"
+                    strokeOpacity={0.5}
+                  />
+                )}
+                <ChartTooltip
                   cursor={{ stroke: "hsl(var(--muted-foreground))", strokeDasharray: 4 }}
-                  content={<RunTooltip score={activeScore} />}
-                />
+                  content={
+                    <ChartTooltipContent
+                      labelFormatter={(_value, payload) => {
+                        const p = payload?.[0]?.payload as RunPoint | undefined;
+                        if (!p) return null;
+                        return (
+                          <div className="truncate max-w-60">
+                            <div className="font-medium">{p.name}</div>
+                            <div className="font-normal text-muted-foreground">
+                              {p.createdAt ? formatTimestamp(p.createdAt) : "—"}
+                            </div>
+                          </div>
+                        );
+                      }}
+                      formatter={(value) => (
+                        <>
+                          <div
+                            className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                            style={{ background: "hsl(var(--chart-1))" }}
+                          />
+                          <div className="flex flex-1 items-center justify-between leading-none">
+                            <span className="text-muted-foreground">{activeScore ?? "score"}</span>
+                            <span className="ml-2 font-mono font-medium tabular-nums text-foreground">
+                              {value == null ? "—" : formatScoreValue(value as number)}
+                            </span>
+                          </div>
+                        </>
+                      )}
+                    />
+                  }
+                />{" "}
                 <Line
                   type="monotone"
                   dataKey="value"
@@ -185,8 +226,59 @@ export default function DatapointRunsChart({
             </ChartContainer>
           </div>
         </div>
-      )}
+      </div>
     </div>
+  );
+}
+
+function RunXAxisTick({
+  x,
+  y,
+  payload,
+  index,
+  points,
+}: {
+  x?: number;
+  y?: number;
+  payload?: { value?: string };
+  index?: number;
+  points: RunPoint[];
+}) {
+  const name = index != null ? points[index]?.name : undefined;
+  const hasName = !!name && name !== "—";
+  const isCurrent = index != null ? !!points[index]?.isCurrent : false;
+  const nameWidth = Math.min(Math.max(900 / points.length, 56), 110);
+  return (
+    <g transform={`translate(${x ?? 0},${y ?? 0})`}>
+      {hasName && (
+        <Text
+          x={0}
+          y={0}
+          dy={4}
+          width={nameWidth}
+          className="truncate"
+          maxLines={1}
+          breakAll
+          textAnchor="middle"
+          verticalAnchor="start"
+          fill={isCurrent ? "hsl(var(--foreground))" : "hsl(var(--secondary-foreground))"}
+          style={{ fontSize: 12, fontWeight: isCurrent ? 600 : 400 }}
+        >
+          {name}
+        </Text>
+      )}
+      <Text
+        x={0}
+        y={0}
+        dy={hasName ? 20 : 4}
+        textAnchor="middle"
+        verticalAnchor="start"
+        fill={isCurrent ? "hsl(var(--foreground))" : "hsl(var(--muted-foreground))"}
+        style={{ fontSize: 11, fontWeight: isCurrent ? 500 : 400 }}
+      >
+        {payload?.value ? shortTime(payload.value) : ""}
+      </Text>
+    </g>
   );
 }
 
@@ -211,39 +303,12 @@ function RunDot({
       <circle
         cx={cx}
         cy={cy}
-        r={isCurrent ? 5 : 3.5}
+        r={isCurrent ? 4 : 3}
         fill={isCurrent ? "hsl(var(--chart-1))" : "hsl(var(--background))"}
         stroke="hsl(var(--chart-1))"
         strokeWidth={isCurrent ? 2 : 1.5}
+        strokeOpacity={isCurrent ? 1 : 0.6}
       />
     </g>
-  );
-}
-
-function RunTooltip({
-  active,
-  payload,
-  score,
-}: {
-  active?: boolean;
-  payload?: Array<{ payload?: RunPoint }>;
-  score?: string;
-}) {
-  if (!active || !payload || payload.length === 0) return null;
-  const point = payload[0]?.payload;
-  if (!point) return null;
-  return (
-    <div className="rounded-md border bg-background p-2 text-xs shadow-md">
-      <div className="font-medium mb-1 truncate max-w-60">
-        {point.name}
-        {point.isCurrent && <span className="ml-1 text-muted-foreground">(current)</span>}
-      </div>
-      <div className="text-muted-foreground">{point.createdAt ? formatTimestamp(point.createdAt) : "—"}</div>
-      <div className="mt-1 flex items-center gap-2">
-        <span className="size-2 rounded-sm shrink-0" style={{ background: "hsl(var(--chart-1))" }} />
-        <span className="text-muted-foreground">{score ?? "score"}</span>
-        <span className="ml-auto font-mono">{point.value === null ? "—" : formatScore(point.value)}</span>
-      </div>
-    </div>
   );
 }

--- a/frontend/components/evaluation/datapoint-runs-chart.tsx
+++ b/frontend/components/evaluation/datapoint-runs-chart.tsx
@@ -147,10 +147,7 @@ export default function DatapointRunsChart({
       {!collapsed && (
         <div className="h-[120px] overflow-x-auto overflow-y-hidden">
           <div className="h-full" style={{ minWidth }}>
-            <ChartContainer
-              config={CHART_CONFIG}
-              className="aspect-auto h-full w-full [&_*:focus]:outline-none [&_*:focus-visible]:outline-none"
-            >
+            <ChartContainer config={CHART_CONFIG} className="aspect-auto h-full w-full">
               <LineChart margin={{ top: 12, right: 16, bottom: 4, left: 8 }} data={points} accessibilityLayer>
                 <XAxis
                   dataKey="createdAt"

--- a/frontend/components/evaluation/evaluation.tsx
+++ b/frontend/components/evaluation/evaluation.tsx
@@ -9,6 +9,7 @@ import { shallow } from "zustand/shallow";
 
 import Chart from "@/components/evaluation/chart";
 import CompareChart from "@/components/evaluation/compare-chart";
+import DatapointRunsChart from "@/components/evaluation/datapoint-runs-chart";
 import EvaluationDatapointsTable from "@/components/evaluation/evaluation-datapoints-table";
 import EvaluationHeader from "@/components/evaluation/evaluation-header";
 import ScoreCard from "@/components/evaluation/score-card";
@@ -32,11 +33,10 @@ import { InfiniteDataTableProvider } from "@/components/ui/infinite-datatable/mo
 import { Skeleton } from "@/components/ui/skeleton";
 import { type EvalRow, type Evaluation as EvaluationType, type EvaluationResultsInfo } from "@/lib/evaluation/types";
 import { useRealtime } from "@/lib/hooks/use-realtime";
-import { formatTimestamp, swrFetcher } from "@/lib/utils";
+import { swrFetcher } from "@/lib/utils";
 
 import { TraceViewSidePanel } from "../traces/trace-view";
 import Header from "../ui/header";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 
 interface EvaluationProps {
   evaluations: EvaluationType[];
@@ -226,6 +226,9 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
 
   // Side-panel + selected-row state for trace view.
   const [selectedScore, setSelectedScore] = useState<string | undefined>(() => scoreNames[0]);
+  // Lives here (not in the chart) so it survives trace switches — the chart remounts
+  // on the side panel's key={traceId}, which would otherwise reset local state.
+  const [runsChartCollapsed, setRunsChartCollapsed] = useState(false);
   const [traceId, setTraceId] = useState<string | undefined>(() => searchParams.get("traceId") ?? undefined);
   const [datapointId, setDatapointId] = useState<string | undefined>(
     () => searchParams.get("datapointId") ?? undefined
@@ -239,6 +242,8 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
     () => allDatapoints?.find((row) => row["id"] === datapointId),
     [allDatapoints, datapointId]
   );
+
+  const selectedIndex = selectedRow != null ? Number(selectedRow["index"]) : NaN;
 
   const handleRowClick = useCallback((row: Row<EvalRow>) => {
     setTraceId(row.original["traceId"] as string);
@@ -270,12 +275,16 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
     push(`${pathName}?${next}`);
   }, [searchParams, pathName, push]);
 
-  const handleTraceChange = (id: string) => {
-    const next = new URLSearchParams(searchParams);
-    next.set("traceId", id);
-    push(`${pathName}?${next}`);
-    setTraceId(id);
-  };
+  const handleTraceChange = useCallback(
+    (id: string) => {
+      const next = new URLSearchParams(searchParams);
+      next.set("traceId", id);
+      next.delete("spanId");
+      push(`${pathName}?${next}`);
+      setTraceId(id);
+    },
+    [searchParams, pathName, push]
+  );
 
   const visibleColumnDefs = useMemo(
     () => selectVisibleColumnDefs(columnDefs, isComparison),
@@ -370,36 +379,19 @@ function EvaluationContent({ evaluations, evaluationId, evaluationName }: Evalua
       </div>
       {traceId && (
         <TraceViewSidePanel onClose={onClose} traceId={traceId}>
-          {targetId && (
-            <div className="h-12 flex flex-none items-center border-b space-x-2 px-4">
-              <Select value={traceId} onValueChange={handleTraceChange}>
-                <SelectTrigger className="flex font-medium text-secondary-foreground">
-                  <SelectValue placeholder="Select evaluation" />
-                </SelectTrigger>
-                <SelectContent>
-                  {(selectedRow?.["traceId"] as string) && (
-                    <SelectItem value={selectedRow!["traceId"] as string}>
-                      <span>
-                        {statsData?.evaluation.name}
-                        <span className="text-secondary-foreground text-xs ml-2">
-                          {formatTimestamp(String(statsData?.evaluation.createdAt))}
-                        </span>
-                      </span>
-                    </SelectItem>
-                  )}
-                  {(selectedRow?.["compared:traceId"] as string) && (
-                    <SelectItem value={selectedRow!["compared:traceId"] as string}>
-                      <span>
-                        {targetStatsData?.evaluation.name}
-                        <span className="text-secondary-foreground text-xs ml-2">
-                          {formatTimestamp(String(targetStatsData?.evaluation.createdAt))}
-                        </span>
-                      </span>
-                    </SelectItem>
-                  )}
-                </SelectContent>
-              </Select>
-            </div>
+          {selectedRow && Number.isFinite(selectedIndex) && evaluations.length > 1 && (
+            <DatapointRunsChart
+              projectId={params.projectId}
+              index={selectedIndex}
+              evaluations={evaluations}
+              currentTraceId={traceId}
+              scoreNames={scoreNames}
+              selectedScore={selectedScore}
+              onSelectScore={setSelectedScore}
+              onSelectTrace={handleTraceChange}
+              collapsed={runsChartCollapsed}
+              onToggleCollapse={() => setRunsChartCollapsed((v) => !v)}
+            />
           )}
         </TraceViewSidePanel>
       )}

--- a/frontend/components/evaluations/evaluations-groups-bar.tsx
+++ b/frontend/components/evaluations/evaluations-groups-bar.tsx
@@ -1,5 +1,6 @@
 import { type ColumnDef } from "@tanstack/react-table";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams } from "next/navigation";
+import { parseAsString, useQueryState } from "nuqs";
 import { useEffect } from "react";
 import useSWR from "swr";
 
@@ -24,21 +25,18 @@ export default function EvaluationsGroupsBar() {
 function EvaluationsGroupsBarContent() {
   const { projectId } = useParams();
 
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const [groupId, setGroupId] = useQueryState("groupId", parseAsString);
 
   const { data: groups, isLoading } = useSWR<EvaluationGroup[]>(
     `/api/projects/${projectId}/evaluation-groups`,
     swrFetcher
   );
 
-  const groupId = searchParams.get("groupId");
-
   useEffect(() => {
     if (groups && groups.length > 0 && !groupId) {
-      router.replace(`/project/${projectId}/evaluations?groupId=${groups[0].groupId}`);
+      void setGroupId(groups[0].groupId);
     }
-  }, [groups, groupId, router, projectId]);
+  }, [groups, groupId, setGroupId]);
 
   const columns: ColumnDef<EvaluationGroup>[] = [
     {

--- a/frontend/components/evaluations/evaluations.tsx
+++ b/frontend/components/evaluations/evaluations.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { type ColumnDef } from "@tanstack/react-table";
-import { useParams, useSearchParams } from "next/navigation";
+import { useParams } from "next/navigation";
+import { parseAsString, useQueryState } from "nuqs";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import AdvancedSearch from "@/components/common/advanced-search";
@@ -113,13 +114,12 @@ export default function Evaluations() {
 function EvaluationsContent() {
   const params = useParams<{ projectId: string }>();
   const { toast } = useToast();
-  const searchParams = useSearchParams();
+  const [groupId] = useQueryState("groupId", parseAsString);
   const { effective, isLoading: isViewLoading, setSearchAndFilters, setFilters } = useTableView();
   const searchValue = useMemo(
     () => ({ filters: effective.filters, search: effective.search }),
     [effective.filters, effective.search]
   );
-  const groupId = searchParams.get("groupId");
   const filter = useMemo(() => effective.filters.map((f) => JSON.stringify(f)), [effective.filters]);
   const search = effective.search.length > 0 ? effective.search : null;
 
@@ -226,7 +226,7 @@ function EvaluationsContent() {
         <EvaluationsGroupsBar />
         <div className="flex flex-col w-full gap-2 overflow-hidden">
           <div className="flex gap-4 items-center">
-            <div className="font-medium text-lg">{searchParams.get("groupId")}</div>
+            <div className="font-medium text-lg">{groupId}</div>
             <Select
               value={aggregationFunction}
               onValueChange={(value) => setAggregationFunction(value as AggregationFunction)}

--- a/frontend/components/traces/span-view/messages.tsx
+++ b/frontend/components/traces/span-view/messages.tsx
@@ -16,7 +16,7 @@ import { useSpanSearchState } from "@/components/traces/span-view/span-search-co
 import { Button } from "@/components/ui/button";
 import { convertToMessages } from "@/lib/spans/types";
 import { type AnthropicMessagesSchema, parseAnthropicInput, parseAnthropicOutput } from "@/lib/spans/types/anthropic";
-import { type GeminiContentsSchema, parseGeminiInput, parseGeminiOutput } from "@/lib/spans/types/gemini";
+import { type GeminiContentsSchema, parseGeminiContents } from "@/lib/spans/types/gemini";
 import { parseGenAIMessages } from "@/lib/spans/types/gen-ai";
 import { LangChainMessageSchema, LangChainMessagesSchema } from "@/lib/spans/types/langchain";
 import { type OpenAIMessagesSchema, parseOpenAIInput, parseOpenAIOutput } from "@/lib/spans/types/openai";
@@ -168,14 +168,9 @@ export function processMessages(data: unknown): ProcessedMessages {
     return { messages: anthropicInput, type: "anthropic" };
   }
 
-  const geminiOutput = parseGeminiOutput(data);
-  if (geminiOutput) {
-    return { messages: geminiOutput, type: "gemini" };
-  }
-
-  const geminiInput = parseGeminiInput(data);
-  if (geminiInput) {
-    return { messages: geminiInput, type: "gemini" };
+  const geminiContents = parseGeminiContents(data);
+  if (geminiContents) {
+    return { messages: geminiContents, type: "gemini" };
   }
 
   return {

--- a/frontend/components/traces/span-view/span-overview.tsx
+++ b/frontend/components/traces/span-view/span-overview.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useMemo } from "react";
+import useSWR from "swr";
 
 import { type MessageLabel } from "@/components/traces/span-view/messages";
 import ContentRenderer from "@/components/ui/content-renderer/index";
@@ -6,7 +7,9 @@ import { spanViewTheme } from "@/components/ui/content-renderer/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PAYLOAD_URL_REGEX } from "@/lib/actions/trace/utils";
 import { useToast } from "@/lib/hooks/use-toast";
+import { parseOpenAIOutput } from "@/lib/spans/types/openai";
 import { type Span } from "@/lib/traces/types";
+import { swrFetcher } from "@/lib/utils.ts";
 
 const normalize = (data: unknown): unknown => {
   if (typeof data === "string") {
@@ -27,41 +30,26 @@ const extractPayloadUrl = (data: unknown): string | null => {
   return null;
 };
 
-const fetchPayload = async (raw: unknown): Promise<unknown> => {
-  const url = extractPayloadUrl(raw);
-  if (!url) return raw;
-  const fullUrl = url.startsWith("/") ? `${url}?payloadType=raw` : url;
-  const response = await fetch(fullUrl);
-  return response.json();
-};
-
 const PureSpanOverview = ({ span }: { span: Span }) => {
   const { toast } = useToast();
 
-  const [inputData, setInputData] = useState<unknown>(span.input);
-  const [outputData, setOutputData] = useState<unknown>(span.output);
-  const [isLoading, setIsLoading] = useState(false);
+  const inputUrl = extractPayloadUrl(span.input);
+  const outputUrl = extractPayloadUrl(span.output);
+  const toFull = (u: string | null) => (u ? (u.startsWith("/") ? `${u}?payloadType=raw` : u) : null);
+  const onError = () => toast({ title: "Error", description: "Failed to load span data.", variant: "destructive" });
 
-  const loadData = useCallback(async () => {
-    const hasInputUrl = extractPayloadUrl(span.input);
-    const hasOutputUrl = extractPayloadUrl(span.output);
-    if (!hasInputUrl && !hasOutputUrl) return;
+  const { data: fetchedInput, isLoading: loadingInput } = useSWR(toFull(inputUrl), swrFetcher, {
+    revalidateOnFocus: false,
+    onError,
+  });
+  const { data: fetchedOutput, isLoading: loadingOutput } = useSWR(toFull(outputUrl), swrFetcher, {
+    revalidateOnFocus: false,
+    onError,
+  });
 
-    try {
-      setIsLoading(true);
-      const [input, output] = await Promise.all([fetchPayload(span.input), fetchPayload(span.output)]);
-      if (hasInputUrl) setInputData(input);
-      if (hasOutputUrl) setOutputData(output);
-    } catch {
-      toast({ title: "Error", description: "Failed to load span data.", variant: "destructive" });
-    } finally {
-      setIsLoading(false);
-    }
-  }, [span.input, span.output, toast]);
-
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
+  const inputData = inputUrl ? fetchedInput : span.input;
+  const outputData = outputUrl ? fetchedOutput : span.output;
+  const isLoading = (!!inputUrl && loadingInput) || (!!outputUrl && loadingOutput);
 
   // Overview = last 2 input messages stitched with the output, rendered through
   // the same ContentRenderer the I/O tabs use so users get the mode toggle
@@ -70,7 +58,8 @@ const PureSpanOverview = ({ span }: { span: Span }) => {
     const input = normalize(inputData);
     const output = normalize(outputData);
     const inputArray = Array.isArray(input) ? input.slice(-2) : [];
-    const outputTail = output == null ? [] : Array.isArray(output) ? output : [output];
+    const openAIOutput = parseOpenAIOutput(output);
+    const outputTail = openAIOutput ?? (output == null ? [] : Array.isArray(output) ? output : [output]);
     const labels: MessageLabel[] = [];
     if (inputArray.length > 0) {
       labels.push({

--- a/frontend/components/traces/trace-view/dynamic-width-layout.tsx
+++ b/frontend/components/traces/trace-view/dynamic-width-layout.tsx
@@ -57,11 +57,12 @@ export default function DynamicWidthLayout({ panels, sidePanelRef }: DynamicWidt
     [resizePanel, visible]
   );
 
-  const traceResize = usePanelResize("trace", dragPanel);
+  // Trace's left-edge handle lives at the side-panel level (TraceViewSidePanel) so it
+  // spans the full height including the header/chart area above this layout.
   const spanResize = usePanelResize("span", dragPanel);
   const chatResize = usePanelResize("chat", dragPanel);
 
-  const isResizing = traceResize.isResizing || spanResize.isResizing || chatResize.isResizing;
+  const isResizing = spanResize.isResizing || chatResize.isResizing;
   const transition = !isResizing && layoutChangeSource === "visibility" ? enterExitTransition : instantTransition;
 
   return (
@@ -75,7 +76,6 @@ export default function DynamicWidthLayout({ panels, sidePanelRef }: DynamicWidt
           animate={{ width: widths.trace }}
           transition={transition}
         >
-          <LeftEdgeResizeHandle onMouseDown={traceResize.handleMouseDown} />
           {panels.tracePanel}
         </motion.div>
 

--- a/frontend/components/traces/trace-view/index.tsx
+++ b/frontend/components/traces/trace-view/index.tsx
@@ -1,9 +1,15 @@
-import React, { useRef } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
+import { shallow } from "zustand/shallow";
 
-import TraceViewStoreProvider, { type TraceViewTrace } from "@/components/traces/trace-view/store";
+import TraceViewStoreProvider, {
+  type ResizablePanel,
+  type TraceViewTrace,
+  useTraceViewStore,
+} from "@/components/traces/trace-view/store";
 import { cn } from "@/lib/utils";
 
 import TraceViewContent from "./trace-view-content";
+import { usePanelResize } from "./use-panel-resize";
 
 interface TraceViewProps {
   traceId: string;
@@ -54,11 +60,51 @@ export function TraceViewSidePanel({
         initialChatOpen={props.showChatInitial}
         initialSearch={props.initialSearch}
       >
-        <div className="w-full h-full flex flex-col">
+        <div className="relative w-full h-full flex flex-col">
+          <SidePanelLeftResizeHandle />
           {children}
           <TraceViewContent {...props} sidePanelRef={sidePanelRef} />
         </div>
       </TraceViewStoreProvider>
+    </div>
+  );
+}
+
+/**
+ * Full-height resize handle pinned to the side panel's left edge. Lives here (not in
+ * DynamicWidthLayout) so the entire left edge is grabbable — including the header area
+ * above the trace panel where children (e.g. the eval runs chart) render. Drives the
+ * trace panel resize; `visible` mirrors trace-view-content's panel-visibility derivation
+ * so the resize math matches what's rendered.
+ */
+function SidePanelLeftResizeHandle() {
+  const { resizePanel, spanPanelOpen, tracesAgentOpen, isAlwaysSelectSpan, isTraceLoading, hasTrace, spansLength } =
+    useTraceViewStore(
+      (s) => ({
+        resizePanel: s.resizePanel,
+        spanPanelOpen: s.spanPanelOpen,
+        tracesAgentOpen: s.tracesAgentOpen,
+        isAlwaysSelectSpan: s.isAlwaysSelectSpan,
+        isTraceLoading: s.isTraceLoading,
+        hasTrace: !!s.trace,
+        spansLength: s.spans.length,
+      }),
+      shallow
+    );
+
+  const isLoading = isTraceLoading && !hasTrace;
+  const showSpan = spanPanelOpen || (isAlwaysSelectSpan && !isLoading && spansLength > 0);
+  const visible = useMemo(() => ({ span: showSpan, chat: tracesAgentOpen }), [showSpan, tracesAgentOpen]);
+
+  const drag = useCallback(
+    (panel: ResizablePanel, delta: number) => resizePanel(panel, delta, visible),
+    [resizePanel, visible]
+  );
+  const { handleMouseDown } = usePanelResize("trace", drag);
+
+  return (
+    <div className="group absolute inset-y-0 left-0 z-[60] w-2 cursor-col-resize" onMouseDown={handleMouseDown}>
+      <div className="absolute inset-y-0 left-0 w-px bg-border transition-colors group-hover:w-0.5 group-hover:bg-blue-400" />
     </div>
   );
 }

--- a/frontend/components/ui/chart.tsx
+++ b/frontend/components/ui/chart.tsx
@@ -60,7 +60,7 @@ function ChartContainer({
         data-slot="chart"
         data-chart={chartId}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden [&_*:focus]:outline-none [&_*:focus-visible]:outline-none [&_.recharts-wrapper]:outline-none",
           className
         )}
         {...props}

--- a/frontend/lib/actions/evaluation/index.ts
+++ b/frontend/lib/actions/evaluation/index.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { compact } from "lodash";
 import { z } from "zod/v4";
 
@@ -304,6 +304,86 @@ export const getEvaluationCellValue = async (input: z.infer<typeof GetEvaluation
   }
 
   return results[0][col.id] ?? null;
+};
+
+/**
+ * Fetch the scores JSON for a single datapoint index across a set of evaluations.
+ * Used by the datapoint-comparison overview: pivot a single datapoint position
+ * across every run in its group.
+ *
+ * Returns one row per (evaluationId, index) found — evaluations that don't
+ * contain this index are simply omitted.
+ */
+export const GetEvaluationDatapointComparisonSchema = z.object({
+  projectId: z.guid(),
+  evaluationIds: z.array(z.guid()).min(1),
+  index: z.number().int().nonnegative(),
+});
+
+export type EvaluationDatapointComparisonRow = {
+  evaluationId: string;
+  index: number;
+  scores: Record<string, number>;
+  traceId: string;
+};
+
+export const getEvaluationDatapointComparison = async (
+  input: z.infer<typeof GetEvaluationDatapointComparisonSchema>
+): Promise<EvaluationDatapointComparisonRow[]> => {
+  const { projectId, evaluationIds, index } = input;
+
+  // Authz: only consider evaluations that actually belong to this project.
+  // Filter at the DB instead of loading every project eval into memory.
+  const owned = await db.query.evaluations.findMany({
+    where: and(eq(evaluations.projectId, projectId), inArray(evaluations.id, evaluationIds)),
+    columns: { id: true },
+  });
+  const filteredIds = owned.map((e) => e.id);
+  if (filteredIds.length === 0) return [];
+
+  // Aliases must NOT shadow a column used in WHERE: ClickHouse resolves the WHERE
+  // reference to the SELECT alias, so `toString(evaluation_id) AS evaluation_id`
+  // would turn `WHERE evaluation_id IN (...)` into a String-vs-UUID compare that
+  // matches nothing. Use distinct alias names (`eval_id` / `tid`) instead.
+  // `index` is inlined (Zod-validated non-negative int) rather than a bound param.
+  // `scores` may come back as a string or an object depending on the driver.
+  const rows = await executeQuery<{
+    eval_id: string;
+    idx: number | string;
+    scores: string | Record<string, unknown>;
+    tid: string;
+  }>({
+    query: `
+      SELECT toString(evaluation_id) AS eval_id, \`index\` AS idx, scores, toString(trace_id) AS tid
+      FROM evaluation_datapoints
+      WHERE evaluation_id IN ({evaluationIds:Array(UUID)})
+        AND \`index\` = ${index}
+    `,
+    parameters: { evaluationIds: filteredIds },
+    projectId,
+  });
+
+  return rows.map((r) => {
+    let scoresObj: Record<string, unknown> | null = null;
+    if (typeof r.scores === "string") {
+      try {
+        scoresObj = r.scores ? (JSON.parse(r.scores) as Record<string, unknown>) : null;
+      } catch {
+        scoresObj = null;
+      }
+    } else if (r.scores && typeof r.scores === "object") {
+      scoresObj = r.scores;
+    }
+
+    const scores: Record<string, number> = scoresObj
+      ? Object.fromEntries(
+          Object.entries(scoresObj).filter(
+            (entry): entry is [string, number] => typeof entry[1] === "number" && Number.isFinite(entry[1])
+          )
+        )
+      : {};
+    return { evaluationId: r.eval_id, index: Number(r.idx), scores, traceId: r.tid };
+  });
 };
 
 export const renameEvaluation = async (input: z.infer<typeof RenameEvaluationSchema>) => {

--- a/frontend/lib/actions/evaluation/index.ts
+++ b/frontend/lib/actions/evaluation/index.ts
@@ -306,14 +306,6 @@ export const getEvaluationCellValue = async (input: z.infer<typeof GetEvaluation
   return results[0][col.id] ?? null;
 };
 
-/**
- * Fetch the scores JSON for a single datapoint index across a set of evaluations.
- * Used by the datapoint-comparison overview: pivot a single datapoint position
- * across every run in its group.
- *
- * Returns one row per (evaluationId, index) found — evaluations that don't
- * contain this index are simply omitted.
- */
 export const GetEvaluationDatapointComparisonSchema = z.object({
   projectId: z.guid(),
   evaluationIds: z.array(z.guid()).min(1),
@@ -348,13 +340,13 @@ export const getEvaluationDatapointComparison = async (
   // `index` is inlined (Zod-validated non-negative int) rather than a bound param.
   // `scores` may come back as a string or an object depending on the driver.
   const rows = await executeQuery<{
-    eval_id: string;
+    evaluationId: string;
     idx: number | string;
     scores: string | Record<string, unknown>;
-    tid: string;
+    traceId: string;
   }>({
     query: `
-      SELECT toString(evaluation_id) AS eval_id, \`index\` AS idx, scores, toString(trace_id) AS tid
+      SELECT evaluation_id AS evaluationId, \`index\` AS idx, scores, trace_id AS traceId
       FROM evaluation_datapoints
       WHERE evaluation_id IN ({evaluationIds:Array(UUID)})
         AND \`index\` = ${index}
@@ -382,7 +374,7 @@ export const getEvaluationDatapointComparison = async (
           )
         )
       : {};
-    return { evaluationId: r.eval_id, index: Number(r.idx), scores, traceId: r.tid };
+    return { evaluationId: r.evaluationId, index: Number(r.idx), scores, traceId: r.traceId };
   });
 };
 

--- a/frontend/lib/spans/types/gemini.ts
+++ b/frontend/lib/spans/types/gemini.ts
@@ -170,6 +170,19 @@ export const parseGeminiOutput = (data: unknown): z.infer<typeof GeminiContentsS
   return candidates.map((c) => c.content);
 };
 
+// Content (input) and Candidate (output) are different Gemini shapes. The span
+// overview stitches input + output into one array, so accept a mix and unwrap
+// any candidates to their inner content.
+const GeminiContentOrCandidateSchema = z.union([GeminiContentSchema, GeminiCandidateSchema]);
+
+/** Parse `data` as a possibly-mixed array of Gemini Contents/Candidates. Returns null on mismatch. */
+export const parseGeminiContents = (data: unknown): z.infer<typeof GeminiContentsSchema> | null => {
+  const arr = Array.isArray(data) ? data : [data];
+  const result = z.array(GeminiContentOrCandidateSchema).safeParse(arr);
+  if (!result.success || result.data.length === 0) return null;
+  return result.data.map((el) => ("content" in el ? el.content : el));
+};
+
 /** Conversion Functions **/
 
 export const convertGeminiToPlaygroundMessages = async (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new ClickHouse read path with inlined `index` (Zod-validated) and cross-evaluation IDs filtered by project ownership; UI changes trace navigation in the eval side panel but does not alter core auth or write paths.
> 
> **Overview**
> Adds **cross-run comparison for a single evaluation row**: a new `GET` API and `getEvaluationDatapointComparison` load scores and trace IDs for the same datapoint `index` across multiple evaluations (project-scoped via Postgres, then ClickHouse). The evaluation trace side panel shows a new **`DatapointRunsChart`** (line chart over runs, score selector, collapsible header) instead of the old two-option trace dropdown; clicking a point switches the active trace and clears `spanId`.
> 
> Smaller follow-ons: evaluations list **`groupId`** uses **nuqs** instead of manual `searchParams`; span **overview** fetches large payloads via **SWR** and normalizes **OpenAI** / mixed **Gemini** content for the stitched messages view; the trace side panel’s **left resize handle** spans the full panel height (including chart/header children); chart wrapper gets focus-outline tweaks for Recharts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c3833d27fc0b877aa9609b1891877bc82905b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->