### PR TITLE
fix: migration in place to create indexes idempotent

### DIFF
--- a/frontend/lib/clickhouse/migrations/48_clusters_centroid_dim_768.sql
+++ b/frontend/lib/clickhouse/migrations/48_clusters_centroid_dim_768.sql
@@ -4,7 +4,7 @@
 -- (Code: 469 centroid_same_dim). We swap in a fresh 768-dim table rather than
 -- ALTER the constraint in place, because adding a constraint to an already
 -- populated 3072-dim table would fail. Any pre-existing clusters are preserved
--- in `old_signal_event_clusters_3072` for operators who want to inspect them;
+-- in `signal_event_clusters_768` for operators who want to inspect them;
 -- it is safe to drop once no longer needed.
 CREATE TABLE IF NOT EXISTS signal_event_clusters_768
 (

--- a/frontend/lib/clickhouse/migrations/48_clusters_centroid_dim_768.sql
+++ b/frontend/lib/clickhouse/migrations/48_clusters_centroid_dim_768.sql
@@ -31,10 +31,10 @@ ALTER TABLE signal_event_clusters_768 ADD INDEX IF NOT EXISTS signal_event_clust
     768
 );
 
-ALTER TABLE signal_event_clusters_768 MATERIALIZE INDEX centroid_cosine_hnsw;
+ALTER TABLE signal_event_clusters_768 MATERIALIZE INDEX signal_event_clusters_centroid_cosine_hnsw;
 
-ALTER TABLE signal_event_clusters_768 ADD INDEX IF NOT EXISTS clusters_project_id_cluster_id_idx (project_id, id) TYPE bloom_filter GRANULARITY 1;
+ALTER TABLE signal_event_clusters_768 ADD INDEX IF NOT EXISTS signal_event_clusters_project_id_cluster_id_idx (project_id, id) TYPE bloom_filter GRANULARITY 1;
 
-ALTER TABLE signal_event_clusters_768 MATERIALIZE INDEX clusters_project_id_cluster_id_idx;
+ALTER TABLE signal_event_clusters_768 MATERIALIZE INDEX signal_event_clusters_project_id_cluster_id_idx;
 
 EXCHANGE TABLES signal_event_clusters AND signal_event_clusters_768;

--- a/frontend/lib/clickhouse/migrations/48_clusters_centroid_dim_768.sql
+++ b/frontend/lib/clickhouse/migrations/48_clusters_centroid_dim_768.sql
@@ -25,7 +25,7 @@ ENGINE = ReplacingMergeTree(updated_at)
 PRIMARY KEY (project_id, signal_id)
 ORDER BY (project_id, signal_id, id);
 
-ALTER TABLE signal_event_clusters_768 ADD INDEX centroid_cosine_hnsw centroid TYPE vector_similarity(
+ALTER TABLE signal_event_clusters_768 ADD INDEX IF NOT EXISTS signal_event_clusters_centroid_cosine_hnsw centroid TYPE vector_similarity(
     'hnsw',
     cosineDistance,
     768
@@ -33,10 +33,8 @@ ALTER TABLE signal_event_clusters_768 ADD INDEX centroid_cosine_hnsw centroid TY
 
 ALTER TABLE signal_event_clusters_768 MATERIALIZE INDEX centroid_cosine_hnsw;
 
-ALTER TABLE signal_event_clusters_768 ADD INDEX clusters_project_id_cluster_id_idx (project_id, id) TYPE bloom_filter GRANULARITY 1;
+ALTER TABLE signal_event_clusters_768 ADD INDEX IF NOT EXISTS clusters_project_id_cluster_id_idx (project_id, id) TYPE bloom_filter GRANULARITY 1;
 
 ALTER TABLE signal_event_clusters_768 MATERIALIZE INDEX clusters_project_id_cluster_id_idx;
 
 EXCHANGE TABLES signal_event_clusters AND signal_event_clusters_768;
-
-RENAME TABLE signal_event_clusters_768 TO old_signal_event_clusters_3072;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches a production ClickHouse table swap for `signal_event_clusters`; wrong reruns could affect cluster search indexes or leave unexpected table names after EXCHANGE.
> 
> **Overview**
> Makes **migration 48** (`48_clusters_centroid_dim_768.sql`) safe to re-run and aligns post-migration table naming with the actual swap.
> 
> Index DDL now uses **`ADD INDEX IF NOT EXISTS`** and **prefixed index names** (`signal_event_clusters_centroid_cosine_hnsw`, `signal_event_clusters_project_id_cluster_id_idx`), with **`MATERIALIZE INDEX`** updated to those names so a partial or repeated run does not fail on duplicate indexes.
> 
> The comment now says pre-exchange cluster data remains in **`signal_event_clusters_768`** for inspection. The **`RENAME TABLE signal_event_clusters_768 TO old_signal_event_clusters_3072`** step after **`EXCHANGE TABLES`** is removed, so the staging table name is no longer renamed to `old_signal_event_clusters_3072` after the exchange.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0b64d22ff74915eb571cb3807b8fb951202fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->