### PR TITLE
fix(spans): skip thinking blocks in heuristic preview extraction

### DIFF
--- a/frontend/lib/actions/spans/previews/heuristic.ts
+++ b/frontend/lib/actions/spans/previews/heuristic.ts
@@ -49,8 +49,13 @@ const findByKey = (value: unknown, target: string): string | null => {
   const obj = value as Record<string, unknown>;
   const direct = obj[target];
   if (isLeaf(direct)) {
-    const formatted = formatLeaf(direct);
-    if (formatted !== null) return formatted;
+    // Skip content from thinking/reasoning blocks; prefer the text part instead.
+    if (target === "content" && obj["type"] === "thinking") {
+      // fall through to search children
+    } else {
+      const formatted = formatLeaf(direct);
+      if (formatted !== null) return formatted;
+    }
   }
   for (const k of Object.keys(obj)) {
     if (METADATA_KEYS.has(k)) continue;

--- a/frontend/lib/actions/spans/previews/heuristic.ts
+++ b/frontend/lib/actions/spans/previews/heuristic.ts
@@ -48,14 +48,11 @@ const findByKey = (value: unknown, target: string): string | null => {
 
   const obj = value as Record<string, unknown>;
   const direct = obj[target];
-  if (isLeaf(direct)) {
-    // Skip content from thinking/reasoning blocks; prefer the text part instead.
-    if (target === "content" && obj["type"] === "thinking") {
-      // fall through to search children
-    } else {
-      const formatted = formatLeaf(direct);
-      if (formatted !== null) return formatted;
-    }
+  // Skip content from thinking/reasoning blocks; prefer the text part instead.
+  const isThinkingBlock = target === "content" && (obj["type"] === "thinking" || obj["type"] === "reasoning");
+  if (isLeaf(direct) && !isThinkingBlock) {
+    const formatted = formatLeaf(direct);
+    if (formatted !== null) return formatted;
   }
   for (const k of Object.keys(obj)) {
     if (METADATA_KEYS.has(k)) continue;


### PR DESCRIPTION
When using reasoning models (e.g. DeepSeek V4 Flash via pydantic_ai), the GenAI output has both a `thinking` part and a `text` part:

```json
[{"role":"assistant","parts":[{"type":"thinking","content":"reasoning..."},{"type":"text","content":"actual reply"}]}]
```

The span detail view correctly renders both. However, the fallback heuristic in `heuristic.ts` searches for `"content"` keys in declaration order, so it returns the thinking block's content instead of the assistant's actual response in the session card and trace list preview.

**Fix:** In `findByKey`, when the target key is `"content"` and the current object has `type === "thinking"`, skip that match and continue searching. The next part (`{"type":"text","content":"actual reply"}`) does not have `type === "thinking"`, so its `content` is returned correctly.

Closes #1749

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in preview extraction UI logic; no auth, persistence, or API changes.
> 
> **Overview**
> **Heuristic span previews** no longer treat `content` on `type: "thinking"` or `type: "reasoning"` parts as the preview string. `findByKey` still walks the same priority keys, but when the target is `content` and the object is a thinking/reasoning block, it skips that leaf and keeps searching so session cards and trace list previews show the assistant **text** reply instead of internal reasoning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21990f826706cc91cb3b0a53946837b32d686ae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->