### PR TITLE
refactor(debugger): DX follow-up

### DIFF
--- a/app-server/src/api/v1/cli/rollouts.rs
+++ b/app-server/src/api/v1/cli/rollouts.rs
@@ -4,17 +4,20 @@ use actix_web::{HttpResponse, patch, post, web};
 use uuid::Uuid;
 
 use crate::{
-    api::v1::rollouts::{RegisterSessionRequest, handle_register_session},
+    api::v1::rollouts::RegisterSessionRequest,
     auth::cli_user::CliProjectAuth,
-    db::{DB, debugger_sessions::update_debugger_session_name},
+    db::{
+        DB,
+        debugger_sessions::{create_or_update_debugger_session, update_debugger_session_name},
+    },
     pubsub::PubSub,
     realtime::{SseMessage, send_to_key},
     routes::types::ResponseResult,
 };
 
 /// `POST /v1/cli/rollouts/{session_id}` — CLI twin of `/v1/rollouts/{session_id}`
-/// (which stays project-API-key for SDKs/customers). Delegates to the shared
-/// `handle_register_session`; differs only in auth (`CliProjectAuth` user token).
+/// (which stays project-API-key for SDKs/customers). Same idempotent upsert and
+/// JSON response; differs only in auth (`CliProjectAuth` user token).
 #[post("rollouts/{session_id}")]
 pub async fn register_session(
     path: web::Path<Uuid>,
@@ -22,7 +25,15 @@ pub async fn register_session(
     auth: CliProjectAuth,
     db: web::Data<DB>,
 ) -> ResponseResult {
-    handle_register_session(path.into_inner(), auth.project_id, body.into_inner().name, db).await
+    let db = db.into_inner();
+    let session_id = path.into_inner();
+    let project_id = auth.project_id;
+    let name = body.into_inner().name;
+
+    let session =
+        create_or_update_debugger_session(&db.pool, &session_id, &project_id, name).await?;
+
+    Ok(HttpResponse::Ok().json(session))
 }
 
 #[derive(serde::Deserialize)]

--- a/app-server/src/api/v1/cli/rollouts.rs
+++ b/app-server/src/api/v1/cli/rollouts.rs
@@ -1,15 +1,29 @@
 use std::sync::Arc;
 
-use actix_web::{HttpResponse, patch, web};
+use actix_web::{HttpResponse, patch, post, web};
 use uuid::Uuid;
 
 use crate::{
+    api::v1::rollouts::{RegisterSessionRequest, handle_register_session},
     auth::cli_user::CliProjectAuth,
     db::{DB, debugger_sessions::update_debugger_session_name},
     pubsub::PubSub,
     realtime::{SseMessage, send_to_key},
     routes::types::ResponseResult,
 };
+
+/// `POST /v1/cli/rollouts/{session_id}` — CLI twin of `/v1/rollouts/{session_id}`
+/// (which stays project-API-key for SDKs/customers). Delegates to the shared
+/// `handle_register_session`; differs only in auth (`CliProjectAuth` user token).
+#[post("rollouts/{session_id}")]
+pub async fn register_session(
+    path: web::Path<Uuid>,
+    body: web::Json<RegisterSessionRequest>,
+    auth: CliProjectAuth,
+    db: web::Data<DB>,
+) -> ResponseResult {
+    handle_register_session(path.into_inner(), auth.project_id, body.into_inner().name, db).await
+}
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/app-server/src/api/v1/rollouts.rs
+++ b/app-server/src/api/v1/rollouts.rs
@@ -33,10 +33,26 @@ pub async fn register_session(
     body: web::Json<RegisterSessionRequest>,
     db: web::Data<DB>,
 ) -> ResponseResult {
+    handle_register_session(
+        path.into_inner(),
+        project_api_key.project_id,
+        body.into_inner().name,
+        db,
+    )
+    .await
+}
+
+/// Shared register (idempotent upsert) handler used by both the project-API-key
+/// `POST /v1/rollouts/{session_id}` and the CLI user-token
+/// `POST /v1/cli/rollouts/{session_id}` routes. Differs only in how the
+/// `project_id` is authenticated; the DB call and JSON response are identical.
+pub async fn handle_register_session(
+    session_id: Uuid,
+    project_id: Uuid,
+    name: Option<String>,
+    db: web::Data<DB>,
+) -> ResponseResult {
     let db = db.into_inner();
-    let session_id = path.into_inner();
-    let project_id = project_api_key.project_id;
-    let name = body.into_inner().name;
 
     let session =
         create_or_update_debugger_session(&db.pool, &session_id, &project_id, name).await?;

--- a/app-server/src/api/v1/rollouts.rs
+++ b/app-server/src/api/v1/rollouts.rs
@@ -33,26 +33,10 @@ pub async fn register_session(
     body: web::Json<RegisterSessionRequest>,
     db: web::Data<DB>,
 ) -> ResponseResult {
-    handle_register_session(
-        path.into_inner(),
-        project_api_key.project_id,
-        body.into_inner().name,
-        db,
-    )
-    .await
-}
-
-/// Shared register (idempotent upsert) handler used by both the project-API-key
-/// `POST /v1/rollouts/{session_id}` and the CLI user-token
-/// `POST /v1/cli/rollouts/{session_id}` routes. Differs only in how the
-/// `project_id` is authenticated; the DB call and JSON response are identical.
-pub async fn handle_register_session(
-    session_id: Uuid,
-    project_id: Uuid,
-    name: Option<String>,
-    db: web::Data<DB>,
-) -> ResponseResult {
     let db = db.into_inner();
+    let session_id = path.into_inner();
+    let project_id = project_api_key.project_id;
+    let name = body.into_inner().name;
 
     let session =
         create_or_update_debugger_session(&db.pool, &session_id, &project_id, name).await?;

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1951,7 +1951,8 @@ fn main() -> anyhow::Result<()> {
                                     .service(routes::sql::json_to_sql)
                                     .service(routes::spans::search_spans)
                                     .service(routes::signal_events::search_signal_events)
-                                    .service(routes::spans::get_skeleton_hashes);
+                                    .service(routes::spans::get_skeleton_hashes)
+                                    .service(routes::rollouts::update_session_name);
                                 #[cfg(feature = "signals")]
                                 let scope = scope
                                     .service(crate::signals::private::routes::submit_signal_job)

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -1920,7 +1920,8 @@ fn main() -> anyhow::Result<()> {
                                         web::scope("/traces")
                                             .service(api::v1::cli::traces::update_trace_metadata),
                                     )
-                                    .service(api::v1::cli::rollouts::update_name),
+                                    .service(api::v1::cli::rollouts::update_name)
+                                    .service(api::v1::cli::rollouts::register_session),
                             )
                             .service(
                                 web::scope("/v1")

--- a/app-server/src/routes/mod.rs
+++ b/app-server/src/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod probes;
 pub mod realtime;
+pub mod rollouts;
 pub mod signal_events;
 pub mod spans;
 pub mod sql;

--- a/app-server/src/routes/rollouts.rs
+++ b/app-server/src/routes/rollouts.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use actix_web::{HttpResponse, patch, web};
+use uuid::Uuid;
+
+use crate::{
+    db::{DB, debugger_sessions::update_debugger_session_name},
+    pubsub::PubSub,
+    realtime::{SseMessage, send_to_key},
+    routes::types::ResponseResult,
+};
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateNameRequest {
+    pub name: String,
+}
+
+/// `PATCH /api/v1/projects/{project_id}/rollouts/{session_id}/name` — rename a
+/// debug session from the frontend (auth handled by the Next.js middleware on
+/// the projects path). Update-only: unknown session id → 404.
+///
+/// Writes the name AND publishes `session_update`, mirroring the CLI rename
+/// (`api::v1::cli::rollouts::update_name`) so both rename paths broadcast the
+/// same event — every open debugger-session view (this tab and others) updates
+/// its title live instead of going stale until reload.
+#[patch("rollouts/{session_id}/name")]
+pub async fn update_session_name(
+    path: web::Path<(Uuid, Uuid)>,
+    body: web::Json<UpdateNameRequest>,
+    db: web::Data<DB>,
+    pubsub: web::Data<Arc<PubSub>>,
+) -> ResponseResult {
+    let db = db.into_inner();
+    let (project_id, session_id) = path.into_inner();
+    let name = body.into_inner().name;
+
+    let updated = update_debugger_session_name(&db.pool, &session_id, &project_id, &name).await?;
+    if !updated {
+        return Ok(HttpResponse::NotFound().json("Session not found"));
+    }
+
+    // Fire-and-forget broadcast (`send_to_key` swallows errors) so a pubsub
+    // failure never fails the rename itself.
+    let message = SseMessage {
+        event_type: "session_update".to_string(),
+        data: serde_json::json!({
+            "sessionId": session_id,
+            "name": name,
+        }),
+    };
+    let key = format!("rollout_session_{}", session_id);
+    send_to_key(pubsub.get_ref().as_ref(), &project_id, &key, message).await;
+
+    Ok(HttpResponse::Ok().finish())
+}

--- a/frontend/app/(auth)/(app)/project/[projectId]/debugger-sessions/[id]/page.tsx
+++ b/frontend/app/(auth)/(app)/project/[projectId]/debugger-sessions/[id]/page.tsx
@@ -16,5 +16,5 @@ export default async function DebuggerSessionPage(props: { params: Promise<{ pro
     { name: sessionName, copyValue: session.id },
   ];
 
-  return <DebuggerSessionView headerPath={headerPath} sessionId={session.id} />;
+  return <DebuggerSessionView headerPath={headerPath} sessionId={session.id} initialName={session.name ?? null} />;
 }

--- a/frontend/app/api/projects/[projectId]/debugger-sessions/[sessionId]/route.ts
+++ b/frontend/app/api/projects/[projectId]/debugger-sessions/[sessionId]/route.ts
@@ -1,6 +1,7 @@
 import { prettifyError, ZodError } from "zod/v4";
 
 import { updateDebuggerSessionName } from "@/lib/actions/debugger-sessions";
+import { NotFoundError } from "@/lib/errors";
 
 export async function PATCH(
   req: Request,
@@ -18,6 +19,10 @@ export async function PATCH(
   } catch (error) {
     if (error instanceof ZodError) {
       return Response.json({ error: prettifyError(error) }, { status: 400 });
+    }
+
+    if (error instanceof NotFoundError) {
+      return Response.json({ error: error.message }, { status: 404 });
     }
 
     return Response.json(

--- a/frontend/app/api/projects/[projectId]/debugger-sessions/[sessionId]/route.ts
+++ b/frontend/app/api/projects/[projectId]/debugger-sessions/[sessionId]/route.ts
@@ -1,0 +1,28 @@
+import { prettifyError, ZodError } from "zod/v4";
+
+import { updateDebuggerSessionName } from "@/lib/actions/debugger-sessions";
+
+export async function PATCH(
+  req: Request,
+  props: { params: Promise<{ projectId: string; sessionId: string }> }
+): Promise<Response> {
+  const { projectId, sessionId } = await props.params;
+
+  try {
+    const body = await req.json();
+    const { name } = body;
+
+    const session = await updateDebuggerSessionName({ projectId, id: sessionId, name });
+
+    return Response.json(session);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return Response.json({ error: prettifyError(error) }, { status: 400 });
+    }
+
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Failed to rename session. Please try again." },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/projects/[projectId]/traces/[traceId]/spans/[spanId]/type/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/[traceId]/spans/[spanId]/type/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { prettifyError, ZodError } from "zod/v4";
+
+import { getSpanType } from "@/lib/actions/span";
+
+export async function GET(
+  _req: Request,
+  props: { params: Promise<{ projectId: string; traceId: string; spanId: string }> }
+): Promise<Response> {
+  const { projectId, traceId, spanId } = await props.params;
+
+  try {
+    const spanType = await getSpanType({ projectId, traceId, spanId });
+
+    if (!spanType) {
+      return NextResponse.json({ error: "Span not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ spanType });
+  } catch (e) {
+    if (e instanceof ZodError) {
+      return NextResponse.json({ error: prettifyError(e) }, { status: 400 });
+    }
+    return NextResponse.json({ error: e instanceof Error ? e.message : "Failed to get span type." }, { status: 500 });
+  }
+}

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
@@ -2,7 +2,7 @@
 
 import { AlertTriangle } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { shallow } from "zustand/shallow";
 
 import SessionSpanPanel from "@/components/traces/session-view/session-span-panel";
@@ -63,36 +63,52 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
     scrollEl?.scrollTo({ top: scrollEl.scrollHeight, behavior: "smooth" });
   }, [scrollEl]);
 
-  // iMessage-style pinning: while at the bottom, follow content growth
-  // (ResizeObserver snap); scrolling up past the slack unpins.
-  useEffect(() => {
-    if (!scrollEl) return;
-    // No initial measure on purpose: short loading content is trivially "at the
-    // bottom", and an initial pin would drag the viewport down as traces load.
-    const pinned = { current: false };
-    const measure = () => {
-      pinned.current = scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - PIN_SLACK_PX;
-    };
-    scrollEl.addEventListener("scroll", measure, { passive: true });
-    const content = scrollEl.firstElementChild;
-    const observer = new ResizeObserver(() => {
-      // "instant" overrides the container's scroll-smooth — an animated snap
-      // fires scroll events outside the slack and unpins mid-flight.
-      if (pinned.current) scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "instant" });
-    });
-    if (content) observer.observe(content);
-    return () => {
-      scrollEl.removeEventListener("scroll", measure);
-      observer.disconnect();
-    };
-  }, [scrollEl]);
+  // Stick-to-bottom decisions only start once the initial runs fetch has
+  // settled: during loading the page is trivially short, so an "at the bottom"
+  // reading taken before history renders would drag an old session's viewport
+  // to the bottom. The /alpha harness (no sessionId) seeds traces at store
+  // creation, so it settles immediately.
+  const [scrollSettled, setScrollSettled] = useState(() => !sessionId);
 
   // Initial fetch of the session's runs (skipped for the /alpha single-trace
   // harness, which seeded base `traces` with one row at store creation).
   useEffect(() => {
     if (!sessionId) return;
-    void storeApi.getState().fetchSessionTraces(sessionId);
+    void storeApi
+      .getState()
+      .fetchSessionTraces(sessionId)
+      .finally(() => setScrollSettled(true));
   }, [sessionId, storeApi]);
+
+  // Seed the pre-growth height AFTER the settle commit (the fetched trace list
+  // is in the DOM by layout-effect time), so the history render itself never
+  // reads as growth from a short page.
+  const prevScrollHeightRef = useRef(0);
+  useLayoutEffect(() => {
+    if (!scrollSettled || !scrollEl) return;
+    prevScrollHeightRef.current = scrollEl.scrollHeight;
+  }, [scrollSettled, scrollEl]);
+
+  // iMessage-style stick-to-bottom, decided at growth time: when content
+  // height changes, follow it iff the viewport was within PIN_SLACK_PX of the
+  // bottom of the PREVIOUS content height. No scroll listener — geometry at
+  // the moment of growth is the whole state, so a fresh live session follows
+  // streamed spans without the user ever having scrolled.
+  useEffect(() => {
+    if (!scrollSettled || !scrollEl) return;
+    const content = scrollEl.firstElementChild;
+    if (!content) return;
+    const observer = new ResizeObserver(() => {
+      const prev = prevScrollHeightRef.current;
+      prevScrollHeightRef.current = scrollEl.scrollHeight;
+      const wasAtBottom = scrollEl.scrollTop + scrollEl.clientHeight >= prev - PIN_SLACK_PX;
+      // "instant" overrides the container's scroll-smooth — an animated snap
+      // lags behind rapid streaming growth.
+      if (wasAtBottom) scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "instant" });
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [scrollSettled, scrollEl]);
 
   const { createdMs, lastActivityMs } = useMemo(() => minMaxFromTraces(traces), [traces]);
 
@@ -140,7 +156,13 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
 
   return (
     <div className="flex flex-1 min-h-0 w-full">
-      <div ref={setScrollEl} className="thin-scrollbar min-h-0 min-w-0 flex-1 scroll-smooth overflow-y-auto">
+      {/* overflow-x-hidden + the article's min-w floor: at narrow widths the
+          article stops compressing and slides under the span panel's left edge
+          instead of crunching its content. */}
+      <div
+        ref={setScrollEl}
+        className="thin-scrollbar min-h-0 min-w-0 flex-1 scroll-smooth overflow-y-auto overflow-x-hidden"
+      >
         <div className="mx-auto flex w-full gap-16 px-6">
           <div className="flex grow-1 justify-center shrink-0 basis-0 min-w-fit">
             {!spanPanelOpen && (
@@ -149,7 +171,7 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
               </div>
             )}
           </div>
-          <div className="min-w-0 w-[720px] pb-[160px]">
+          <div className="min-w-[560px] w-[720px] pb-[160px]">
             <SessionHeader
               title={sessionName}
               createdMs={createdMs}

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
@@ -193,6 +193,8 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
                 <Skeleton className="h-10 w-full" />
                 <Skeleton className="h-10 w-full" />
               </div>
+            ) : traces.length === 0 ? (
+              <div className="flex justify-center py-16 text-sm text-muted-foreground">No runs in this session yet</div>
             ) : (
               <DebuggerTraceList scrollEl={scrollEl} projectId={projectId} sessionId={sessionId} />
             )}

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
@@ -18,10 +18,8 @@ import SessionHeader from "./session-header";
 import SessionOutline from "./session-outline";
 import { useDebuggerSessionViewStore, useDebuggerSessionViewStoreRaw } from "./store";
 
-// How close to the bottom counts as "pinned" for stick-to-bottom. Must exceed
-// the article column's 160px bottom padding — stopping where the last trace
-// ends still counts as "at the bottom" — while staying small enough that a
-// deliberate scroll-up unpins.
+// "Pinned" slack for stick-to-bottom. Must exceed the article's 160px bottom
+// padding (stopping at the last trace counts) yet let a scroll-up unpin.
 const PIN_SLACK_PX = 200;
 
 // Earliest run start / latest run end across loaded traces (epoch ms).
@@ -65,17 +63,12 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
     scrollEl?.scrollTo({ top: scrollEl.scrollHeight, behavior: "smooth" });
   }, [scrollEl]);
 
-  // iMessage-style pinning: while the user sits at (or near) the bottom, keep
-  // them there as streamed spans/traces grow the content. Pinned-ness is a ref
-  // updated on every user scroll; a ResizeObserver on the content column snaps
-  // the scroll back down whenever the content height changes while pinned.
-  // Scrolling up past the slack unpins, so reading history is never hijacked.
+  // iMessage-style pinning: while at the bottom, follow content growth
+  // (ResizeObserver snap); scrolling up past the slack unpins.
   useEffect(() => {
     if (!scrollEl) return;
-    // Starts unpinned and only a real scroll event can pin — there is no initial
-    // measure on purpose. On load the content is still short ("at the bottom" is
-    // trivially true), and an initial pin would drag the viewport down as traces
-    // stream in. Scrolling to the bottom (incl. the pill's smooth scroll) pins.
+    // No initial measure on purpose: short loading content is trivially "at the
+    // bottom", and an initial pin would drag the viewport down as traces load.
     const pinned = { current: false };
     const measure = () => {
       pinned.current = scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - PIN_SLACK_PX;
@@ -83,11 +76,8 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
     scrollEl.addEventListener("scroll", measure, { passive: true });
     const content = scrollEl.firstElementChild;
     const observer = new ResizeObserver(() => {
-      // Instant (not smooth) — growth can come every frame while streaming and
-      // queued smooth scrolls would rubber-band.
-      // `behavior: "instant"` overrides the container's `scroll-smooth` CSS —
-      // a smooth snap animates through positions outside the slack, whose
-      // scroll events would unpin us mid-flight and kill the follow.
+      // "instant" overrides the container's scroll-smooth — an animated snap
+      // fires scroll events outside the slack and unpins mid-flight.
       if (pinned.current) scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "instant" });
     });
     if (content) observer.observe(content);
@@ -129,9 +119,8 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
           storeApi.getState().setSessionName(payload.name);
         }
       },
-      // Session deleted (DELETE /v1/.../rollouts/{id}) → toast + bounce to the list.
-      // Payload is `{session_id}` (snake_case, see app-server rollouts.rs::delete).
-      // The channel is per-session, so any session_deleted here is for THIS session.
+      // Session deleted → toast + bounce to the list. Payload `{session_id}`
+      // (snake_case, see rollouts.rs::delete); the channel is per-session.
       session_deleted: (event: MessageEvent) => {
         const payload = JSON.parse(event.data) as { session_id?: string };
         if (sessionId && payload.session_id && payload.session_id !== sessionId) return;

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
@@ -18,10 +18,11 @@ import SessionHeader from "./session-header";
 import SessionOutline from "./session-outline";
 import { useDebuggerSessionViewStore, useDebuggerSessionViewStoreRaw } from "./store";
 
-// How close to the bottom counts as "pinned" for stick-to-bottom. Small enough
-// that a deliberate scroll-up unpins immediately; big enough that sub-pixel
-// rounding and momentum-scroll settle don't break the pin.
-const PIN_SLACK_PX = 40;
+// How close to the bottom counts as "pinned" for stick-to-bottom. Must exceed
+// the article column's 160px bottom padding — stopping where the last trace
+// ends still counts as "at the bottom" — while staying small enough that a
+// deliberate scroll-up unpins.
+const PIN_SLACK_PX = 200;
 
 // Earliest run start / latest run end across loaded traces (epoch ms).
 const minMaxFromTraces = (traces: { startTime: string; endTime: string }[]) => {
@@ -84,7 +85,10 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
     const observer = new ResizeObserver(() => {
       // Instant (not smooth) — growth can come every frame while streaming and
       // queued smooth scrolls would rubber-band.
-      if (pinned.current) scrollEl.scrollTop = scrollEl.scrollHeight;
+      // `behavior: "instant"` overrides the container's `scroll-smooth` CSS —
+      // a smooth snap animates through positions outside the slack, whose
+      // scroll events would unpin us mid-flight and kill the follow.
+      if (pinned.current) scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "instant" });
     });
     if (content) observer.observe(content);
     return () => {

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertTriangle } from "lucide-react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { shallow } from "zustand/shallow";
 
@@ -9,6 +9,7 @@ import SessionSpanPanel from "@/components/traces/session-view/session-span-pane
 import { useSessionViewBaseStore } from "@/components/traces/session-view/store";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useRealtime } from "@/lib/hooks/use-realtime";
+import { useToast } from "@/lib/hooks/use-toast";
 import { type RealtimeSpan } from "@/lib/traces/types";
 
 import DebuggerTraceList from "./debugger-trace-list";
@@ -39,6 +40,8 @@ const minMaxFromTraces = (traces: { startTime: string; endTime: string }[]) => {
 // a right spacer; span clicks open the in-flow SessionSpanPanel.
 export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: string }) {
   const { projectId } = useParams<{ projectId: string }>();
+  const router = useRouter();
+  const { toast } = useToast();
   const storeApi = useDebuggerSessionViewStoreRaw();
 
   const { traces, spanPanelOpen, isTracesLoading, tracesError } = useSessionViewBaseStore(
@@ -122,8 +125,17 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId?: 
           storeApi.getState().setSessionName(payload.name);
         }
       },
+      // Session deleted (DELETE /v1/.../rollouts/{id}) → toast + bounce to the list.
+      // Payload is `{session_id}` (snake_case, see app-server rollouts.rs::delete).
+      // The channel is per-session, so any session_deleted here is for THIS session.
+      session_deleted: (event: MessageEvent) => {
+        const payload = JSON.parse(event.data) as { session_id?: string };
+        if (sessionId && payload.session_id && payload.session_id !== sessionId) return;
+        toast({ variant: "destructive", title: "Session deleted" });
+        router.push(`/project/${projectId}/debugger-sessions`);
+      },
     }),
-    [storeApi, sessionId]
+    [storeApi, sessionId, projectId, router, toast]
   );
 
   useRealtime({

--- a/frontend/components/debugger-sessions/debugger-session-view/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/index.tsx
@@ -17,6 +17,10 @@ interface DebuggerSessionViewProps {
   headerPath?: ComponentProps<typeof Header>["path"];
   // Debugger session id — drives the trace fetch + realtime span streaming.
   sessionId?: string;
+  // The session's real name (null when never named). Seeds the editable title's
+  // raw name so it can show a "Set session name" placeholder vs. the breadcrumb,
+  // which falls back to the id.
+  initialName?: string | null;
 }
 
 // Last breadcrumb segment is the session/trace title rendered in the header.
@@ -67,7 +71,7 @@ function LiveSessionBreadcrumb({ path }: { path: ComponentProps<typeof Header>["
   return <Header path={livePath} />;
 }
 
-export default function DebuggerSessionView({ trace, headerPath, sessionId }: DebuggerSessionViewProps) {
+export default function DebuggerSessionView({ trace, headerPath, sessionId, initialName }: DebuggerSessionViewProps) {
   // Multi-trace session view (not the /alpha single-trace harness) is a viewed session.
   useEffect(() => {
     if (sessionId) track("debugger_sessions", "session_viewed");
@@ -82,6 +86,7 @@ export default function DebuggerSessionView({ trace, headerPath, sessionId }: De
       key={sessionId ?? trace?.id}
       initialTraceRow={initialTraceRow}
       initialSessionName={sessionTitle}
+      initialSessionNameRaw={initialName ?? null}
     >
       <LiveSessionBreadcrumb path={path} />
       <div className="flex-none border-t" />

--- a/frontend/components/debugger-sessions/debugger-session-view/run-comment.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/run-comment.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 
 import { noteMarkdownComponents, noteProseClassName, spanTagsToLinks } from "./note-markdown";
 import { headingAnchorId, parseNoteHeadings, slugify } from "./session-outline/utils";
-import { SpanChip } from "./span-reference";
+import { SelfResolvingSpanChip } from "./span-reference";
 import { useDebuggerSessionViewStore } from "./store";
 
 interface RunCommentProps {
@@ -83,7 +83,7 @@ export default function RunComment({ traceId }: RunCommentProps) {
               : referenceText;
           const id = spanId;
           return (
-            <SpanChip
+            <SelfResolvingSpanChip
               label={
                 preview ? (
                   <>
@@ -93,6 +93,8 @@ export default function RunComment({ traceId }: RunCommentProps) {
                   children
                 )
               }
+              traceId={traceId}
+              spanId={id}
               spanType={getSpanType(traceId, id)}
               onClick={() => setSelectedSpan({ traceId, spanId: id })}
             />

--- a/frontend/components/debugger-sessions/debugger-session-view/session-header/editable-session-title.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/session-header/editable-session-title.tsx
@@ -33,6 +33,11 @@ export default function EditableSessionTitle({ name, sessionId, onRenamed }: Edi
   const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(name ?? "");
   const [editing, setEditing] = useState(false);
+  // Escape cancels the edit, but its programmatic `.blur()` fires `onBlur` →
+  // `commit` SYNCHRONOUSLY, before React flushes the `setValue(name)` reset — so
+  // `commit`'s closure would still see the typed text and issue a rename. This
+  // ref lets `commit` detect the cancel and bail before any request.
+  const cancelRef = useRef(false);
 
   // Adopt external (SSE / store) name changes — e.g. a CLI rename of the open
   // session — without clobbering an in-progress edit or fighting a just-blurred
@@ -48,6 +53,12 @@ export default function EditableSessionTitle({ name, sessionId, onRenamed }: Edi
 
   const commit = async () => {
     setEditing(false);
+    // Escape-triggered blur: discard the edit without persisting.
+    if (cancelRef.current) {
+      cancelRef.current = false;
+      setValue(name ?? "");
+      return;
+    }
     const trimmed = value.trim();
     // No-op (unchanged) or an attempt to clear the name → just restore the field.
     if (trimmed === (name ?? "") || trimmed.length === 0) {
@@ -100,6 +111,7 @@ export default function EditableSessionTitle({ name, sessionId, onRenamed }: Edi
             e.preventDefault();
             inputRef.current?.blur();
           } else if (e.key === "Escape") {
+            cancelRef.current = true;
             setValue(name ?? "");
             setEditing(false);
             inputRef.current?.blur();

--- a/frontend/components/debugger-sessions/debugger-session-view/session-header/editable-session-title.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/session-header/editable-session-title.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+import { useToast } from "@/lib/hooks/use-toast";
+import { cn } from "@/lib/utils";
+
+const PLACEHOLDER = "Set session name";
+
+interface EditableSessionTitleProps {
+  /** The session's real name, or null when never named (→ show the placeholder). */
+  name: string | null;
+  sessionId: string;
+  /** Update the store on a successful rename (drives the title + breadcrumb live). */
+  onRenamed: (name: string) => void;
+}
+
+/**
+ * Ghost-input session title (Google-Drive / Figma style): it looks exactly like
+ * the static title until you click it, then an outline appears — the text itself
+ * never changes size, weight, color, or position. An empty name shows a
+ * "Set session name" placeholder. Saves on Enter/blur, reverts on Escape.
+ *
+ * The field hugs its text via a hidden sizer span (so the focus outline wraps the
+ * text, not the whole column). `-ml-1` + `px-1` keep the text glyphs in the exact
+ * same spot whether or not the (always-present, transparent-until-focus) border
+ * is visible, so clicking causes zero layout shift.
+ */
+export default function EditableSessionTitle({ name, sessionId, onRenamed }: EditableSessionTitleProps) {
+  const { projectId } = useParams<{ projectId: string }>();
+  const { toast } = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(name ?? "");
+  const [editing, setEditing] = useState(false);
+
+  // Adopt external (SSE / store) name changes — e.g. a CLI rename of the open
+  // session — without clobbering an in-progress edit or fighting a just-blurred
+  // commit. Keyed on a ref of the last-seen name so a mere focus/blur toggle never
+  // resets the field; only a genuine change to `name` does.
+  const lastSyncedName = useRef(name);
+  useEffect(() => {
+    if (name !== lastSyncedName.current) {
+      lastSyncedName.current = name;
+      if (!editing) setValue(name ?? "");
+    }
+  }, [name, editing]);
+
+  const commit = async () => {
+    setEditing(false);
+    const trimmed = value.trim();
+    // No-op (unchanged) or an attempt to clear the name → just restore the field.
+    if (trimmed === (name ?? "") || trimmed.length === 0) {
+      setValue(name ?? "");
+      return;
+    }
+    // Persist first; update the store (title + breadcrumb) only on success so a
+    // failed rename cleanly reverts — important when the prior name was null and
+    // there's no string to optimistically roll back to.
+    try {
+      const res = await fetch(`/api/projects/${projectId}/debugger-sessions/${sessionId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: trimmed }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error ?? "Failed to rename session");
+      }
+      onRenamed(trimmed);
+    } catch (e) {
+      setValue(name ?? "");
+      toast({
+        variant: "destructive",
+        title: "Could not rename session",
+        description: e instanceof Error ? e.message : "Please try again.",
+      });
+    }
+  };
+
+  return (
+    <div className="-ml-1 grid max-w-full grid-cols-1 items-center">
+      {/* Hidden sizer: dictates the field's width from the text/placeholder so the
+          focus outline hugs the text. Mirrors the input's box (padding + border). */}
+      <span
+        aria-hidden
+        className="invisible col-start-1 row-start-1 whitespace-pre rounded border border-transparent px-1 text-2xl font-medium"
+      >
+        {value || PLACEHOLDER}
+      </span>
+      <input
+        ref={inputRef}
+        value={value}
+        placeholder={PLACEHOLDER}
+        aria-label="Session name"
+        spellCheck={false}
+        onChange={(e) => setValue(e.target.value)}
+        onFocus={() => setEditing(true)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            inputRef.current?.blur();
+          } else if (e.key === "Escape") {
+            setValue(name ?? "");
+            setEditing(false);
+            inputRef.current?.blur();
+          }
+        }}
+        className={cn(
+          "col-start-1 row-start-1 w-full min-w-0 rounded border border-transparent bg-transparent px-1",
+          "text-2xl font-medium text-foreground outline-none transition-colors",
+          "placeholder:text-muted-foreground focus:border-input"
+        )}
+      />
+    </div>
+  );
+}

--- a/frontend/components/debugger-sessions/debugger-session-view/session-header/editable-session-title.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/session-header/editable-session-title.tsx
@@ -80,8 +80,6 @@ export default function EditableSessionTitle({ name, sessionId, onRenamed }: Edi
 
   return (
     <div className="-ml-1 grid max-w-full grid-cols-1 items-center">
-      {/* Hidden sizer: dictates the field's width from the text/placeholder so the
-          focus outline hugs the text. Mirrors the input's box (padding + border). */}
       <span
         aria-hidden
         className="invisible col-start-1 row-start-1 whitespace-pre rounded border border-transparent px-1 text-2xl font-medium"
@@ -110,7 +108,9 @@ export default function EditableSessionTitle({ name, sessionId, onRenamed }: Edi
         className={cn(
           "col-start-1 row-start-1 w-full min-w-0 rounded border border-transparent bg-transparent px-1",
           "text-2xl font-medium text-foreground outline-none transition-colors",
-          "placeholder:text-muted-foreground focus:border-input"
+          "placeholder:text-muted-foreground rounded placeholder:font-normal",
+          "hover:ring hover:ring-green-5 hover:ring-offset-[4px] hover:ring-muted-foreground/20 hover:ring-offset-secondary hover:bg-secondary",
+          "focus:ring focus:ring-green-5 focus:ring-offset-[4px] focus:ring-muted-foreground/35 focus:ring-offset-secondary focus:bg-secondary"
         )}
       />
     </div>

--- a/frontend/components/debugger-sessions/debugger-session-view/session-header/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/session-header/index.tsx
@@ -2,6 +2,8 @@
 import { Check, Copy } from "lucide-react";
 import { type MouseEvent, useState } from "react";
 
+import { useDebuggerSessionViewStore } from "../store";
+import EditableSessionTitle from "./editable-session-title";
 import { fmtRelative } from "./utils";
 
 export interface SessionHeaderProps {
@@ -21,6 +23,8 @@ export interface SessionHeaderProps {
  */
 export default function SessionHeader({ title, createdMs, lastActivityMs, runCount, sessionId }: SessionHeaderProps) {
   const [copied, setCopied] = useState(false);
+  const sessionNameRaw = useDebuggerSessionViewStore((s) => s.sessionNameRaw);
+  const setSessionName = useDebuggerSessionViewStore((s) => s.setSessionName);
 
   const onCopy = async (e: MouseEvent<HTMLButtonElement>) => {
     try {
@@ -40,7 +44,11 @@ export default function SessionHeader({ title, createdMs, lastActivityMs, runCou
 
   return (
     <header className="flex flex-col gap-3 py-5 h-[180px] pt-14">
-      <h1 className="text-2xl font-medium text-foreground">{title}</h1>
+      {sessionId ? (
+        <EditableSessionTitle name={sessionNameRaw} sessionId={sessionId} onRenamed={setSessionName} />
+      ) : (
+        <h1 className="text-2xl font-medium text-foreground">{title}</h1>
+      )}
       <div className="flex items-center gap-2.5 text-sm text-secondary-foreground">
         <span>Created {fmtRelative(createdMs)}</span>
         <span>·</span>

--- a/frontend/components/debugger-sessions/debugger-session-view/span-reference.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/span-reference.tsx
@@ -1,10 +1,71 @@
 "use client";
 
-import React from "react";
+import { useParams } from "next/navigation";
+import React, { useEffect, useState } from "react";
 
 import { createSpanTypeIcon } from "@/components/traces/span-type-icon";
 import { SpanType } from "@/lib/traces/types";
 import { SPAN_TYPE_TO_COLOR } from "@/lib/traces/utils";
+
+// Module-level so re-renders/remounts and repeated references share one fetch.
+const spanTypeCache = new Map<string, Promise<SpanType | null>>();
+
+function resolveSpanType(projectId: string, traceId: string, spanId: string): Promise<SpanType | null> {
+  const key = `${projectId}:${spanId}`;
+  const cached = spanTypeCache.get(key);
+  if (cached) return cached;
+  const promise = (async () => {
+    try {
+      const res = await fetch(`/api/projects/${projectId}/traces/${traceId}/spans/${spanId}/type`);
+      if (!res.ok) throw new Error("Failed to resolve span type");
+      const data = (await res.json()) as { spanType?: SpanType };
+      return data.spanType ?? null;
+    } catch {
+      // Don't poison the cache — a later mount can retry.
+      spanTypeCache.delete(key);
+      return null;
+    }
+  })();
+  spanTypeCache.set(key, promise);
+  return promise;
+}
+
+/** Prefers the store-provided type (live/expanded — zero fetches); otherwise resolves via API. */
+function useResolvedSpanType(traceId: string, spanId: string, spanType: SpanType | undefined) {
+  const { projectId } = useParams<{ projectId: string }>();
+  const [resolved, setResolved] = useState<SpanType | null>(null);
+
+  useEffect(() => {
+    if (spanType || !projectId) return;
+    let cancelled = false;
+    resolveSpanType(projectId, traceId, spanId).then((type) => {
+      if (!cancelled && type) setResolved(type);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, traceId, spanId, spanType]);
+
+  return spanType ?? resolved ?? undefined;
+}
+
+/** SpanChip that resolves its own span type when the store doesn't have it (e.g. after reload). */
+export function SelfResolvingSpanChip({
+  label,
+  traceId,
+  spanId,
+  spanType,
+  onClick,
+}: {
+  label: React.ReactNode;
+  traceId: string;
+  spanId: string;
+  spanType: SpanType | undefined;
+  onClick: () => void;
+}) {
+  const resolvedType = useResolvedSpanType(traceId, spanId, spanType);
+  return <SpanChip label={label} spanType={resolvedType} onClick={onClick} />;
+}
 
 /**
  * Inline span-reference chip used inside debugger run comments. Styling mirrors

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -215,6 +215,10 @@ export const createDebuggerSessionViewStore = (options?: {
               (s) =>
                 ({
                   traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: true },
+                  // Mirror into the base `traceSpansLoading` flag: shared base-store
+                  // consumers (SessionCondensedTimeline) read that for their skeleton,
+                  // while traceSpansFetching is our in-flight dedupe guard.
+                  traceSpansLoading: { ...s.traceSpansLoading, [trace.id]: true },
                   traceSpansError: { ...s.traceSpansError, [trace.id]: undefined },
                 }) as Partial<DebuggerSessionViewStore>
             );
@@ -248,6 +252,7 @@ export const createDebuggerSessionViewStore = (options?: {
                 (s) =>
                   ({
                     traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: false },
+                    traceSpansLoading: { ...s.traceSpansLoading, [trace.id]: false },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }
@@ -388,6 +393,8 @@ export const createDebuggerSessionViewStore = (options?: {
               (s) =>
                 ({
                   traceSpansFetching: { ...s.traceSpansFetching, [traceId]: true },
+                  // Keep base `traceSpansLoading` in sync for shared timeline skeleton.
+                  traceSpansLoading: { ...s.traceSpansLoading, [traceId]: true },
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
@@ -445,6 +452,7 @@ export const createDebuggerSessionViewStore = (options?: {
                 (s) =>
                   ({
                     traceSpansFetching: { ...s.traceSpansFetching, [traceId]: false },
+                    traceSpansLoading: { ...s.traceSpansLoading, [traceId]: false },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -128,7 +128,10 @@ const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {})
 });
 
 interface DebuggerSessionViewState {
-  traceFetchState: Record<string, "loading" | "loaded">;
+  // Per-trace span fetch in flight. Dedupes concurrent fetches and drives the
+  // skeleton; expand ALWAYS refetches (idempotent recency merge), so a failed
+  // fetch heals on the next expand. Transient, not persisted.
+  traceSpansFetching: Record<string, boolean>;
   sessionName: string;
 
   // True when a run was added live via trace_update — drives the "New trace" pill
@@ -140,10 +143,10 @@ interface DebuggerSessionViewState {
 }
 
 interface DebuggerSessionViewActions {
-  // Expand-path fetch override, gated on `traceFetchState` (NOT slot shape): if a
-  // catch-up fetch already ran (loading/loaded) do nothing; if idle (a list row
-  // never expanded) fetch once via the base slice, owning `traceFetchState` so the
-  // debugger UI reads ONE source. Idempotent.
+  // Expand-path fetch override: ALWAYS fetches (skipped only while another fetch
+  // for the same trace is in flight). Fetches directly — never via the base slice,
+  // whose guard is shape-based and would skip the historical fetch once any SSE
+  // span has upserted into the slot.
   ensureTraceSpans: (trace: TraceRow) => Promise<void>;
 
   // Fetch this session's runs (traces) via the `rollout.session_id` metadata
@@ -205,7 +208,7 @@ export const createDebuggerSessionViewStore = (options?: {
           traces: options?.initialTraceRow ? [options.initialTraceRow] : [],
 
           sessionName: options?.initialSessionName ?? "Session",
-          traceFetchState: {},
+          traceSpansFetching: {},
           newTraceNotice: false,
           isInitialTracesLoaded: false,
 
@@ -214,13 +217,12 @@ export const createDebuggerSessionViewStore = (options?: {
             // flight or already settled, do nothing — spans stream in independently
             // and the recency merge keeps them correct. Only an idle (never-fetched)
             // list row reaches the fetch below.
-            const fetchState = get().traceFetchState[trace.id];
-            if (fetchState === "loading" || fetchState === "loaded") return;
+            if (get().traceSpansFetching[trace.id]) return;
 
             // Set "loading" synchronously (before any await) so a span streaming in
             // between this set and the fetch settling can never flash "No spans
             // found" — this is the exact P1 race class. The debugger segment UI
-            // reads ONLY `traceFetchState`; the base slice's `traceSpansLoading`
+            // reads ONLY `traceSpansFetching`; the base slice's `traceSpansLoading`
             // stays untouched for the regular session view.
             //
             // AbortController stance (decided): no abort plumbing. Per-trace fetches
@@ -231,7 +233,7 @@ export const createDebuggerSessionViewStore = (options?: {
             set(
               (s) =>
                 ({
-                  traceFetchState: { ...s.traceFetchState, [trace.id]: "loading" },
+                  traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: true },
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
@@ -262,7 +264,7 @@ export const createDebuggerSessionViewStore = (options?: {
               set(
                 (s) =>
                   ({
-                    traceFetchState: { ...s.traceFetchState, [trace.id]: "loaded" },
+                    traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: false },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }
@@ -380,10 +382,10 @@ export const createDebuggerSessionViewStore = (options?: {
               // Any spans that raced ahead of this event are already in `traceSpans`
               // (applyRealtimeSpan upserts unconditionally) — nothing to seed or flush.
               get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata)]);
-              // Kick the catch-up fetch FIRST so it sets traceFetchState="loading"
+              // Kick the catch-up fetch FIRST so it marks the trace as fetching
               // synchronously; setTraceExpanded then triggers the ensureTraceSpans
               // override, which sees "loading" and short-circuits — one fetch, not two.
-              // hydrateTraceRow owns this trace's traceFetchState lifecycle.
+              // before the auto-expand fires — exactly one fetch per new run.
               void get().hydrateTraceRow(t.traceId);
               get().setTraceExpanded(t.traceId, true);
               // Surface the "New trace" pill so the user can jump to the new run — but
@@ -426,16 +428,16 @@ export const createDebuggerSessionViewStore = (options?: {
             // `startTime !== endTime` shape check that the P1 race defeated (a streamed
             // span bumped endTime past startTime before this ran, so the guard passed
             // and the flag-clear in finally was skipped → stuck skeleton).
-            if (get().traceFetchState[traceId]) return;
+            if (get().traceSpansFetching[traceId]) return;
 
-            // hydrateTraceRow is the sole owner of traceFetchState. Set "loading" in
+            // Mark fetching in
             // the SYNCHRONOUS prefix (before ANY await) — this is the exact P1 trap:
             // a span streaming in between this call and the fetch settling must never
             // flash "No spans found" before the skeleton is shown.
             set(
               (s) =>
                 ({
-                  traceFetchState: { ...s.traceFetchState, [traceId]: "loading" },
+                  traceSpansFetching: { ...s.traceSpansFetching, [traceId]: true },
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
@@ -504,7 +506,7 @@ export const createDebuggerSessionViewStore = (options?: {
               set(
                 (s) =>
                   ({
-                    traceFetchState: { ...s.traceFetchState, [traceId]: "loaded" },
+                    traceSpansFetching: { ...s.traceSpansFetching, [traceId]: false },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -217,12 +217,11 @@ export const createDebuggerSessionViewStore = (options?: {
             const fetchState = get().traceFetchState[trace.id];
             if (fetchState === "loading" || fetchState === "loaded") return;
 
-            // BOUNDARY DECISION: the base slice keeps its own `traceSpansLoading` for
-            // the regular session view; the debugger segment UI reads ONLY
-            // `traceFetchState`. Set "loading" synchronously (before any await) so a
-            // span streaming in between this set and the fetch settling can never flash
-            // "No spans found" — this is the exact P1 race class. The base fetch's
-            // `traceSpansLoading` still runs underneath but the debugger UI ignores it.
+            // Set "loading" synchronously (before any await) so a span streaming in
+            // between this set and the fetch settling can never flash "No spans
+            // found" — this is the exact P1 race class. The debugger segment UI
+            // reads ONLY `traceFetchState`; the base slice's `traceSpansLoading`
+            // stays untouched for the regular session view.
             //
             // AbortController stance (decided): no abort plumbing. Per-trace fetches
             // fire once (state-guarded above), late responses are harmless through the
@@ -236,7 +235,29 @@ export const createDebuggerSessionViewStore = (options?: {
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
-              await baseSlice.ensureTraceSpans(trace);
+              // Fetch directly instead of delegating to baseSlice.ensureTraceSpans:
+              // the base guard is shape-based (`if (traceSpans[id])`) and spans now
+              // upsert unconditionally, so an active run that streamed even one SSE
+              // span before first expand would make the base skip the ClickHouse
+              // historical fetch entirely. Merge fetched-wins so duplicates resolve
+              // to the fuller CH span; streamed-only spans are preserved.
+              const { projectId } = get();
+              if (!projectId) return;
+              const spanParams = new URLSearchParams();
+              spanParams.append("searchIn", "input");
+              spanParams.append("searchIn", "output");
+              spanParams.set("startDate", new Date(new Date(trace.startTime).getTime() - 1000).toISOString());
+              spanParams.set("endDate", new Date(new Date(trace.endTime).getTime() + 1000).toISOString());
+              const res = await fetch(`/api/projects/${projectId}/traces/${trace.id}/spans?${spanParams.toString()}`);
+              if (res.ok) {
+                const fetchedSpans = (await res.json()) as TraceViewSpan[];
+                if (fetchedSpans.length > 0) {
+                  get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
+                }
+              }
+            } catch {
+              // Best-effort, same semantics as hydrateTraceRow: failure still reaches
+              // "loaded"; the UI shows whatever streamed.
             } finally {
               set(
                 (s) =>

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -137,10 +137,16 @@ interface DebuggerSessionViewState {
   // and flushed into `traceSpans` when the slot is created. Transient, not persisted.
   realtimeSpanBuffer: Record<string, TraceViewSpan[]>;
 
-  // Displayed session name (the SessionHeader title). Seeded from the breadcrumb
-  // prop at store creation; updated live by the `session_update` realtime event so
-  // a rename reflects without reload.
+  // Displayed session name used by the BREADCRUMB. Seeded from the breadcrumb prop
+  // (`name ?? id`) at store creation; updated live by the `session_update` realtime
+  // event so a rename reflects without reload.
   sessionName: string;
+
+  // The session's REAL name, or null when it has never been named. Drives the
+  // editable page title (the ghost input shows a "Set session name" placeholder
+  // when null) — distinct from `sessionName`, which falls back to the id for the
+  // breadcrumb. Updated alongside `sessionName` on rename.
+  sessionNameRaw: string | null;
 
   // True when a run was added live via trace_update — drives the "New trace" pill
   // at the bottom of the view. Cleared on pill click / dismiss. Transient.
@@ -208,6 +214,7 @@ export type DebuggerSessionViewStore = BaseSessionViewStore & DebuggerSessionVie
 const createDebuggerSessionViewStore = (options?: {
   initialTraceRow?: TraceRow;
   initialSessionName?: string;
+  initialSessionNameRaw?: string | null;
   projectId?: string;
   storeKey?: string;
 }) =>
@@ -228,6 +235,7 @@ const createDebuggerSessionViewStore = (options?: {
 
           noteMetadataKey: NOTE_METADATA_KEY,
           sessionName: options?.initialSessionName ?? "Session",
+          sessionNameRaw: options?.initialSessionNameRaw ?? null,
           realtimeSpanBuffer: {},
           newTraceNotice: false,
           tracesHydrated: false,
@@ -538,7 +546,8 @@ const createDebuggerSessionViewStore = (options?: {
             }
           },
 
-          setSessionName: (name) => set({ sessionName: name } as Partial<DebuggerSessionViewStore>),
+          setSessionName: (name) =>
+            set({ sessionName: name, sessionNameRaw: name } as Partial<DebuggerSessionViewStore>),
 
           dismissNewTraceNotice: () => set({ newTraceNotice: false } as Partial<DebuggerSessionViewStore>),
 
@@ -576,6 +585,7 @@ export const DebuggerSessionViewContext = createContext<StoreApi<DebuggerSession
 interface DebuggerSessionViewStoreProviderProps {
   initialTraceRow?: TraceRow;
   initialSessionName?: string;
+  initialSessionNameRaw?: string | null;
   storeKey?: string;
 }
 
@@ -583,11 +593,12 @@ const DebuggerSessionViewStoreProvider = ({
   children,
   initialTraceRow,
   initialSessionName,
+  initialSessionNameRaw,
   storeKey,
 }: PropsWithChildren<DebuggerSessionViewStoreProviderProps>) => {
   const { projectId } = useParams<{ projectId: string }>();
   const [storeState] = useState(() =>
-    createDebuggerSessionViewStore({ initialTraceRow, initialSessionName, projectId, storeKey })
+    createDebuggerSessionViewStore({ initialTraceRow, initialSessionName, initialSessionNameRaw, projectId, storeKey })
   );
 
   // Provide both the base context (shared session-view children) and the

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -215,10 +215,6 @@ export const createDebuggerSessionViewStore = (options?: {
               (s) =>
                 ({
                   traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: true },
-                  // Mirror into the base `traceSpansLoading` flag: shared base-store
-                  // consumers (SessionCondensedTimeline) read that for their skeleton,
-                  // while traceSpansFetching is our in-flight dedupe guard.
-                  traceSpansLoading: { ...s.traceSpansLoading, [trace.id]: true },
                   traceSpansError: { ...s.traceSpansError, [trace.id]: undefined },
                 }) as Partial<DebuggerSessionViewStore>
             );
@@ -252,7 +248,6 @@ export const createDebuggerSessionViewStore = (options?: {
                 (s) =>
                   ({
                     traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: false },
-                    traceSpansLoading: { ...s.traceSpansLoading, [trace.id]: false },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }
@@ -393,8 +388,6 @@ export const createDebuggerSessionViewStore = (options?: {
               (s) =>
                 ({
                   traceSpansFetching: { ...s.traceSpansFetching, [traceId]: true },
-                  // Keep base `traceSpansLoading` in sync for shared timeline skeleton.
-                  traceSpansLoading: { ...s.traceSpansLoading, [traceId]: true },
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
@@ -452,7 +445,6 @@ export const createDebuggerSessionViewStore = (options?: {
                 (s) =>
                   ({
                     traceSpansFetching: { ...s.traceSpansFetching, [traceId]: false },
-                    traceSpansLoading: { ...s.traceSpansLoading, [traceId]: false },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -229,7 +229,9 @@ export const createDebuggerSessionViewStore = (options?: {
               const fetchedSpans = (await res.json()) as TraceViewSpan[];
               // Always write the slot (even empty) so the expanded body resolves out
               // of its skeleton; merge preserves anything streamed in meanwhile.
-              get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
+              // incomingWins=false: on a re-expand a lagging CH snapshot must not
+              // clobber equal-recency live SSE spans — ties keep the live span.
+              get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, false));
             } catch {
               // The UI keeps whatever streamed; re-expand retries.
               set(
@@ -430,7 +432,9 @@ export const createDebuggerSessionViewStore = (options?: {
               const fetchedSpans = (await spansRes.json()) as TraceViewSpan[];
               if (fetchedSpans.length > 0) {
                 const live = get().traceSpans[traceId] ?? [];
-                get().setTraceSpans(traceId, mergeSpans(live, fetchedSpans, true));
+                // incomingWins=false: keep equal-recency live SSE spans over a
+                // possibly-lagging CH snapshot (same tie-break as the expand fetch).
+                get().setTraceSpans(traceId, mergeSpans(live, fetchedSpans, false));
               }
             } catch {
               // The UI keeps whatever streamed; re-expand retries.

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -10,17 +10,16 @@ import {
 } from "@/components/traces/session-view/store/base";
 import { type TraceViewSpan } from "@/components/traces/trace-view/store/base";
 import { enrichSpansWithPending } from "@/components/traces/trace-view/utils";
+import { toast } from "@/lib/hooks/use-toast";
 import { type RealtimeSpan, type SpanType, type TraceRow } from "@/lib/traces/types";
 
-// Trace-metadata key the coding agent writes its run note to. Naming stays
-// `rollout.*` to match `rollout.session_id`. The value is an opaque markdown string.
+// Trace-metadata key the agent writes its run note to (markdown string).
 export const NOTE_METADATA_KEY = "rollout.note";
 
 // Max runs fetched per session (mirrors the previous multi-trace-view cap).
 const MAX_RUNS = 200;
 
-// Normalize a trace_update payload's `metadata` (object OR JSON string) into the
-// Record<string,string> shape `TraceRow.metadata` carries.
+// Normalize metadata (object OR JSON string) into TraceRow's Record<string,string>.
 const normalizeMetadata = (metadata: unknown): Record<string, string> => {
   if (!metadata) return {};
   if (typeof metadata === "string") {
@@ -39,10 +38,8 @@ const normalizeMetadata = (metadata: unknown): Record<string, string> => {
   return {};
 };
 
-// Map a streamed RealtimeSpan onto the TraceViewSpan shape the shared list reads.
-// Only `"update"` mode exists now (span_start is dead — see content component).
-// Token/cost fields come off `gen_ai.usage.*` attributes, mirroring trace-view's
-// onRealtimeUpdateSpans — without this, streamed LLM spans render 0 tokens / $0.
+// Map a streamed RealtimeSpan onto TraceViewSpan. Token/cost come off
+// `gen_ai.usage.*` attrs — without this, streamed LLM spans render 0 tokens / $0.
 const realtimeToTraceViewSpan = (s: RealtimeSpan): TraceViewSpan => {
   const attrs = (s.attributes ?? {}) as Record<string, unknown>;
   const num = (key: string) => Number(attrs[key]) || 0;
@@ -78,10 +75,8 @@ const realtimeToTraceViewSpan = (s: RealtimeSpan): TraceViewSpan => {
   } as TraceViewSpan;
 };
 
-// Merge incoming spans into an existing list: dedupe by spanId (incoming wins,
-// preserving the existing span's `collapsed`), sort by startTime, enrich pending.
-// `incomingWins=false` flips precedence so a base list (e.g. a CH fetch) overrides
-// streamed duplicates for the same spanId.
+// Dedupe by spanId (newest endTime wins; `incomingWins` breaks ties), preserve
+// `collapsed`, sort by startTime, enrich pending.
 const mergeSpans = (base: TraceViewSpan[], incoming: TraceViewSpan[], incomingWins = true): TraceViewSpan[] => {
   const byId = new Map<string, TraceViewSpan>();
   for (const s of base) byId.set(s.spanId, s);
@@ -91,14 +86,12 @@ const mergeSpans = (base: TraceViewSpan[], incoming: TraceViewSpan[], incomingWi
       byId.set(s.spanId, s);
       continue;
     }
-    // Real spans always replace pending placeholders (whose endTime is synthesized
-    // from children and can run ahead); a placeholder never replaces a real span.
+    // Real spans always beat pending placeholders (whose endTime can run ahead).
     if (prev.pending !== s.pending) {
       if (prev.pending) byId.set(s.spanId, { ...s, collapsed: prev.collapsed });
       continue;
     }
-    // Per-span recency: never let an older snapshot (e.g. a lagging CH hydrate)
-    // replace a fresher version of the same span. endTime tie → side precedence.
+    // Per-span recency: an older snapshot (e.g. lagging CH fetch) never wins.
     const prevEnd = new Date(prev.endTime).getTime();
     const incEnd = new Date(s.endTime).getTime();
     const incomingNewer = incEnd > prevEnd || (incEnd === prevEnd && incomingWins);
@@ -108,8 +101,7 @@ const mergeSpans = (base: TraceViewSpan[], incoming: TraceViewSpan[], incomingWi
   return enrichSpansWithPending(merged);
 };
 
-// Build a minimal TraceRow slot for a trace we only know the id (and maybe
-// metadata) of — used by /alpha seeding and live trace_update of an unknown run.
+// Minimal TraceRow for a trace we only know the id of (live trace_update).
 const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {}): TraceRow => ({
   id: traceId,
   startTime: new Date().toISOString(),
@@ -128,59 +120,51 @@ const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {})
 });
 
 interface DebuggerSessionViewState {
-  // Per-trace span fetch in flight. Dedupes concurrent fetches and drives the
-  // skeleton; expand ALWAYS refetches (idempotent recency merge), so a failed
-  // fetch heals on the next expand. Transient, not persisted.
+  // Per-trace span fetch in flight: dedupes concurrent fetches, drives the
+  // skeleton. Expand always refetches, so a failed fetch heals on re-expand.
   traceSpansFetching: Record<string, boolean>;
   sessionName: string;
 
-  // True when a run was added live via trace_update — drives the "New trace" pill
-  // at the bottom of the view. Cleared on pill click / dismiss. Transient.
+  // A run was added live → "New trace" pill. Cleared on click / dismiss.
   newTraceNotice: boolean;
 
-  // Prevents "New trace" pill from being shown on page load
+  // Prevents the "New trace" pill from flashing on page load.
   isInitialTracesLoaded: boolean;
 }
 
 interface DebuggerSessionViewActions {
-  // Expand-path fetch override: ALWAYS fetches (skipped only while another fetch
-  // for the same trace is in flight). Fetches directly — never via the base slice,
-  // whose guard is shape-based and would skip the historical fetch once any SSE
-  // span has upserted into the slot.
+  // Expand-path fetch: always fetches (deduped while in flight), directly — the
+  // base slice's shape-based guard would skip the fetch once any SSE span landed.
   ensureTraceSpans: (trace: TraceRow) => Promise<void>;
 
-  // Fetch this session's runs (traces) via the `rollout.session_id` metadata
-  // filter, oldest-first, into base `traces`. Reads projectId from base state.
+  // Fetch the session's runs via the `rollout.session_id` metadata filter.
   fetchSessionTraces: (sessionId: string) => Promise<void>;
 
-  // Realtime: upsert a streamed span into its (already-loaded) trace.
+  // Realtime: upsert a streamed span.
   applyRealtimeSpan: (span: RealtimeSpan) => void;
 
-  // Realtime: batch entry point for a span_update payload (one store call per event).
+  // Batch entry point for a span_update payload.
   applyRealtimeSpans: (spans: RealtimeSpan[]) => void;
 
   // Realtime: merge a trace_update into the run list (add + auto-expand if new).
   applyTraceUpdate: (t: { traceId: string; metadata?: unknown; hasBrowserSession?: boolean }) => void;
 
-  // Realtime: batch entry point for a trace_update payload (one store call per event).
+  // Batch entry point for a trace_update payload.
   applyTraceUpdates: (traces: { traceId: string; metadata?: unknown; hasBrowserSession?: boolean }[]) => void;
 
-  // Fetch the full TraceRow (real stats: tokens/cost/startTime) for a single
-  // trace and merge it onto the existing row. Used to hydrate a run that first
-  // appeared via a trace_update (whose payload carries no stats). Preserves the
-  // row's current metadata (already merged from realtime) and its bumped endTime.
+  // One-shot catch-up for a realtime-added run: real row stats + pre-subscribe
+  // spans (trace_update payloads carry neither).
   hydrateTraceRow: (traceId: string) => Promise<void>;
 
-  // Update the displayed session name live (driven by the `session_update`
-  // realtime event after a rename via PATCH /v1/.../rollouts/{id}/name).
+  // Live rename (driven by the `session_update` realtime event).
   setSessionName: (name: string) => void;
 
   // Hide the "New trace" pill (pill click or its X).
   dismissNewTraceNotice: () => void;
 
-  // Read the agent-authored note (`rollout.note`) off a run's metadata object.
+  // Agent-authored note (`rollout.note`) off a run's metadata.
   noteForTrace: (traceId: string) => string | undefined;
-  // Span type for an already-loaded span (drives the span-ref chip icon color).
+  // Span type for a loaded span (drives the span-ref chip icon).
   getSpanType: (traceId: string, spanId: string) => SpanType | undefined;
 }
 
@@ -200,8 +184,7 @@ export const createDebuggerSessionViewStore = (options?: {
         return {
           ...baseSlice,
 
-          // Seeded at store creation (projectId is static for the page) instead of
-          // synced from the URL param in an effect.
+          // Seeded at creation (static per page) — no URL-param sync effect.
           projectId: options?.projectId,
 
           // Seed base `traces` with the single /alpha trace when provided.
@@ -213,23 +196,8 @@ export const createDebuggerSessionViewStore = (options?: {
           isInitialTracesLoaded: false,
 
           ensureTraceSpans: async (trace) => {
-            // State-based idempotence (never shape-based): if a catch-up fetch is in
-            // flight or already settled, do nothing — spans stream in independently
-            // and the recency merge keeps them correct. Only an idle (never-fetched)
-            // list row reaches the fetch below.
             if (get().traceSpansFetching[trace.id]) return;
 
-            // Set "loading" synchronously (before any await) so a span streaming in
-            // between this set and the fetch settling can never flash "No spans
-            // found" — this is the exact P1 race class. The debugger segment UI
-            // reads ONLY `traceSpansFetching`; the base slice's `traceSpansLoading`
-            // stays untouched for the regular session view.
-            //
-            // AbortController stance (decided): no abort plumbing. Per-trace fetches
-            // fire once (state-guarded above), late responses are harmless through the
-            // recency merge, and the store is recreated per session (provider keyed by
-            // sessionId). Zustand vanilla has no dispose hook to hang a controller off,
-            // so we skip it entirely rather than invent lifecycle.
             set(
               (s) =>
                 ({
@@ -237,12 +205,6 @@ export const createDebuggerSessionViewStore = (options?: {
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
-              // Fetch directly instead of delegating to baseSlice.ensureTraceSpans:
-              // the base guard is shape-based (`if (traceSpans[id])`) and spans now
-              // upsert unconditionally, so an active run that streamed even one SSE
-              // span before first expand would make the base skip the ClickHouse
-              // historical fetch entirely. Merge fetched-wins so duplicates resolve
-              // to the fuller CH span; streamed-only spans are preserved.
               const { projectId } = get();
               if (!projectId) return;
               const spanParams = new URLSearchParams();
@@ -251,15 +213,18 @@ export const createDebuggerSessionViewStore = (options?: {
               spanParams.set("startDate", new Date(new Date(trace.startTime).getTime() - 1000).toISOString());
               spanParams.set("endDate", new Date(new Date(trace.endTime).getTime() + 1000).toISOString());
               const res = await fetch(`/api/projects/${projectId}/traces/${trace.id}/spans?${spanParams.toString()}`);
-              if (res.ok) {
-                const fetchedSpans = (await res.json()) as TraceViewSpan[];
-                if (fetchedSpans.length > 0) {
-                  get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
-                }
+              if (!res.ok) throw new Error("Failed to load spans");
+              const fetchedSpans = (await res.json()) as TraceViewSpan[];
+              if (fetchedSpans.length > 0) {
+                get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
               }
             } catch {
-              // Best-effort, same semantics as hydrateTraceRow: failure still reaches
-              // "loaded"; the UI shows whatever streamed.
+              // The UI keeps whatever streamed; re-expand retries.
+              toast({
+                variant: "destructive",
+                title: "Failed to load spans",
+                description: "Collapse and expand the run to retry.",
+              });
             } finally {
               set(
                 (s) =>
@@ -295,13 +260,8 @@ export const createDebuggerSessionViewStore = (options?: {
                 return;
               }
               const body = (await res.json()) as { items: TraceRow[] };
-              // The /traces endpoint returns `metadata` as a raw JSON STRING (the CH
-              // `metadata` column is selected verbatim — see lib/actions/traces/utils.ts;
-              // the traces table parses it lazily in JsonTooltip). `TraceRow.metadata`
-              // is typed as an object, so normalize here before storing — otherwise
-              // noteForTrace / getSpanType read the string as an object and notes +
-              // outline headings never render. (Realtime trace_update already ships a
-              // JSON object and goes through normalizeMetadata in applyTraceUpdate.)
+              // /traces returns `metadata` as a raw JSON string; normalize or notes
+              // and outline headings never render.
               const normalized = (body.items ?? []).map((item) => ({
                 ...item,
                 metadata: normalizeMetadata(item.metadata),
@@ -310,12 +270,8 @@ export const createDebuggerSessionViewStore = (options?: {
               const sorted = normalized.sort(
                 (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
               );
-              // MERGE with current rows instead of replacing: a run that started while
-              // this fetch was in flight was added by applyTraceUpdate but is absent
-              // from the (CH-lagged) response — replacing wholesale wipes its row and
-              // its streamed spans. Fetched rows win per-id (richer stats) but keep the
-              // live row's merged metadata + realtime-bumped endTime (same semantics as
-              // hydrateTraceRow); realtime-only rows are kept as-is.
+              // MERGE, don't replace: a run added live mid-fetch is absent from the
+              // CH-lagged response — wholesale replace would wipe it.
               get().setTraces((prev) => {
                 const prevById = new Map(prev.map((t) => [t.id, t]));
                 const merged = sorted.map((fetched) => {
@@ -338,8 +294,7 @@ export const createDebuggerSessionViewStore = (options?: {
               get().setTracesError(e instanceof Error ? e.message : "Failed to load session traces");
             } finally {
               get().setIsTracesLoading(false);
-              // Mark hydrated even on error: a failed initial fetch shouldn't leave the
-              // pill permanently suppressed — subsequent live runs are genuinely new.
+              // Even on error, so a failed initial fetch can't suppress the pill forever.
               set({ isInitialTracesLoaded: true } as Partial<DebuggerSessionViewStore>);
             }
           },
@@ -348,19 +303,12 @@ export const createDebuggerSessionViewStore = (options?: {
             const traceId = span.traceId;
             const tvSpan = realtimeToTraceViewSpan(span);
 
-            // Unconditional upsert into the dumb spans map (create the array if absent).
-            // Spans and trace rows are independent streams — a span can arrive before
-            // its trace_update creates the row, which is fine: the recency-aware merge
-            // dedupes by spanId, and the segment renders whatever the map holds. No
-            // buffer, no conditions; this is what kills the old "(no spans)" race.
+            // Unconditional upsert — a span may arrive before its trace_update creates
+            // the row; it just sits in the map until the row renders.
             get().setTraceSpans(traceId, mergeSpans(get().traceSpans[traceId] ?? [], [tvSpan]));
 
-            // Bump the owning trace row's endTime when the span extends past it (keeps
-            // list stats/ordering correct for a live run). Find the row FIRST and only
-            // rebuild `traces` when the endTime actually moves — otherwise every streamed
-            // span would mint a new array identity and bust every derived memo
-            // (previewTraces, traceIds, allSpansById, …) for no change (finding #6). No-op
-            // if the row doesn't exist yet — endTime is seeded from trace_update / hydrate.
+            // Bump the row's endTime — but only rebuild `traces` when it actually
+            // moves, or every streamed span would bust the derived memos.
             const spanEndMs = new Date(span.endTime).getTime();
             if (Number.isNaN(spanEndMs)) return;
             const targetRow = get().traces.find((t) => t.id === traceId);
@@ -378,28 +326,19 @@ export const createDebuggerSessionViewStore = (options?: {
             const existing = get().traces.find((row) => row.id === t.traceId);
 
             if (!existing) {
-              // Unknown run → add a lightweight row (placeholder stats) to the ordering.
-              // Any spans that raced ahead of this event are already in `traceSpans`
-              // (applyRealtimeSpan upserts unconditionally) — nothing to seed or flush.
+              // Unknown run → add a placeholder row; any spans that raced ahead are
+              // already in `traceSpans`.
               get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata)]);
-              // Kick the catch-up fetch FIRST so it marks the trace as fetching
-              // synchronously; setTraceExpanded then triggers the ensureTraceSpans
-              // override, which sees "loading" and short-circuits — one fetch, not two.
-              // before the auto-expand fires — exactly one fetch per new run.
+              // Hydrate FIRST: its sync prefix marks fetching, so the auto-expand's
+              // ensureTraceSpans dedupes — one fetch per new run.
               void get().hydrateTraceRow(t.traceId);
               get().setTraceExpanded(t.traceId, true);
-              // Surface the "New trace" pill so the user can jump to the new run — but
-              // only once the initial fetch has settled, so a trace_update that beat the
-              // first fetch (for a run already in the initial set) can't flash it on load.
+              // Pill only after the initial fetch settles, so it can't flash on load.
               if (get().isInitialTracesLoaded) set({ newTraceNotice: true } as Partial<DebuggerSessionViewStore>);
               return;
             }
 
-            // Known run → merge metadata (makes live note updates work: `rollout.note`
-            // arrives here after a POST /v1/traces/metadata patch) AND any non-metadata
-            // fields the payload carries (e.g. hasBrowserSession). Bail only when there
-            // is genuinely nothing to apply, so a browser-session signal isn't dropped
-            // just because the metadata happened to be empty (finding #10).
+            // Known run → merge metadata (live note updates) + hasBrowserSession.
             const hasMetadata = Object.keys(metadata).length > 0;
             const hasBrowserSession = typeof t.hasBrowserSession === "boolean";
             if (!hasMetadata && !hasBrowserSession) return;
@@ -423,17 +362,10 @@ export const createDebuggerSessionViewStore = (options?: {
           hydrateTraceRow: async (traceId) => {
             const { projectId } = get();
             if (!projectId) return;
-            // State-based idempotence (never shape-based): if a catch-up fetch already
-            // ran or is running for this trace, don't re-fetch. This replaces the old
-            // `startTime !== endTime` shape check that the P1 race defeated (a streamed
-            // span bumped endTime past startTime before this ran, so the guard passed
-            // and the flag-clear in finally was skipped → stuck skeleton).
             if (get().traceSpansFetching[traceId]) return;
 
-            // Mark fetching in
-            // the SYNCHRONOUS prefix (before ANY await) — this is the exact P1 trap:
-            // a span streaming in between this call and the fetch settling must never
-            // flash "No spans found" before the skeleton is shown.
+            // Mark fetching in the SYNCHRONOUS prefix (before any await) so a streamed
+            // span can never flash "No spans found" ahead of the skeleton.
             set(
               (s) =>
                 ({
@@ -446,7 +378,7 @@ export const createDebuggerSessionViewStore = (options?: {
               params.set("pageSize", "1");
               params.append("filter", JSON.stringify({ column: "id", operator: "eq", value: traceId }));
               const res = await fetch(`/api/projects/${projectId}/traces?${params.toString()}`);
-              if (!res.ok) return;
+              if (!res.ok) throw new Error("Failed to load run");
               const body = (await res.json()) as { items: TraceRow[] };
               const fetched = body.items?.[0];
               if (!fetched) return;
@@ -455,9 +387,8 @@ export const createDebuggerSessionViewStore = (options?: {
               get().setTraces((traces) =>
                 traces.map((row) => {
                   if (row.id !== traceId) return row;
-                  // Keep the live-merged metadata + any realtime-bumped endTime if it's
-                  // already ahead of the fetched row's (mid-run, the fetched snapshot
-                  // may lag the streamed spans).
+                  // Keep live-merged metadata + a realtime-bumped endTime that's ahead
+                  // of the (possibly lagging) fetched snapshot.
                   const liveEndAhead = new Date(row.endTime).getTime() > new Date(fetched.endTime).getTime();
                   return {
                     ...fetched,
@@ -467,13 +398,8 @@ export const createDebuggerSessionViewStore = (options?: {
                 })
               );
 
-              // Recover spans that were persisted in ClickHouse BEFORE the view opened
-              // (a run already in progress) — the realtime stream only carries spans
-              // emitted after we subscribed. Fetch once now that we have REAL trace
-              // times (the new-run slot's lazy fetch was intentionally skipped because
-              // it would have windowed on placeholder "now" times). Merge CH-wins over
-              // the realtime-fed slot so duplicates resolve to the fuller fetched span,
-              // and any spans that streamed in during this fetch are preserved.
+              // Recover spans persisted BEFORE we subscribed, now that real trace
+              // times are known; merge preserves anything streamed meanwhile.
               const startDate = new Date(new Date(fetched.startTime).getTime() - 1000).toISOString();
               const endDate = new Date(new Date(fetched.endTime).getTime() + 1000).toISOString();
               const spanParams = new URLSearchParams();
@@ -484,25 +410,21 @@ export const createDebuggerSessionViewStore = (options?: {
               const spansRes = await fetch(
                 `/api/projects/${projectId}/traces/${traceId}/spans?${spanParams.toString()}`
               );
-              if (spansRes.ok) {
-                const fetchedSpans = (await spansRes.json()) as TraceViewSpan[];
-                if (fetchedSpans.length > 0) {
-                  const live = get().traceSpans[traceId] ?? [];
-                  // CH-wins: base = live (realtime), incoming = fetched with incomingWins.
-                  get().setTraceSpans(traceId, mergeSpans(live, fetchedSpans, true));
-                }
+              if (!spansRes.ok) throw new Error("Failed to load spans");
+              const fetchedSpans = (await spansRes.json()) as TraceViewSpan[];
+              if (fetchedSpans.length > 0) {
+                const live = get().traceSpans[traceId] ?? [];
+                get().setTraceSpans(traceId, mergeSpans(live, fetchedSpans, true));
               }
             } catch {
-              // Best-effort hydration — placeholder stats / realtime-fed spans remain on
-              // failure. HYDRATE-FAILURE SEMANTICS (decided): a failed fetch still reaches
-              // "loaded" below — the UI shows whatever spans streamed (or "No spans found"
-              // if none). We do NOT retry: the state-based idempotence guard means a
-              // re-expand won't re-fetch. Kept simple per spec; if a failed run needs a
-              // retry affordance later, surface a manual refresh rather than auto-retry.
+              // The UI keeps whatever streamed; re-expand retries.
+              toast({
+                variant: "destructive",
+                title: "Failed to load run data",
+                description: "Collapse and expand the run to retry.",
+              });
             } finally {
-              // "loaded" unconditionally (success OR failure) — the skeleton must always
-              // resolve. This is the structural fix for the stuck-skeleton P1: there is no
-              // early-return path that can skip this finally.
+              // Unconditional — the skeleton must always resolve (the old P1).
               set(
                 (s) =>
                   ({
@@ -526,7 +448,6 @@ export const createDebuggerSessionViewStore = (options?: {
         };
       },
       {
-        // Distinct from `session-view-state` AND the parked `debugger-session-state`.
         name: options?.storeKey ?? "debugger-session-view-state",
         partialize: (state) => ({
           sessionPanelWidth: state.sessionPanelWidth,

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -128,34 +128,15 @@ const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {})
 });
 
 interface DebuggerSessionViewState {
-  // Run note source-of-truth lives on each TraceRow's metadata; no extra state.
-  noteMetadataKey: string;
-
-  // Per-trace catch-up-fetch lifecycle — the single explicit source of truth for
-  // "have we loaded this trace's spans?" Replaces the old shape-inference (missing
-  // slot = not loaded; `[]` = placeholder-or-empty) plus the realtimeSpanBuffer /
-  // traceHydrating / traceSpansConfirmedEmpty machinery. Semantics:
-  //   absent  → idle / never fetched (a list-fetched row that's never been expanded)
-  //   loading → a catch-up fetch is in flight; UI shows the skeleton
-  //   loaded  → fetch settled (success OR failure); UI shows whatever spans streamed,
-  //             or "No spans found" when the map is empty
-  // Spans stream independently into `traceSpans` regardless of this state. Transient,
-  // NOT in persist partialize.
   traceFetchState: Record<string, "loading" | "loaded">;
-
-  // Displayed session name (the SessionHeader title). Seeded from the breadcrumb
-  // prop at store creation; updated live by the `session_update` realtime event so
-  // a rename reflects without reload.
   sessionName: string;
 
   // True when a run was added live via trace_update — drives the "New trace" pill
   // at the bottom of the view. Cleared on pill click / dismiss. Transient.
   newTraceNotice: boolean;
 
-  // True once the initial fetchSessionTraces has settled. Gates newTraceNotice so a
-  // trace_update that races ahead of the first fetch (for a run already in the
-  // initial set) can't flash the "New trace" pill on page load (finding #8).
-  tracesHydrated: boolean;
+  // Prevents "New trace" pill from being shown on page load
+  isInitialTracesLoaded: boolean;
 }
 
 interface DebuggerSessionViewActions {
@@ -223,11 +204,10 @@ export const createDebuggerSessionViewStore = (options?: {
           // Seed base `traces` with the single /alpha trace when provided.
           traces: options?.initialTraceRow ? [options.initialTraceRow] : [],
 
-          noteMetadataKey: NOTE_METADATA_KEY,
           sessionName: options?.initialSessionName ?? "Session",
           traceFetchState: {},
           newTraceNotice: false,
-          tracesHydrated: false,
+          isInitialTracesLoaded: false,
 
           ensureTraceSpans: async (trace) => {
             // State-based idempotence (never shape-based): if a catch-up fetch is in
@@ -337,7 +317,7 @@ export const createDebuggerSessionViewStore = (options?: {
               get().setIsTracesLoading(false);
               // Mark hydrated even on error: a failed initial fetch shouldn't leave the
               // pill permanently suppressed — subsequent live runs are genuinely new.
-              set({ tracesHydrated: true } as Partial<DebuggerSessionViewStore>);
+              set({ isInitialTracesLoaded: true } as Partial<DebuggerSessionViewStore>);
             }
           },
 
@@ -388,7 +368,7 @@ export const createDebuggerSessionViewStore = (options?: {
               // Surface the "New trace" pill so the user can jump to the new run — but
               // only once the initial fetch has settled, so a trace_update that beat the
               // first fetch (for a run already in the initial set) can't flash it on load.
-              if (get().tracesHydrated) set({ newTraceNotice: true } as Partial<DebuggerSessionViewStore>);
+              if (get().isInitialTracesLoaded) set({ newTraceNotice: true } as Partial<DebuggerSessionViewStore>);
               return;
             }
 

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -135,7 +135,7 @@ interface DebuggerSessionViewState {
 interface DebuggerSessionViewActions {
   // Expand-path fetch: always fetches (deduped while in flight), directly — the
   // base slice's shape-based guard would skip the fetch once any SSE span landed.
-  ensureTraceSpans: (trace: TraceRow) => Promise<void>;
+  fetchTraceSpans: (trace: TraceRow) => Promise<void>;
 
   // Fetch the session's runs via the `rollout.session_id` metadata filter.
   fetchSessionTraces: (sessionId: string) => Promise<void>;
@@ -195,7 +195,7 @@ export const createDebuggerSessionViewStore = (options?: {
           newTraceNotice: false,
           isInitialTracesLoaded: false,
 
-          ensureTraceSpans: async (trace) => {
+          fetchTraceSpans: async (trace) => {
             if (get().traceSpansFetching[trace.id]) return;
 
             set(
@@ -208,8 +208,6 @@ export const createDebuggerSessionViewStore = (options?: {
               const { projectId } = get();
               if (!projectId) return;
               const spanParams = new URLSearchParams();
-              spanParams.append("searchIn", "input");
-              spanParams.append("searchIn", "output");
               spanParams.set("startDate", new Date(new Date(trace.startTime).getTime() - 1000).toISOString());
               spanParams.set("endDate", new Date(new Date(trace.endTime).getTime() + 1000).toISOString());
               const res = await fetch(`/api/projects/${projectId}/traces/${trace.id}/spans?${spanParams.toString()}`);
@@ -330,7 +328,7 @@ export const createDebuggerSessionViewStore = (options?: {
               // already in `traceSpans`.
               get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata)]);
               // Hydrate FIRST: its sync prefix marks fetching, so the auto-expand's
-              // ensureTraceSpans dedupes — one fetch per new run.
+              // fetchTraceSpans dedupes — one fetch per new run.
               void get().hydrateTraceRow(t.traceId);
               get().setTraceExpanded(t.traceId, true);
               // Pill only after the initial fetch settles, so it can't flash on load.
@@ -403,8 +401,6 @@ export const createDebuggerSessionViewStore = (options?: {
               const startDate = new Date(new Date(fetched.startTime).getTime() - 1000).toISOString();
               const endDate = new Date(new Date(fetched.endTime).getTime() + 1000).toISOString();
               const spanParams = new URLSearchParams();
-              spanParams.append("searchIn", "input");
-              spanParams.append("searchIn", "output");
               spanParams.set("startDate", startDate);
               spanParams.set("endDate", endDate);
               const spansRes = await fetch(

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -81,7 +81,7 @@ const realtimeToTraceViewSpan = (s: RealtimeSpan): TraceViewSpan => {
 // Merge incoming spans into an existing list: dedupe by spanId (incoming wins,
 // preserving the existing span's `collapsed`), sort by startTime, enrich pending.
 // `incomingWins=false` flips precedence so a base list (e.g. a CH fetch) overrides
-// buffered/streamed duplicates for the same spanId.
+// streamed duplicates for the same spanId.
 const mergeSpans = (base: TraceViewSpan[], incoming: TraceViewSpan[], incomingWins = true): TraceViewSpan[] => {
   const byId = new Map<string, TraceViewSpan>();
   for (const s of base) byId.set(s.spanId, s);
@@ -131,11 +131,17 @@ interface DebuggerSessionViewState {
   // Run note source-of-truth lives on each TraceRow's metadata; no extra state.
   noteMetadataKey: string;
 
-  // Realtime spans that arrived for a trace whose `traceSpans[traceId]` slot
-  // didn't exist yet (the backend dispatches the span branch and the trace_update
-  // branch concurrently, so spans can race ahead of the slot). Buffered by traceId
-  // and flushed into `traceSpans` when the slot is created. Transient, not persisted.
-  realtimeSpanBuffer: Record<string, TraceViewSpan[]>;
+  // Per-trace catch-up-fetch lifecycle — the single explicit source of truth for
+  // "have we loaded this trace's spans?" Replaces the old shape-inference (missing
+  // slot = not loaded; `[]` = placeholder-or-empty) plus the realtimeSpanBuffer /
+  // traceHydrating / traceSpansConfirmedEmpty machinery. Semantics:
+  //   absent  → idle / never fetched (a list-fetched row that's never been expanded)
+  //   loading → a catch-up fetch is in flight; UI shows the skeleton
+  //   loaded  → fetch settled (success OR failure); UI shows whatever spans streamed,
+  //             or "No spans found" when the map is empty
+  // Spans stream independently into `traceSpans` regardless of this state. Transient,
+  // NOT in persist partialize.
+  traceFetchState: Record<string, "loading" | "loaded">;
 
   // Displayed session name (the SessionHeader title). Seeded from the breadcrumb
   // prop at store creation; updated live by the `session_update` realtime event so
@@ -150,22 +156,13 @@ interface DebuggerSessionViewState {
   // trace_update that races ahead of the first fetch (for a run already in the
   // initial set) can't flash the "New trace" pill on page load (finding #8).
   tracesHydrated: boolean;
-
-  // Per-trace "hydration in flight" flag (set while hydrateTraceRow runs). Drives
-  // the segment skeleton so a placeholder empty `[]` slot doesn't flash "No spans
-  // found" before the one-shot hydrate fetch settles. Transient.
-  traceHydrating: Record<string, boolean>;
-
-  // Per-trace "a fetch returned 0 spans" flag. A genuinely-empty trace stays
-  // empty; without this the ensureTraceSpans override would treat its `[]` slot as
-  // not-loaded and refetch on every re-expand (a loop). Transient.
-  traceSpansConfirmedEmpty: Record<string, boolean>;
 }
 
 interface DebuggerSessionViewActions {
-  // Refetch override: a defined-but-empty `[]` slot is a placeholder (seeded from
-  // the realtime buffer by applyTraceUpdate), NOT a confirmed-empty result, so
-  // collapse→re-expand should retry it. Delegates to the base fetch otherwise.
+  // Expand-path fetch override, gated on `traceFetchState` (NOT slot shape): if a
+  // catch-up fetch already ran (loading/loaded) do nothing; if idle (a list row
+  // never expanded) fetch once via the base slice, owning `traceFetchState` so the
+  // debugger UI reads ONE source. Idempotent.
   ensureTraceSpans: (trace: TraceRow) => Promise<void>;
 
   // Fetch this session's runs (traces) via the `rollout.session_id` metadata
@@ -205,7 +202,7 @@ interface DebuggerSessionViewActions {
 
 export type DebuggerSessionViewStore = BaseSessionViewStore & DebuggerSessionViewState & DebuggerSessionViewActions;
 
-const createDebuggerSessionViewStore = (options?: {
+export const createDebuggerSessionViewStore = (options?: {
   initialTraceRow?: TraceRow;
   initialSessionName?: string;
   projectId?: string;
@@ -228,52 +225,43 @@ const createDebuggerSessionViewStore = (options?: {
 
           noteMetadataKey: NOTE_METADATA_KEY,
           sessionName: options?.initialSessionName ?? "Session",
-          realtimeSpanBuffer: {},
+          traceFetchState: {},
           newTraceNotice: false,
           tracesHydrated: false,
-          traceHydrating: {},
-          traceSpansConfirmedEmpty: {},
 
           ensureTraceSpans: async (trace) => {
-            const state = get();
-            const slot = state.traceSpans[trace.id];
-            // Skip when spans already exist, a load/hydrate is in flight, or a prior
-            // fetch confirmed the trace is genuinely empty (refetch-loop guard).
-            if (
-              (slot && slot.length > 0) ||
-              state.traceSpansLoading[trace.id] ||
-              state.traceHydrating[trace.id] ||
-              state.traceSpansConfirmedEmpty[trace.id]
-            ) {
-              return;
-            }
-            // Drop a placeholder empty `[]` slot so base ensureTraceSpans (which
-            // early-returns on ANY defined slot) actually fetches on re-expand.
-            if (slot && slot.length === 0) {
-              const next = { ...get().traceSpans };
-              delete next[trace.id];
-              set({ traceSpans: next } as Partial<DebuggerSessionViewStore>);
-            }
-            await baseSlice.ensureTraceSpans(trace);
-            // Flush realtime spans that buffered for this KNOWN run (its slot didn't
-            // exist when they streamed, so applyRealtimeSpan couldn't merge them and
-            // the new-run flush in applyTraceUpdate never ran). Recency-aware merge.
-            const buffered = get().realtimeSpanBuffer[trace.id];
-            if (buffered?.length) {
-              get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], buffered));
-              set((s) => {
-                const next = { ...s.realtimeSpanBuffer };
-                delete next[trace.id];
-                return { realtimeSpanBuffer: next } as Partial<DebuggerSessionViewStore>;
-              });
-            }
-            // Mark genuinely-empty results so future re-expands don't refetch.
-            const after = get().traceSpans[trace.id];
-            if (after && after.length === 0) {
+            // State-based idempotence (never shape-based): if a catch-up fetch is in
+            // flight or already settled, do nothing — spans stream in independently
+            // and the recency merge keeps them correct. Only an idle (never-fetched)
+            // list row reaches the fetch below.
+            const fetchState = get().traceFetchState[trace.id];
+            if (fetchState === "loading" || fetchState === "loaded") return;
+
+            // BOUNDARY DECISION: the base slice keeps its own `traceSpansLoading` for
+            // the regular session view; the debugger segment UI reads ONLY
+            // `traceFetchState`. Set "loading" synchronously (before any await) so a
+            // span streaming in between this set and the fetch settling can never flash
+            // "No spans found" — this is the exact P1 race class. The base fetch's
+            // `traceSpansLoading` still runs underneath but the debugger UI ignores it.
+            //
+            // AbortController stance (decided): no abort plumbing. Per-trace fetches
+            // fire once (state-guarded above), late responses are harmless through the
+            // recency merge, and the store is recreated per session (provider keyed by
+            // sessionId). Zustand vanilla has no dispose hook to hang a controller off,
+            // so we skip it entirely rather than invent lifecycle.
+            set(
+              (s) =>
+                ({
+                  traceFetchState: { ...s.traceFetchState, [trace.id]: "loading" },
+                }) as Partial<DebuggerSessionViewStore>
+            );
+            try {
+              await baseSlice.ensureTraceSpans(trace);
+            } finally {
               set(
                 (s) =>
                   ({
-                    traceSpansConfirmedEmpty: { ...s.traceSpansConfirmedEmpty, [trace.id]: true },
+                    traceFetchState: { ...s.traceFetchState, [trace.id]: "loaded" },
                   }) as Partial<DebuggerSessionViewStore>
               );
             }
@@ -321,11 +309,9 @@ const createDebuggerSessionViewStore = (options?: {
               );
               // MERGE with current rows instead of replacing: a run that started while
               // this fetch was in flight was added by applyTraceUpdate but is absent
-              // from the (CH-lagged) response — replacing wholesale wipes its row, and
-              // the next trace_update then re-runs the new-run branch and clobbers the
-              // populated spans slot with the (already-flushed) empty buffer →
-              // "(no spans)". Fetched rows win per-id (richer stats) but keep the live
-              // row's merged metadata + realtime-bumped endTime (same semantics as
+              // from the (CH-lagged) response — replacing wholesale wipes its row and
+              // its streamed spans. Fetched rows win per-id (richer stats) but keep the
+              // live row's merged metadata + realtime-bumped endTime (same semantics as
               // hydrateTraceRow); realtime-only rows are kept as-is.
               get().setTraces((prev) => {
                 const prevById = new Map(prev.map((t) => [t.id, t]));
@@ -359,22 +345,12 @@ const createDebuggerSessionViewStore = (options?: {
             const traceId = span.traceId;
             const tvSpan = realtimeToTraceViewSpan(span);
 
-            if (get().traceSpans[traceId]) {
-              // Slot exists → merge straight into the live list (dedupe + sort + enrich).
-              get().setTraceSpans(traceId, mergeSpans(get().traceSpans[traceId], [tvSpan]));
-            } else {
-              // Slot not created yet. The backend dispatches the span branch and the
-              // trace_update branch concurrently, so spans routinely arrive BEFORE the
-              // trace_update creates the slot. Buffer here (dedupe by spanId); the
-              // new-run branch in applyTraceUpdate flushes the buffer once the slot
-              // exists. Previously these spans were dropped → "(no spans)" on short runs.
-              set((state) => {
-                const buffered = state.realtimeSpanBuffer[traceId] ?? [];
-                return {
-                  realtimeSpanBuffer: { ...state.realtimeSpanBuffer, [traceId]: mergeSpans(buffered, [tvSpan]) },
-                } as Partial<DebuggerSessionViewStore>;
-              });
-            }
+            // Unconditional upsert into the dumb spans map (create the array if absent).
+            // Spans and trace rows are independent streams — a span can arrive before
+            // its trace_update creates the row, which is fine: the recency-aware merge
+            // dedupes by spanId, and the segment renders whatever the map holds. No
+            // buffer, no conditions; this is what kills the old "(no spans)" race.
+            get().setTraceSpans(traceId, mergeSpans(get().traceSpans[traceId] ?? [], [tvSpan]));
 
             // Bump the owning trace row's endTime when the span extends past it (keeps
             // list stats/ordering correct for a live run). Find the row FIRST and only
@@ -399,38 +375,16 @@ const createDebuggerSessionViewStore = (options?: {
             const existing = get().traces.find((row) => row.id === t.traceId);
 
             if (!existing) {
-              // Unknown run → add a lightweight slot (placeholder stats) and append to
-              // ordering. Initialize the spans slot to the FLUSHED realtime buffer (any
-              // spans that raced ahead of this event) so the run is realtime-fed: with a
-              // non-empty/defined `traceSpans[id]`, the auto-expand's ensureTraceSpans
-              // short-circuits and we skip the doomed lazy fetch (it would window on the
-              // placeholder "now" times AND lag ClickHouse → return [], the "(no spans)"
-              // bug). Pre-existing CH spans for a run that started before view-open are
-              // recovered by the one-shot fetch in hydrateTraceRow (real times, merged).
-              const buffered = get().realtimeSpanBuffer[t.traceId] ?? [];
-              // Never overwrite an existing populated slot: the row can vanish-and-
-              // return (e.g. it was realtime-added, then a wholesale traces update
-              // dropped it) while the slot kept its streamed spans — re-seeding from
-              // the (already-flushed, empty) buffer would wipe them.
-              const existingSlot = get().traceSpans[t.traceId];
+              // Unknown run → add a lightweight row (placeholder stats) to the ordering.
+              // Any spans that raced ahead of this event are already in `traceSpans`
+              // (applyRealtimeSpan upserts unconditionally) — nothing to seed or flush.
               get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata)]);
-              get().setTraceSpans(t.traceId, existingSlot ? mergeSpans(existingSlot, buffered) : buffered);
-              set((state) => {
-                if (!(t.traceId in state.realtimeSpanBuffer)) return {} as Partial<DebuggerSessionViewStore>;
-                const next = { ...state.realtimeSpanBuffer };
-                delete next[t.traceId];
-                return { realtimeSpanBuffer: next } as Partial<DebuggerSessionViewStore>;
-              });
-              // Mark hydrating BEFORE expanding: setTraceExpanded triggers the
-              // ensureTraceSpans override, whose guard then short-circuits the doomed
-              // lazy fetch (placeholder "now" times + CH lag → []). hydrateTraceRow
-              // owns the real fetch and clears the flag in its finally.
-              set(
-                (s) =>
-                  ({ traceHydrating: { ...s.traceHydrating, [t.traceId]: true } }) as Partial<DebuggerSessionViewStore>
-              );
-              get().setTraceExpanded(t.traceId, true);
+              // Kick the catch-up fetch FIRST so it sets traceFetchState="loading"
+              // synchronously; setTraceExpanded then triggers the ensureTraceSpans
+              // override, which sees "loading" and short-circuits — one fetch, not two.
+              // hydrateTraceRow owns this trace's traceFetchState lifecycle.
               void get().hydrateTraceRow(t.traceId);
+              get().setTraceExpanded(t.traceId, true);
               // Surface the "New trace" pill so the user can jump to the new run — but
               // only once the initial fetch has settled, so a trace_update that beat the
               // first fetch (for a run already in the initial set) can't flash it on load.
@@ -466,14 +420,22 @@ const createDebuggerSessionViewStore = (options?: {
           hydrateTraceRow: async (traceId) => {
             const { projectId } = get();
             if (!projectId) return;
-            // Skip if the row already has real stats (a slot has startTime===endTime).
-            const current = get().traces.find((t) => t.id === traceId);
-            if (current && current.startTime !== current.endTime) return;
+            // State-based idempotence (never shape-based): if a catch-up fetch already
+            // ran or is running for this trace, don't re-fetch. This replaces the old
+            // `startTime !== endTime` shape check that the P1 race defeated (a streamed
+            // span bumped endTime past startTime before this ran, so the guard passed
+            // and the flag-clear in finally was skipped → stuck skeleton).
+            if (get().traceFetchState[traceId]) return;
 
-            // Mark hydrating so the segment shows the skeleton (not "No spans found")
-            // for a placeholder empty `[]` slot while this fetch is in flight.
+            // hydrateTraceRow is the sole owner of traceFetchState. Set "loading" in
+            // the SYNCHRONOUS prefix (before ANY await) — this is the exact P1 trap:
+            // a span streaming in between this call and the fetch settling must never
+            // flash "No spans found" before the skeleton is shown.
             set(
-              (s) => ({ traceHydrating: { ...s.traceHydrating, [traceId]: true } }) as Partial<DebuggerSessionViewStore>
+              (s) =>
+                ({
+                  traceFetchState: { ...s.traceFetchState, [traceId]: "loading" },
+                }) as Partial<DebuggerSessionViewStore>
             );
             try {
               const params = new URLSearchParams();
@@ -528,13 +490,22 @@ const createDebuggerSessionViewStore = (options?: {
                 }
               }
             } catch {
-              // Best-effort hydration — placeholder stats / realtime-fed spans remain on failure.
+              // Best-effort hydration — placeholder stats / realtime-fed spans remain on
+              // failure. HYDRATE-FAILURE SEMANTICS (decided): a failed fetch still reaches
+              // "loaded" below — the UI shows whatever spans streamed (or "No spans found"
+              // if none). We do NOT retry: the state-based idempotence guard means a
+              // re-expand won't re-fetch. Kept simple per spec; if a failed run needs a
+              // retry affordance later, surface a manual refresh rather than auto-retry.
             } finally {
-              set((s) => {
-                const next = { ...s.traceHydrating };
-                delete next[traceId];
-                return { traceHydrating: next } as Partial<DebuggerSessionViewStore>;
-              });
+              // "loaded" unconditionally (success OR failure) — the skeleton must always
+              // resolve. This is the structural fix for the stuck-skeleton P1: there is no
+              // early-return path that can skip this finally.
+              set(
+                (s) =>
+                  ({
+                    traceFetchState: { ...s.traceFetchState, [traceId]: "loaded" },
+                  }) as Partial<DebuggerSessionViewStore>
+              );
             }
           },
 

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -202,6 +202,7 @@ export const createDebuggerSessionViewStore = (options?: {
               (s) =>
                 ({
                   traceSpansFetching: { ...s.traceSpansFetching, [trace.id]: true },
+                  traceSpansError: { ...s.traceSpansError, [trace.id]: undefined },
                 }) as Partial<DebuggerSessionViewStore>
             );
             try {
@@ -213,11 +214,17 @@ export const createDebuggerSessionViewStore = (options?: {
               const res = await fetch(`/api/projects/${projectId}/traces/${trace.id}/spans?${spanParams.toString()}`);
               if (!res.ok) throw new Error("Failed to load spans");
               const fetchedSpans = (await res.json()) as TraceViewSpan[];
-              if (fetchedSpans.length > 0) {
-                get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
-              }
+              // Always write the slot (even empty) — TraceItem's two-phase expand
+              // waits for spans/traceSpansError to become defined before opening.
+              get().setTraceSpans(trace.id, mergeSpans(get().traceSpans[trace.id] ?? [], fetchedSpans, true));
             } catch {
               // The UI keeps whatever streamed; re-expand retries.
+              set(
+                (s) =>
+                  ({
+                    traceSpansError: { ...s.traceSpansError, [trace.id]: "Failed to load spans" },
+                  }) as Partial<DebuggerSessionViewStore>
+              );
               toast({
                 variant: "destructive",
                 title: "Failed to load spans",

--- a/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
@@ -164,6 +164,8 @@ export default function TraceSegment({
   const toggleSpanCollapse = useSessionViewBaseStore((s) => s.toggleSpanCollapse);
   const scrollToTraceId = useSessionViewBaseStore((s) => s.scrollToTraceId);
   const consumeScrollToTrace = useSessionViewBaseStore((s) => s.consumeScrollToTrace);
+  const scrollToGroup = useSessionViewBaseStore((s) => s.scrollToGroup);
+  const consumeScrollToGroup = useSessionViewBaseStore((s) => s.consumeScrollToGroup);
 
   const note = useDebuggerSessionViewStore((s) => s.noteForTrace(traceId));
   // In-flight → skeleton; settled + empty → "No spans found". Expanding starts a
@@ -294,6 +296,35 @@ export default function TraceSegment({
     return () => cancelAnimationFrame(rafId);
   }, [selectedSpan, rows, traceId, virtualizer]);
 
+  // Scroll to a subagent group's header when the condensed timeline requests it
+  // (clicking a group box). The debugger renders per-trace virtualizers rather
+  // than the flat SessionList, so this segment owns the scroll for its own trace.
+  // Offset by the sticky header height so the target lands below it; the second
+  // (rAF) pass corrects for estimateSize-vs-real-height drift, mirroring list.tsx.
+  useEffect(() => {
+    if (!scrollToGroup || scrollToGroup.traceId !== traceId) return;
+    const idx = rows.findIndex((r) => r.type === "group-header" && r.group.groupId === scrollToGroup.groupId);
+    if (idx === -1) {
+      // Group header isn't a row here (collapsed trace or tree mode) — nothing to
+      // scroll to; clear so a later matching render isn't blocked by a stale request.
+      consumeScrollToGroup();
+      return;
+    }
+    const scrollToGroupRow = () => {
+      const offset = virtualizer.getOffsetForIndex(idx, "start")?.[0];
+      if (offset !== undefined) {
+        const headerH = headerRef.current?.offsetHeight ?? 0;
+        scrollEl?.scrollTo({ top: Math.max(0, offset - headerH), behavior: "auto" });
+      }
+    };
+    scrollToGroupRow();
+    const rafId = requestAnimationFrame(() => {
+      scrollToGroupRow();
+      consumeScrollToGroup();
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [scrollToGroup, traceId, rows, virtualizer, scrollEl, consumeScrollToGroup]);
+
   return (
     <div id={traceAnchorId(traceId)} className="relative">
       {note && (
@@ -307,7 +338,9 @@ export default function TraceSegment({
           When collapsed the body below it is the (non-sticky) TraceCollapsedBody
           sibling, so the stuck header pins just the ~40px bar over its own body —
           the same row-split the regular view does, without a flat-row builder. */}
-      <div ref={headerRef} data-vrow className="sticky top-0 z-20 bg-background">
+      <div ref={headerRef} data-vrow className="sticky top-0 z-20 bg-background flex flex-col">
+        {/* Spacer */}
+        <div className="bg-background w-full h-2" />
         <CopyFlag label="Copy trace ID" toastTitle="Copied trace ID" value={traceId}>
           <TraceItem
             trace={trace}

--- a/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
@@ -30,9 +30,8 @@ import RunComment from "./run-comment";
 import { traceAnchorId } from "./session-outline/utils";
 import { useDebuggerSessionViewStore } from "./store";
 
-// Paste-to-agent prompt for "cache and rerun from here": the SDK resolves
-// LMNR_DEBUG_CACHE_UNTIL from a span id (see lmnr-ts debug/config.ts
-// parseCacheUntil) — no need to compute an occurrence count here.
+// Paste-to-agent prompt for "cache and rerun from here"; the SDK resolves
+// LMNR_DEBUG_CACHE_UNTIL from a span id directly.
 const rerunPrompt = (traceId: string, spanId: string, sessionId?: string) =>
   [
     "Rerun the agent with these env vars:",
@@ -167,9 +166,8 @@ export default function TraceSegment({
   const consumeScrollToTrace = useSessionViewBaseStore((s) => s.consumeScrollToTrace);
 
   const note = useDebuggerSessionViewStore((s) => s.noteForTrace(traceId));
-  // Fetch-in-flight → skeleton; settled + empty → "No spans found". Expanding
-  // always starts a fetch (synchronously, in the ensureTraceSpans override), so
-  // an expanded-but-empty segment is never mislabeled empty before its fetch.
+  // In-flight → skeleton; settled + empty → "No spans found". Expanding starts a
+  // fetch synchronously, so an empty segment is never mislabeled pre-fetch.
   const isLoading = useDebuggerSessionViewStore((s) => !!s.traceSpansFetching[traceId]);
 
   const rows = useMemo<TranscriptRow[]>(() => {
@@ -182,12 +180,8 @@ export default function TraceSegment({
   const headerRef = useRef<HTMLDivElement>(null);
   const [scrollMargin, setScrollMargin] = useState(0);
 
-  // R1: when THIS trace was just collapsed, bring its header into view — only if
-  // out of view (mirrors the regular view's scrollToIndex align:"auto"). The
-  // debugger has no flat-row virtualizer to scrollToIndex against; the header is
-  // plain DOM, so we bounds-check it against the page scroll container and scroll
-  // only when it's outside the viewport, then consume the one-shot request. Keyed
-  // on `expanded` too so it runs AFTER the collapse rebuilds this segment's height.
+  // On collapse, bring this trace's header into view only if it's out of view.
+  // Keyed on `expanded` so it runs after the collapse rebuilds segment height.
   useEffect(() => {
     if (scrollToTraceId !== traceId) return;
     const header = headerRef.current;
@@ -205,10 +199,8 @@ export default function TraceSegment({
     consumeScrollToTrace();
   }, [scrollToTraceId, traceId, expanded, scrollEl, consumeScrollToTrace]);
 
-  // Measure this viewport's offset within the scroll content (rect math instead
-  // of offsetTop — robust to positioned ancestors). Re-measured whenever the
-  // column's height changes (layoutVersion) since anything above us moving
-  // shifts the offset. The ±1px guard keeps re-measure→re-render convergent.
+  // Measure this viewport's offset in the scroll content; re-measured on column
+  // height changes (layoutVersion). The ±1px guard keeps it convergent.
   useLayoutEffect(() => {
     const el = viewportRef.current;
     if (!el || !scrollEl) return;

--- a/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
@@ -147,10 +147,9 @@ export default function TraceSegment({
   const traceId = trace.id;
 
   // Narrow per-trace store selections: streamed spans re-render only this segment.
-  const { spans, loading, error, expanded, selectedSpan } = useSessionViewBaseStore(
+  const { spans, error, expanded, selectedSpan } = useSessionViewBaseStore(
     (s) => ({
       spans: s.traceSpans[traceId],
-      loading: s.traceSpansLoading[traceId],
       error: s.traceSpansError[traceId],
       expanded: s.expandedTraceIds.has(traceId),
       selectedSpan: s.selectedSpan,
@@ -168,9 +167,13 @@ export default function TraceSegment({
   const consumeScrollToTrace = useSessionViewBaseStore((s) => s.consumeScrollToTrace);
 
   const note = useDebuggerSessionViewStore((s) => s.noteForTrace(traceId));
-  // True while hydrateTraceRow's one-shot fetch is in flight for this run — keeps
-  // a placeholder empty `[]` slot on the skeleton instead of "No spans found".
-  const hydrating = useDebuggerSessionViewStore((s) => !!s.traceHydrating[traceId]);
+  // ONE source of truth for "have this trace's spans loaded?" (decided: read
+  // traceFetchState, NOT the base slice's traceSpansLoading). "loading" → skeleton;
+  // "loaded" + empty → "No spans found"; absent (a list row not yet expanded) is
+  // treated as still-loading once expanded, since expanding flips it to "loading"
+  // synchronously via the ensureTraceSpans override.
+  const fetchState = useDebuggerSessionViewStore((s) => s.traceFetchState[traceId]);
+  const isLoading = fetchState !== "loaded";
 
   const rows = useMemo<TranscriptRow[]>(() => {
     if (!expanded || !spans || spans.length === 0) return [];
@@ -335,14 +338,14 @@ export default function TraceSegment({
       {!expanded && <TraceCollapsedBody trace={trace} traceIO={traceIO} />}
 
       {expanded && error && <div className="py-4 px-2 text-sm text-destructive">{error}</div>}
-      {expanded && !error && (!spans || (spans.length === 0 && (loading || hydrating))) && (
+      {expanded && !error && (!spans || spans.length === 0) && isLoading && (
         <div className="flex flex-col gap-2 py-2 px-2">
           <Skeleton className="h-5 w-full" />
           <Skeleton className="h-5 w-3/4" />
           <Skeleton className="h-5 w-2/3" />
         </div>
       )}
-      {expanded && !error && spans && spans.length === 0 && !loading && !hydrating && (
+      {expanded && !error && (!spans || spans.length === 0) && !isLoading && (
         <div className="py-4 px-2 text-sm text-muted-foreground">No spans found for this trace.</div>
       )}
 

--- a/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
@@ -299,8 +299,8 @@ export default function TraceSegment({
   // Scroll to a subagent group's header when the condensed timeline requests it
   // (clicking a group box). The debugger renders per-trace virtualizers rather
   // than the flat SessionList, so this segment owns the scroll for its own trace.
-  // Offset by the sticky header height so the target lands below it; the second
-  // (rAF) pass corrects for estimateSize-vs-real-height drift, mirroring list.tsx.
+  // `scrollToIndex` self-measures and centers the row (clear of the sticky header),
+  // mirroring the selected-span scroll above.
   useEffect(() => {
     if (!scrollToGroup || scrollToGroup.traceId !== traceId) return;
     const idx = rows.findIndex((r) => r.type === "group-header" && r.group.groupId === scrollToGroup.groupId);
@@ -310,20 +310,12 @@ export default function TraceSegment({
       consumeScrollToGroup();
       return;
     }
-    const scrollToGroupRow = () => {
-      const offset = virtualizer.getOffsetForIndex(idx, "start")?.[0];
-      if (offset !== undefined) {
-        const headerH = headerRef.current?.offsetHeight ?? 0;
-        scrollEl?.scrollTo({ top: Math.max(0, offset - headerH), behavior: "auto" });
-      }
-    };
-    scrollToGroupRow();
     const rafId = requestAnimationFrame(() => {
-      scrollToGroupRow();
+      virtualizer.scrollToIndex(idx, { align: "center" });
       consumeScrollToGroup();
     });
     return () => cancelAnimationFrame(rafId);
-  }, [scrollToGroup, traceId, rows, virtualizer, scrollEl, consumeScrollToGroup]);
+  }, [scrollToGroup, traceId, rows, virtualizer, consumeScrollToGroup]);
 
   return (
     <div id={traceAnchorId(traceId)} className="relative">
@@ -349,6 +341,7 @@ export default function TraceSegment({
             totalTraces={totalTraces}
             onToggle={() => toggleTraceExpanded(traceId)}
             analyticsFeature="debugger_sessions"
+            timelineLoading={isLoading}
           />
         </CopyFlag>
       </div>

--- a/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/trace-segment.tsx
@@ -167,13 +167,10 @@ export default function TraceSegment({
   const consumeScrollToTrace = useSessionViewBaseStore((s) => s.consumeScrollToTrace);
 
   const note = useDebuggerSessionViewStore((s) => s.noteForTrace(traceId));
-  // ONE source of truth for "have this trace's spans loaded?" (decided: read
-  // traceFetchState, NOT the base slice's traceSpansLoading). "loading" → skeleton;
-  // "loaded" + empty → "No spans found"; absent (a list row not yet expanded) is
-  // treated as still-loading once expanded, since expanding flips it to "loading"
-  // synchronously via the ensureTraceSpans override.
-  const fetchState = useDebuggerSessionViewStore((s) => s.traceFetchState[traceId]);
-  const isLoading = fetchState !== "loaded";
+  // Fetch-in-flight → skeleton; settled + empty → "No spans found". Expanding
+  // always starts a fetch (synchronously, in the ensureTraceSpans override), so
+  // an expanded-but-empty segment is never mislabeled empty before its fetch.
+  const isLoading = useDebuggerSessionViewStore((s) => !!s.traceSpansFetching[traceId]);
 
   const rows = useMemo<TranscriptRow[]>(() => {
     if (!expanded || !spans || spans.length === 0) return [];

--- a/frontend/components/traces/session-view/session-condensed-timeline/close-button.tsx
+++ b/frontend/components/traces/session-view/session-condensed-timeline/close-button.tsx
@@ -1,0 +1,20 @@
+import { X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface CloseButtonProps {
+  onClose: () => void;
+}
+
+/** Absolutely-positioned X in the top-right of the session condensed timeline.
+ *  Styled to match the trace-view timeline-toggle's open/`enabled`-state X
+ *  (only the position anchor changes from `top-full` to `top-0`). */
+export default function CloseButton({ onClose }: CloseButtonProps) {
+  return (
+    <div className="absolute z-40 top-0 right-0 flex items-end overflow-hidden h-6 w-7 bg-muted border-b border-l rounded-none rounded-bl">
+      <Button onClick={onClose} variant="ghost" size="icon" className="size-5 min-w-5">
+        <X className="size-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
@@ -36,18 +36,21 @@ const EMPTY_SET = new Set<string>();
 
 interface SessionCondensedTimelineProps {
   trace: TraceRow;
+  /** Whether this trace's spans are being fetched (drives the skeleton). Passed in
+   *  rather than read from the store: the loading flag (traceSpansFetching) lives on
+   *  the debugger store, which this base-dir component intentionally doesn't import. */
+  isLoading: boolean;
 }
 
 /** Per-trace condensed timeline for the (debugger) session panel. Reuses the
  *  store-free trace-view leaves, but sources all state from the session base
  *  store keyed by `trace.id` instead of one global trace. */
-function SessionCondensedTimeline({ trace }: SessionCondensedTimelineProps) {
+function SessionCondensedTimeline({ trace, isLoading }: SessionCondensedTimelineProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const timelineContentRef = useRef<HTMLDivElement>(null);
 
   const {
     spans,
-    isSpansLoading,
     zoom,
     visibleSpanIds,
     selectedSpan,
@@ -66,7 +69,6 @@ function SessionCondensedTimeline({ trace }: SessionCondensedTimelineProps) {
   } = useSessionViewBaseStore(
     (s) => ({
       spans: s.traceSpans[trace.id],
-      isSpansLoading: s.traceSpansLoading[trace.id] ?? false,
       zoom: s.condensedTimelineZoomByTrace[trace.id] ?? MIN_ZOOM,
       visibleSpanIds: s.condensedTimelineVisibleSpanIdsByTrace[trace.id] ?? EMPTY_SET,
       selectedSpan: s.selectedSpan,
@@ -224,7 +226,7 @@ function SessionCondensedTimeline({ trace }: SessionCondensedTimelineProps) {
   }, [scrollStartTime, scrollEndTime, spanTimelineStartMs, timelineWidthInMilliseconds]);
 
   const renderContent = () => {
-    if (isSpansLoading) {
+    if (isLoading) {
       return (
         <div className="flex flex-col gap-2 py-2 w-full h-full">
           <Skeleton className="h-6 w-full" />

--- a/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
@@ -226,7 +226,9 @@ function SessionCondensedTimeline({ trace, isLoading }: SessionCondensedTimeline
   }, [scrollStartTime, scrollEndTime, spanTimelineStartMs, timelineWidthInMilliseconds]);
 
   const renderContent = () => {
-    if (isLoading) {
+    // Skeleton only when there's nothing to show — SSE-streamed spans render
+    // even while the ClickHouse fetch is still in flight.
+    if (isLoading && isEmpty(condensedSpans)) {
       return (
         <div className="flex flex-col gap-2 py-2 w-full h-full">
           <Skeleton className="h-6 w-full" />

--- a/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
@@ -323,7 +323,7 @@ function SessionCondensedTimeline({ trace }: SessionCondensedTimelineProps) {
 
   return (
     <div
-      className="relative flex flex-col h-[180px] w-full overflow-hidden border-t"
+      className="relative flex flex-col h-[90px] w-full overflow-hidden border-t"
       onClick={(e) => e.stopPropagation()}
     >
       <div

--- a/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { isEmpty } from "lodash";
+import React, { memo, useCallback, useMemo, useRef, useState } from "react";
+import { shallow } from "zustand/shallow";
+
+import CondensedTimelineElement, {
+  ROW_HEIGHT,
+} from "@/components/traces/trace-view/condensed-timeline/condensed-timeline-element";
+import Controls from "@/components/traces/trace-view/condensed-timeline/controls";
+import SelectionIndicator from "@/components/traces/trace-view/condensed-timeline/selection-indicator";
+import SelectionOverlay from "@/components/traces/trace-view/condensed-timeline/selection-overlay";
+import SubagentGroupElement from "@/components/traces/trace-view/condensed-timeline/subagent-group-element";
+import {
+  formatTimeMarkerLabel,
+  useDynamicTimeIntervals,
+} from "@/components/traces/trace-view/condensed-timeline/use-dynamic-time-intervals";
+import { useHoverNeedle } from "@/components/traces/trace-view/condensed-timeline/use-hover-needle";
+import { useScrollToSpan } from "@/components/traces/trace-view/condensed-timeline/use-scroll-to-span";
+import { useWheelZoom } from "@/components/traces/trace-view/condensed-timeline/use-wheel-zoom";
+import { MAX_ZOOM, MIN_ZOOM, ZOOM_INCREMENT } from "@/components/traces/trace-view/store";
+import { type TraceViewSpan } from "@/components/traces/trace-view/store/base";
+import {
+  computeSubagentGroups,
+  computeVisibleSpanIds,
+  transformSpansToCondensedTimeline,
+} from "@/components/traces/trace-view/store/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+import { type TraceRow } from "@/lib/traces/types";
+import { cn } from "@/lib/utils";
+
+import { useSessionViewBaseStore } from "../store";
+import CloseButton from "./close-button";
+
+const EMPTY_SET = new Set<string>();
+
+interface SessionCondensedTimelineProps {
+  trace: TraceRow;
+}
+
+/** Per-trace condensed timeline for the (debugger) session panel. Reuses the
+ *  store-free trace-view leaves, but sources all state from the session base
+ *  store keyed by `trace.id` instead of one global trace. */
+function SessionCondensedTimeline({ trace }: SessionCondensedTimelineProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const timelineContentRef = useRef<HTMLDivElement>(null);
+
+  const {
+    spans,
+    isSpansLoading,
+    zoom,
+    visibleSpanIds,
+    selectedSpan,
+    setSelectedSpan,
+    mode,
+    transcriptExpandedGroups,
+    scrollStartTime,
+    scrollEndTime,
+    isCostHeatmapVisible,
+    setCondensedTimelineZoom,
+    setCondensedTimelineVisibleSpanIds,
+    clearCondensedTimelineSelection,
+    setIsCostHeatmapVisible,
+    setTimelineOpen,
+    requestScrollToGroup,
+  } = useSessionViewBaseStore(
+    (s) => ({
+      spans: s.traceSpans[trace.id],
+      isSpansLoading: s.traceSpansLoading[trace.id] ?? false,
+      zoom: s.condensedTimelineZoomByTrace[trace.id] ?? MIN_ZOOM,
+      visibleSpanIds: s.condensedTimelineVisibleSpanIdsByTrace[trace.id] ?? EMPTY_SET,
+      selectedSpan: s.selectedSpan,
+      setSelectedSpan: s.setSelectedSpan,
+      mode: s.traceViewModes[trace.id] ?? "transcript",
+      transcriptExpandedGroups: s.transcriptExpandedGroups,
+      scrollStartTime: s.scrollStartTime,
+      scrollEndTime: s.scrollEndTime,
+      isCostHeatmapVisible: s.isCostHeatmapVisible,
+      setCondensedTimelineZoom: s.setCondensedTimelineZoom,
+      setCondensedTimelineVisibleSpanIds: s.setCondensedTimelineVisibleSpanIds,
+      clearCondensedTimelineSelection: s.clearCondensedTimelineSelection,
+      setIsCostHeatmapVisible: s.setIsCostHeatmapVisible,
+      setTimelineOpen: s.setTimelineOpen,
+      requestScrollToGroup: s.requestScrollToGroup,
+    }),
+    shallow
+  );
+
+  const spanList = useMemo(() => spans ?? [], [spans]);
+
+  const {
+    spans: condensedSpans,
+    startTime: spanTimelineStartMs,
+    totalDurationMs,
+    timelineWidthInMilliseconds,
+    totalRows,
+  } = useMemo(() => transformSpansToCondensedTimeline(spanList), [spanList]);
+
+  const maxSpanCost = useMemo(() => spanList.reduce((m, s) => Math.max(m, s.totalCost), 0), [spanList]);
+
+  const subagentGroups = useMemo(() => computeSubagentGroups(spanList), [spanList]);
+
+  // Resolve the session-scoped selection to a span of THIS trace.
+  const selectedSpanForThisTrace = useMemo<TraceViewSpan | undefined>(
+    () =>
+      selectedSpan && selectedSpan.traceId === trace.id
+        ? spanList.find((s) => s.spanId === selectedSpan.spanId)
+        : undefined,
+    [selectedSpan, trace.id, spanList]
+  );
+
+  const groupBoxes = useMemo(() => {
+    if (subagentGroups.length === 0) return [];
+    const posById = new Map(condensedSpans.map((c) => [c.span.spanId, c]));
+    const boxes: Array<{
+      groupId: string;
+      left: number;
+      width: number;
+      topRow: number;
+      rowSpan: number;
+      collapsed: boolean;
+    }> = [];
+    for (const group of subagentGroups) {
+      let minLeft = Infinity;
+      let maxRight = -Infinity;
+      let minRow = Infinity;
+      let maxRow = -Infinity;
+      for (const spanId of group.spanIds) {
+        const pos = posById.get(spanId);
+        if (!pos) continue;
+        if (pos.left < minLeft) minLeft = pos.left;
+        if (pos.left + pos.width > maxRight) maxRight = pos.left + pos.width;
+        if (pos.row < minRow) minRow = pos.row;
+        if (pos.row > maxRow) maxRow = pos.row;
+      }
+      if (!Number.isFinite(minLeft) || !Number.isFinite(maxRight)) continue;
+      boxes.push({
+        groupId: group.groupId,
+        left: minLeft,
+        width: maxRight - minLeft,
+        topRow: minRow,
+        rowSpan: maxRow - minRow + 1,
+        collapsed: mode === "tree" ? false : !transcriptExpandedGroups.has(`${trace.id}::${group.groupId}`),
+      });
+    }
+    return boxes;
+  }, [subagentGroups, condensedSpans, transcriptExpandedGroups, mode, trace.id]);
+
+  const { markers: timeMarkers, setContainerRef } = useDynamicTimeIntervals({ totalDurationMs, zoom });
+
+  const combinedScrollRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      (scrollRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      setContainerRef(node);
+    },
+    [setContainerRef]
+  );
+
+  const [isScrolled, setIsScrolled] = useState(false);
+  const selectedCount = visibleSpanIds.size;
+
+  const { needleLeft, hoverTimeMs, handleMouseMove, handleMouseLeave } = useHoverNeedle(scrollRef, totalDurationMs);
+
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    setIsScrolled(e.currentTarget.scrollTop > 0);
+  }, []);
+
+  useScrollToSpan(scrollRef, selectedSpanForThisTrace, condensedSpans);
+
+  const setZoom = useCallback(
+    (z: number) => setCondensedTimelineZoom(trace.id, z),
+    [setCondensedTimelineZoom, trace.id]
+  );
+
+  useWheelZoom(scrollRef, zoom, setZoom);
+
+  const handleZoom = useCallback(
+    (direction: "in" | "out") => {
+      const container = scrollRef.current;
+      if (!container) return;
+
+      const newZoom = direction === "in" ? zoom + ZOOM_INCREMENT : zoom - ZOOM_INCREMENT;
+      if (newZoom < MIN_ZOOM || newZoom > MAX_ZOOM) return;
+
+      const containerWidth = container.clientWidth;
+      const centerX = container.scrollLeft + containerWidth / 2;
+      const fraction = centerX / container.scrollWidth;
+
+      setZoom(newZoom);
+
+      requestAnimationFrame(() => {
+        const newScrollWidth = container.scrollWidth;
+        const newScrollLeft = fraction * newScrollWidth - containerWidth / 2;
+        container.scrollLeft = Math.max(0, Math.min(newScrollLeft, newScrollWidth - containerWidth));
+      });
+    },
+    [zoom, setZoom]
+  );
+
+  const handleSelectionComplete = useCallback(
+    (selectedIds: Set<string>) => {
+      setCondensedTimelineVisibleSpanIds(trace.id, computeVisibleSpanIds(selectedIds, spanList));
+    },
+    [spanList, setCondensedTimelineVisibleSpanIds, trace.id]
+  );
+
+  const handleSpanClick = useCallback(
+    (span: TraceViewSpan) => {
+      if (!span.pending) setSelectedSpan({ traceId: trace.id, spanId: span.spanId });
+    },
+    [setSelectedSpan, trace.id]
+  );
+
+  const contentHeight = (totalRows + 1) * ROW_HEIGHT;
+
+  const scrollIndicator = useMemo(() => {
+    if (scrollStartTime === undefined || scrollEndTime === undefined || timelineWidthInMilliseconds <= 0) return null;
+    const rawLeft = ((scrollStartTime - spanTimelineStartMs) / timelineWidthInMilliseconds) * 100;
+    const rawWidth = ((scrollEndTime - scrollStartTime) / timelineWidthInMilliseconds) * 100;
+    const left = Math.max(0, Math.min(100, rawLeft));
+    const width = Math.max(0, Math.min(100 - left, rawWidth));
+    if (width <= 0) return null;
+    return { left, width };
+  }, [scrollStartTime, scrollEndTime, spanTimelineStartMs, timelineWidthInMilliseconds]);
+
+  const renderContent = () => {
+    if (isSpansLoading) {
+      return (
+        <div className="flex flex-col gap-2 py-2 w-full h-full">
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-full w-full" />
+        </div>
+      );
+    }
+
+    if (isEmpty(condensedSpans)) {
+      return (
+        <div className="flex items-center justify-center h-full text-sm text-muted-foreground">No spans found</div>
+      );
+    }
+
+    return (
+      <div className="relative h-full" style={{ width: `${100 * zoom}%`, minHeight: contentHeight }}>
+        {/* Time marker lines - full height */}
+        {timeMarkers.map((marker, index) => (
+          <div
+            key={`marker-${index}`}
+            className="absolute top-0 bottom-[-60px] w-px pointer-events-none bg-muted"
+            style={{ left: `${marker.positionPercent}%` }}
+          />
+        ))}
+
+        {/* Scroll indicator */}
+        {scrollIndicator && (
+          <div
+            className="absolute bottom-[-60px] top-0 bg-muted/75 pointer-events-none"
+            style={{ left: `${scrollIndicator.left}%`, width: `${scrollIndicator.width}%` }}
+          />
+        )}
+
+        {/* Sticky header - time marker labels */}
+        <div
+          className={cn(
+            "sticky top-0 z-30 h-6 text-xs pointer-events-none select-none",
+            isScrolled && "bg-gradient-to-b from-[hsla(240,4%,9%,90%)] via-[hsla(240,4%,9%,80%)] to-transparent"
+          )}
+        >
+          {timeMarkers.map((marker, index) => (
+            <div
+              key={index}
+              className="absolute flex items-center h-full"
+              style={{ left: `${marker.positionPercent}%` }}
+            >
+              <div className="text-secondary-foreground truncate text-[10px] whitespace-nowrap pl-1">
+                {marker.label}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Timeline content */}
+        <div ref={timelineContentRef} className="relative h-full" style={{ minHeight: contentHeight }}>
+          {condensedSpans.map((condensedSpan) => {
+            const hasGroupSelection = visibleSpanIds.size > 0;
+            const isIncludedInGroupSelection = hasGroupSelection ? visibleSpanIds.has(condensedSpan.span.spanId) : null;
+
+            return (
+              <CondensedTimelineElement
+                key={condensedSpan.span.spanId}
+                condensedSpan={condensedSpan}
+                selectedSpan={selectedSpanForThisTrace}
+                isIncludedInGroupSelection={isIncludedInGroupSelection}
+                maxSpanCost={maxSpanCost}
+                isCostHeatmapVisible={isCostHeatmapVisible}
+                onClick={handleSpanClick}
+              />
+            );
+          })}
+
+          {groupBoxes.map((box) => (
+            <SubagentGroupElement
+              key={box.groupId}
+              groupId={box.groupId}
+              left={box.left}
+              width={box.width}
+              topRow={box.topRow}
+              rowSpan={box.rowSpan}
+              collapsed={box.collapsed}
+              onRequestScroll={(groupId) => requestScrollToGroup(trace.id, groupId)}
+            />
+          ))}
+
+          <SelectionOverlay
+            spans={condensedSpans}
+            containerRef={timelineContentRef}
+            scrollContainerRef={scrollRef}
+            onSelectionComplete={handleSelectionComplete}
+          />
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="relative flex flex-col h-[180px] w-full overflow-hidden border-t"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div
+        ref={combinedScrollRef}
+        className="flex-1 overflow-auto relative min-h-0 bg-muted/50 h-full minimal-scrollbar"
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        onScroll={handleScroll}
+      >
+        <div className="px-2 h-full">{renderContent()}</div>
+      </div>
+
+      {/* Hover needle */}
+      {needleLeft !== null && (
+        <div className="absolute inset-y-0 pointer-events-none z-[35]" style={{ left: `${needleLeft}%` }}>
+          <div className="absolute top-0 h-6 flex items-center -translate-x-1/2">
+            <div className="px-1.5 py-0.5 bg-primary text-white text-[10px] rounded whitespace-nowrap">
+              {hoverTimeMs !== null ? formatTimeMarkerLabel(Math.round(hoverTimeMs)) : ""}
+            </div>
+          </div>
+          <div className="absolute top-[6px] bottom-0 w-px bg-primary/50" />
+        </div>
+      )}
+
+      <SelectionIndicator selectedCount={selectedCount} onClear={() => clearCondensedTimelineSelection(trace.id)} />
+
+      <Controls
+        onZoomIn={() => handleZoom("in")}
+        onZoomOut={() => handleZoom("out")}
+        zoom={zoom}
+        isCostHeatmapVisible={isCostHeatmapVisible}
+        onToggleCostHeatmap={setIsCostHeatmapVisible}
+      />
+
+      <CloseButton onClose={() => setTimelineOpen(trace.id, false)} />
+    </div>
+  );
+}
+
+export default memo(SessionCondensedTimeline);

--- a/frontend/components/traces/session-view/session-panel/trace-control-bar.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-control-bar.tsx
@@ -77,7 +77,7 @@ export default function TraceControlBar({ trace, analyticsFeature = "sessions" }
           onClick={handleToggleTimeline}
           variant="outline"
           className={cn(
-            "h-6 text-xs px-1.5",
+            "h-6 text-xs px-1.5 bg-transparent",
             isTimelineOpen ? "border-primary text-primary hover:bg-primary/10" : "hover:bg-secondary"
           )}
         >

--- a/frontend/components/traces/session-view/session-panel/trace-control-bar.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-control-bar.tsx
@@ -1,9 +1,12 @@
+import { GanttChart } from "lucide-react";
 import { shallow } from "zustand/shallow";
 
 import Metadata from "@/components/traces/trace-view/metadata";
 import ViewToggle, { type ViewTab } from "@/components/traces/trace-view/view-toggle";
+import { Button } from "@/components/ui/button";
 import { type Feature, track } from "@/lib/posthog";
 import { type TraceRow } from "@/lib/traces/types";
+import { cn } from "@/lib/utils";
 
 import { useSessionViewBaseStore } from "../store";
 
@@ -28,15 +31,25 @@ function metadataToString(metadata: TraceRow["metadata"] | string | undefined): 
 /** Per-trace Tree/Transcript + Content toggle and Metadata button. Rendered in
  *  the expanded trace header's control strip in both session surfaces. */
 export default function TraceControlBar({ trace, analyticsFeature = "sessions" }: TraceControlBarProps) {
-  const { mode, showContent, setTraceViewMode, toggleTraceShowTreeContent } = useSessionViewBaseStore(
-    (s) => ({
-      mode: s.traceViewModes[trace.id] ?? "transcript",
-      showContent: s.traceShowTreeContent[trace.id] ?? true,
-      setTraceViewMode: s.setTraceViewMode,
-      toggleTraceShowTreeContent: s.toggleTraceShowTreeContent,
-    }),
-    shallow
-  );
+  const { mode, showContent, setTraceViewMode, toggleTraceShowTreeContent, isTimelineOpen, toggleTimelineOpen } =
+    useSessionViewBaseStore(
+      (s) => ({
+        mode: s.traceViewModes[trace.id] ?? "transcript",
+        showContent: s.traceShowTreeContent[trace.id] ?? true,
+        setTraceViewMode: s.setTraceViewMode,
+        toggleTraceShowTreeContent: s.toggleTraceShowTreeContent,
+        isTimelineOpen: s.timelineOpenTraceIds.has(trace.id),
+        toggleTimelineOpen: s.toggleTimelineOpen,
+      }),
+      shallow
+    );
+
+  const isDebugger = analyticsFeature === "debugger_sessions";
+
+  const handleToggleTimeline = () => {
+    track(analyticsFeature, "condensed_timeline_toggled", { traceId: trace.id, open: !isTimelineOpen });
+    toggleTimelineOpen(trace.id);
+  };
 
   const handleTabChange = (next: ViewTab) => {
     if (next !== mode) {
@@ -48,14 +61,30 @@ export default function TraceControlBar({ trace, analyticsFeature = "sessions" }
   const metaString = metadataToString(trace.metadata as TraceRow["metadata"] | string | undefined);
 
   return (
-    <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
-      <ViewToggle
-        tab={mode}
-        onTabChange={handleTabChange}
-        showContent={showContent}
-        onToggleContent={() => toggleTraceShowTreeContent(trace.id)}
-      />
-      <Metadata metadata={metaString} />
+    <div className="flex items-center justify-between gap-2" onClick={(e) => e.stopPropagation()}>
+      <div className="flex">
+        <ViewToggle
+          tab={mode}
+          onTabChange={handleTabChange}
+          showContent={showContent}
+          onToggleContent={() => toggleTraceShowTreeContent(trace.id)}
+        />
+        <Metadata metadata={metaString} />
+      </div>
+
+      {isDebugger && (
+        <Button
+          onClick={handleToggleTimeline}
+          variant="outline"
+          className={cn(
+            "h-6 text-xs px-1.5",
+            isTimelineOpen ? "border-primary text-primary hover:bg-primary/10" : "hover:bg-secondary"
+          )}
+        >
+          <GanttChart size={14} className="mr-1" />
+          Timeline
+        </Button>
+      )}
     </div>
   );
 }

--- a/frontend/components/traces/session-view/session-panel/trace-item.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-item.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AnimatePresence, motion } from "framer-motion";
 import { ChevronDown, Copy, ExternalLink, Loader2 } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -50,19 +51,31 @@ export default function TraceItem({
   // Only the data the header chrome needs: `spans` gates the pending-expand
   // spinner; `spansError` lets a failed lazy-load still flip out of pending.
   // The collapsed body (input + last-span preview) is its own row now.
-  const { spans, spansError, ensureTraceSpans, isTimelineOpen } = useSessionViewBaseStore(
+  const { spans, spansError, ensureTraceSpans, isTimelineOpen, setTimelineOpen } = useSessionViewBaseStore(
     (s) => ({
       spans: s.traceSpans[trace.id],
       spansError: s.traceSpansError[trace.id],
       ensureTraceSpans: s.ensureTraceSpans,
       isTimelineOpen: s.timelineOpenTraceIds.has(trace.id),
+      setTimelineOpen: s.setTimelineOpen,
     }),
     shallow
   );
 
+  const isDebugger = analyticsFeature === "debugger_sessions";
+
   // Debugger-only: the toggle lives in the expanded control bar, so the timeline
   // must never orphan-render under a collapsed card.
-  const showTimeline = analyticsFeature === "debugger_sessions" && expanded && isTimelineOpen;
+  const showTimeline = isDebugger && expanded && isTimelineOpen;
+
+  // Default the timeline open each time a debugger card expands. Runs only on the
+  // expand transition (not on `isTimelineOpen` changes), so a manual close while
+  // expanded sticks — it only re-opens on the next expand.
+  useEffect(() => {
+    if (isDebugger && expanded) {
+      setTimelineOpen(trace.id, true);
+    }
+  }, [isDebugger, expanded, trace.id, setTimelineOpen]);
 
   const pendingExpandRef = useRef(false);
   const [isPendingExpand, setIsPendingExpand] = useState(false);
@@ -203,7 +216,20 @@ export default function TraceItem({
               </span>
             </div>
           </button>
-          {showTimeline && <SessionCondensedTimeline trace={trace} />}
+          <AnimatePresence initial={false}>
+            {showTimeline && (
+              <motion.div
+                key="condensed-timeline"
+                className="overflow-hidden"
+                initial={{ height: 0, opacity: 0.5 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0.5 }}
+                transition={{ duration: 0.25, ease: "easeOut" }}
+              >
+                <SessionCondensedTimeline trace={trace} />
+              </motion.div>
+            )}
+          </AnimatePresence>
           {expanded && (
             <div className="bg-secondary/75 px-3 py-2 border-t">
               <TraceControlBar trace={trace} analyticsFeature={analyticsFeature} />

--- a/frontend/components/traces/session-view/session-panel/trace-item.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-item.tsx
@@ -136,20 +136,14 @@ export default function TraceItem({
           the side+bottom borders and bottom rounding, stitching one card across
           two virtual rows. The header button's own `border-b` (collapsed) is the
           single divider. When expanded the body rows below are borderless spans. */}
-      <div
-        className={cn(
-          "overflow-hidden w-full border-x border-t border-[rgba(232,232,232,0.1)]",
-          expanded ? "bg-muted rounded-lg border-b" : "bg-muted/75 rounded-t-lg"
-        )}
-      >
+      <div className={cn("overflow-hidden w-full border border-x border-t", expanded ? "rounded-lg" : "rounded-t-lg")}>
         <div onClick={handleToggle} className={cn("w-full flex flex-col transition-all ease-in-out")}>
           <button
             type="button"
             className={cn(
-              "w-full flex items-center justify-between text-left cursor-pointer transition-all ease-in-out h-[40px]",
-              expanded
-                ? "pl-1.5 pr-3 hover:bg-muted/80"
-                : "pl-1.5 pr-3 bg-[rgba(232,232,232,0.02)] border-b border-[rgba(232,232,232,0.1)] hover:bg-[rgba(232,232,232,0.04)]"
+              "w-full flex items-center justify-between text-left cursor-pointer transition-all ease-in-out h-[40px] pl-1.5 pr-3 bg-muted/75",
+
+              "hover:bg-muted/90"
             )}
           >
             <div className="flex items-center gap-2 min-w-0">
@@ -220,7 +214,7 @@ export default function TraceItem({
             {showTimeline && (
               <motion.div
                 key="condensed-timeline"
-                className="overflow-hidden"
+                className="overflow-hidden border-b"
                 initial={{ height: 0, opacity: 0.5 }}
                 animate={{ height: "auto", opacity: 1 }}
                 exit={{ height: 0, opacity: 0.5 }}
@@ -231,7 +225,7 @@ export default function TraceItem({
             )}
           </AnimatePresence>
           {expanded && (
-            <div className="bg-secondary/75 px-3 py-2 border-t">
+            <div className={cn("px-3 py-2", showTimeline ? "bg-muted/75" : "bg-muted/50 border-t")}>
               <TraceControlBar trace={trace} analyticsFeature={analyticsFeature} />
             </div>
           )}

--- a/frontend/components/traces/session-view/session-panel/trace-item.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-item.tsx
@@ -49,11 +49,11 @@ export default function TraceItem({
   // Only the data the header chrome needs: `spans` gates the pending-expand
   // spinner; `spansError` lets a failed lazy-load still flip out of pending.
   // The collapsed body (input + last-span preview) is its own row now.
-  const { spans, spansError, ensureTraceSpans } = useSessionViewBaseStore(
+  const { spans, spansError, fetchTraceSpans } = useSessionViewBaseStore(
     (s) => ({
       spans: s.traceSpans[trace.id],
       spansError: s.traceSpansError[trace.id],
-      ensureTraceSpans: s.ensureTraceSpans,
+      fetchTraceSpans: s.fetchTraceSpans,
     }),
     shallow
   );
@@ -84,8 +84,8 @@ export default function TraceItem({
     }
     pendingExpandRef.current = true;
     setIsPendingExpand(true);
-    ensureTraceSpans(trace);
-  }, [expanded, spans, onToggle, ensureTraceSpans, trace]);
+    fetchTraceSpans(trace);
+  }, [expanded, spans, onToggle, fetchTraceSpans, trace]);
 
   const handleCopyTraceId = useCallback(async () => {
     await navigator.clipboard.writeText(trace.id);

--- a/frontend/components/traces/session-view/session-panel/trace-item.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-item.tsx
@@ -33,6 +33,9 @@ interface TraceItemProps {
   /** Which surface this card belongs to — drives the control bar's analytics
    *  attribution. The debugger passes "debugger_sessions"; defaults to "sessions". */
   analyticsFeature?: "sessions" | "debugger_sessions";
+  /** Spans-fetch-in-flight for this trace, forwarded to the condensed timeline's
+   *  skeleton. Only the debugger renders the timeline and owns this flag. */
+  timelineLoading?: boolean;
 }
 
 export default function TraceItem({
@@ -43,6 +46,7 @@ export default function TraceItem({
   onToggle,
   className,
   analyticsFeature,
+  timelineLoading,
 }: TraceItemProps) {
   const params = useParams<{ projectId: string }>();
   const projectId = params.projectId;
@@ -195,7 +199,7 @@ export default function TraceItem({
                 exit={{ height: 0, opacity: 0.5 }}
                 transition={{ duration: 0.25, ease: "easeOut" }}
               >
-                <SessionCondensedTimeline trace={trace} />
+                <SessionCondensedTimeline trace={trace} isLoading={timelineLoading ?? false} />
               </motion.div>
             )}
           </AnimatePresence>

--- a/frontend/components/traces/session-view/session-panel/trace-item.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-item.tsx
@@ -18,6 +18,7 @@ import { track } from "@/lib/posthog";
 import { type TraceRow } from "@/lib/traces/types";
 import { cn } from "@/lib/utils";
 
+import SessionCondensedTimeline from "../session-condensed-timeline";
 import { useSessionViewBaseStore } from "../store";
 import TraceControlBar from "./trace-control-bar";
 
@@ -49,14 +50,19 @@ export default function TraceItem({
   // Only the data the header chrome needs: `spans` gates the pending-expand
   // spinner; `spansError` lets a failed lazy-load still flip out of pending.
   // The collapsed body (input + last-span preview) is its own row now.
-  const { spans, spansError, ensureTraceSpans } = useSessionViewBaseStore(
+  const { spans, spansError, ensureTraceSpans, isTimelineOpen } = useSessionViewBaseStore(
     (s) => ({
       spans: s.traceSpans[trace.id],
       spansError: s.traceSpansError[trace.id],
       ensureTraceSpans: s.ensureTraceSpans,
+      isTimelineOpen: s.timelineOpenTraceIds.has(trace.id),
     }),
     shallow
   );
+
+  // Debugger-only: the toggle lives in the expanded control bar, so the timeline
+  // must never orphan-render under a collapsed card.
+  const showTimeline = analyticsFeature === "debugger_sessions" && expanded && isTimelineOpen;
 
   const pendingExpandRef = useRef(false);
   const [isPendingExpand, setIsPendingExpand] = useState(false);
@@ -197,6 +203,7 @@ export default function TraceItem({
               </span>
             </div>
           </button>
+          {showTimeline && <SessionCondensedTimeline trace={trace} />}
           {expanded && (
             <div className="bg-secondary/75 px-3 py-2 border-t">
               <TraceControlBar trace={trace} analyticsFeature={analyticsFeature} />

--- a/frontend/components/traces/session-view/session-panel/trace-item.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-item.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ChevronDown, Copy, ExternalLink, Loader2 } from "lucide-react";
+import { ChevronDown, Copy, ExternalLink } from "lucide-react";
 import { useParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { shallow } from "zustand/shallow";
 
 import { formatShortRelativeTime } from "@/components/client-timestamp-formatter";
@@ -46,45 +46,19 @@ export default function TraceItem({
   const projectId = params.projectId;
   const { toast } = useToast();
 
-  // Only the data the header chrome needs: `spans` gates the pending-expand
-  // spinner; `spansError` lets a failed lazy-load still flip out of pending.
-  // The collapsed body (input + last-span preview) is its own row now.
-  const { spans, spansError, fetchTraceSpans } = useSessionViewBaseStore(
+  const { spans, fetchTraceSpans } = useSessionViewBaseStore(
     (s) => ({
       spans: s.traceSpans[trace.id],
-      spansError: s.traceSpansError[trace.id],
       fetchTraceSpans: s.fetchTraceSpans,
     }),
     shallow
   );
 
-  const pendingExpandRef = useRef(false);
-  const [isPendingExpand, setIsPendingExpand] = useState(false);
-
-  useEffect(() => {
-    if (!pendingExpandRef.current) return;
-    if (spans || spansError) {
-      pendingExpandRef.current = false;
-      queueMicrotask(() => {
-        setIsPendingExpand(false);
-        onToggle();
-      });
-    }
-  }, [spans, spansError, onToggle]);
-
+  // Expand immediately — the expanded body owns its loading/empty/error states.
   const handleToggle = useCallback(() => {
     track("sessions", expanded ? "trace_card_collapsed" : "trace_card_expanded", { traceId: trace.id });
-    if (expanded) {
-      onToggle();
-      return;
-    }
-    if (spans) {
-      onToggle();
-      return;
-    }
-    pendingExpandRef.current = true;
-    setIsPendingExpand(true);
-    fetchTraceSpans(trace);
+    if (!expanded && !spans) void fetchTraceSpans(trace);
+    onToggle();
   }, [expanded, spans, onToggle, fetchTraceSpans, trace]);
 
   const handleCopyTraceId = useCallback(async () => {
@@ -177,7 +151,6 @@ export default function TraceItem({
               <span className="text-[13px] leading-[17px] text-secondary-foreground whitespace-nowrap">
                 {relativeTime}
               </span>
-              {isPendingExpand && <Loader2 size={16} className="text-secondary-foreground animate-spin" />}
               <span
                 className={cn(
                   "flex items-center justify-center rounded-full pl-1 pr-1 py-0.5 text-xs font-medium leading-[17px] text-secondary-foreground whitespace-nowrap",

--- a/frontend/components/traces/session-view/session-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-timeline/index.tsx
@@ -28,7 +28,7 @@ function SessionTimeline() {
     selectedSpan,
     setSelectedSpan,
     toggleTraceExpanded,
-    ensureTraceSpans,
+    fetchTraceSpans,
     zoom,
     setZoom,
     setSessionTimelineEnabled,
@@ -43,7 +43,7 @@ function SessionTimeline() {
       selectedSpan: s.selectedSpan,
       setSelectedSpan: s.setSelectedSpan,
       toggleTraceExpanded: s.toggleTraceExpanded,
-      ensureTraceSpans: s.ensureTraceSpans,
+      fetchTraceSpans: s.fetchTraceSpans,
       zoom: s.sessionTimelineZoom,
       setZoom: s.setSessionTimelineZoom,
       setSessionTimelineEnabled: s.setSessionTimelineEnabled,
@@ -78,7 +78,7 @@ function SessionTimeline() {
 
   // Two-phase expand (mirrors list/trace-item.tsx): when the user clicks a
   // collapsed trace whose spans aren't loaded yet, we DON'T flip
-  // `expandedTraceIds` immediately — we kick off `ensureTraceSpans` and
+  // `expandedTraceIds` immediately — we kick off `fetchTraceSpans` and
   // flush to expand once spans arrive. The bar meanwhile shows a shimmer
   // (driven by `traceSpansLoading` → `bar.shimmer` in utils.ts).
   //
@@ -119,9 +119,9 @@ function SessionTimeline() {
       const trace = traces.find((t) => t.id === traceId);
       if (!trace) return;
       pendingExpandIdsRef.current.add(traceId);
-      void ensureTraceSpans(trace);
+      void fetchTraceSpans(trace);
     },
-    [expandedTraceIds, traceSpans, traces, toggleTraceExpanded, ensureTraceSpans]
+    [expandedTraceIds, traceSpans, traces, toggleTraceExpanded, fetchTraceSpans]
   );
 
   const handleSpanBarClick = useCallback(

--- a/frontend/components/traces/session-view/session-view-content.tsx
+++ b/frontend/components/traces/session-view/session-view-content.tsx
@@ -36,7 +36,7 @@ export default function SessionViewContent({ sessionId }: SessionViewContentProp
     );
 
   // Push projectId into the store so store-owned async actions
-  // (e.g. ensureTraceSpans) can issue requests without prop-drilling.
+  // (e.g. fetchTraceSpans) can issue requests without prop-drilling.
   useEffect(() => {
     setProjectId(projectId);
   }, [projectId, setProjectId]);

--- a/frontend/components/traces/session-view/store/base.ts
+++ b/frontend/components/traces/session-view/store/base.ts
@@ -47,6 +47,16 @@ export interface BaseSessionViewState {
   /** Per-trace LLM-content visibility in tree mode. Absent → true (default). Not persisted. */
   traceShowTreeContent: Record<string, boolean>;
 
+  /** Per-trace condensed-timeline open/closed state. Toggled by the control-bar
+   *  button and the in-timeline X. Debugger-only at the render layer. Not persisted. */
+  timelineOpenTraceIds: Set<string>;
+  /** Per-trace condensed-timeline zoom. Absent → MIN_ZOOM. Not persisted. */
+  condensedTimelineZoomByTrace: Record<string, number>;
+  /** Per-trace drag-selected visible span ids (with ancestors). Absent → empty. Not persisted. */
+  condensedTimelineVisibleSpanIdsByTrace: Record<string, Set<string>>;
+  /** Shared cost-heatmap toggle across all cards' timelines. Not persisted. */
+  isCostHeatmapVisible: boolean;
+
   /** One-shot scroll request: timeline click → panel list scrolls to group header. */
   scrollToGroup: { traceId: string; groupId: string } | null;
   /** One-shot scroll request: a trace was collapsed → scroll its header into view. */
@@ -99,6 +109,13 @@ export interface BaseSessionViewActions {
 
   setTraceViewMode: (traceId: string, mode: "tree" | "transcript") => void;
   toggleTraceShowTreeContent: (traceId: string) => void;
+
+  toggleTimelineOpen: (traceId: string) => void;
+  setTimelineOpen: (traceId: string, open: boolean) => void;
+  setCondensedTimelineZoom: (traceId: string, zoom: number) => void;
+  setCondensedTimelineVisibleSpanIds: (traceId: string, ids: Set<string>) => void;
+  clearCondensedTimelineSelection: (traceId: string) => void;
+  setIsCostHeatmapVisible: (visible: boolean) => void;
   /** Flip `collapsed` on one span inside a trace's span array. Writes a NEW
    *  array identity so flat-row useMemos keyed on traceSpans recompute. */
   toggleSpanCollapse: (traceId: string, spanId: string) => void;
@@ -197,6 +214,10 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
     transcriptExpandedGroups: new Set<string>(),
     traceViewModes: {},
     traceShowTreeContent: {},
+    timelineOpenTraceIds: new Set<string>(),
+    condensedTimelineZoomByTrace: {},
+    condensedTimelineVisibleSpanIdsByTrace: {},
+    isCostHeatmapVisible: false,
     scrollToGroup: null,
     scrollToTraceId: null,
 
@@ -352,6 +373,43 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
       const current = get().traceShowTreeContent[traceId] ?? true;
       set({ traceShowTreeContent: { ...get().traceShowTreeContent, [traceId]: !current } } as Partial<T>);
     },
+
+    toggleTimelineOpen: (traceId) => {
+      const next = new Set(get().timelineOpenTraceIds);
+      if (next.has(traceId)) next.delete(traceId);
+      else next.add(traceId);
+      set({ timelineOpenTraceIds: next } as Partial<T>);
+    },
+    setTimelineOpen: (traceId, open) => {
+      const prev = get().timelineOpenTraceIds;
+      if (open === prev.has(traceId)) return;
+      const next = new Set(prev);
+      if (open) next.add(traceId);
+      else next.delete(traceId);
+      set({ timelineOpenTraceIds: next } as Partial<T>);
+    },
+    setCondensedTimelineZoom: (traceId, zoom) =>
+      set({
+        condensedTimelineZoomByTrace: {
+          ...get().condensedTimelineZoomByTrace,
+          [traceId]: Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom)),
+        },
+      } as Partial<T>),
+    setCondensedTimelineVisibleSpanIds: (traceId, ids) =>
+      set({
+        condensedTimelineVisibleSpanIdsByTrace: {
+          ...get().condensedTimelineVisibleSpanIdsByTrace,
+          [traceId]: ids,
+        },
+      } as Partial<T>),
+    clearCondensedTimelineSelection: (traceId) =>
+      set({
+        condensedTimelineVisibleSpanIdsByTrace: {
+          ...get().condensedTimelineVisibleSpanIdsByTrace,
+          [traceId]: new Set(),
+        },
+      } as Partial<T>),
+    setIsCostHeatmapVisible: (visible) => set({ isCostHeatmapVisible: visible } as Partial<T>),
     toggleSpanCollapse: (traceId, spanId) => {
       const spans = get().traceSpans[traceId];
       if (!spans) return;

--- a/frontend/components/traces/session-view/store/base.ts
+++ b/frontend/components/traces/session-view/store/base.ts
@@ -81,7 +81,7 @@ export interface BaseSessionViewActions {
 
   /** Fetch spans for a trace if not already loaded or currently loading.
    *  Idempotent: safe to call repeatedly on mount of TraceItem. */
-  ensureTraceSpans: (trace: TraceRow) => Promise<void>;
+  fetchTraceSpans: (trace: TraceRow) => Promise<void>;
 
   toggleTraceExpanded: (traceId: string) => void;
   setTraceExpanded: (traceId: string, expanded: boolean) => void;
@@ -225,7 +225,7 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
     setIsTracesLoading: (isTracesLoading) => set({ isTracesLoading } as Partial<T>),
     setTracesError: (tracesError) => set({ tracesError } as Partial<T>),
 
-    ensureTraceSpans: async (trace) => {
+    fetchTraceSpans: async (trace) => {
       const state = get();
       const { projectId } = state;
       if (!projectId) return;
@@ -238,8 +238,6 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
 
       try {
         const params = new URLSearchParams();
-        params.append("searchIn", "input");
-        params.append("searchIn", "output");
         const startDate = new Date(new Date(trace.startTime).getTime() - 1000).toISOString();
         const endDate = new Date(new Date(trace.endTime).getTime() + 1000).toISOString();
         params.set("startDate", startDate);
@@ -273,9 +271,9 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
       }
     },
 
-    // open recursion: delegates to get().ensureTraceSpans — a derived store's override wins.
+    // open recursion: delegates to get().fetchTraceSpans — a derived store's override wins.
     // Any transition to `expanded=true` also kicks off span loading (idempotent
-    // via `ensureTraceSpans`'s internal dedupe).
+    // via `fetchTraceSpans`'s internal dedupe).
     toggleTraceExpanded: (traceId) => {
       const state = get();
       const prev = state.expandedTraceIds;
@@ -289,10 +287,10 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
 
       if (willExpand) {
         const trace = state.traces.find((t) => t.id === traceId);
-        if (trace) void get().ensureTraceSpans(trace);
+        if (trace) void get().fetchTraceSpans(trace);
       }
     },
-    // open recursion: delegates to get().ensureTraceSpans — a derived store's override wins.
+    // open recursion: delegates to get().fetchTraceSpans — a derived store's override wins.
     setTraceExpanded: (traceId, expanded) => {
       const state = get();
       const prev = state.expandedTraceIds;
@@ -304,16 +302,16 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
 
       if (expanded) {
         const trace = state.traces.find((t) => t.id === traceId);
-        if (trace) void get().ensureTraceSpans(trace);
+        if (trace) void get().fetchTraceSpans(trace);
       }
     },
-    // open recursion: delegates to get().ensureTraceSpans — a derived store's override wins.
+    // open recursion: delegates to get().fetchTraceSpans — a derived store's override wins.
     expandAllTraces: () => {
       const state = get();
       const all = new Set(state.traces.map((t) => t.id));
       set({ expandedTraceIds: all } as Partial<T>);
       for (const trace of state.traces) {
-        void get().ensureTraceSpans(trace);
+        void get().fetchTraceSpans(trace);
       }
     },
 

--- a/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useMemo } from "react";
 
 import { type TraceViewSpan } from "@/components/traces/trace-view/store";
-import { useTraceViewBaseStore } from "@/components/traces/trace-view/store/base";
 import { type CondensedTimelineSpan } from "@/components/traces/trace-view/store/utils";
 import { SPAN_TYPE_TO_COLOR } from "@/lib/traces/utils";
 import { cn } from "@/lib/utils";
@@ -13,6 +12,7 @@ interface CondensedTimelineElementProps {
   selectedSpan?: TraceViewSpan;
   isIncludedInGroupSelection: boolean | null;
   maxSpanCost: number;
+  isCostHeatmapVisible: boolean;
   onClick: (span: TraceViewSpan) => void;
 }
 
@@ -21,11 +21,10 @@ const CondensedTimelineElement = ({
   selectedSpan,
   isIncludedInGroupSelection,
   maxSpanCost,
+  isCostHeatmapVisible,
   onClick,
 }: CondensedTimelineElementProps) => {
   const { span, left, width, row } = condensedSpan;
-
-  const isCostHeatmapVisible = useTraceViewBaseStore((state) => state.isCostHeatmapVisible);
 
   const isSelected = useMemo(() => selectedSpan?.spanId === span.spanId, [span.spanId, selectedSpan?.spanId]);
   const opacity = isIncludedInGroupSelection === false ? "opacity-30" : "";

--- a/frontend/components/traces/trace-view/condensed-timeline/controls.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/controls.tsx
@@ -1,7 +1,6 @@
 import { DollarSign, Minus, Plus } from "lucide-react";
 
 import { MAX_ZOOM, MIN_ZOOM } from "@/components/traces/trace-view/store";
-import { useTraceViewBaseStore } from "@/components/traces/trace-view/store/base";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -9,15 +8,18 @@ import { cn } from "@/lib/utils";
 interface ControlsProps {
   onZoomIn: () => void;
   onZoomOut: () => void;
+  zoom: number;
+  isCostHeatmapVisible: boolean;
+  onToggleCostHeatmap: (visible: boolean) => void;
 }
 
-export default function Controls({ onZoomIn, onZoomOut }: ControlsProps) {
-  const { condensedTimelineZoom, isCostHeatmapVisible, setIsCostHeatmapVisible } = useTraceViewBaseStore((state) => ({
-    condensedTimelineZoom: state.condensedTimelineZoom,
-    isCostHeatmapVisible: state.isCostHeatmapVisible,
-    setIsCostHeatmapVisible: state.setIsCostHeatmapVisible,
-  }));
-
+export default function Controls({
+  onZoomIn,
+  onZoomOut,
+  zoom,
+  isCostHeatmapVisible,
+  onToggleCostHeatmap,
+}: ControlsProps) {
   return (
     <div className="absolute bottom-1.5 right-1.5 z-40 flex items-center gap-1 h-[24px]">
       <TooltipProvider delayDuration={300}>
@@ -28,7 +30,7 @@ export default function Controls({ onZoomIn, onZoomOut }: ControlsProps) {
                 "flex items-center gap-0.5 h-[24px] px-1.5 rounded-md bg-muted text-xs text-muted-foreground hover:bg-secondary transition-colors border",
                 isCostHeatmapVisible && "border-primary/50 text-primary bg-muted"
               )}
-              onClick={() => setIsCostHeatmapVisible(!isCostHeatmapVisible)}
+              onClick={() => onToggleCostHeatmap(!isCostHeatmapVisible)}
             >
               <DollarSign className="size-3" />
               <span>Cost heatmap</span>
@@ -38,22 +40,10 @@ export default function Controls({ onZoomIn, onZoomOut }: ControlsProps) {
         </Tooltip>
       </TooltipProvider>
       <div className="flex items-center border rounded-md bg-muted px-0.5 h-[24px]">
-        <Button
-          disabled={condensedTimelineZoom >= MAX_ZOOM}
-          className="size-5 min-w-5"
-          variant="ghost"
-          size="icon"
-          onClick={onZoomIn}
-        >
+        <Button disabled={zoom >= MAX_ZOOM} className="size-5 min-w-5" variant="ghost" size="icon" onClick={onZoomIn}>
           <Plus className="size-3" />
         </Button>
-        <Button
-          disabled={condensedTimelineZoom <= MIN_ZOOM}
-          className="size-5 min-w-5"
-          variant="ghost"
-          size="icon"
-          onClick={onZoomOut}
-        >
+        <Button disabled={zoom <= MIN_ZOOM} className="size-5 min-w-5" variant="ghost" size="icon" onClick={onZoomOut}>
           <Minus className="size-3" />
         </Button>
       </div>

--- a/frontend/components/traces/trace-view/condensed-timeline/index.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/index.tsx
@@ -43,6 +43,8 @@ function CondensedTimeline() {
     transcriptExpandedGroups,
     requestScrollToGroup,
     tab,
+    isCostHeatmapVisible,
+    setIsCostHeatmapVisible,
   } = useTraceViewBaseStore((state) => ({
     getCondensedTimelineData: state.getCondensedTimelineData,
     getCondensedSubagentGroups: state.getCondensedSubagentGroups,
@@ -64,6 +66,8 @@ function CondensedTimeline() {
     transcriptExpandedGroups: state.transcriptExpandedGroups,
     requestScrollToGroup: state.requestScrollToGroup,
     tab: state.tab,
+    isCostHeatmapVisible: state.isCostHeatmapVisible,
+    setIsCostHeatmapVisible: state.setIsCostHeatmapVisible,
   }));
 
   const {
@@ -297,6 +301,7 @@ function CondensedTimeline() {
                   selectedSpan={selectedSpan}
                   isIncludedInGroupSelection={isIncludedInGroupSelection}
                   maxSpanCost={maxSpanCost}
+                  isCostHeatmapVisible={isCostHeatmapVisible}
                   onClick={handleSpanClick}
                 />
               );
@@ -362,7 +367,13 @@ function CondensedTimeline() {
       <SelectionIndicator selectedCount={selectedCount} onClear={clearCondensedTimelineSelection} />
 
       {/* Zoom controls */}
-      <Controls onZoomIn={() => handleZoom("in")} onZoomOut={() => handleZoom("out")} />
+      <Controls
+        onZoomIn={() => handleZoom("in")}
+        onZoomOut={() => handleZoom("out")}
+        zoom={condensedTimelineZoom}
+        isCostHeatmapVisible={isCostHeatmapVisible}
+        onToggleCostHeatmap={setIsCostHeatmapVisible}
+      />
     </div>
   );
 }

--- a/frontend/lib/actions/debugger-sessions/index.ts
+++ b/frontend/lib/actions/debugger-sessions/index.ts
@@ -6,6 +6,7 @@ import { PaginationSchema } from "@/lib/actions/common/types";
 import { executeQuery } from "@/lib/actions/sql";
 import { db } from "@/lib/db/drizzle";
 import { debuggerSessions, sharedTraces } from "@/lib/db/migrations/schema";
+import { NotFoundError } from "@/lib/errors";
 
 export type DebuggerSession = {
   id: string;
@@ -122,26 +123,30 @@ export const UpdateDebuggerSessionNameSchema = z.object({
 });
 
 /**
- * Rename a debugger session (update-only, project-scoped). Throws when no row
- * matches `(id, projectId)` so the API route can surface a clear error rather
- * than silently creating a ghost session. The FE convention is a Next API route
- * + drizzle (mirrors dataset/project rename); the CLI rename has its own
- * app-server endpoint (`PATCH /v1/cli/rollouts/{id}/name`).
+ * Rename a debugger session (update-only, project-scoped). Routes through
+ * app-server rather than writing the row directly, because app-server also
+ * broadcasts `session_update` over realtime — so every open debugger-session
+ * view (this tab and others) updates its title live, the same way the CLI
+ * rename does. app-server owns both the write and the broadcast (single source
+ * of truth). A missing session → `NotFoundError` (404), distinct from a 500.
  */
 export const updateDebuggerSessionName = async (input: z.infer<typeof UpdateDebuggerSessionNameSchema>) => {
   const { projectId, id, name } = UpdateDebuggerSessionNameSchema.parse(input);
 
-  const [session] = await db
-    .update(debuggerSessions)
-    .set({ name })
-    .where(and(eq(debuggerSessions.id, id), eq(debuggerSessions.projectId, projectId)))
-    .returning();
+  const res = await fetch(`${process.env.BACKEND_URL}/api/v1/projects/${projectId}/rollouts/${id}/name`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
 
-  if (!session) {
-    throw new Error("Session not found");
+  if (res.status === 404) {
+    throw new NotFoundError("Session not found");
+  }
+  if (!res.ok) {
+    throw new Error("Failed to rename session");
   }
 
-  return session;
+  return { id, projectId, name };
 };
 
 export async function getDebuggerSession(input: z.infer<typeof GetDebuggerSessionSchema>) {

--- a/frontend/lib/actions/debugger-sessions/index.ts
+++ b/frontend/lib/actions/debugger-sessions/index.ts
@@ -115,6 +115,35 @@ export const createDebuggerSession = async (input: z.infer<typeof CreateDebugger
   return session;
 };
 
+export const UpdateDebuggerSessionNameSchema = z.object({
+  projectId: z.guid(),
+  id: z.guid(),
+  name: z.string().trim().min(1),
+});
+
+/**
+ * Rename a debugger session (update-only, project-scoped). Throws when no row
+ * matches `(id, projectId)` so the API route can surface a clear error rather
+ * than silently creating a ghost session. The FE convention is a Next API route
+ * + drizzle (mirrors dataset/project rename); the CLI rename has its own
+ * app-server endpoint (`PATCH /v1/cli/rollouts/{id}/name`).
+ */
+export const updateDebuggerSessionName = async (input: z.infer<typeof UpdateDebuggerSessionNameSchema>) => {
+  const { projectId, id, name } = UpdateDebuggerSessionNameSchema.parse(input);
+
+  const [session] = await db
+    .update(debuggerSessions)
+    .set({ name })
+    .where(and(eq(debuggerSessions.id, id), eq(debuggerSessions.projectId, projectId)))
+    .returning();
+
+  if (!session) {
+    throw new Error("Session not found");
+  }
+
+  return session;
+};
+
 export async function getDebuggerSession(input: z.infer<typeof GetDebuggerSessionSchema>) {
   const { projectId, id } = GetDebuggerSessionSchema.parse(input);
 

--- a/frontend/lib/actions/span/index.ts
+++ b/frontend/lib/actions/span/index.ts
@@ -174,6 +174,29 @@ export async function pushSpanToLabelingQueue(input: z.infer<typeof PushSpanSche
   });
 }
 
+export const GetSpanTypeSchema = z.object({
+  projectId: z.guid(),
+  traceId: z.guid(),
+  spanId: z.guid(),
+});
+
+export async function getSpanType(input: z.infer<typeof GetSpanTypeSchema>): Promise<SpanType | null> {
+  const { projectId, traceId, spanId } = GetSpanTypeSchema.parse(input);
+
+  const rows = await executeQuery<{ spanType: SpanType }>({
+    projectId,
+    query: `
+      SELECT span_type as spanType
+      FROM spans
+      WHERE trace_id = {traceId: UUID} AND span_id = {spanId: UUID}
+      LIMIT 1
+    `,
+    parameters: { traceId, spanId },
+  });
+
+  return rows[0]?.spanType ?? null;
+}
+
 export const GetSpanTypesSchema = z.object({
   projectId: z.guid(),
   spanIds: z.array(z.string()),

--- a/frontend/lib/errors.ts
+++ b/frontend/lib/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Thrown by data actions when a scoped resource doesn't exist, so API route
+ * handlers can map it to a 404 (instead of a generic 500) and clients can tell
+ * "missing" apart from "server error".
+ */
+export class NotFoundError extends Error {
+  constructor(message = "Not found") {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}


### PR DESCRIPTION
…ring project-key route

Extract a shared handle_register_session in api/v1/rollouts.rs and have both the project-API-key POST /v1/rollouts/{id} and the new CLI user-token POST /v1/cli/rollouts/{id} (CliProjectAuth) delegate to it. Register the CLI route in the /v1/cli scope. Project-key behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches realtime session lifecycle, concurrent span merge semantics, and new app-server routes for register/rename; incorrect merge or auth wiring could cause stale UI or failed CLI registration, but changes are scoped to debugger/session views rather than core ingestion.
> 
> **Overview**
> **Debugger session naming** gets end-to-end support: **CLI** `POST /v1/cli/rollouts/{session_id}` mirrors the SDK register upsert with user-token auth; the **UI** renames via a Next `PATCH` that calls app-server `PATCH /api/v1/projects/{projectId}/rollouts/{id}/name`, which persists and broadcasts **`session_update`** (matching the CLI rename path). The session view adds an **editable title** (`sessionNameRaw` vs breadcrumb fallback) and handles **`session_deleted`** with a toast and redirect.
> 
> **Debugger UX and data loading** add a **per-trace condensed timeline** in the debugger session panel (toggle on trace cards, shared session-store zoom/selection state, refactored timeline leaves to accept props instead of trace-view store). Span loading is reworked: **`ensureTraceSpans` → `fetchTraceSpans`** (debugger override always refetches on expand with deduped in-flight state), realtime span buffering is removed in favor of unconditional upserts, and hydrate/expand merges prefer fresher SSE spans over lagging CH snapshots. **Stick-to-bottom** waits until initial traces load; empty sessions show a message; note **span chips** can resolve type via new **`GET .../spans/{spanId}/type`**.
> 
> **Supporting pieces:** `NotFoundError` for 404 mapping on rename; narrow layout tweaks (`min-w`, overflow); scroll-to-subagent-group from the condensed timeline; trace expand no longer blocks on a pending spinner before opening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de79bd1c81f6faf91eb63272f18589f59e7971e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->