### PR TITLE
refactor(landing): Align mobile understand-why copy with desktop

### DIFF
--- a/frontend/components/landing/header/index.tsx
+++ b/frontend/components/landing/header/index.tsx
@@ -55,7 +55,7 @@ export default function LandingHeader({ hasSession, className, isIncludePadding 
               dimensions — no visual change. Setting one dimension and leaving
               the other auto silences the Next.js "modified, but not the other"
               warning that fill-mode + sized wrapper was triggering. */}
-          <Image alt="Laminar logo" src={logo} className="w-[80px] md:w-[100px] h-auto -translate-y-0.5" priority />
+          <Image alt="Laminar logo" src={logo} className="w-[100px] h-auto md:-translate-y-0.5" priority />
         </Link>
         <div className={cn("flex md:gap-[40px] items-center justify-center", "gap-4")}>
           <nav className="hidden md:flex md:gap-[32px] items-center font-sans-landing md:text-sm leading-normal whitespace-nowrap text-xs">
@@ -87,12 +87,12 @@ export default function LandingHeader({ hasSession, className, isIncludePadding 
             ) : (
               <>
                 <Link href="/sign-in">
-                  <LandingButton variant="minimal" size="xs" className="py-1.5">
+                  <LandingButton variant="minimal" size="xs" className="py-2 sm:py-1.5">
                     Sign in
                   </LandingButton>
                 </Link>
                 <Link href="/sign-up">
-                  <LandingButton variant="outline" size="xs" className="py-1 px-3">
+                  <LandingButton variant="outline" size="xs" className="py-2 sm:py-1 px-4 sm:px-3">
                     Sign up
                   </LandingButton>
                 </Link>

--- a/frontend/components/landing/sections/understand-why-trace-view/mobile.tsx
+++ b/frontend/components/landing/sections/understand-why-trace-view/mobile.tsx
@@ -12,9 +12,6 @@ import SlackNotificationCard from "../slack-notification-card";
 // Mock card widths intentionally overflow the typical phone viewport — the
 // page root has `overflow-x-clip` so the visuals read at full scale without
 // causing horizontal scroll.
-const MOBILE_HREF_SIGNALS = "https://laminar.sh/docs/signals";
-const MOBILE_HREF_TRACE = "https://laminar.sh/docs/tracing";
-
 const UnderstandWhyTraceViewMobile = () => {
   // Parallax for the transcript image — scroll-driven Y shift so the card
   // breathes as it passes through the viewport.
@@ -27,19 +24,20 @@ const UnderstandWhyTraceViewMobile = () => {
 
   return (
     <section className="w-full flex flex-col gap-16 px-6 py-16">
-      {/* 01. Notifications */}
+      {/* 01. Signals */}
       <div className="flex flex-col gap-6 items-start w-full">
         <div className="flex flex-col gap-3 items-start">
           <span className={microLabel}>01.</span>
           <h2 className={subSection}>{"Get alerts when\nyour agent breaks."}</h2>
           <p className={bodyMedium}>
-            Describe what you want to track in plain English. Laminar analyzes traces of your agent and pings you in
-            Slack the moment a trace matches.
+            {
+              'Signals let you describe the error in plain English – "agent is stuck in a loop". Laminar reads every agent run and pings you in Slack when it happens.'
+            }
           </p>
         </div>
         <div className="bg-landing-surface-550 relative w-full overflow-hidden h-[280px] px-5 py-4 flex flex-col justify-center">
           <SlackNotificationCard className="w-[600px] max-w-[600px] shrink-0" />
-          <SectionFootnote name="Notifications" href={MOBILE_HREF_SIGNALS} />
+          <SectionFootnote name="Signals" href="https://laminar.sh/docs/signals/introduction" />
         </div>
       </div>
 
@@ -52,17 +50,17 @@ const UnderstandWhyTraceViewMobile = () => {
         </div>
         <div className="bg-landing-surface-550 relative w-full overflow-hidden h-[280px] px-5 py-4 flex flex-col justify-center">
           <SignalEventCard className="w-[600px] max-w-[600px] shrink-0" />
-          <SectionFootnote name="Trace view" href={MOBILE_HREF_TRACE} />
+          <SectionFootnote name="Signals" href="https://laminar.sh/docs/signals/introduction" />
         </div>
       </div>
 
       {/* Transcript — clear, concise view of your agent run */}
       <div className="flex flex-col gap-6 items-start w-full">
         <div className="flex flex-col gap-3 items-start">
-          <h3 className={subSubSection}>Clear, concise view of your agent run</h3>
+          <h3 className={subSubSection}>A clear, concise view of your agent run</h3>
           <p className={bodyMedium}>
-            Laminar makes the agent run navigable by surfacing input, LLM reasoning, tool calls, and sub-agents as a
-            readable transcript.
+            Laminar makes the agent run easily navigable by surfacing input, LLM reasoning, tool calls, and sub-agents
+            in a readable transcript and timeline.
           </p>
         </div>
         <div className="bg-landing-surface-550 relative w-full overflow-hidden h-[360px]">
@@ -83,7 +81,7 @@ const UnderstandWhyTraceViewMobile = () => {
             <div className="absolute top-0 left-0 right-0 h-[40px] bg-gradient-to-b from-landing-surface-550/80 to-transparent pointer-events-none z-10" />
           </div>
           <div className="absolute bottom-0 left-0 right-0 h-[160px] bg-gradient-to-t from-landing-surface-550 to-transparent pointer-events-none z-10" />
-          <SectionFootnote name="Transcript" href={MOBILE_HREF_TRACE} />
+          <SectionFootnote name="Transcript view" href="https://laminar.sh/docs/platform/viewing-traces" />
         </div>
       </div>
 
@@ -94,9 +92,10 @@ const UnderstandWhyTraceViewMobile = () => {
           card bottom-right-anchored as it shrinks. */}
       <div className="flex flex-col gap-6 items-start w-full">
         <div className="flex flex-col gap-3 items-start">
-          <h3 className={subSubSection}>Long complex run? Chat with AI</h3>
+          <h3 className={subSubSection}>Ask any question about your agent run</h3>
           <p className={bodyMedium}>
-            Ask any question, dive deep into any agent run. Click span references to jump straight into context.
+            Dive deep into any issue within the agent run by simply asking. Get answers that reference specific context
+            that you can jump to directly.
           </p>
         </div>
         <div className="bg-landing-surface-550 relative w-full overflow-hidden h-[360px] flex items-end justify-end px-8 pt-4 pb-12">
@@ -113,7 +112,7 @@ const UnderstandWhyTraceViewMobile = () => {
             />
           </div>
           <div className="absolute top-0 left-0 right-0 h-[40px] bg-gradient-to-b from-landing-surface-550/80 to-transparent pointer-events-none z-10" />
-          <SectionFootnote name="Ask AI" href={MOBILE_HREF_TRACE} />
+          <SectionFootnote name="Ask AI" href="https://laminar.sh/docs/platform/viewing-traces#chat-with-trace" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Mobile `UnderstandWhy` section rendered different copy than the desktop scrolly-tell — body text, sub-card subtitles, footnote labels, and docs hrefs all drifted. This PR brings mobile in line with the desktop `BANDS` config in `understand-why-trace-view/index.tsx`, with two intentional deviations:
  - **No inline interactive links** in the transcript sub-card body (desktop has `<TimelineBodyLink>` buttons that drive `selectAndRevealSpan` inside the bento — mobile has no bento, so they'd point at nothing). Plain wording verbatim.
  - **Section 2 footnote stays "Signals"** (not "Transcript view" as on desktop) because mobile's section 2 mock is the `SignalEventCard`, not a transcript. Desktop labels phase 2 as "Transcript view" because it morphs into one — mobile has no morph.
- Also strips three single-use `MOBILE_HREF_*` constants and inlines the URLs at each `SectionFootnote`.
- Separate cleanup commit: tightens header logo width + auth-button padding on small viewports (lifted from a stale working-copy diff; not part of the copy work).

## Test plan
- [ ] Build the frontend with `pnpm run build && pnpm start`, hit `/` at mobile width (<768px), and visually confirm all four blocks (Signals slack mock, Signals signal-event mock, Transcript sub-card, Ask AI sub-card) render the desktop wording with the correct footnote labels and docs links.
- [ ] Click each `SectionFootnote` "Learn more" arrow and verify it lands on the right docs page (`/signals/introduction`, `/signals/introduction`, `/platform/viewing-traces`, `/platform/viewing-traces#chat-with-trace`).
- [ ] At desktop width, verify the scrolly-tell still renders the original (unchanged) `BANDS` copy across the four phases.
- [ ] Eyeball the landing header at mobile width: logo not clipped, sign-in/sign-up buttons keep their tap-target height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy and Tailwind-only header tweaks; no auth, API, or data-path changes.
> 
> **Overview**
> **Mobile “Understand why”** copy, footnote labels, and docs links now match the desktop `BANDS` config in `understand-why-trace-view/index.tsx` (Signals wording, transcript/Ask AI sub-headlines and bodies, and inlined docs URLs instead of `MOBILE_HREF_*` constants). Section 2’s footnote stays **Signals** (mobile still shows `SignalEventCard`, not a morphing transcript).
> 
> **Landing header** tweaks small-viewport layout: logo uses a fixed `w-[100px]` with `md:-translate-y-0.5`, and sign-in/sign-up buttons get slightly larger tap targets (`py-2` / wider padding below `sm`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce225753484090e707bac4613fa8ffb189bafdd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->