### PR TITLE
don't enforce http

### DIFF
--- a/frontend/app/api/broker/slack/start/route.ts
+++ b/frontend/app/api/broker/slack/start/route.ts
@@ -5,7 +5,7 @@ import { authenticateInstance, buildSlackAuthorizeUrl, getBearerToken, mintState
 
 const StartRequestSchema = z.object({
   workspaceId: z.guid(),
-  returnUrl: z.url({ protocol: /^https$/ }),
+  returnUrl: z.url(),
 });
 
 // Server-to-server: the calling instance authenticates with its issued key and


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> `returnUrl` still drives post-OAuth browser redirects; dropping HTTPS-only validation increases exposure if instances can supply attacker-controlled URLs, though auth and signed state requirements are unchanged.
> 
> **Overview**
> Relaxes **`returnUrl` validation** on the Slack broker **`POST /api/broker/slack/start`** request body: it is still required to be a valid URL via `z.url()`, but the previous **HTTPS-only** constraint (`protocol: /^https$/`) is removed.
> 
> That lets calling instances pass **`http://` return URLs** (e.g. local dev) while the rest of the start flow—instance bearer auth, `mintState`, and Slack authorize URL generation—is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ff07f5bf5b1128fa3f5e283043cf8ea4d0e88f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->