### PR TITLE
fix(debugger): fix realtime merging logic

### DIFF
--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
@@ -18,10 +18,8 @@ import SessionHeader from "./session-header";
 import SessionOutline from "./session-outline";
 import { useDebuggerSessionViewStore, useDebuggerSessionViewStoreRaw } from "./store";
 
-// How close to the bottom counts as "pinned" for stick-to-bottom. Must exceed
-// the article column's 160px bottom padding — stopping where the last trace
-// ends still counts as "at the bottom" — while staying small enough that a
-// deliberate scroll-up unpins.
+// "Pinned" slack for stick-to-bottom. Must exceed the article's 160px bottom
+// padding (stopping at the last trace counts) yet let a scroll-up unpin.
 const PIN_SLACK_PX = 200;
 
 // Earliest run start / latest run end across loaded traces (epoch ms).
@@ -65,17 +63,12 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
     scrollEl?.scrollTo({ top: scrollEl.scrollHeight, behavior: "smooth" });
   }, [scrollEl]);
 
-  // iMessage-style pinning: while the user sits at (or near) the bottom, keep
-  // them there as streamed spans/traces grow the content. Pinned-ness is a ref
-  // updated on every user scroll; a ResizeObserver on the content column snaps
-  // the scroll back down whenever the content height changes while pinned.
-  // Scrolling up past the slack unpins, so reading history is never hijacked.
+  // iMessage-style pinning: while at the bottom, follow content growth
+  // (ResizeObserver snap); scrolling up past the slack unpins.
   useEffect(() => {
     if (!scrollEl) return;
-    // Starts unpinned and only a real scroll event can pin — there is no initial
-    // measure on purpose. On load the content is still short ("at the bottom" is
-    // trivially true), and an initial pin would drag the viewport down as traces
-    // stream in. Scrolling to the bottom (incl. the pill's smooth scroll) pins.
+    // No initial measure on purpose: short loading content is trivially "at the
+    // bottom", and an initial pin would drag the viewport down as traces load.
     const pinned = { current: false };
     const measure = () => {
       pinned.current = scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - PIN_SLACK_PX;
@@ -83,11 +76,8 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
     scrollEl.addEventListener("scroll", measure, { passive: true });
     const content = scrollEl.firstElementChild;
     const observer = new ResizeObserver(() => {
-      // Instant (not smooth) — growth can come every frame while streaming and
-      // queued smooth scrolls would rubber-band.
-      // `behavior: "instant"` overrides the container's `scroll-smooth` CSS —
-      // a smooth snap animates through positions outside the slack, whose
-      // scroll events would unpin us mid-flight and kill the follow.
+      // "instant" overrides the container's scroll-smooth — an animated snap
+      // fires scroll events outside the slack and unpins mid-flight.
       if (pinned.current) scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "instant" });
     });
     if (content) observer.observe(content);
@@ -129,9 +119,8 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
           storeApi.getState().setSessionName(payload.name);
         }
       },
-      // Session deleted (DELETE /v1/.../rollouts/{id}) → toast + bounce to the list.
-      // Payload is `{session_id}` (snake_case, see app-server rollouts.rs::delete).
-      // The channel is per-session, so any session_deleted here is for THIS session.
+      // Session deleted → toast + bounce to the list. Payload `{session_id}`
+      // (snake_case, see rollouts.rs::delete); the channel is per-session.
       session_deleted: (event: MessageEvent) => {
         const payload = JSON.parse(event.data) as { session_id?: string };
         if (sessionId && payload.session_id && payload.session_id !== sessionId) return;

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
@@ -18,10 +18,11 @@ import SessionHeader from "./session-header";
 import SessionOutline from "./session-outline";
 import { useDebuggerSessionViewStore, useDebuggerSessionViewStoreRaw } from "./store";
 
-// How close to the bottom counts as "pinned" for stick-to-bottom. Small enough
-// that a deliberate scroll-up unpins immediately; big enough that sub-pixel
-// rounding and momentum-scroll settle don't break the pin.
-const PIN_SLACK_PX = 40;
+// How close to the bottom counts as "pinned" for stick-to-bottom. Must exceed
+// the article column's 160px bottom padding — stopping where the last trace
+// ends still counts as "at the bottom" — while staying small enough that a
+// deliberate scroll-up unpins.
+const PIN_SLACK_PX = 200;
 
 // Earliest run start / latest run end across loaded traces (epoch ms).
 const minMaxFromTraces = (traces: { startTime: string; endTime: string }[]) => {
@@ -84,7 +85,10 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
     const observer = new ResizeObserver(() => {
       // Instant (not smooth) — growth can come every frame while streaming and
       // queued smooth scrolls would rubber-band.
-      if (pinned.current) scrollEl.scrollTop = scrollEl.scrollHeight;
+      // `behavior: "instant"` overrides the container's `scroll-smooth` CSS —
+      // a smooth snap animates through positions outside the slack, whose
+      // scroll events would unpin us mid-flight and kill the follow.
+      if (pinned.current) scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "instant" });
     });
     if (content) observer.observe(content);
     return () => {

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertTriangle } from "lucide-react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { shallow } from "zustand/shallow";
 
@@ -9,6 +9,7 @@ import SessionSpanPanel from "@/components/traces/session-view/session-span-pane
 import { useSessionViewBaseStore } from "@/components/traces/session-view/store";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useRealtime } from "@/lib/hooks/use-realtime";
+import { useToast } from "@/lib/hooks/use-toast";
 import { type RealtimeSpan } from "@/lib/traces/types";
 
 import DebuggerTraceList from "./debugger-trace-list";
@@ -39,6 +40,8 @@ const minMaxFromTraces = (traces: { startTime: string; endTime: string }[]) => {
 // a right spacer; span clicks open the in-flow SessionSpanPanel.
 export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: string }) {
   const { projectId } = useParams<{ projectId: string }>();
+  const router = useRouter();
+  const { toast } = useToast();
   const storeApi = useDebuggerSessionViewStoreRaw();
 
   const { traces, spanPanelOpen, isTracesLoading, tracesError } = useSessionViewBaseStore(
@@ -122,8 +125,17 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
           storeApi.getState().setSessionName(payload.name);
         }
       },
+      // Session deleted (DELETE /v1/.../rollouts/{id}) → toast + bounce to the list.
+      // Payload is `{session_id}` (snake_case, see app-server rollouts.rs::delete).
+      // The channel is per-session, so any session_deleted here is for THIS session.
+      session_deleted: (event: MessageEvent) => {
+        const payload = JSON.parse(event.data) as { session_id?: string };
+        if (sessionId && payload.session_id && payload.session_id !== sessionId) return;
+        toast({ variant: "destructive", title: "Session deleted" });
+        router.push(`/project/${projectId}/debugger-sessions`);
+      },
     }),
