### PR TITLE
fix: bump framer motion version

### DIFF
--- a/frontend/components/signal/clusters-section/cluster-breadcrumb.tsx
+++ b/frontend/components/signal/clusters-section/cluster-breadcrumb.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, type Transition } from "framer-motion";
 
 import ClusterIcon, { type IconVariant } from "@/components/signal/clusters-section/cluster-list/cluster-icon";
 import { UNCLUSTERED_ID } from "@/lib/actions/clusters";
@@ -21,21 +21,29 @@ interface ClusterBreadcrumbProps {
 
 const slideIn = {
   initial: { opacity: 0.3, x: -45 },
-  animate: { opacity: 1, x: 0, transition: { type: "spring", stiffness: 300, damping: 30, mass: 0.3 } },
+  animate: {
+    opacity: 1,
+    x: 0,
+    transition: { type: "spring", stiffness: 300, damping: 30, mass: 0.3 } as Transition,
+  },
   exit: {
     opacity: 0.3,
     x: -20,
-    transition: { duration: 0.1, ease: "easeOut" },
+    transition: { duration: 0.1, ease: "easeOut" } as Transition,
   },
 };
 
 const slashSlideIn = {
   initial: { opacity: 0.3, x: -12 },
-  animate: { opacity: 1, x: 0, transition: { type: "spring", stiffness: 300, damping: 30, mass: 0.8 } },
+  animate: {
+    opacity: 1,
+    x: 0,
+    transition: { type: "spring", stiffness: 300, damping: 30, mass: 0.8 } as Transition,
+  },
   exit: {
     opacity: 0.3,
     x: -8,
-    transition: { duration: 0.1, ease: "easeOut" },
+    transition: { duration: 0.1, ease: "easeOut" } as Transition,
   },
 };
 
@@ -43,7 +51,7 @@ const levelTransition = {
   initial: { opacity: 0, width: 0 },
   animate: { opacity: 1, width: "auto" },
   exit: { opacity: 0, width: 0 },
-  transition: { type: "spring", stiffness: 300, damping: 30, mass: 0.3 },
+  transition: { type: "spring", stiffness: 300, damping: 30, mass: 0.3 } as Transition,
 };
 
 // Slash width (~6px at text-sm) + gap to match parent's gap-2 (8px) on each side

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,7 +101,7 @@
     "date-fns": "^3.6.0",
     "dotenv": "^16.6.1",
     "drizzle-orm": "^0.45.2",
-    "framer-motion": "^11.18.2",
+    "framer-motion": "^12.40.0",
     "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "ioredis": "^5.9.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -222,8 +222,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.7)
       framer-motion:
-        specifier: ^11.18.2
-        version: 11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -4758,8 +4758,8 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
 
-  framer-motion@11.18.2:
-    resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -5486,11 +5486,11 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
-  motion-dom@11.18.1:
-    resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
 
-  motion-utils@11.18.1:
-    resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -11077,10 +11077,10 @@ snapshots:
 
   format@0.2.2: {}
 
-  framer-motion@11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  framer-motion@12.40.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      motion-dom: 11.18.1
-      motion-utils: 11.18.1
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.3
@@ -12096,11 +12096,11 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
-  motion-dom@11.18.1:
+  motion-dom@12.40.0:
     dependencies:
-      motion-utils: 11.18.1
+      motion-utils: 12.39.0
 
-  motion-utils@11.18.1: {}
+  motion-utils@12.39.0: {}
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency bump with localized typing fixes; no auth, data, or business-logic changes.
> 
> **Overview**
> Upgrades **framer-motion** from v11 to **v12.40.0** in the frontend (`package.json` and lockfile).
> 
> The only application code change is in `cluster-breadcrumb.tsx`: it imports Framer’s `Transition` type and asserts spring/ease transition objects with `as Transition` so they still type-check under the stricter v12 typings. Animation behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 881465ab03b017c925734821eebd4aec4c1d8b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->