### PR TITLE
docs: remove obsolete qdrant reference from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ cp frontend/.env.local.example frontend/.env.local
 docker compose -f docker-compose-local-dev-full.yml up
 ```
 
-This will spin up postgres, qdrant, clickhouse, and RabbitMQ.
+This will spin up postgres, clickhouse, and RabbitMQ.
 
 ### 2. Run app server in development mode
 


### PR DESCRIPTION
Qdrant was removed from the stack (replaced by Quickwit for full-text search). The `docker-compose-local-dev-full.yml` no longer includes a qdrant service, but line 102 of CONTRIBUTING.md still tells contributors that running the compose file will spin up qdrant. This confuses new contributors who look for qdrant config that doesn't exist.

**Change:** Remove `qdrant` from the service list in the description of `docker-compose-local-dev-full.yml`.

Before:
> This will spin up postgres, qdrant, clickhouse, and RabbitMQ.

After:
> This will spin up postgres, clickhouse, and RabbitMQ.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration impact.
> 
> **Overview**
> Updates the **Advanced** local-dev setup instructions so they match what `docker-compose-local-dev-full.yml` actually starts.
> 
> The sentence describing dependency containers no longer lists **qdrant**; it now names **postgres**, **clickhouse**, and **RabbitMQ** only, aligning contributor docs with the current stack (Qdrant removed in favor of Quickwit for full-text search).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c73c2198e5849918a5defe36abc6003cb5dd94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->