### PR TITLE
fix(signals): support `ne` operator on tags trigger filters

### DIFF
--- a/app-server/src/db/trace.rs
+++ b/app-server/src/db/trace.rs
@@ -663,4 +663,56 @@ mod tests {
             "Ne filter should return false when span name exists in accumulated names"
         );
     }
+
+    /// tags Eq: matches when the tag is present on the trace.
+    #[test]
+    fn test_tags_eq_filter() {
+        let trace_id = Uuid::new_v4();
+        let project_id = Uuid::new_v4();
+
+        let mut trace = make_trace(trace_id, project_id, Some(Uuid::new_v4()), None);
+        trace.tags = vec!["prod".to_string(), "urgent".to_string()];
+
+        let filters = vec![Filter {
+            column: "tags".to_string(),
+            operator: FilterOperator::Eq,
+            value: json!("urgent"),
+        }];
+
+        assert!(trace.matches_filters(&[], &filters));
+    }
+
+    /// tags Ne: matches when the tag is absent, does NOT match when present.
+    /// Regression test — `Ne` previously fell through to the catch-all arm and
+    /// always returned false, so a `tags != x` trigger never fired.
+    #[test]
+    fn test_tags_ne_filter() {
+        let trace_id = Uuid::new_v4();
+        let project_id = Uuid::new_v4();
+
+        let mut trace = make_trace(trace_id, project_id, Some(Uuid::new_v4()), None);
+        trace.tags = vec!["prod".to_string()];
+
+        // Tag absent -> `tags != "staging"` should match.
+        let absent = vec![Filter {
+            column: "tags".to_string(),
+            operator: FilterOperator::Ne,
+            value: json!("staging"),
+        }];
+        assert!(
+            trace.matches_filters(&[], &absent),
+            "Ne filter should match when the tag is not present"
+        );
+
+        // Tag present -> `tags != "prod"` should not match.
+        let present = vec![Filter {
+            column: "tags".to_string(),
+            operator: FilterOperator::Ne,
+            value: json!("prod"),
+        }];
+        assert!(
+            !trace.matches_filters(&[], &present),
+            "Ne filter should not match when the tag is present"
+        );
+    }
 }

--- a/app-server/src/db/utils.rs
+++ b/app-server/src/db/utils.rs
@@ -79,9 +79,10 @@ pub fn evaluate_array_contains_filter(
 
     match operator {
         FilterOperator::Eq => array.iter().any(|item| item == target),
+        FilterOperator::Ne => !array.iter().any(|item| item == target),
         _ => {
             log::warn!(
-                "Invalid operator {:?} for array containment filter, only eq/includes supported",
+                "Invalid operator {:?} for array containment filter, only eq/ne supported",
                 operator
             );
             false


### PR DESCRIPTION
## Summary
- `evaluate_array_contains_filter` (`app-server/src/db/utils.rs`) only handled `FilterOperator::Eq`; every other operator fell through to the catch-all arm and returned `false`.
- The `tags` signal-trigger column is wired to this evaluator (`app-server/src/db/trace.rs:192`), so a trigger configured as `tags != "x"` evaluated to `false` for every trace — the signal never fired, silently, with only a `warn!` log.
- Handle `Ne` as the negation of the containment check, matching the existing `span_name` handler (`Eq => has`, `Ne => !has`, `trace.rs:204-206`) and the `Ne` support already in `evaluate_string_filter`. Corrected the unsupported-operator warn text to `eq/ne`.
- Added regression tests `test_tags_eq_filter` / `test_tags_ne_filter` in `db::trace::tests`.

```rust
FilterOperator::Eq => array.iter().any(|item| item == target),
FilterOperator::Ne => !array.iter().any(|item| item == target),
```

## Verification
```
cargo test --bin app-server db::trace::tests
test result: ok. 5 passed; 0 failed; 0 ignored
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to signal filter evaluation with unit tests; no auth, data migration, or broad API surface changes.
> 
> **Overview**
> Signal triggers using **`tags != "…"`** were broken: `evaluate_array_contains_filter` only treated **`Eq`** as “tag present”; **`Ne`** hit the default arm and always returned **false**, so those triggers never matched.
> 
> The change adds **`Ne`** as the negation of the same containment check (aligned with **`span_name`** and **`evaluate_string_filter`**), and updates the unsupported-operator log to mention **eq/ne**. Regression tests **`test_tags_eq_filter`** and **`test_tags_ne_filter`** cover tag present/absent cases on **`Trace::matches_filters`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ec5fad5a2399fb40279af2f1cc0d2525e4289e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

