### PR TITLE
fix(cache): honor entry expiry in CacheManager.exists() memory fallback

### DIFF
--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -28,7 +28,7 @@ interface RedisSetOptions {
   expireAt?: Date;
 }
 
-class CacheManager {
+export class CacheManager {
   private redisClient: Redis | null = null;
   private memoryCache: Map<string, CacheEntry<any>> = new Map();
   private readonly useRedis: boolean;
@@ -218,7 +218,14 @@ class CacheManager {
       }
     } else {
       const entry = this.memoryCache.get(key);
-      return !!entry;
+      if (!entry) {
+        return false;
+      }
+      if (entry.expiresAt && entry.expiresAt < Date.now()) {
+        this.memoryCache.delete(key);
+        return false;
+      }
+      return true;
     }
   }
 }

--- a/frontend/tests/cache-exists-expiry.test.ts
+++ b/frontend/tests/cache-exists-expiry.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CacheManager } from "@/lib/cache";
+
+// Build an instance with no Redis configured so we exercise the in-memory fallback.
+const memoryCache = (() => {
+  delete process.env.REDIS_URL;
+  return new CacheManager();
+})();
+
+test("exists() returns false for an expired entry in the in-memory cache", async () => {
+  await memoryCache.set("expired-key", 1, { expireAt: new Date(Date.now() - 1000) });
+
+  // Must agree with get(), which treats the entry as gone.
+  assert.equal(await memoryCache.exists("expired-key"), false);
+  assert.equal(await memoryCache.get("expired-key"), null);
+});
+
+test("exists() returns true for a live entry in the in-memory cache", async () => {
+  await memoryCache.set("live-key", 1, { expireAfterSeconds: 60 });
+
+  assert.equal(await memoryCache.exists("live-key"), true);
+});

--- a/frontend/tests/cache-exists-expiry.test.ts
+++ b/frontend/tests/cache-exists-expiry.test.ts
@@ -4,10 +4,10 @@ import { test } from "node:test";
 import { CacheManager } from "@/lib/cache";
 
 // Build an instance with no Redis configured so we exercise the in-memory fallback.
-const memoryCache = (() => {
-  delete process.env.REDIS_URL;
-  return new CacheManager();
-})();
+const savedRedisUrl = process.env.REDIS_URL;
+delete process.env.REDIS_URL;
+const memoryCache = new CacheManager();
+process.env.REDIS_URL = savedRedisUrl; // restore so other test files are not affected
 
 test("exists() returns false for an expired entry in the in-memory cache", async () => {
   await memoryCache.set("expired-key", 1, { expireAt: new Date(Date.now() - 1000) });

--- a/frontend/tests/cache-exists-expiry.test.ts
+++ b/frontend/tests/cache-exists-expiry.test.ts
@@ -7,7 +7,11 @@ import { CacheManager } from "@/lib/cache";
 const savedRedisUrl = process.env.REDIS_URL;
 delete process.env.REDIS_URL;
 const memoryCache = new CacheManager();
-process.env.REDIS_URL = savedRedisUrl; // restore so other test files are not affected
+if (savedRedisUrl !== undefined) {
+  process.env.REDIS_URL = savedRedisUrl;
+} else {
+  delete process.env.REDIS_URL;
+} // restore so other test files are not affected
 
 test("exists() returns false for an expired entry in the in-memory cache", async () => {
   await memoryCache.set("expired-key", 1, { expireAt: new Date(Date.now() - 1000) });


### PR DESCRIPTION
## Summary
- The in-memory branch of `CacheManager.exists()` (`frontend/lib/cache.ts`) returned `!!entry` without checking `expiresAt`.
- Both `get()` and `getAndRemoveIfMatch()` already drop expired entries, so `exists()` could report a key as present while `get()` returns `null` for the same key — an inconsistent contract.
- A caller that uses `exists()` as a gate (e.g. `isAutocompleteCacheExists` in `lib/actions/autocomplete/cache.ts`) would treat a stale entry as live and skip refreshing it.
- Fix mirrors the expiry check in `get()`: delete the expired entry and return `false`. The Redis branch is unchanged (server-side TTL already handles expiry).
- Exported `CacheManager` so the in-memory contract can be unit-tested without a Redis server, and added regression tests.

```ts
// before
const entry = this.memoryCache.get(key);
return !!entry;

// after
const entry = this.memoryCache.get(key);
if (!entry) return false;
if (entry.expiresAt && entry.expiresAt < Date.now()) {
  this.memoryCache.delete(key);
  return false;
}
return true;
```

## Verification
```
pnpm test
# tests 117  # pass 117  # fail 0
```
New tests: `tests/cache-exists-expiry.test.ts` (expired -> false and agrees with get(); live -> true).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized cache contract fix with tests; no auth or data-model changes, and Redis behavior is untouched.
> 
> **Overview**
> Aligns the in-memory **`CacheManager.exists()`** path with **`get()`** by treating past-**`expiresAt`** entries as absent: delete the stale entry and return **`false`**, instead of reporting presence from a non-expired check. Redis **`exists()`** is unchanged (TTL still handled server-side).
> 
> **`CacheManager`** is now **exported** so the in-memory path can be unit-tested without Redis. New tests in **`cache-exists-expiry.test.ts`** cover expired vs live keys and that **`exists()`** matches **`get()`**.
> 
> This fixes callers such as **`isAutocompleteCacheExists`** that gate refresh on **`exists()`**—they could previously see a key as live while **`get()`** returned **`null`** when **`REDIS_URL`** is unset (dev/local memory cache).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d8fb9a02cbb501086e7f163f196c4a4ab7287b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->