### PR TITLE
fix(reports): advance scheduler checkpoint after enqueue, not before

### DIFF
--- a/app-server/src/reports/scheduler.rs
+++ b/app-server/src/reports/scheduler.rs
@@ -98,6 +98,19 @@ async fn check_and_enqueue(
 
     let hours_to_check = hour_boundaries_between(last_check, now);
     if hours_to_check.is_empty() {
+        // Advance the checkpoint even when there's nothing to enqueue so that
+        // a cold-start (or cache flush) doesn't permanently stall the scheduler.
+        if last_check_ts.is_none() {
+            if let Err(e) = cache
+                .insert(REPORT_SCHEDULER_LAST_CHECK_CACHE_KEY, now.timestamp())
+                .await
+            {
+                log::warn!(
+                    "[Reports Scheduler] Failed to write bootstrap checkpoint: {:?}",
+                    e
+                );
+            }
+        }
         return Ok(());
     }
     log::info!(

--- a/app-server/src/reports/scheduler.rs
+++ b/app-server/src/reports/scheduler.rs
@@ -96,10 +96,6 @@ async fn check_and_enqueue(
         now
     );
 
-    let _ = cache
-        .insert(REPORT_SCHEDULER_LAST_CHECK_CACHE_KEY, now.timestamp())
-        .await;
-
     let hours_to_check = hour_boundaries_between(last_check, now);
     if hours_to_check.is_empty() {
         return Ok(());
@@ -131,6 +127,13 @@ async fn check_and_enqueue(
                 );
             }
         }
+    }
+
+    if let Err(e) = cache
+        .insert(REPORT_SCHEDULER_LAST_CHECK_CACHE_KEY, now.timestamp())
+        .await
+    {
+        log::warn!("[Reports Scheduler] Failed to write checkpoint: {:?}", e);
     }
 
     Ok(())


### PR DESCRIPTION
In `check_and_enqueue`, the checkpoint (`REPORT_SCHEDULER_LAST_CHECK_CACHE_KEY`) was written to Redis **before** the enqueue loop ran. If the process crashed or the message queue was unavailable mid-loop, the checkpoint had already advanced — those hours were silently skipped on the next run.

**Fix:** Move the `cache.insert` call to **after** the enqueue loop completes. Also replace `let _ =` with `if let Err(e) =` so checkpoint write failures are logged as warnings rather than silently swallowed.

This ensures that if the process crashes before all enqueues complete, the next run will re-process the same window. The enqueue operations are idempotent on the consumer side, so reprocessing a window is safe.

Closes #1586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when scheduled report hours are considered done; mis-timed checkpoints could duplicate or delay report triggers, though re-enqueue is intended to be safe.
> 
> **Overview**
> The reports scheduler no longer advances the Redis **last-check** checkpoint before enqueueing. It writes `report_scheduler_last_check` **after** the hour loop finishes, so a crash or queue failure during enqueue leaves the same time window eligible on the next tick (consumers are treated as safe to re-run).
> 
> When there are no hour boundaries to process, it still **bootstraps** the checkpoint on first run (missing cache key) so cold starts or cache flushes do not stall forever. Checkpoint write errors are **logged as warnings** instead of being ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe9194084e2d645921378399e86aeafb73193cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->