### PR TITLE
fix: add recharts to optimize imports

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     turbopackFileSystemCacheForDev: true,
+    // Rewrites barrel imports from "recharts" into direct submodule imports at build
+    // time. Reshapes the chunk graph to avoid the Turbopack production interop split that
+    // left recharts' internal usePrefersReducedMotion unlinked ("(0, v.usePrefersReducedMotion) is not a function").
+    optimizePackageImports: ["recharts"],
   },
   reactStrictMode: false,
   logging: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single experimental Next.js build option with no auth, data, or API changes; main risk is build/bundle behavior for chart pages.
> 
> **Overview**
> Adds **`recharts`** to Next.js **`experimental.optimizePackageImports`** in `next.config.ts` so barrel imports are rewritten to direct submodule paths at build time.
> 
> This targets a **Turbopack production** chunk/interop issue that broke Recharts internals (e.g. `usePrefersReducedMotion` not a function) while leaving chart source imports unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c0e4c76109c3f2ac6f83a5e5d971ccbc5136714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->