-    [storeApi, sessionId]
+    [storeApi, sessionId, projectId, router, toast]
   );
 
   useRealtime({

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -128,7 +128,10 @@ const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {})
 });
 
 interface DebuggerSessionViewState {
-  traceFetchState: Record<string, "loading" | "loaded">;
+  // Per-trace span fetch in flight. Dedupes concurrent fetches and drives the
+  // skeleton; expand ALWAYS refetches (idempotent recency merge), so a failed
+  // fetch heals on the next expand. Transient, not persisted.
+  traceSpansFetching: Record<string, boolean>;
   sessionName: string;
 
   // True when a run was added live via trace_update — drives the "New trace" pill
@@ -140,10 +143,10 @@ interface DebuggerSessionViewState {
 }
 
 interface DebuggerSessionViewActions {
-  // Expand-path fetch override, gated on `traceFetchState` (NOT slot shape): if a
-  // catch-up fetch already ran (loading/loaded) do nothing; if idle (a list row
-  // never expanded) fetch once via the base slice, owning `traceFetchState` so the
-  // debugger UI reads ONE source. Idempotent.
+  // Expand-path fetch override: ALWAYS fetches (skipped only while another fetch
+  // for the same trace is in flight). Fetches directly — never via the base slice,
+  // whose guard is shape-based and would skip the historical fetch once any SSE
+  // span has upserted into the slot.
   ensureTraceSpans: (trace: TraceRow) => Promise<void>;
 
   // Fetch this session's runs (traces) via the `rollout.session_id` metadata
@@ -205,7 +208,7 @@ export const createDebuggerSessionViewStore = (options?: {
           traces: options?.initialTraceRow ? [options.initialTraceRow] : [],
 
           sessionName: options?.initialSessionName ?? "Session",
-          traceFetchState: {},
+          traceSpansFetching: {},
           newTraceNotice: false,
           isInitialTracesLoaded: false,
 
@@ -214,13 +217,12 @@ export const createDebuggerSessionViewStore = (options?: {
             // flight or already settled, do nothing — spans stream in independently
             // and the recency merge keeps them correct. Only an idle (never-fetched)
             // list row reaches the fetch below.
-            const fetchState = get().traceFetchState[trace.id];
-            if (fetchState === "loading" || fetchState === "loaded") return;
+            if (get().traceSpansFetching[trace.id]) return;
 
             // Set "loading" synchronously (before any await) so a span streaming in
             // between this set and the fetch settling can never flash "No spans
             // found" — this is the exact P1 race class. The debugger segment UI
-            // reads ONLY `traceFetchState`; the base slice's `traceSpansLoading`
+            // reads ONLY `traceSpansFetching`; the base slice's `traceSpansLoading`
             // stays untouched for the regular session view.
             //
             // AbortController stance (decided): no abort plumbing. Per-trace fetches
@@ -231,7 +233,7 @@ export const createDebuggerSessionViewStore = (options?: {
             set(
               (s) =>
                 ({
-                  traceFetchState: { ...s.traceFetchState, [trace.id]: "loading" },
+                  traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: true },
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
@@ -262,7 +264,7 @@ export const createDebuggerSessionViewStore = (options?: {
               set(
                 (s) =>
                   ({
-                    traceFetchState: { ...s.traceFetchState, [trace.id]: "loaded" },
+                    traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: false },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }
@@ -380,10 +382,10 @@ export const createDebuggerSessionViewStore = (options?: {
               // Any spans that raced ahead of this event are already in `traceSpans`
               // (applyRealtimeSpan upserts unconditionally) — nothing to seed or flush.
               get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata)]);
-              // Kick the catch-up fetch FIRST so it sets traceFetchState="loading"
+              // Kick the catch-up fetch FIRST so it marks the trace as fetching
               // synchronously; setTraceExpanded then triggers the ensureTraceSpans
               // override, which sees "loading" and short-circuits — one fetch, not two.
-              // hydrateTraceRow owns this trace's traceFetchState lifecycle.
+              // before the auto-expand fires — exactly one fetch per new run.
               void get().hydrateTraceRow(t.traceId);
               get().setTraceExpanded(t.traceId, true);
               // Surface the "New trace" pill so the user can jump to the new run — but
@@ -426,16 +428,16 @@ export const createDebuggerSessionViewStore = (options?: {
             // `startTime !== endTime` shape check that the P1 race defeated (a streamed
             // span bumped endTime past startTime before this ran, so the guard passed
             // and the flag-clear in finally was skipped → stuck skeleton).
-            if (get().traceFetchState[traceId]) return;
+            if (get().traceSpansFetching[traceId]) return;
 
-            // hydrateTraceRow is the sole owner of traceFetchState. Set "loading" in
+            // Mark fetching in
             // the SYNCHRONOUS prefix (before ANY await) — this is the exact P1 trap:
             // a span streaming in between this call and the fetch settling must never
             // flash "No spans found" before the skeleton is shown.
             set(
               (s) =>
                 ({
-                  traceFetchState: { ...s.traceFetchState, [traceId]: "loading" },
+                  traceSpansFetching: { ...s.traceSpansFetching, [traceId]: true },
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
@@ -504,7 +506,7 @@ export const createDebuggerSessionViewStore = (options?: {
               set(
                 (s) =>
                   ({
-                    traceFetchState: { ...s.traceFetchState, [traceId]: "loaded" },
+                    traceSpansFetching: { ...s.traceSpansFetching, [traceId]: false },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -217,12 +217,11 @@ export const createDebuggerSessionViewStore = (options?: {
             const fetchState = get().traceFetchState[trace.id];
             if (fetchState === "loading" || fetchState === "loaded") return;
 
-            // BOUNDARY DECISION: the base slice keeps its own `traceSpansLoading` for
-            // the regular session view; the debugger segment UI reads ONLY
-            // `traceFetchState`. Set "loading" synchronously (before any await) so a
-            // span streaming in between this set and the fetch settling can never flash
-            // "No spans found" — this is the exact P1 race class. The base fetch's
-            // `traceSpansLoading` still runs underneath but the debugger UI ignores it.
+            // Set "loading" synchronously (before any await) so a span streaming in
+            // between this set and the fetch settling can never flash "No spans
+            // found" — this is the exact P1 race class. The debugger segment UI
+            // reads ONLY `traceFetchState`; the base slice's `traceSpansLoading`
+            // stays untouched for the regular session view.
             //
             // AbortController stance (decided): no abort plumbing. Per-trace fetches
             // fire once (state-guarded above), late responses are harmless through the
@@ -236,7 +235,29 @@ export const createDebuggerSessionViewStore = (options?: {
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
-              await baseSlice.ensureTraceSpans(trace);
+              // Fetch directly instead of delegating to baseSlice.ensureTraceSpans:
+              // the base guard is shape-based (`if (traceSpans[id])`) and spans now
+              // upsert unconditionally, so an active run that streamed even one SSE
+              // span before first expand would make the base skip the ClickHouse
+              // historical fetch entirely. Merge fetched-wins so duplicates resolve
+              // to the fuller CH span; streamed-only spans are preserved.
+              const { projectId } = get();
+              if (!projectId) return;
+              const spanParams = new URLSearchParams();
+              spanParams.append("searchIn", "input");
+              spanParams.append("searchIn", "output");
+              spanParams.set("startDate", new Date(new Date(trace.startTime).getTime() - 1000).toISOString());
+              spanParams.set("endDate", new Date(new Date(trace.endTime).getTime() + 1000).toISOString());
+              const res = await fetch(`/api/projects/${projectId}/traces/${trace.id}/spans?${spanParams.toString()}`);
+              if (res.ok) {
+                const fetchedSpans = (await res.json()) as TraceViewSpan[];
+                if (fetchedSpans.length > 0) {
+                  get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
+                }
+              }
+            } catch {
+              // Best-effort, same semantics as hydrateTraceRow: failure still reaches
+              // "loaded"; the UI shows whatever streamed.
             } finally {
               set(
                 (s) =>

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -10,17 +10,16 @@ import {
 } from "@/components/traces/session-view/store/base";
 import { type TraceViewSpan } from "@/components/traces/trace-view/store/base";
 import { enrichSpansWithPending } from "@/components/traces/trace-view/utils";
+import { toast } from "@/lib/hooks/use-toast";
 import { type RealtimeSpan, type SpanType, type TraceRow } from "@/lib/traces/types";
 
-// Trace-metadata key the coding agent writes its run note to. Naming stays
-// `rollout.*` to match `rollout.session_id`. The value is an opaque markdown string.
+// Trace-metadata key the agent writes its run note to (markdown string).
 export const NOTE_METADATA_KEY = "rollout.note";
 
 // Max runs fetched per session (mirrors the previous multi-trace-view cap).
 const MAX_RUNS = 200;
 
-// Normalize a trace_update payload's `metadata` (object OR JSON string) into the
-// Record<string,string> shape `TraceRow.metadata` carries.
+// Normalize metadata (object OR JSON string) into TraceRow's Record<string,string>.
 const normalizeMetadata = (metadata: unknown): Record<string, string> => {
   if (!metadata) return {};
   if (typeof metadata === "string") {
@@ -39,10 +38,8 @@ const normalizeMetadata = (metadata: unknown): Record<string, string> => {
   return {};
 };
 
-// Map a streamed RealtimeSpan onto the TraceViewSpan shape the shared list reads.
-// Only `"update"` mode exists now (span_start is dead — see content component).
-// Token/cost fields come off `gen_ai.usage.*` attributes, mirroring trace-view's
-// onRealtimeUpdateSpans — without this, streamed LLM spans render 0 tokens / $0.
+// Map a streamed RealtimeSpan onto TraceViewSpan. Token/cost come off
+// `gen_ai.usage.*` attrs — without this, streamed LLM spans render 0 tokens / $0.
 const realtimeToTraceViewSpan = (s: RealtimeSpan): TraceViewSpan => {
   const attrs = (s.attributes ?? {}) as Record<string, unknown>;
   const num = (key: string) => Number(attrs[key]) || 0;
@@ -78,10 +75,8 @@ const realtimeToTraceViewSpan = (s: RealtimeSpan): TraceViewSpan => {
   } as TraceViewSpan;
 };
 
-// Merge incoming spans into an existing list: dedupe by spanId (incoming wins,
-// preserving the existing span's `collapsed`), sort by startTime, enrich pending.
-// `incomingWins=false` flips precedence so a base list (e.g. a CH fetch) overrides
-// streamed duplicates for the same spanId.
+// Dedupe by spanId (newest endTime wins; `incomingWins` breaks ties), preserve
+// `collapsed`, sort by startTime, enrich pending.
 const mergeSpans = (base: TraceViewSpan[], incoming: TraceViewSpan[], incomingWins = true): TraceViewSpan[] => {
   const byId = new Map<string, TraceViewSpan>();
   for (const s of base) byId.set(s.spanId, s);
@@ -91,14 +86,12 @@ const mergeSpans = (base: TraceViewSpan[], incoming: TraceViewSpan[], incomingWi
       byId.set(s.spanId, s);
       continue;
     }
-    // Real spans always replace pending placeholders (whose endTime is synthesized
-    // from children and can run ahead); a placeholder never replaces a real span.
+    // Real spans always beat pending placeholders (whose endTime can run ahead).
     if (prev.pending !== s.pending) {
       if (prev.pending) byId.set(s.spanId, { ...s, collapsed: prev.collapsed });
       continue;
     }
-    // Per-span recency: never let an older snapshot (e.g. a lagging CH hydrate)
-    // replace a fresher version of the same span. endTime tie → side precedence.
+    // Per-span recency: an older snapshot (e.g. lagging CH fetch) never wins.
     const prevEnd = new Date(prev.endTime).getTime();
     const incEnd = new Date(s.endTime).getTime();
     const incomingNewer = incEnd > prevEnd || (incEnd === prevEnd && incomingWins);
@@ -108,8 +101,7 @@ const mergeSpans = (base: TraceViewSpan[], incoming: TraceViewSpan[], incomingWi
   return enrichSpansWithPending(merged);
 };
 
-// Build a minimal TraceRow slot for a trace we only know the id (and maybe
-// metadata) of — used by /alpha seeding and live trace_update of an unknown run.
+// Minimal TraceRow for a trace we only know the id of (live trace_update).
 const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {}): TraceRow => ({
   id: traceId,
   startTime: new Date().toISOString(),
@@ -128,59 +120,51 @@ const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {})
 });
 
 interface DebuggerSessionViewState {
-  // Per-trace span fetch in flight. Dedupes concurrent fetches and drives the
-  // skeleton; expand ALWAYS refetches (idempotent recency merge), so a failed
-  // fetch heals on the next expand. Transient, not persisted.
+  // Per-trace span fetch in flight: dedupes concurrent fetches, drives the
+  // skeleton. Expand always refetches, so a failed fetch heals on re-expand.
   traceSpansFetching: Record<string, boolean>;
   sessionName: string;
 
-  // True when a run was added live via trace_update — drives the "New trace" pill
-  // at the bottom of the view. Cleared on pill click / dismiss. Transient.
+  // A run was added live → "New trace" pill. Cleared on click / dismiss.
   newTraceNotice: boolean;
 
-  // Prevents "New trace" pill from being shown on page load
+  // Prevents the "New trace" pill from flashing on page load.
   isInitialTracesLoaded: boolean;
 }
 
 interface DebuggerSessionViewActions {
-  // Expand-path fetch override: ALWAYS fetches (skipped only while another fetch
-  // for the same trace is in flight). Fetches directly — never via the base slice,
-  // whose guard is shape-based and would skip the historical fetch once any SSE
-  // span has upserted into the slot.
+  // Expand-path fetch: always fetches (deduped while in flight), directly — the
+  // base slice's shape-based guard would skip the fetch once any SSE span landed.
   ensureTraceSpans: (trace: TraceRow) => Promise<void>;
 
-  // Fetch this session's runs (traces) via the `rollout.session_id` metadata
-  // filter, oldest-first, into base `traces`. Reads projectId from base state.
+  // Fetch the session's runs via the `rollout.session_id` metadata filter.
   fetchSessionTraces: (sessionId: string) => Promise<void>;
 
-  // Realtime: upsert a streamed span into its (already-loaded) trace.
+  // Realtime: upsert a streamed span.
   applyRealtimeSpan: (span: RealtimeSpan) => void;
 
-  // Realtime: batch entry point for a span_update payload (one store call per event).
+  // Batch entry point for a span_update payload.
   applyRealtimeSpans: (spans: RealtimeSpan[]) => void;
 
   // Realtime: merge a trace_update into the run list (add + auto-expand if new).
   applyTraceUpdate: (t: { traceId: string; metadata?: unknown; hasBrowserSession?: boolean }) => void;
 
-  // Realtime: batch entry point for a trace_update payload (one store call per event).
+  // Batch entry point for a trace_update payload.
   applyTraceUpdates: (traces: { traceId: string; metadata?: unknown; hasBrowserSession?: boolean }[]) => void;
 
-  // Fetch the full TraceRow (real stats: tokens/cost/startTime) for a single
-  // trace and merge it onto the existing row. Used to hydrate a run that first
-  // appeared via a trace_update (whose payload carries no stats). Preserves the
-  // row's current metadata (already merged from realtime) and its bumped endTime.
+  // One-shot catch-up for a realtime-added run: real row stats + pre-subscribe
+  // spans (trace_update payloads carry neither).
   hydrateTraceRow: (traceId: string) => Promise<void>;
 
-  // Update the displayed session name live (driven by the `session_update`
-  // realtime event after a rename via PATCH /v1/.../rollouts/{id}/name).
+  // Live rename (driven by the `session_update` realtime event).
   setSessionName: (name: string) => void;
 
   // Hide the "New trace" pill (pill click or its X).
   dismissNewTraceNotice: () => void;
 
-  // Read the agent-authored note (`rollout.note`) off a run's metadata object.
+  // Agent-authored note (`rollout.note`) off a run's metadata.
   noteForTrace: (traceId: string) => string | undefined;
-  // Span type for an already-loaded span (drives the span-ref chip icon color).
+  // Span type for a loaded span (drives the span-ref chip icon).
   getSpanType: (traceId: string, spanId: string) => SpanType | undefined;
 }
 
@@ -200,8 +184,7 @@ export const createDebuggerSessionViewStore = (options?: {
         return {
           ...baseSlice,
 
-          // Seeded at store creation (projectId is static for the page) instead of
-          // synced from the URL param in an effect.
+          // Seeded at creation (static per page) — no URL-param sync effect.
           projectId: options?.projectId,
 
           // Seed base `traces` with the single /alpha trace when provided.
@@ -213,23 +196,8 @@ export const createDebuggerSessionViewStore = (options?: {
           isInitialTracesLoaded: false,
 
           ensureTraceSpans: async (trace) => {
-            // State-based idempotence (never shape-based): if a catch-up fetch is in
-            // flight or already settled, do nothing — spans stream in independently
-            // and the recency merge keeps them correct. Only an idle (never-fetched)
-            // list row reaches the fetch below.
             if (get().traceSpansFetching[trace.id]) return;
 
-            // Set "loading" synchronously (before any await) so a span streaming in
-            // between this set and the fetch settling can never flash "No spans
-            // found" — this is the exact P1 race class. The debugger segment UI
-            // reads ONLY `traceSpansFetching`; the base slice's `traceSpansLoading`
-            // stays untouched for the regular session view.
-            //
-            // AbortController stance (decided): no abort plumbing. Per-trace fetches
-            // fire once (state-guarded above), late responses are harmless through the
-            // recency merge, and the store is recreated per session (provider keyed by
-            // sessionId). Zustand vanilla has no dispose hook to hang a controller off,
-            // so we skip it entirely rather than invent lifecycle.
             set(
               (s) =>
                 ({
@@ -237,12 +205,6 @@ export const createDebuggerSessionViewStore = (options?: {
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
-              // Fetch directly instead of delegating to baseSlice.ensureTraceSpans:
-              // the base guard is shape-based (`if (traceSpans[id])`) and spans now
-              // upsert unconditionally, so an active run that streamed even one SSE
-              // span before first expand would make the base skip the ClickHouse
-              // historical fetch entirely. Merge fetched-wins so duplicates resolve
-              // to the fuller CH span; streamed-only spans are preserved.
               const { projectId } = get();
               if (!projectId) return;
               const spanParams = new URLSearchParams();
@@ -251,15 +213,18 @@ export const createDebuggerSessionViewStore = (options?: {
               spanParams.set("startDate", new Date(new Date(trace.startTime).getTime() - 1000).toISOString());
               spanParams.set("endDate", new Date(new Date(trace.endTime).getTime() + 1000).toISOString());
               const res = await fetch(`/api/projects/${projectId}/traces/${trace.id}/spans?${spanParams.toString()}`);
-              if (res.ok) {
-                const fetchedSpans = (await res.json()) as TraceViewSpan[];
-                if (fetchedSpans.length > 0) {
-                  get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
-                }
+              if (!res.ok) throw new Error("Failed to load spans");
+              const fetchedSpans = (await res.json()) as TraceViewSpan[];
+              if (fetchedSpans.length > 0) {
+                get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
               }
             } catch {
-              // Best-effort, same semantics as hydrateTraceRow: failure still reaches
-              // "loaded"; the UI shows whatever streamed.
+              // The UI keeps whatever streamed; re-expand retries.
+              toast({
+                variant: "destructive",
+                title: "Failed to load spans",
+                description: "Collapse and expand the run to retry.",
+              });
             } finally {
               set(
                 (s) =>
@@ -295,13 +260,8 @@ export const createDebuggerSessionViewStore = (options?: {
                 return;
               }
               const body = (await res.json()) as { items: TraceRow[] };
-              // The /traces endpoint returns `metadata` as a raw JSON STRING (the CH
-              // `metadata` column is selected verbatim — see lib/actions/traces/utils.ts;
-              // the traces table parses it lazily in JsonTooltip). `TraceRow.metadata`
-              // is typed as an object, so normalize here before storing — otherwise
-              // noteForTrace / getSpanType read the string as an object and notes +
-              // outline headings never render. (Realtime trace_update already ships a
-              // JSON object and goes through normalizeMetadata in applyTraceUpdate.)
+              // /traces returns `metadata` as a raw JSON string; normalize or notes
+              // and outline headings never render.
               const normalized = (body.items ?? []).map((item) => ({
                 ...item,
                 metadata: normalizeMetadata(item.metadata),
@@ -310,12 +270,8 @@ export const createDebuggerSessionViewStore = (options?: {
               const sorted = normalized.sort(
                 (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
               );
-              // MERGE with current rows instead of replacing: a run that started while
-              // this fetch was in flight was added by applyTraceUpdate but is absent
-              // from the (CH-lagged) response — replacing wholesale wipes its row and
-              // its streamed spans. Fetched rows win per-id (richer stats) but keep the
-              // live row's merged metadata + realtime-bumped endTime (same semantics as
-              // hydrateTraceRow); realtime-only rows are kept as-is.
+              // MERGE, don't replace: a run added live mid-fetch is absent from the
+              // CH-lagged response — wholesale replace would wipe it.
               get().setTraces((prev) => {
                 const prevById = new Map(prev.map((t) => [t.id, t]));
                 const merged = sorted.map((fetched) => {
@@ -338,8 +294,7 @@ export const createDebuggerSessionViewStore = (options?: {
               get().setTracesError(e instanceof Error ? e.message : "Failed to load session traces");
             } finally {
               get().setIsTracesLoading(false);
-              // Mark hydrated even on error: a failed initial fetch shouldn't leave the
-              // pill permanently suppressed — subsequent live runs are genuinely new.
+              // Even on error, so a failed initial fetch can't suppress the pill forever.
               set({ isInitialTracesLoaded: true } as Partial<DebuggerSessionViewStore>);
             }
           },
@@ -348,19 +303,12 @@ export const createDebuggerSessionViewStore = (options?: {
             const traceId = span.traceId;
             const tvSpan = realtimeToTraceViewSpan(span);
 
-            // Unconditional upsert into the dumb spans map (create the array if absent).
-            // Spans and trace rows are independent streams — a span can arrive before
-            // its trace_update creates the row, which is fine: the recency-aware merge
-            // dedupes by spanId, and the segment renders whatever the map holds. No
-            // buffer, no conditions; this is what kills the old "(no spans)" race.
+            // Unconditional upsert — a span may arrive before its trace_update creates
+            // the row; it just sits in the map until the row renders.
             get().setTraceSpans(traceId, mergeSpans(get().traceSpans[traceId] ?? [], [tvSpan]));
 
-            // Bump the owning trace row's endTime when the span extends past it (keeps
-            // list stats/ordering correct for a live run). Find the row FIRST and only
-            // rebuild `traces` when the endTime actually moves — otherwise every streamed
-            // span would mint a new array identity and bust every derived memo
-            // (previewTraces, traceIds, allSpansById, …) for no change (finding #6). No-op
-            // if the row doesn't exist yet — endTime is seeded from trace_update / hydrate.
+            // Bump the row's endTime — but only rebuild `traces` when it actually
+            // moves, or every streamed span would bust the derived memos.
             const spanEndMs = new Date(span.endTime).getTime();
             if (Number.isNaN(spanEndMs)) return;
             const targetRow = get().traces.find((t) => t.id === traceId);
@@ -378,28 +326,19 @@ export const createDebuggerSessionViewStore = (options?: {
             const existing = get().traces.find((row) => row.id === t.traceId);
 
             if (!existing) {
-              // Unknown run → add a lightweight row (placeholder stats) to the ordering.
-              // Any spans that raced ahead of this event are already in `traceSpans`
-              // (applyRealtimeSpan upserts unconditionally) — nothing to seed or flush.
+              // Unknown run → add a placeholder row; any spans that raced ahead are
+              // already in `traceSpans`.
               get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata)]);
-              // Kick the catch-up fetch FIRST so it marks the trace as fetching
-              // synchronously; setTraceExpanded then triggers the ensureTraceSpans
-              // override, which sees "loading" and short-circuits — one fetch, not two.
-              // before the auto-expand fires — exactly one fetch per new run.
+              // Hydrate FIRST: its sync prefix marks fetching, so the auto-expand's
+              // ensureTraceSpans dedupes — one fetch per new run.
               void get().hydrateTraceRow(t.traceId);
               get().setTraceExpanded(t.traceId, true);
-              // Surface the "New trace" pill so the user can jump to the new run — but
-              // only once the initial fetch has settled, so a trace_update that beat the
-              // first fetch (for a run already in the initial set) can't flash it on load.
+              // Pill only after the initial fetch settles, so it can't flash on load.
               if (get().isInitialTracesLoaded) set({ newTraceNotice: true } as Partial<DebuggerSessionViewStore>);
               return;
             }
 
-            // Known run → merge metadata (makes live note updates work: `rollout.note`
-            // arrives here after a POST /v1/traces/metadata patch) AND any non-metadata
-            // fields the payload carries (e.g. hasBrowserSession). Bail only when there
-            // is genuinely nothing to apply, so a browser-session signal isn't dropped
-            // just because the metadata happened to be empty (finding #10).
+            // Known run → merge metadata (live note updates) + hasBrowserSession.
             const hasMetadata = Object.keys(metadata).length > 0;
             const hasBrowserSession = typeof t.hasBrowserSession === "boolean";
             if (!hasMetadata && !hasBrowserSession) return;
@@ -423,17 +362,10 @@ export const createDebuggerSessionViewStore = (options?: {
           hydrateTraceRow: async (traceId) => {
             const { projectId } = get();
             if (!projectId) return;
-            // State-based idempotence (never shape-based): if a catch-up fetch already
-            // ran or is running for this trace, don't re-fetch. This replaces the old
-            // `startTime !== endTime` shape check that the P1 race defeated (a streamed
-            // span bumped endTime past startTime before this ran, so the guard passed
-            // and the flag-clear in finally was skipped → stuck skeleton).
             if (get().traceSpansFetching[traceId]) return;
 
-            // Mark fetching in
-            // the SYNCHRONOUS prefix (before ANY await) — this is the exact P1 trap:
-            // a span streaming in between this call and the fetch settling must never
-            // flash "No spans found" before the skeleton is shown.
+            // Mark fetching in the SYNCHRONOUS prefix (before any await) so a streamed
+            // span can never flash "No spans found" ahead of the skeleton.
             set(
               (s) =>
                 ({
@@ -446,7 +378,7 @@ export const createDebuggerSessionViewStore = (options?: {
               params.set("pageSize", "1");
               params.append("filter", JSON.stringify({ column: "id", operator: "eq", value: traceId }));
               const res = await fetch(`/api/projects/${projectId}/traces?${params.toString()}`);
-              if (!res.ok) return;
+              if (!res.ok) throw new Error("Failed to load run");
               const body = (await res.json()) as { items: TraceRow[] };
               const fetched = body.items?.[0];
               if (!fetched) return;
@@ -455,9 +387,8 @@ export const createDebuggerSessionViewStore = (options?: {
               get().setTraces((traces) =>
                 traces.map((row) => {
                   if (row.id !== traceId) return row;
-                  // Keep the live-merged metadata + any realtime-bumped endTime if it's
-                  // already ahead of the fetched row's (mid-run, the fetched snapshot
-                  // may lag the streamed spans).
+                  // Keep live-merged metadata + a realtime-bumped endTime that's ahead
+                  // of the (possibly lagging) fetched snapshot.
                   const liveEndAhead = new Date(row.endTime).getTime() > new Date(fetched.endTime).getTime();
                   return {
                     ...fetched,
@@ -467,13 +398,8 @@ export const createDebuggerSessionViewStore = (options?: {
                 })
               );
 
-              // Recover spans that were persisted in ClickHouse BEFORE the view opened
-              // (a run already in progress) — the realtime stream only carries spans
-              // emitted after we subscribed. Fetch once now that we have REAL trace
-              // times (the new-run slot's lazy fetch was intentionally skipped because
-              // it would have windowed on placeholder "now" times). Merge CH-wins over
-              // the realtime-fed slot so duplicates resolve to the fuller fetched span,
-              // and any spans that streamed in during this fetch are preserved.
+              // Recover spans persisted BEFORE we subscribed, now that real trace
+              // times are known; merge preserves anything streamed meanwhile.
               const startDate = new Date(new Date(fetched.startTime).getTime() - 1000).toISOString();
               const endDate = new Date(new Date(fetched.endTime).getTime() + 1000).toISOString();
               const spanParams = new URLSearchParams();
@@ -484,25 +410,21 @@ export const createDebuggerSessionViewStore = (options?: {
               const spansRes = await fetch(
                 `/api/projects/${projectId}/traces/${traceId}/spans?${spanParams.toString()}`
               );
-              if (spansRes.ok) {
-                const fetchedSpans = (await spansRes.json()) as TraceViewSpan[];
-                if (fetchedSpans.length > 0) {
-                  const live = get().traceSpans[traceId] ?? [];
-                  // CH-wins: base = live (realtime), incoming = fetched with incomingWins.
-                  get().setTraceSpans(traceId, mergeSpans(live, fetchedSpans, true));
-                }
+              if (!spansRes.ok) throw new Error("Failed to load spans");
+              const fetchedSpans = (await spansRes.json()) as TraceViewSpan[];
+              if (fetchedSpans.length > 0) {
+                const live = get().traceSpans[traceId] ?? [];
+                get().setTraceSpans(traceId, mergeSpans(live, fetchedSpans, true));
               }
             } catch {
-              // Best-effort hydration — placeholder stats / realtime-fed spans remain on
-              // failure. HYDRATE-FAILURE SEMANTICS (decided): a failed fetch still reaches
-              // "loaded" below — the UI shows whatever spans streamed (or "No spans found"
-              // if none). We do NOT retry: the state-based idempotence guard means a
-              // re-expand won't re-fetch. Kept simple per spec; if a failed run needs a
-              // retry affordance later, surface a manual refresh rather than auto-retry.
+              // The UI keeps whatever streamed; re-expand retries.
+              toast({
+                variant: "destructive",
+                title: "Failed to load run data",
+                description: "Collapse and expand the run to retry.",
+              });
             } finally {
-              // "loaded" unconditionally (success OR failure) — the skeleton must always
-              // resolve. This is the structural fix for the stuck-skeleton P1: there is no
-              // early-return path that can skip this finally.
+              // Unconditional — the skeleton must always resolve (the old P1).
               set(
                 (s) =>
                   ({
@@ -526,7 +448,6 @@ export const createDebuggerSessionViewStore = (options?: {
         };
       },
       {
-        // Distinct from `session-view-state` AND the parked `debugger-session-state`.
         name: options?.storeKey ?? "debugger-session-view-state",
         partialize: (state) => ({
           sessionPanelWidth: state.sessionPanelWidth,

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -128,34 +128,15 @@ const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {})
 });
 
 interface DebuggerSessionViewState {
-  // Run note source-of-truth lives on each TraceRow's metadata; no extra state.
-  noteMetadataKey: string;
-
-  // Per-trace catch-up-fetch lifecycle — the single explicit source of truth for
-  // "have we loaded this trace's spans?" Replaces the old shape-inference (missing
-  // slot = not loaded; `[]` = placeholder-or-empty) plus the realtimeSpanBuffer /
-  // traceHydrating / traceSpansConfirmedEmpty machinery. Semantics:
-  //   absent  → idle / never fetched (a list-fetched row that's never been expanded)
-  //   loading → a catch-up fetch is in flight; UI shows the skeleton
-  //   loaded  → fetch settled (success OR failure); UI shows whatever spans streamed,
-  //             or "No spans found" when the map is empty
-  // Spans stream independently into `traceSpans` regardless of this state. Transient,
-  // NOT in persist partialize.
   traceFetchState: Record<string, "loading" | "loaded">;
-
-  // Displayed session name (the SessionHeader title). Seeded from the breadcrumb
-  // prop at store creation; updated live by the `session_update` realtime event so
-  // a rename reflects without reload.
   sessionName: string;
 
   // True when a run was added live via trace_update — drives the "New trace" pill
   // at the bottom of the view. Cleared on pill click / dismiss. Transient.
   newTraceNotice: boolean;
 
-  // True once the initial fetchSessionTraces has settled. Gates newTraceNotice so a
-  // trace_update that races ahead of the first fetch (for a run already in the
-  // initial set) can't flash the "New trace" pill on page load (finding #8).
-  tracesHydrated: boolean;
+  // Prevents "New trace" pill from being shown on page load
+  isInitialTracesLoaded: boolean;
 }
 
 interface DebuggerSessionViewActions {
@@ -223,11 +204,10 @@ export const createDebuggerSessionViewStore = (options?: {
           // Seed base `traces` with the single /alpha trace when provided.
           traces: options?.initialTraceRow ? [options.initialTraceRow] : [],
 
-          noteMetadataKey: NOTE_METADATA_KEY,
           sessionName: options?.initialSessionName ?? "Session",
           traceFetchState: {},
           newTraceNotice: false,
-          tracesHydrated: false,
+          isInitialTracesLoaded: false,
 
           ensureTraceSpans: async (trace) => {
             // State-based idempotence (never shape-based): if a catch-up fetch is in
@@ -337,7 +317,7 @@ export const createDebuggerSessionViewStore = (options?: {
               get().setIsTracesLoading(false);
               // Mark hydrated even on error: a failed initial fetch shouldn't leave the
               // pill permanently suppressed — subsequent live runs are genuinely new.
-              set({ tracesHydrated: true } as Partial<DebuggerSessionViewStore>);
+              set({ isInitialTracesLoaded: true } as Partial<DebuggerSessionViewStore>);
             }
           },
 
@@ -388,7 +368,7 @@ export const createDebuggerSessionViewStore = (options?: {
               // Surface the "New trace" pill so the user can jump to the new run — but
               // only once the initial fetch has settled, so a trace_update that beat the
               // first fetch (for a run already in the initial set) can't flash it on load.
-              if (get().tracesHydrated) set({ newTraceNotice: true } as Partial<DebuggerSessionViewStore>);
+              if (get().isInitialTracesLoaded) set({ newTraceNotice: true } as Partial<DebuggerSessionViewStore>);
               return;
             }
 

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -135,7 +135,7 @@ interface DebuggerSessionViewState {
 interface DebuggerSessionViewActions {
   // Expand-path fetch: always fetches (deduped while in flight), directly — the
   // base slice's shape-based guard would skip the fetch once any SSE span landed.
-  ensureTraceSpans: (trace: TraceRow) => Promise<void>;
+  fetchTraceSpans: (trace: TraceRow) => Promise<void>;
 
   // Fetch the session's runs via the `rollout.session_id` metadata filter.
   fetchSessionTraces: (sessionId: string) => Promise<void>;
@@ -195,7 +195,7 @@ export const createDebuggerSessionViewStore = (options?: {
           newTraceNotice: false,
           isInitialTracesLoaded: false,
 
-          ensureTraceSpans: async (trace) => {
+          fetchTraceSpans: async (trace) => {
             if (get().traceSpansFetching[trace.id]) return;
 
             set(
@@ -208,8 +208,6 @@ export const createDebuggerSessionViewStore = (options?: {
               const { projectId } = get();
               if (!projectId) return;
               const spanParams = new URLSearchParams();
-              spanParams.append("searchIn", "input");
-              spanParams.append("searchIn", "output");
               spanParams.set("startDate", new Date(new Date(trace.startTime).getTime() - 1000).toISOString());
               spanParams.set("endDate", new Date(new Date(trace.endTime).getTime() + 1000).toISOString());
               const res = await fetch(`/api/projects/${projectId}/traces/${trace.id}/spans?${spanParams.toString()}`);
@@ -330,7 +328,7 @@ export const createDebuggerSessionViewStore = (options?: {
               // already in `traceSpans`.
               get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata)]);
               // Hydrate FIRST: its sync prefix marks fetching, so the auto-expand's
-              // ensureTraceSpans dedupes — one fetch per new run.
+              // fetchTraceSpans dedupes — one fetch per new run.
               void get().hydrateTraceRow(t.traceId);
               get().setTraceExpanded(t.traceId, true);
               // Pill only after the initial fetch settles, so it can't flash on load.
@@ -403,8 +401,6 @@ export const createDebuggerSessionViewStore = (options?: {
               const startDate = new Date(new Date(fetched.startTime).getTime() - 1000).toISOString();
               const endDate = new Date(new Date(fetched.endTime).getTime() + 1000).toISOString();
               const spanParams = new URLSearchParams();
-              spanParams.append("searchIn", "input");
-              spanParams.append("searchIn", "output");
               spanParams.set("startDate", startDate);
               spanParams.set("endDate", endDate);
               const spansRes = await fetch(

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -81,7 +81,7 @@ const realtimeToTraceViewSpan = (s: RealtimeSpan): TraceViewSpan => {
 // Merge incoming spans into an existing list: dedupe by spanId (incoming wins,
 // preserving the existing span's `collapsed`), sort by startTime, enrich pending.
 // `incomingWins=false` flips precedence so a base list (e.g. a CH fetch) overrides
-// buffered/streamed duplicates for the same spanId.
+// streamed duplicates for the same spanId.
 const mergeSpans = (base: TraceViewSpan[], incoming: TraceViewSpan[], incomingWins = true): TraceViewSpan[] => {
   const byId = new Map<string, TraceViewSpan>();
   for (const s of base) byId.set(s.spanId, s);
@@ -131,11 +131,17 @@ interface DebuggerSessionViewState {
   // Run note source-of-truth lives on each TraceRow's metadata; no extra state.
   noteMetadataKey: string;
 
-  // Realtime spans that arrived for a trace whose `traceSpans[traceId]` slot
-  // didn't exist yet (the backend dispatches the span branch and the trace_update
-  // branch concurrently, so spans can race ahead of the slot). Buffered by traceId
-  // and flushed into `traceSpans` when the slot is created. Transient, not persisted.
-  realtimeSpanBuffer: Record<string, TraceViewSpan[]>;
+  // Per-trace catch-up-fetch lifecycle — the single explicit source of truth for
+  // "have we loaded this trace's spans?" Replaces the old shape-inference (missing
+  // slot = not loaded; `[]` = placeholder-or-empty) plus the realtimeSpanBuffer /
+  // traceHydrating / traceSpansConfirmedEmpty machinery. Semantics:
+  //   absent  → idle / never fetched (a list-fetched row that's never been expanded)
+  //   loading → a catch-up fetch is in flight; UI shows the skeleton
+  //   loaded  → fetch settled (success OR failure); UI shows whatever spans streamed,
+  //             or "No spans found" when the map is empty
+  // Spans stream independently into `traceSpans` regardless of this state. Transient,
+  // NOT in persist partialize.
+  traceFetchState: Record<string, "loading" | "loaded">;
 
   // Displayed session name (the SessionHeader title). Seeded from the breadcrumb
   // prop at store creation; updated live by the `session_update` realtime event so
@@ -150,22 +156,13 @@ interface DebuggerSessionViewState {
   // trace_update that races ahead of the first fetch (for a run already in the
   // initial set) can't flash the "New trace" pill on page load (finding #8).
   tracesHydrated: boolean;
-
-  // Per-trace "hydration in flight" flag (set while hydrateTraceRow runs). Drives
-  // the segment skeleton so a placeholder empty `[]` slot doesn't flash "No spans
-  // found" before the one-shot hydrate fetch settles. Transient.
-  traceHydrating: Record<string, boolean>;
-
-  // Per-trace "a fetch returned 0 spans" flag. A genuinely-empty trace stays
-  // empty; without this the ensureTraceSpans override would treat its `[]` slot as
-  // not-loaded and refetch on every re-expand (a loop). Transient.
-  traceSpansConfirmedEmpty: Record<string, boolean>;
 }
 
 interface DebuggerSessionViewActions {
-  // Refetch override: a defined-but-empty `[]` slot is a placeholder (seeded from
-  // the realtime buffer by applyTraceUpdate), NOT a confirmed-empty result, so
-  // collapse→re-expand should retry it. Delegates to the base fetch otherwise.
+  // Expand-path fetch override, gated on `traceFetchState` (NOT slot shape): if a
+  // catch-up fetch already ran (loading/loaded) do nothing; if idle (a list row
+  // never expanded) fetch once via the base slice, owning `traceFetchState` so the
+  // debugger UI reads ONE source. Idempotent.
   ensureTraceSpans: (trace: TraceRow) => Promise<void>;
 
   // Fetch this session's runs (traces) via the `rollout.session_id` metadata
@@ -205,7 +202,7 @@ interface DebuggerSessionViewActions {
 
 export type DebuggerSessionViewStore = BaseSessionViewStore & DebuggerSessionViewState & DebuggerSessionViewActions;
 
-const createDebuggerSessionViewStore = (options?: {
+export const createDebuggerSessionViewStore = (options?: {
   initialTraceRow?: TraceRow;
   initialSessionName?: string;
   projectId?: string;
@@ -228,52 +225,43 @@ const createDebuggerSessionViewStore = (options?: {
 
           noteMetadataKey: NOTE_METADATA_KEY,
           sessionName: options?.initialSessionName ?? "Session",
-          realtimeSpanBuffer: {},
+          traceFetchState: {},
           newTraceNotice: false,
           tracesHydrated: false,
-          traceHydrating: {},
-          traceSpansConfirmedEmpty: {},
 
           ensureTraceSpans: async (trace) => {
-            const state = get();
-            const slot = state.traceSpans[trace.id];
-            // Skip when spans already exist, a load/hydrate is in flight, or a prior
-            // fetch confirmed the trace is genuinely empty (refetch-loop guard).
-            if (
-              (slot && slot.length > 0) ||
-              state.traceSpansLoading[trace.id] ||
-              state.traceHydrating[trace.id] ||
-              state.traceSpansConfirmedEmpty[trace.id]
-            ) {
-              return;
-            }
-            // Drop a placeholder empty `[]` slot so base ensureTraceSpans (which
-            // early-returns on ANY defined slot) actually fetches on re-expand.
-            if (slot && slot.length === 0) {
-              const next = { ...get().traceSpans };
-              delete next[trace.id];
-              set({ traceSpans: next } as Partial<DebuggerSessionViewStore>);
-            }
-            await baseSlice.ensureTraceSpans(trace);
-            // Flush realtime spans that buffered for this KNOWN run (its slot didn't
-            // exist when they streamed, so applyRealtimeSpan couldn't merge them and
-            // the new-run flush in applyTraceUpdate never ran). Recency-aware merge.
-            const buffered = get().realtimeSpanBuffer[trace.id];
-            if (buffered?.length) {
-              get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], buffered));
-              set((s) => {
-                const next = { ...s.realtimeSpanBuffer };
-                delete next[trace.id];
-                return { realtimeSpanBuffer: next } as Partial<DebuggerSessionViewStore>;
-              });
-            }
-            // Mark genuinely-empty results so future re-expands don't refetch.
-            const after = get().traceSpans[trace.id];
-            if (after && after.length === 0) {
+            // State-based idempotence (never shape-based): if a catch-up fetch is in
+            // flight or already settled, do nothing — spans stream in independently
+            // and the recency merge keeps them correct. Only an idle (never-fetched)
+            // list row reaches the fetch below.
+            const fetchState = get().traceFetchState[trace.id];
+            if (fetchState === "loading" || fetchState === "loaded") return;
+
+            // BOUNDARY DECISION: the base slice keeps its own `traceSpansLoading` for
+            // the regular session view; the debugger segment UI reads ONLY
+            // `traceFetchState`. Set "loading" synchronously (before any await) so a
+            // span streaming in between this set and the fetch settling can never flash
+            // "No spans found" — this is the exact P1 race class. The base fetch's
+            // `traceSpansLoading` still runs underneath but the debugger UI ignores it.
+            //
+            // AbortController stance (decided): no abort plumbing. Per-trace fetches
+            // fire once (state-guarded above), late responses are harmless through the
+            // recency merge, and the store is recreated per session (provider keyed by
+            // sessionId). Zustand vanilla has no dispose hook to hang a controller off,
+            // so we skip it entirely rather than invent lifecycle.
+            set(
+              (s) =>
+                ({
+                  traceFetchState: { ...s.traceFetchState, [trace.id]: "loading" },
+                }) as Partial<DebuggerSessionViewStore>
+            );
+            try {
+              await baseSlice.ensureTraceSpans(trace);
+            } finally {
               set(
                 (s) =>
                   ({
-                    traceSpansConfirmedEmpty: { ...s.traceSpansConfirmedEmpty, [trace.id]: true },
+                    traceFetchState: { ...s.traceFetchState, [trace.id]: "loaded" },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }
@@ -321,11 +309,9 @@ const createDebuggerSessionViewStore = (options?: {
               );
               // MERGE with current rows instead of replacing: a run that started while
               // this fetch was in flight was added by applyTraceUpdate but is absent
-              // from the (CH-lagged) response — replacing wholesale wipes its row, and
-              // the next trace_update then re-runs the new-run branch and clobbers the
-              // populated spans slot with the (already-flushed) empty buffer →
-              // "(no spans)". Fetched rows win per-id (richer stats) but keep the live
-              // row's merged metadata + realtime-bumped endTime (same semantics as
+              // from the (CH-lagged) response — replacing wholesale wipes its row and
+              // its streamed spans. Fetched rows win per-id (richer stats) but keep the
+              // live row's merged metadata + realtime-bumped endTime (same semantics as
               // hydrateTraceRow); realtime-only rows are kept as-is.
               get().setTraces((prev) => {
                 const prevById = new Map(prev.map((t) => [t.id, t]));
@@ -359,22 +345,12 @@ const createDebuggerSessionViewStore = (options?: {
             const traceId = span.traceId;
             const tvSpan = realtimeToTraceViewSpan(span);
 
-            if (get().traceSpans[traceId]) {
-              // Slot exists → merge straight into the live list (dedupe + sort + enrich).
-              get().setTraceSpans(traceId, mergeSpans(get().traceSpans[traceId], [tvSpan]));
-            } else {
-              // Slot not created yet. The backend dispatches the span branch and the
-              // trace_update branch concurrently, so spans routinely arrive BEFORE the
-              // trace_update creates the slot. Buffer here (dedupe by spanId); the
-              // new-run branch in applyTraceUpdate flushes the buffer once the slot
-              // exists. Previously these spans were dropped → "(no spans)" on short runs.
-              set((state) => {
-                const buffered = state.realtimeSpanBuffer[traceId] ?? [];
-                return {
-                  realtimeSpanBuffer: { ...state.realtimeSpanBuffer, [traceId]: mergeSpans(buffered, [tvSpan]) },
-                } as Partial<DebuggerSessionViewStore>;
-              });
-            }
+            // Unconditional upsert into the dumb spans map (create the array if absent).
+            // Spans and trace rows are independent streams — a span can arrive before
+            // its trace_update creates the row, which is fine: the recency-aware merge
+            // dedupes by spanId, and the segment renders whatever the map holds. No
+            // buffer, no conditions; this is what kills the old "(no spans)" race.
+            get().setTraceSpans(traceId, mergeSpans(get().traceSpans[traceId] ?? [], [tvSpan]));
 
             // Bump the owning trace row's endTime when the span extends past it (keeps
             // list stats/ordering correct for a live run). Find the row FIRST and only
@@ -399,38 +375,16 @@ const createDebuggerSessionViewStore = (options?: {
             const existing = get().traces.find((row) => row.id === t.traceId);
 
             if (!existing) {
-              // Unknown run → add a lightweight slot (placeholder stats) and append to
-              // ordering. Initialize the spans slot to the FLUSHED realtime buffer (any
-              // spans that raced ahead of this event) so the run is realtime-fed: with a
-              // non-empty/defined `traceSpans[id]`, the auto-expand's ensureTraceSpans
-              // short-circuits and we skip the doomed lazy fetch (it would window on the
-              // placeholder "now" times AND lag ClickHouse → return [], the "(no spans)"
-              // bug). Pre-existing CH spans for a run that started before view-open are
-              // recovered by the one-shot fetch in hydrateTraceRow (real times, merged).
-              const buffered = get().realtimeSpanBuffer[t.traceId] ?? [];
-              // Never overwrite an existing populated slot: the row can vanish-and-
-              // return (e.g. it was realtime-added, then a wholesale traces update
-              // dropped it) while the slot kept its streamed spans — re-seeding from
-              // the (already-flushed, empty) buffer would wipe them.
-              const existingSlot = get().traceSpans[t.traceId];
+              // Unknown run → add a lightweight row (placeholder stats) to the ordering.
+              // Any spans that raced ahead of this event are already in `traceSpans`
+              // (applyRealtimeSpan upserts unconditionally) — nothing to seed or flush.
               get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata)]);
-              get().setTraceSpans(t.traceId, existingSlot ? mergeSpans(existingSlot, buffered) : buffered);
-              set((state) => {
-                if (!(t.traceId in state.realtimeSpanBuffer)) return {} as Partial<DebuggerSessionViewStore>;
-                const next = { ...state.realtimeSpanBuffer };
-                delete next[t.traceId];
-                return { realtimeSpanBuffer: next } as Partial<DebuggerSessionViewStore>;
-              });
-              // Mark hydrating BEFORE expanding: setTraceExpanded triggers the
-              // ensureTraceSpans override, whose guard then short-circuits the doomed
-              // lazy fetch (placeholder "now" times + CH lag → []). hydrateTraceRow
-              // owns the real fetch and clears the flag in its finally.
-              set(
-                (s) =>
-                  ({ traceHydrating: { ...s.traceHydrating, [t.traceId]: true } }) as Partial<DebuggerSessionViewStore>
-              );
-              get().setTraceExpanded(t.traceId, true);
+              // Kick the catch-up fetch FIRST so it sets traceFetchState="loading"
+              // synchronously; setTraceExpanded then triggers the ensureTraceSpans
+              // override, which sees "loading" and short-circuits — one fetch, not two.
+              // hydrateTraceRow owns this trace's traceFetchState lifecycle.
               void get().hydrateTraceRow(t.traceId);
+              get().setTraceExpanded(t.traceId, true);
               // Surface the "New trace" pill so the user can jump to the new run — but
               // only once the initial fetch has settled, so a trace_update that beat the
               // first fetch (for a run already in the initial set) can't flash it on load.
@@ -466,14 +420,22 @@ const createDebuggerSessionViewStore = (options?: {
           hydrateTraceRow: async (traceId) => {
             const { projectId } = get();
             if (!projectId) return;
-            // Skip if the row already has real stats (a slot has startTime===endTime).
-            const current = get().traces.find((t) => t.id === traceId);
-            if (current && current.startTime !== current.endTime) return;
+            // State-based idempotence (never shape-based): if a catch-up fetch already
+            // ran or is running for this trace, don't re-fetch. This replaces the old
+            // `startTime !== endTime` shape check that the P1 race defeated (a streamed
+            // span bumped endTime past startTime before this ran, so the guard passed
+            // and the flag-clear in finally was skipped → stuck skeleton).
+            if (get().traceFetchState[traceId]) return;
 
-            // Mark hydrating so the segment shows the skeleton (not "No spans found")
-            // for a placeholder empty `[]` slot while this fetch is in flight.
+            // hydrateTraceRow is the sole owner of traceFetchState. Set "loading" in
+            // the SYNCHRONOUS prefix (before ANY await) — this is the exact P1 trap:
+            // a span streaming in between this call and the fetch settling must never
+            // flash "No spans found" before the skeleton is shown.
             set(
-              (s) => ({ traceHydrating: { ...s.traceHydrating, [traceId]: true } }) as Partial<DebuggerSessionViewStore>
+              (s) =>
+                ({
+                  traceFetchState: { ...s.traceFetchState, [traceId]: "loading" },
+                }) as Partial<DebuggerSessionViewStore>
             );
             try {
               const params = new URLSearchParams();
@@ -528,13 +490,22 @@ const createDebuggerSessionViewStore = (options?: {
                 }
               }
             } catch {
-              // Best-effort hydration — placeholder stats / realtime-fed spans remain on failure.
+              // Best-effort hydration — placeholder stats / realtime-fed spans remain on
+              // failure. HYDRATE-FAILURE SEMANTICS (decided): a failed fetch still reaches
+              // "loaded" below — the UI shows whatever spans streamed (or "No spans found"
+              // if none). We do NOT retry: the state-based idempotence guard means a
+              // re-expand won't re-fetch. Kept simple per spec; if a failed run needs a
+              // retry affordance later, surface a manual refresh rather than auto-retry.
             } finally {
-              set((s) => {
-                const next = { ...s.traceHydrating };
-                delete next[traceId];
-                return { traceHydrating: next } as Partial<DebuggerSessionViewStore>;
-              });
+              // "loaded" unconditionally (success OR failure) — the skeleton must always
+              // resolve. This is the structural fix for the stuck-skeleton P1: there is no
+              // early-return path that can skip this finally.
+              set(
+                (s) =>
+                  ({
+                    traceFetchState: { ...s.traceFetchState, [traceId]: "loaded" },
+                  }) as Partial<DebuggerSessionViewStore>
+              );
             }
           },
 

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -202,6 +202,7 @@ export const createDebuggerSessionViewStore = (options?: {
               (s) =>
                 ({
                   traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: true },
+                  traceSpansError: { ...s.traceSpansError, [trace.id]: undefined },
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
@@ -213,11 +214,17 @@ export const createDebuggerSessionViewStore = (options?: {
               const res = await fetch(`/api/projects/${projectId}/traces/${trace.id}/spans?${spanParams.toString()}`);
               if (!res.ok) throw new Error("Failed to load spans");
               const fetchedSpans = (await res.json()) as TraceViewSpan[];
-              if (fetchedSpans.length > 0) {
-                get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
-              }
+              // Always write the slot (even empty) — TraceItem's two-phase expand
+              // waits for spans/traceSpansError to become defined before opening.
+              get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
             } catch {
               // The UI keeps whatever streamed; re-expand retries.
+              set(
+                (s) =>
+                  ({
+                    traceSpansError: { ...s.traceSpansError, [trace.id]: "Failed to load spans" },
+                  }) as Partial<DebuggerSessionViewStore>
+              );
               toast({
                 variant: "destructive",
                 title: "Failed to load spans",

--- a/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
@@ -30,9 +30,8 @@ import RunComment from "./run-comment";
 import { traceAnchorId } from "./session-outline/utils";
 import { useDebuggerSessionViewStore } from "./store";
 
-// Paste-to-agent prompt for "cache and rerun from here": the SDK resolves
-// LMNR_DEBUG_CACHE_UNTIL from a span id (see lmnr-ts debug/config.ts
-// parseCacheUntil) — no need to compute an occurrence count here.
+// Paste-to-agent prompt for "cache and rerun from here"; the SDK resolves
+// LMNR_DEBUG_CACHE_UNTIL from a span id directly.
 const rerunPrompt = (traceId: string, spanId: string, sessionId?: string) =>
   [
     "Rerun the agent with these env vars:",
@@ -167,9 +166,8 @@ export default function TraceSegment({
   const consumeScrollToTrace = useSessionViewBaseStore((s) => s.consumeScrollToTrace);
 
   const note = useDebuggerSessionViewStore((s) => s.noteForTrace(traceId));
-  // Fetch-in-flight → skeleton; settled + empty → "No spans found". Expanding
-  // always starts a fetch (synchronously, in the ensureTraceSpans override), so
-  // an expanded-but-empty segment is never mislabeled empty before its fetch.
+  // In-flight → skeleton; settled + empty → "No spans found". Expanding starts a
+  // fetch synchronously, so an empty segment is never mislabeled pre-fetch.
   const isLoading = useDebuggerSessionViewStore((s) => !!s.traceSpansFetching[traceId]);
 
   const rows = useMemo<TranscriptRow[]>(() => {
@@ -182,12 +180,8 @@ export default function TraceSegment({
   const headerRef = useRef<HTMLDivElement>(null);
   const [scrollMargin, setScrollMargin] = useState(0);
 
-  // R1: when THIS trace was just collapsed, bring its header into view — only if
-  // out of view (mirrors the regular view's scrollToIndex align:"auto"). The
-  // debugger has no flat-row virtualizer to scrollToIndex against; the header is
-  // plain DOM, so we bounds-check it against the page scroll container and scroll
-  // only when it's outside the viewport, then consume the one-shot request. Keyed
-  // on `expanded` too so it runs AFTER the collapse rebuilds this segment's height.
+  // On collapse, bring this trace's header into view only if it's out of view.
+  // Keyed on `expanded` so it runs after the collapse rebuilds segment height.
   useEffect(() => {
     if (scrollToTraceId !== traceId) return;
     const header = headerRef.current;
@@ -205,10 +199,8 @@ export default function TraceSegment({
     consumeScrollToTrace();
   }, [scrollToTraceId, traceId, expanded, scrollEl, consumeScrollToTrace]);
 
-  // Measure this viewport's offset within the scroll content (rect math instead
-  // of offsetTop — robust to positioned ancestors). Re-measured whenever the
-  // column's height changes (layoutVersion) since anything above us moving
-  // shifts the offset. The ±1px guard keeps re-measure→re-render convergent.
+  // Measure this viewport's offset in the scroll content; re-measured on column
+  // height changes (layoutVersion). The ±1px guard keeps it convergent.
   useLayoutEffect(() => {
     const el = viewportRef.current;
     if (!el || !scrollEl) return;

--- a/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
@@ -147,10 +147,9 @@ export default function TraceSegment({
   const traceId = trace.id;
 
   // Narrow per-trace store selections: streamed spans re-render only this segment.
-  const { spans, loading, error, expanded, selectedSpan } = useSessionViewBaseStore(
+  const { spans, error, expanded, selectedSpan } = useSessionViewBaseStore(
     (s) => ({
       spans: s.traceSpans[traceId],
-      loading: s.traceSpansLoading[traceId],
       error: s.traceSpansError[traceId],
       expanded: s.expandedTraceIds.has(traceId),
       selectedSpan: s.selectedSpan,
@@ -168,9 +167,13 @@ export default function TraceSegment({
   const consumeScrollToTrace = useSessionViewBaseStore((s) => s.consumeScrollToTrace);
 
   const note = useDebuggerSessionViewStore((s) => s.noteForTrace(traceId));
-  // True while hydrateTraceRow's one-shot fetch is in flight for this run — keeps
-  // a placeholder empty `[]` slot on the skeleton instead of "No spans found".
-  const hydrating = useDebuggerSessionViewStore((s) => !!s.traceHydrating[traceId]);
+  // ONE source of truth for "have this trace's spans loaded?" (decided: read
+  // traceFetchState, NOT the base slice's traceSpansLoading). "loading" → skeleton;
+  // "loaded" + empty → "No spans found"; absent (a list row not yet expanded) is
+  // treated as still-loading once expanded, since expanding flips it to "loading"
+  // synchronously via the ensureTraceSpans override.
+  const fetchState = useDebuggerSessionViewStore((s) => s.traceFetchState[traceId]);
+  const isLoading = fetchState !== "loaded";
 
   const rows = useMemo<TranscriptRow[]>(() => {
     if (!expanded || !spans || spans.length === 0) return [];
@@ -335,14 +338,14 @@ export default function TraceSegment({
       {!expanded && <TraceCollapsedBody trace={trace} traceIO={traceIO} />}
 
       {expanded && error && <div className="py-4 px-2 text-sm text-destructive">{error}</div>}
-      {expanded && !error && (!spans || (spans.length === 0 && (loading || hydrating))) && (
+      {expanded && !error && (!spans || spans.length === 0) && isLoading && (
         <div className="flex flex-col gap-2 py-2 px-2">
           <Skeleton className="h-5 w-full" />
           <Skeleton className="h-5 w-3/4" />
           <Skeleton className="h-5 w-2/3" />
         </div>
       )}
-      {expanded && !error && spans && spans.length === 0 && !loading && !hydrating && (
+      {expanded && !error && (!spans || spans.length === 0) && !isLoading && (
         <div className="py-4 px-2 text-sm text-muted-foreground">No spans found for this trace.</div>
       )}
 

--- a/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
@@ -167,13 +167,10 @@ export default function TraceSegment({
   const consumeScrollToTrace = useSessionViewBaseStore((s) => s.consumeScrollToTrace);
 
   const note = useDebuggerSessionViewStore((s) => s.noteForTrace(traceId));
-  // ONE source of truth for "have this trace's spans loaded?" (decided: read
-  // traceFetchState, NOT the base slice's traceSpansLoading). "loading" → skeleton;
-  // "loaded" + empty → "No spans found"; absent (a list row not yet expanded) is
-  // treated as still-loading once expanded, since expanding flips it to "loading"
-  // synchronously via the ensureTraceSpans override.
-  const fetchState = useDebuggerSessionViewStore((s) => s.traceFetchState[traceId]);
-  const isLoading = fetchState !== "loaded";
+  // Fetch-in-flight → skeleton; settled + empty → "No spans found". Expanding
+  // always starts a fetch (synchronously, in the ensureTraceSpans override), so
+  // an expanded-but-empty segment is never mislabeled empty before its fetch.
+  const isLoading = useDebuggerSessionViewStore((s) => !!s.traceSpansFetching[traceId]);
 
   const rows = useMemo<TranscriptRow[]>(() => {
     if (!expanded || !spans || spans.length === 0) return [];

--- a/frontend/components/traces/session-view/session-panel/trace-item.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-item.tsx
@@ -49,11 +49,11 @@ export default function TraceItem({
   // Only the data the header chrome needs: `spans` gates the pending-expand
   // spinner; `spansError` lets a failed lazy-load still flip out of pending.
   // The collapsed body (input + last-span preview) is its own row now.
-  const { spans, spansError, ensureTraceSpans } = useSessionViewBaseStore(
+  const { spans, spansError, fetchTraceSpans } = useSessionViewBaseStore(
     (s) => ({
       spans: s.traceSpans[trace.id],
       spansError: s.traceSpansError[trace.id],
-      ensureTraceSpans: s.ensureTraceSpans,
+      fetchTraceSpans: s.fetchTraceSpans,
     }),
     shallow
   );
@@ -84,8 +84,8 @@ export default function TraceItem({
     }
     pendingExpandRef.current = true;
     setIsPendingExpand(true);
-    ensureTraceSpans(trace);
-  }, [expanded, spans, onToggle, ensureTraceSpans, trace]);
+    fetchTraceSpans(trace);
+  }, [expanded, spans, onToggle, fetchTraceSpans, trace]);
 
   const handleCopyTraceId = useCallback(async () => {
     await navigator.clipboard.writeText(trace.id);

--- a/frontend/components/traces/session-view/session-panel/trace-item.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-item.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ChevronDown, Copy, ExternalLink, Loader2 } from "lucide-react";
+import { ChevronDown, Copy, ExternalLink } from "lucide-react";
 import { useParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { shallow } from "zustand/shallow";
 
 import { formatShortRelativeTime } from "@/components/client-timestamp-formatter";
@@ -46,45 +46,19 @@ export default function TraceItem({
   const projectId = params.projectId;
   const { toast } = useToast();
 
-  // Only the data the header chrome needs: `spans` gates the pending-expand
-  // spinner; `spansError` lets a failed lazy-load still flip out of pending.
-  // The collapsed body (input + last-span preview) is its own row now.
-  const { spans, spansError, fetchTraceSpans } = useSessionViewBaseStore(
+  const { spans, fetchTraceSpans } = useSessionViewBaseStore(
     (s) => ({
       spans: s.traceSpans[trace.id],
-      spansError: s.traceSpansError[trace.id],
       fetchTraceSpans: s.fetchTraceSpans,
     }),
     shallow
   );
 
-  const pendingExpandRef = useRef(false);
-  const [isPendingExpand, setIsPendingExpand] = useState(false);
-
-  useEffect(() => {
-    if (!pendingExpandRef.current) return;
-    if (spans || spansError) {
-      pendingExpandRef.current = false;
-      queueMicrotask(() => {
-        setIsPendingExpand(false);
-        onToggle();
-      });
-    }
-  }, [spans, spansError, onToggle]);
-
+  // Expand immediately — the expanded body owns its loading/empty/error states.
   const handleToggle = useCallback(() => {
     track("sessions", expanded ? "trace_card_collapsed" : "trace_card_expanded", { traceId: trace.id });
-    if (expanded) {
-      onToggle();
-      return;
-    }
-    if (spans) {
-      onToggle();
-      return;
-    }
-    pendingExpandRef.current = true;
-    setIsPendingExpand(true);
-    fetchTraceSpans(trace);
+    if (!expanded && !spans) void fetchTraceSpans(trace);
+    onToggle();
   }, [expanded, spans, onToggle, fetchTraceSpans, trace]);
 
   const handleCopyTraceId = useCallback(async () => {
@@ -177,7 +151,6 @@ export default function TraceItem({
               <span className="text-[13px] leading-[17px] text-secondary-foreground whitespace-nowrap">
                 {relativeTime}
               </span>
-              {isPendingExpand && <Loader2 size={16} className="text-secondary-foreground animate-spin" />}
               <span
                 className={cn(
                   "flex items-center justify-center rounded-full pl-1 pr-1 py-0.5 text-xs font-medium leading-[17px] text-secondary-foreground whitespace-nowrap",

--- a/frontend/components/traces/session-view/session-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-timeline/index.tsx
@@ -28,7 +28,7 @@ function SessionTimeline() {
     selectedSpan,
     setSelectedSpan,
     toggleTraceExpanded,
-    ensureTraceSpans,
+    fetchTraceSpans,
     zoom,
     setZoom,
     setSessionTimelineEnabled,
@@ -43,7 +43,7 @@ function SessionTimeline() {
       selectedSpan: s.selectedSpan,
       setSelectedSpan: s.setSelectedSpan,
       toggleTraceExpanded: s.toggleTraceExpanded,
-      ensureTraceSpans: s.ensureTraceSpans,
+      fetchTraceSpans: s.fetchTraceSpans,
       zoom: s.sessionTimelineZoom,
       setZoom: s.setSessionTimelineZoom,
       setSessionTimelineEnabled: s.setSessionTimelineEnabled,
@@ -78,7 +78,7 @@ function SessionTimeline() {
 
   // Two-phase expand (mirrors list/trace-item.tsx): when the user clicks a
   // collapsed trace whose spans aren't loaded yet, we DON'T flip
-  // `expandedTraceIds` immediately — we kick off `ensureTraceSpans` and
+  // `expandedTraceIds` immediately — we kick off `fetchTraceSpans` and
   // flush to expand once spans arrive. The bar meanwhile shows a shimmer
   // (driven by `traceSpansLoading` → `bar.shimmer` in utils.ts).
   //
@@ -119,9 +119,9 @@ function SessionTimeline() {
       const trace = traces.find((t) => t.id === traceId);
       if (!trace) return;
       pendingExpandIdsRef.current.add(traceId);
-      void ensureTraceSpans(trace);
+      void fetchTraceSpans(trace);
     },
-    [expandedTraceIds, traceSpans, traces, toggleTraceExpanded, ensureTraceSpans]
+    [expandedTraceIds, traceSpans, traces, toggleTraceExpanded, fetchTraceSpans]
   );
 
   const handleSpanBarClick = useCallback(

--- a/frontend/components/traces/session-view/session-view-content.tsx
+++ b/frontend/components/traces/session-view/session-view-content.tsx
@@ -36,7 +36,7 @@ export default function SessionViewContent({ sessionId }: SessionViewContentProp
     );
 
   // Push projectId into the store so store-owned async actions
-  // (e.g. ensureTraceSpans) can issue requests without prop-drilling.
+  // (e.g. fetchTraceSpans) can issue requests without prop-drilling.
   useEffect(() => {
     setProjectId(projectId);
   }, [projectId, setProjectId]);

--- a/frontend/components/traces/session-view/store/base.ts
+++ b/frontend/components/traces/session-view/store/base.ts
@@ -81,7 +81,7 @@ export interface BaseSessionViewActions {
 
   /** Fetch spans for a trace if not already loaded or currently loading.
    *  Idempotent: safe to call repeatedly on mount of TraceItem. */
-  ensureTraceSpans: (trace: TraceRow) => Promise<void>;
+  fetchTraceSpans: (trace: TraceRow) => Promise<void>;
 
   toggleTraceExpanded: (traceId: string) => void;
   setTraceExpanded: (traceId: string, expanded: boolean) => void;
@@ -225,7 +225,7 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
     setIsTracesLoading: (isTracesLoading) => set({ isTracesLoading } as Partial<T>),
     setTracesError: (tracesError) => set({ tracesError } as Partial<T>),
 
-    ensureTraceSpans: async (trace) => {
+    fetchTraceSpans: async (trace) => {
       const state = get();
       const { projectId } = state;
       if (!projectId) return;
@@ -238,8 +238,6 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
 
       try {
         const params = new URLSearchParams();
-        params.append("searchIn", "input");
-        params.append("searchIn", "output");
         const startDate = new Date(new Date(trace.startTime).getTime() - 1000).toISOString();
         const endDate = new Date(new Date(trace.endTime).getTime() + 1000).toISOString();
         params.set("startDate", startDate);
@@ -273,9 +271,9 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
       }
     },
 
-    // open recursion: delegates to get().ensureTraceSpans — a derived store's override wins.
+    // open recursion: delegates to get().fetchTraceSpans — a derived store's override wins.
     // Any transition to `expanded=true` also kicks off span loading (idempotent
-    // via `ensureTraceSpans`'s internal dedupe).
+    // via `fetchTraceSpans`'s internal dedupe).
     toggleTraceExpanded: (traceId) => {
       const state = get();
       const prev = state.expandedTraceIds;
@@ -289,10 +287,10 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
 
       if (willExpand) {
         const trace = state.traces.find((t) => t.id === traceId);
-        if (trace) void get().ensureTraceSpans(trace);
+        if (trace) void get().fetchTraceSpans(trace);
       }
     },
-    // open recursion: delegates to get().ensureTraceSpans — a derived store's override wins.
+    // open recursion: delegates to get().fetchTraceSpans — a derived store's override wins.
     setTraceExpanded: (traceId, expanded) => {
       const state = get();
       const prev = state.expandedTraceIds;
@@ -304,16 +302,16 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
 
       if (expanded) {
         const trace = state.traces.find((t) => t.id === traceId);
-        if (trace) void get().ensureTraceSpans(trace);
+        if (trace) void get().fetchTraceSpans(trace);
       }
     },
-    // open recursion: delegates to get().ensureTraceSpans — a derived store's override wins.
+    // open recursion: delegates to get().fetchTraceSpans — a derived store's override wins.
     expandAllTraces: () => {
       const state = get();
       const all = new Set(state.traces.map((t) => t.id));
       set({ expandedTraceIds: all } as Partial<T>);
       for (const trace of state.traces) {
-        void get().ensureTraceSpans(trace);
+        void get().fetchTraceSpans(trace);
       }
     },
 


### PR DESCRIPTION
## What

Replaces the debugger session store's shape-inference machinery with one explicit per-trace lifecycle field, fixing the stuck-skeleton race (greptile P1) structurally.

### Store refactor (`traceFetchState`)
- Spans (SSE or fetch) now upsert **unconditionally** into `traceSpans[traceId]` through the existing recency-aware merge — `realtimeSpanBuffer` and both flush paths are deleted; spans arriving before their run registers just sit in the map until the row renders.
- `traceFetchState: Record<traceId, "loading" | "loaded">` replaces `traceHydrating`, `traceSpansConfirmedEmpty`, and the placeholder-slot dance. Set in the synchronous prefix of both fetch paths; cleared in `finally` — the flag-stuck-forever class is unrepresentable now.
- Skeleton while `"loading"`; "No spans found" only when `"loaded"` and empty. A failed hydrate settles to `"loaded"` showing whatever streamed (no auto-retry).
- No AbortControllers by design: fetches fire once (state-guarded), late responses are harmless through the recency merge, and the store is recreated per session.

### `session_deleted` SSE handler
The view subscribed to `rollout_session_{id}` but ignored `session_deleted` (published by the SDK delete endpoint) — an open page kept streaming after the row was gone. Now: destructive toast + redirect to the sessions list. Payload casing verified against the Rust publisher.

### Stick-to-bottom fixes
- The pin's snap uses `behavior: "instant"` — the container's `scroll-smooth` CSS was animating the snap, and the animation's own scroll events unpinned mid-flight.
- `PIN_SLACK_PX` 40 → 200 so stopping at the last trace (above the article's 160px bottom padding) counts as pinned.

## Notes
- +118/−132 vs dev for the refactor; net deletion overall.
- `pnpm type-check` clean; lint at pre-existing baseline (zero new).
- Behavior verified by a temporary headless store test (event-order simulations incl. the P1 repro), removed before commit per review policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span/realtime merge and expand-fetch paths used during live debugging; mistakes could cause wrong empty states or dropped spans, but scope is mostly debugger session UI with a shared rename on the base store.
> 
> **Overview**
> Refactors **debugger session** realtime and span loading so streamed spans always merge into `traceSpans` (no `realtimeSpanBuffer` or placeholder-slot logic), with per-trace **`traceSpansFetching`** driving skeleton vs empty states and **`fetchTraceSpans` / `hydrateTraceRow`** always clearing that flag in `finally`.
> 
> Adds a **`session_deleted`** SSE handler (destructive toast + redirect to the sessions list). Tweaks **stick-to-bottom** (`behavior: "instant"`, larger pin slack). Renames shared **`ensureTraceSpans` → `fetchTraceSpans`**; debugger **trace cards expand immediately** while the segment owns loading UI; span fetches drop redundant `searchIn` query params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a07a2aec997c52148b6e805245bf09bf9a34bd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->