### PR TITLE
refactor(frontend): unify color scales as OKLCH

### DIFF
--- a/frontend/app/(auth)/onboarding/page.tsx
+++ b/frontend/app/(auth)/onboarding/page.tsx
@@ -84,7 +84,7 @@ export default async function OnboardingPage(props: OnboardingPageProps) {
 
   return (
     <UserContextProvider user={user}>
-      <div className="flex flex-col min-h-screen w-full bg-landing-surface-700">
+      <div className="flex flex-col min-h-screen w-full bg-surface-700">
         <OnboardingWizard
           initial={initial}
           slackClientId={process.env.SLACK_CLIENT_ID}

--- a/frontend/app/blog/layout.tsx
+++ b/frontend/app/blog/layout.tsx
@@ -10,7 +10,7 @@ export default async function BlogLayout({ children }: PropsWithChildren) {
   const session = await getServerSession();
 
   return (
-    <div className="min-h-screen flex flex-col bg-landing-surface-700">
+    <div className="min-h-screen flex flex-col bg-surface-700">
       <LandingHeader
         hasSession={session !== null && session !== undefined}
         isIncludePadding

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -46,17 +46,17 @@
   --font-sans-landing: var(--font-general-sans);
   --font-manrope: var(--font-manrope);
 
-  --color-border: hsl(var(--border));
+  --color-border: var(--color-surface-300); /* ΔE 4.07 */
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
-  --color-background: hsl(var(--background));
+  --color-background: var(--color-surface-1000); /* ΔE 0.32 */
   --color-foreground: hsl(var(--foreground));
 
-  --color-primary: hsl(var(--primary));
-  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-primary: var(--color-primary-400);
+  --color-primary-foreground: var(--color-foreground-100);
 
-  --color-secondary: hsl(var(--secondary));
-  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-secondary: var(--color-surface-800); /* ΔE 0.00 */
+  --color-secondary-foreground: var(--color-foreground-200);
 
   --color-success: hsl(var(--success));
   --color-success-foreground: hsl(var(--success-foreground));
@@ -67,16 +67,16 @@
   --color-success-bright: hsl(var(--success-bright));
   --color-destructive-bright: hsl(var(--destructive-bright));
 
-  --color-muted: hsl(var(--muted));
-  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-muted: var(--color-surface-500); /* ΔE 2.91 */
+  --color-muted-foreground: var(--color-foreground-400);
 
-  --color-accent: hsl(var(--accent));
+  --color-accent: var(--color-surface-400); /* ΔE 4.67 */
   --color-accent-foreground: hsl(var(--accent-foreground));
 
-  --color-popover: hsl(var(--popover));
+  --color-popover: var(--color-surface-800); /* ΔE 0.52 */
   --color-popover-foreground: hsl(var(--popover-foreground));
 
-  --color-card: hsl(var(--card));
+  --color-card: var(--color-surface-800); /* ΔE 0.00 */
   --color-card-foreground: hsl(var(--card-foreground));
 
   --color-sidebar: hsl(var(--sidebar-background));
@@ -95,25 +95,31 @@
 
   --color-subagent: hsl(var(--subagent));
 
-  /*TODO: unify landing and platform colors*/
-  --color-landing-primary-200: rgb(218 135 95);
-  --color-landing-primary-300: rgb(213 126 87);
-  --color-landing-primary-400: rgb(208 117 78);
-  --color-landing-surface-400: rgb(46 46 47);
-  --color-landing-surface-500: rgb(37 37 38);
-  --color-landing-surface-550: rgb(32 32 33);
-  --color-landing-surface-600: rgb(27 27 28);
-  --color-landing-surface-700: rgb(22 22 23);
-  --color-landing-surface-800: rgb(15 15 15);
-  --color-landing-surface-900: rgb(5 5 5);
-  --color-landing-text-100: rgb(255 255 255);
-  --color-landing-text-200: rgb(195 196 200);
-  --color-landing-text-300: rgb(146 148 156);
-  --color-landing-text-400: rgb(124 126 133);
-  --color-landing-text-500: rgb(95 97 102);
-  --color-landing-text-600: rgb(67 68 71);
-  --color-landing-primary-400-10: rgb(208 117 78 / 0.1);
-  --color-landing-primary-400-50: rgb(208 117 78 / 0.5);
+  /* Surface elevation ramp — neutral, dark-theme  */
+  --color-surface-300: oklch(0.2891 0 0); /* #2b2b2b */
+  --color-surface-400: oklch(0.2686 0 0); /* #262626 */
+  --color-surface-500: oklch(0.2478 0 0); /* #212121 */
+  --color-surface-600: oklch(0.2264 0 0); /* #1c1c1c */
+  --color-surface-700: oklch(0.2046 0 0); /* #171717 */
+  --color-surface-800: oklch(0.1822 0 0); /* #121212 */
+  --color-surface-900: oklch(0.1591 0 0); /* #0d0d0d */
+  --color-surface-1000: oklch(0.1344 0 0); /* #080808 */
+
+  /* Foreground (text) ramp — neutral, dark-theme */
+  --color-foreground-50: oklch(1 0 0); /* #ffffff */
+  --color-foreground-100: oklch(0.9249 0 0); /* #e6e6e6 */
+  --color-foreground-200: oklch(0.7731 0 0); /* #b5b5b5 */
+  --color-foreground-300: oklch(0.696 0 0); /* #9d9d9d */
+  --color-foreground-400: oklch(0.6167 0 0); /* #858585 */
+  --color-foreground-500: oklch(0.4962 0 0); /* #626262 */
+  --color-foreground-600: oklch(0.3904 0 0); /* #454545 */
+
+  /* Primary brand ramp — 400 is the canonical brand orange (= --color-primary). */
+  --color-primary-200: oklch(0.7019 0.1158 46.05); /* rgb(218 135 95) */
+  --color-primary-300: oklch(0.6789 0.1207 44.39); /* rgb(213 126 87) */
+  --color-primary-400: oklch(0.6559 0.1262 43.33); /* rgb(208 117 78) */
+  --color-primary-400-10: oklch(0.6559 0.1262 43.33 / 0.1);
+  --color-primary-400-50: oklch(0.6559 0.1262 43.33 / 0.5);
 
   --breakpoint-3xl: 112rem;
 }
@@ -136,14 +142,14 @@
     background: transparent;
   }
   &::-webkit-scrollbar-thumb {
-    background-color: rgb(67 68 71);
+    background-color: var(--color-foreground-600);
     border-radius: 9999px;
   }
   &::-webkit-scrollbar-thumb:hover {
-    background-color: rgb(95 97 102);
+    background-color: var(--color-foreground-500);
   }
   scrollbar-width: thin;
-  scrollbar-color: rgb(67 68 71) transparent;
+  scrollbar-color: var(--color-foreground-600) transparent;
 }
 
 @utility hide-arrow {
@@ -248,7 +254,8 @@
    than primary-400 was) with a near-opaque fill and a wider shadow
    ring, then settles back. */
 @keyframes signal-span-flash {
-  0%, 100% {
+  0%,
+  100% {
     box-shadow: 0 0 0 0 rgb(218 135 95 / 0);
     background-color: rgb(234 232 224 / 0.15);
   }
@@ -277,7 +284,7 @@
   }
 
   ::selection {
-    background-color: var(--color-landing-primary-400-50);
+    background-color: var(--color-primary-400-50);
     color: white;
   }
 
@@ -285,7 +292,6 @@
     letter-spacing: 0.002em;
     font-weight: 450;
   }
-
 }
 
 /* TODO(blog): strip pasted `class="px-2 py-1"` from Strapi posts, then move
@@ -305,7 +311,7 @@
 .blog-article th,
 .blog-article td {
   padding: 0.75rem 0;
-  border-bottom: 1px solid var(--color-landing-text-600);
+  border-bottom: 1px solid var(--color-foreground-600);
   vertical-align: top;
   text-align: left;
 }
@@ -321,6 +327,5 @@
   font-weight: 500;
 }
 .blog-article td {
-  color: var(--color-landing-text-200);
+  color: var(--color-foreground-200);
 }
-

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -96,6 +96,7 @@
   --color-subagent: hsl(var(--subagent));
 
   /* Surface elevation ramp — neutral, dark-theme  */
+  --color-surface-200: oklch(0.3092 0 0); /* #303030 */
   --color-surface-300: oklch(0.2891 0 0); /* #2b2b2b */
   --color-surface-400: oklch(0.2686 0 0); /* #262626 */
   --color-surface-500: oklch(0.2478 0 0); /* #212121 */

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -46,16 +46,16 @@
   --font-sans-landing: var(--font-general-sans);
   --font-manrope: var(--font-manrope);
 
-  --color-border: var(--color-surface-300); /* ΔE 4.07 */
+  --color-border: var(--color-surface-300);
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
-  --color-background: var(--color-surface-1000); /* ΔE 0.32 */
+  --color-background: var(--color-surface-1000);
   --color-foreground: hsl(var(--foreground));
 
   --color-primary: var(--color-primary-400);
   --color-primary-foreground: var(--color-foreground-100);
 
-  --color-secondary: var(--color-surface-800); /* ΔE 0.00 */
+  --color-secondary: var(--color-surface-800);
   --color-secondary-foreground: var(--color-foreground-200);
 
   --color-success: hsl(var(--success));
@@ -67,16 +67,16 @@
   --color-success-bright: hsl(var(--success-bright));
   --color-destructive-bright: hsl(var(--destructive-bright));
 
-  --color-muted: var(--color-surface-500); /* ΔE 2.91 */
+  --color-muted: var(--color-surface-500);
   --color-muted-foreground: var(--color-foreground-400);
 
-  --color-accent: var(--color-surface-400); /* ΔE 4.67 */
+  --color-accent: var(--color-surface-400);
   --color-accent-foreground: hsl(var(--accent-foreground));
 
-  --color-popover: var(--color-surface-800); /* ΔE 0.52 */
+  --color-popover: var(--color-surface-800);
   --color-popover-foreground: hsl(var(--popover-foreground));
 
-  --color-card: var(--color-surface-800); /* ΔE 0.00 */
+  --color-card: var(--color-surface-800);
   --color-card-foreground: hsl(var(--card-foreground));
 
   --color-sidebar: hsl(var(--sidebar-background));

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -27,7 +27,7 @@ export default async function PricingPage() {
   const session = await getServerSession();
 
   return (
-    <div className="bg-landing-surface-700 flex flex-col w-full min-h-screen">
+    <div className="bg-surface-700 flex flex-col w-full min-h-screen">
       <LandingHeader
         hasSession={session !== null && session !== undefined}
         isIncludePadding

--- a/frontend/components/auth/provider-button.tsx
+++ b/frontend/components/auth/provider-button.tsx
@@ -21,7 +21,7 @@ export function ProviderButton({ icon, label, onClick, isLoading, isDisabled }: 
       variant="outline"
       onClick={onClick}
       disabled={isDisabled || isLoading}
-      className="text-[16px] py-6 px-4 pr-6 w-full bg-landing-surface-400 hover:bg-landing-surface-500"
+      className="text-[16px] py-6 px-4 pr-6 w-full bg-surface-200 hover:bg-surface-400"
     >
       <div className="h-5 w-5">{isLoading ? <IconSpinner className="animate-spin" /> : icon}</div>
       <div className="ml-2">{label}</div>

--- a/frontend/components/auth/sign-in.tsx
+++ b/frontend/components/auth/sign-in.tsx
@@ -22,7 +22,7 @@ const SignIn = ({ callbackUrl }: SignInProps) => {
   }, []);
 
   return (
-    <div className="flex flex-1 flex-col h-full py-4 px-5 bg-landing-surface-700">
+    <div className="flex flex-1 flex-col h-full py-4 px-5 bg-surface-700">
       <Link href="/" className="block shrink-0 self-start">
         <Image alt="Laminar logo" src={logo} className="w-[100px] h-auto" priority />
       </Link>

--- a/frontend/components/auth/sign-up.tsx
+++ b/frontend/components/auth/sign-up.tsx
@@ -22,7 +22,7 @@ const SignUp = ({ callbackUrl }: SignUpProps) => {
   }, []);
 
   return (
-    <div className="flex flex-1 flex-col h-full py-4 px-5 bg-landing-surface-700">
+    <div className="flex flex-1 flex-col h-full py-4 px-5 bg-surface-700">
       <Link href="/" className="block shrink-0 self-start">
         <Image alt="Laminar logo" src={logo} className="w-[100px] h-auto" priority />
       </Link>

--- a/frontend/components/blog/blog-list.tsx
+++ b/frontend/components/blog/blog-list.tsx
@@ -25,10 +25,7 @@ const ThumbImage = ({
   height: number;
   className?: string;
 }) => (
-  <div
-    className={cn("relative overflow-hidden bg-landing-surface-600 rounded shrink-0", className)}
-    style={{ width, height }}
-  >
+  <div className={cn("relative overflow-hidden bg-surface-600 rounded shrink-0", className)} style={{ width, height }}>
     {src && (
       <Image
         src={src}
@@ -44,15 +41,13 @@ const ThumbImage = ({
 const ListRow = ({ post, routePrefix, isFirst }: { post: BlogListItem; routePrefix: string; isFirst: boolean }) => (
   <Link
     href={postHref(routePrefix, post.slug)}
-    className={cn("flex items-start gap-10 py-5 no-underline group", !isFirst && "border-t border-landing-surface-500")}
+    className={cn("flex items-start gap-10 py-5 no-underline group", !isFirst && "border-t border-surface-400")}
   >
     {post.data.image && (
       <ThumbImage src={post.data.image} alt={post.data.title} width={180} height={110} className="hidden sm:block" />
     )}
     <div className="flex-1 min-w-0 flex flex-col gap-1.5">
-      <p className={cn(subSection, "text-white text-xl leading-7 group-hover:text-landing-text-100")}>
-        {post.data.title}
-      </p>
+      <p className={cn(subSection, "text-white text-xl leading-7 group-hover:text-foreground-50")}>{post.data.title}</p>
       <p className={cn(microLabel, "mt-1")}>
         {formatUTCDate(post.data.date)} · {post.data.author.name}
       </p>
@@ -65,7 +60,7 @@ export default function BlogList({ posts, routePrefix }: Props) {
     <div className="flex flex-col items-center w-full px-6 md:px-0 pt-[100px] pb-[72px] md:pb-[120px]">
       <div className={cn("flex flex-col items-start w-full gap-8", LANDING_COLUMN_MAX_W)}>
         {posts.length === 0 ? (
-          <p className="text-landing-text-300 text-sm">No posts yet.</p>
+          <p className="text-foreground-300 text-sm">No posts yet.</p>
         ) : (
           <div className="flex flex-col w-full">
             {posts.map((post, idx) => (

--- a/frontend/components/blog/blog-sidebar.tsx
+++ b/frontend/components/blog/blog-sidebar.tsx
@@ -24,13 +24,13 @@ export default function BlogSidebar({ tocItems, className }: Props) {
     <aside className={cn("flex flex-col gap-8 max-h-[calc(100vh-6rem)]", className)}>
       <Link
         href="/sign-up"
-        className="flex items-center justify-center w-full h-[36px] rounded-sm bg-landing-primary-200 hover:bg-landing-primary-400 transition-colors no-underline shrink-0"
+        className="flex items-center justify-center w-full h-[36px] rounded-sm bg-primary-200 hover:bg-primary-400 transition-colors no-underline shrink-0"
       >
         <span className="font-sans-landing font-medium text-sm text-black">Get started with Laminar</span>
       </Link>
 
       {tocItems.length > 0 && (
-        <div className="flex flex-col gap-3 pt-6 border-t border-landing-surface-500 flex-1 min-h-0">
+        <div className="flex flex-col gap-3 pt-6 border-t border-surface-400 flex-1 min-h-0">
           <TableOfContents headings={tocItems} className="flex-1 min-h-0" />
         </div>
       )}

--- a/frontend/components/blog/post-content/post-layout.tsx
+++ b/frontend/components/blog/post-content/post-layout.tsx
@@ -34,7 +34,7 @@ export default function PostLayout({ data, backHref, tocItems, children }: Props
       <div className={cn("flex flex-col gap-6 w-full", LANDING_COLUMN_MAX_W)}>
         <Link
           href={backHref}
-          className="text-sm text-landing-text-300 hover:text-landing-text-100 flex items-center gap-1.5 w-fit no-underline"
+          className="text-sm text-foreground-300 hover:text-foreground-50 flex items-center gap-1.5 w-fit no-underline"
         >
           <ArrowLeft size={16} />
           All blog posts
@@ -44,7 +44,7 @@ export default function PostLayout({ data, backHref, tocItems, children }: Props
           {data.title}
         </h1>
 
-        <p className="text-sm text-landing-text-300">
+        <p className="text-sm text-foreground-300">
           {formatUTCDate(data.date)} · {data.author.name}
           {data.tags?.[0] ? ` · ${data.tags[0]}` : ""}
         </p>
@@ -69,7 +69,7 @@ export default function PostLayout({ data, backHref, tocItems, children }: Props
           <div className="flex flex-col gap-4">
             <Link
               href={backHref}
-              className="inline-flex items-center gap-1.5 text-sm text-landing-text-300 hover:text-white no-underline w-fit transition-colors"
+              className="inline-flex items-center gap-1.5 text-sm text-foreground-300 hover:text-white no-underline w-fit transition-colors"
             >
               <ArrowLeft size={16} />
               All blog posts

--- a/frontend/components/blog/table-of-contents.tsx
+++ b/frontend/components/blog/table-of-contents.tsx
@@ -94,7 +94,7 @@ export default function TableOfContents({ headings, className }: Props) {
           instead of extending through the scrollable region. */}
       <div className="relative flex flex-col">
         {/* Continuous muted track — spans the full scroll content height. */}
-        <div className="absolute left-0 top-0 bottom-0 w-px bg-landing-surface-500" />
+        <div className="absolute left-0 top-0 bottom-0 w-px bg-surface-400" />
 
         {/* Highlight — animates between row positions. Initial mount uses
             `initial={false}` so the very first frame snaps to the measured
@@ -130,7 +130,7 @@ export default function TableOfContents({ headings, className }: Props) {
                   h.level === 1 && "pl-2",
                   h.level === 2 && "pl-5",
                   h.level >= 3 && "pl-8",
-                  isActive ? "text-white" : "text-landing-text-300 group-hover:text-landing-text-100"
+                  isActive ? "text-white" : "text-foreground-300 group-hover:text-foreground-50"
                 )}
               >
                 {h.text}

--- a/frontend/components/debugger-sessions/debugger-session-view/new-trace-pill.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/new-trace-pill.tsx
@@ -37,7 +37,7 @@ export default function NewTracePill({
 
   return (
     <div className="absolute bottom-6 left-1/2 z-30 -translate-x-1/2">
-      <div className="flex items-center overflow-hidden rounded-full border bg-primary shadow-md hover:bg-landing-primary-300">
+      <div className="flex items-center overflow-hidden rounded-full border bg-primary shadow-md hover:bg-primary-300">
         <button
           type="button"
           className="pl-3 py-1.5 text-sm font-medium"

--- a/frontend/components/debugger-sessions/debugger-session-view/span-reference.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/span-reference.tsx
@@ -86,7 +86,7 @@ export function SpanChip({
   return (
     <button
       onClick={onClick}
-      className="inline-flex items-center gap-1 rounded border border-landing-text-300/20 bg-landing-text-300/20 pl-1 pr-1.5 align-middle hover:bg-landing-text-300/30 transition-colors"
+      className="inline-flex items-center gap-1 rounded border border-foreground-300/20 bg-foreground-300/20 pl-1 pr-1.5 align-middle hover:bg-foreground-300/30 transition-colors"
     >
       <span
         className="inline-flex items-center justify-center rounded size-4 shrink-0"

--- a/frontend/components/integrations/frameworks-grid.tsx
+++ b/frontend/components/integrations/frameworks-grid.tsx
@@ -86,7 +86,7 @@ const FrameworksGrid = ({ className }: Props) => (
             className={cn("size-4 object-contain", integration.iconClassName)}
           />
         </div>
-        <p className="text-sm text-landing-text-200 transition-colors group-hover:text-white">{integration.alt}</p>
+        <p className="text-sm text-foreground-200 transition-colors group-hover:text-white">{integration.alt}</p>
       </Link>
     ))}
     <Link
@@ -97,7 +97,7 @@ const FrameworksGrid = ({ className }: Props) => (
       <div className="flex items-center justify-center size-4 shrink-0">
         <Plus className="text-secondary-foreground" />
       </div>
-      <p className="text-sm text-landing-text-200 transition-colors group-hover:text-white">All integrations</p>
+      <p className="text-sm text-foreground-200 transition-colors group-hover:text-white">All integrations</p>
     </Link>
   </div>
 );

--- a/frontend/components/landing/class-names.ts
+++ b/frontend/components/landing/class-names.ts
@@ -22,7 +22,7 @@ export const bodyMedium = "font-sans-landing text-foreground-200 whitespace-pre-
 
 // Tiny, wide-tracked muted label — used for step numbers above section
 // titles ("03.", "04.", ...) and for the SectionFootnote name + LEARN
-// MORE row at the bottom of each surface-550 mock panel. Single source
+// MORE row at the bottom of each surface-500 mock panel. Single source
 // of truth so all those labels stay visually consistent.
 export const microLabel = "font-sans-landing text-foreground-300";
 

--- a/frontend/components/landing/class-names.ts
+++ b/frontend/components/landing/class-names.ts
@@ -18,13 +18,13 @@ export const subSubSection =
   "font-sans-landing font-medium text-white whitespace-pre-line text-lg leading-6 font-[500]";
 
 // Section body copy under each subSection — "MCP, CLI, and SQL API to bring Laminar...", etc.
-export const bodyMedium = "font-sans-landing text-landing-text-200 whitespace-pre-line text-lg";
+export const bodyMedium = "font-sans-landing text-foreground-200 whitespace-pre-line text-lg";
 
 // Tiny, wide-tracked muted label — used for step numbers above section
 // titles ("03.", "04.", ...) and for the SectionFootnote name + LEARN
 // MORE row at the bottom of each surface-550 mock panel. Single source
 // of truth so all those labels stay visually consistent.
-export const microLabel = "font-sans-landing text-landing-text-300";
+export const microLabel = "font-sans-landing text-foreground-300";
 
 // Center-column width for the landing/blog/pricing pages. Scales up on
 // xl/2xl screens so the column doesn't look cramped on large displays.

--- a/frontend/components/landing/cta-buttons.tsx
+++ b/frontend/components/landing/cta-buttons.tsx
@@ -15,16 +15,16 @@ export default function CTAButtons({ className }: Props) {
     <div className={cn("flex flex-row gap-3 items-center", className)}>
       <Link
         href="/sign-up"
-        className="flex items-center justify-center w-[160px] h-[36px] rounded-sm bg-landing-primary-200 hover:bg-landing-primary-400 transition-colors no-underline"
+        className="flex items-center justify-center w-[160px] h-[36px] rounded-sm bg-primary-200 hover:bg-primary-400 transition-colors no-underline"
       >
         <span className="font-sans-landing font-medium text-sm text-black">Get started – free</span>
       </Link>
       <Link
         href="https://cal.com/robert-lmnr/demo"
         target="_blank"
-        className="flex items-center justify-center w-[160px] h-[36px] rounded-sm border border-landing-text-600 hover:bg-landing-surface-600 transition-colors no-underline"
+        className="flex items-center justify-center w-[160px] h-[36px] rounded-sm border border-foreground-600 hover:bg-surface-600 transition-colors no-underline"
       >
-        <span className="font-sans-landing font-medium text-sm text-landing-text-200">Book a demo</span>
+        <span className="font-sans-landing font-medium text-sm text-foreground-200">Book a demo</span>
       </Link>
     </div>
   );

--- a/frontend/components/landing/footer/index.tsx
+++ b/frontend/components/landing/footer/index.tsx
@@ -63,7 +63,7 @@ const FooterLinkText = ({ link }: { link: FooterLink }) => (
   <Link
     href={link.href}
     target={link.external ? "_blank" : undefined}
-    className="text-sm text-landing-text-300 hover:text-landing-text-100 transition-colors whitespace-nowrap"
+    className="text-sm text-foreground-300 hover:text-foreground-50 transition-colors whitespace-nowrap"
   >
     {link.label}
   </Link>
@@ -99,7 +99,7 @@ const Footer = ({ className }: Props) => (
   <div className={cn("flex flex-col items-center w-full", className)}>
     <div
       className={cn(
-        "w-full border-t border-landing-surface-500",
+        "w-full border-t border-surface-400",
         LANDING_COLUMN_MAX_W,
         "md:pt-20 md:pb-[120px]",
         "pt-16 pb-20",

--- a/frontend/components/landing/header/github-stars-button.tsx
+++ b/frontend/components/landing/header/github-stars-button.tsx
@@ -43,10 +43,10 @@ export default function GitHubStarsButton({ owner, repo, className }: GitHubStar
       )}
     >
       <div className="flex items-center h-full">
-        <IconGitHub className="w-4 h-4 text-landing-text-300 group-hover:text-landing-text-100" />
+        <IconGitHub className="w-4 h-4 text-foreground-300 group-hover:text-foreground-50" />
       </div>
       {stars !== null && (
-        <span className="font-sans text-xs font-medium text-landing-text-300 group-hover:text-landing-text-100">
+        <span className="font-sans text-xs font-medium text-foreground-300 group-hover:text-foreground-50">
           {formatCount(stars)}
         </span>
       )}

--- a/frontend/components/landing/header/index.tsx
+++ b/frontend/components/landing/header/index.tsx
@@ -59,19 +59,19 @@ export default function LandingHeader({ hasSession, className, isIncludePadding 
         </Link>
         <div className={cn("flex md:gap-[40px] items-center justify-center", "gap-4")}>
           <nav className="hidden md:flex md:gap-[32px] items-center font-sans-landing md:text-sm leading-normal whitespace-nowrap text-xs">
-            <Link href="https://laminar.sh/docs" target="_blank" className="no-underline hover:text-landing-text-200">
+            <Link href="https://laminar.sh/docs" target="_blank" className="no-underline hover:text-foreground-200">
               Docs
             </Link>
-            <Link href="/blog" className="no-underline hover:text-landing-text-200">
+            <Link href="/blog" className="no-underline hover:text-foreground-200">
               Blog
             </Link>
-            <Link href="/pricing" className="no-underline hover:text-landing-text-200">
+            <Link href="/pricing" className="no-underline hover:text-foreground-200">
               Pricing
             </Link>
             <Link
               target="_blank"
               href="https://cal.com/robert-lmnr/demo"
-              className="no-underline hover:text-landing-text-200"
+              className="no-underline hover:text-foreground-200"
             >
               Book demo
             </Link>
@@ -100,7 +100,7 @@ export default function LandingHeader({ hasSession, className, isIncludePadding 
             )}
             <button
               type="button"
-              className="md:hidden p-1 text-landing-text-300"
+              className="md:hidden p-1 text-foreground-300"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
             >
@@ -112,17 +112,17 @@ export default function LandingHeader({ hasSession, className, isIncludePadding 
       {/* Mobile Menu Overlay - starts below header */}
       <div
         className={cn(
-          "fixed left-0 right-0 bottom-0 top-[60px] z-40 bg-landing-surface-700 md:hidden transition-opacity duration-300",
+          "fixed left-0 right-0 bottom-0 top-[60px] z-40 bg-surface-700 md:hidden transition-opacity duration-300",
           mobileMenuOpen ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
         )}
       >
-        <nav className="flex flex-col px-[32px] pt-12 border-t border-t-landing-surface-400 gap-5">
+        <nav className="flex flex-col px-[32px] pt-12 border-t border-t-surface-200 gap-5">
           {NAV_LINKS.map((link) => (
             <Link
               key={link.href}
               href={link.href}
               target={link.external ? "_blank" : undefined}
-              className="font-sans-landing font-medium text-[28px] leading-[30px] text-white no-underline hover:text-landing-text-200 tracking-tight"
+              className="font-sans-landing font-medium text-[28px] leading-[30px] text-white no-underline hover:text-foreground-200 tracking-tight"
               onClick={() => setMobileMenuOpen(false)}
             >
               {link.label}

--- a/frontend/components/landing/hero/index.tsx
+++ b/frontend/components/landing/hero/index.tsx
@@ -25,7 +25,7 @@ const Hero = ({ className, hasSession }: Props) => (
             Ship reliable agents{` `}
             <br className="block sm:hidden" />
           </h1>
-          <p className={cn("font-sans-landing text-[20px] text-landing-text-200")}>
+          <p className={cn("font-sans-landing text-[20px] text-foreground-200")}>
             Laminar catches every agent failure, surfaces what to fix, and confirms the fix resolved it.
           </p>
         </div>
@@ -33,16 +33,16 @@ const Hero = ({ className, hasSession }: Props) => (
         <div className="flex flex-row gap-3 items-center">
           <Link
             href="/sign-up"
-            className="flex items-center justify-center w-[160px] h-[36px] rounded-sm bg-landing-primary-200 hover:bg-landing-primary-400 transition-colors no-underline"
+            className="flex items-center justify-center w-[160px] h-[36px] rounded-sm bg-primary-200 hover:bg-primary-400 transition-colors no-underline"
           >
             <span className="font-sans-landing font-medium text-sm text-black">Get started – free</span>
           </Link>
           <Link
             href="https://laminar.sh/docs"
             target="_blank"
-            className="flex items-center justify-center w-[160px] h-[36px] rounded-sm border border-landing-text-600 hover:bg-landing-surface-600 transition-colors no-underline"
+            className="flex items-center justify-center w-[160px] h-[36px] rounded-sm border border-foreground-600 hover:bg-surface-600 transition-colors no-underline"
           >
-            <span className="font-sans-landing font-medium text-sm text-landing-text-200">Docs</span>
+            <span className="font-sans-landing font-medium text-sm text-foreground-200">Docs</span>
           </Link>
         </div>
       </div>

--- a/frontend/components/landing/hero/logo-strip.tsx
+++ b/frontend/components/landing/hero/logo-strip.tsx
@@ -16,7 +16,7 @@ const LOGOS = [
 const LogoStrip = ({ className }: Props) => (
   <div className={cn("grid grid-cols-2 md:grid-cols-5 gap-2 w-full max-w-[960px]", className)}>
     {LOGOS.map(({ id, Component, className: logoClassName }) => (
-      <div key={id} className="flex items-center justify-center h-13 rounded bg-landing-surface-550">
+      <div key={id} className="flex items-center justify-center h-13 rounded bg-surface-500">
         <Component className={cn("opacity-50", logoClassName)} />
       </div>
     ))}

--- a/frontend/components/landing/index.tsx
+++ b/frontend/components/landing/index.tsx
@@ -28,7 +28,7 @@ interface Props {
 // past 880 and remain horizontally centered at stage 6), then the remaining
 // sections in the standard 880px column below.
 const Landing = ({ className, hasSession }: Props) => (
-  <div className={cn("bg-landing-surface-700 overflow-x-clip flex flex-col", className)}>
+  <div className={cn("bg-surface-700 overflow-x-clip flex flex-col", className)}>
     <Hero hasSession={hasSession} />
     {/* 80px controls the gap to the section above */}
     <UnderstandWhy className="md:mt-[calc(80px-(100vh-760px)/2)]" />

--- a/frontend/components/landing/landing-button.tsx
+++ b/frontend/components/landing/landing-button.tsx
@@ -10,7 +10,7 @@ interface LandingButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 const LandingButton = React.forwardRef<HTMLButtonElement, LandingButtonProps>(
   ({ className, variant = "minimal", size = "md", children, ...props }, ref) => {
     const baseStyles =
-      "font-sans-landing text-landing-text-200 leading-normal whitespace-nowrap cursor-pointer flex items-center justify-center rounded-md transition-colors disabled:opacity-50 disabled:pointer-events-none";
+      "font-sans-landing text-foreground-200 leading-normal whitespace-nowrap cursor-pointer flex items-center justify-center rounded-md transition-colors disabled:opacity-50 disabled:pointer-events-none";
 
     const sizeStyles = {
       xs: "px-2 py-0.5 text-xs md:text-sm",
@@ -20,10 +20,10 @@ const LandingButton = React.forwardRef<HTMLButtonElement, LandingButtonProps>(
     };
 
     const variantStyles = {
-      minimal: "hover:text-landing-text-100",
-      solid: "bg-landing-surface-500 hover:bg-landing-surface-400",
-      outline: "outline outline-landing-text-600 hover:text-landing-text-100 hover:bg-primary-foreground/5",
-      primary: "bg-landing-primary-200 text-black font-medium rounded-sm hover:bg-landing-primary-400",
+      minimal: "hover:text-foreground-50",
+      solid: "bg-surface-400 hover:bg-surface-200",
+      outline: "outline outline-foreground-600 hover:text-foreground-50 hover:bg-primary-foreground/5",
+      primary: "bg-primary-200 text-black font-medium rounded-sm hover:bg-primary-400",
     };
 
     return (

--- a/frontend/components/landing/pricing/index.tsx
+++ b/frontend/components/landing/pricing/index.tsx
@@ -39,7 +39,7 @@ export default function Pricing() {
             href="https://laminar.sh/docs/signals/introduction"
             target="_blank"
             rel="noopener noreferrer"
-            className="underline hover:text-landing-text-100"
+            className="underline hover:text-foreground-50"
           >
             Signals docs
           </a>
@@ -89,7 +89,7 @@ export default function Pricing() {
             <h2 className={cn(subSection, "text-white")}>Frequently asked questions</h2>
             <Accordion type="single" collapsible className="w-full">
               {faqItems.map((item) => (
-                <AccordionItem key={item.id} value={item.id} className="border-landing-surface-500">
+                <AccordionItem key={item.id} value={item.id} className="border-surface-400">
                   <AccordionTrigger
                     className={cn("text-white text-lg leading-6 py-6")}
                     onClick={() => handleQuestionClick(item.question)}

--- a/frontend/components/landing/pricing/pricing-calculator.tsx
+++ b/frontend/components/landing/pricing/pricing-calculator.tsx
@@ -139,7 +139,7 @@ function TierColumn({
   const extraSignals = Math.max(0, signalStepsProcessed - estimate.includedSignalSteps);
 
   return (
-    <div className="bg-landing-surface-550 h-full rounded p-5 space-y-4">
+    <div className="bg-surface-500 h-full rounded p-5 space-y-4">
       <TierHeader name={estimate.name} tooltip={tooltip} />
 
       <div className="space-y-2 text-sm">
@@ -148,42 +148,42 @@ function TierColumn({
             <span>Base</span>
             <span>${formatDollars(estimate.basePrice)}</span>
           </div>
-          <div className={cn(microLabel, "mt-0.5 text-landing-text-300")}>
+          <div className={cn(microLabel, "mt-0.5 text-foreground-300")}>
             {formatDataSize(estimate.includedDataGB)} + {formatNumber(estimate.includedSignalSteps)} Signals steps
             included
           </div>
         </div>
 
         {estimate.dataOverageCost > 0 ? (
-          <div className="flex justify-between text-landing-text-200">
+          <div className="flex justify-between text-foreground-200">
             <span>
               {formatDataSize(extraDataGB)} × ${estimate.dataOverageRate}/GB
             </span>
             <span>+${formatDollars(estimate.dataOverageCost)}</span>
           </div>
         ) : (
-          <div className="flex justify-between text-landing-text-300">
+          <div className="flex justify-between text-foreground-300">
             <span>Data ({formatDataSize(dataGB)})</span>
             <span>Included</span>
           </div>
         )}
 
         {estimate.signalOverageCost > 0 ? (
-          <div className="flex justify-between text-landing-text-200">
+          <div className="flex justify-between text-foreground-200">
             <span>
               {formatNumber(extraSignals)} × ${estimate.signalOverageRate}/step
             </span>
             <span>+${formatDollars(estimate.signalOverageCost)}</span>
           </div>
         ) : (
-          <div className="flex justify-between text-landing-text-300">
+          <div className="flex justify-between text-foreground-300">
             <span>Signals steps processed ({formatNumber(signalStepsProcessed)})</span>
             <span>Included</span>
           </div>
         )}
       </div>
 
-      <div className="border-t pt-3 border-landing-surface-500">
+      <div className="border-t pt-3 border-surface-400">
         <div className={cn(subSection, "flex justify-between text-lg leading-6 text-white")}>
           <span>Total</span>
           <span>${formatDollars(estimate.total)}/mo</span>
@@ -191,14 +191,10 @@ function TierColumn({
       </div>
 
       <div className="flex flex-wrap gap-2">
-        <span
-          className={cn(microLabel, "inline-flex items-center rounded-sm px-2 py-0.5 bg-landing-surface-500 text-sm")}
-        >
+        <span className={cn(microLabel, "inline-flex items-center rounded-sm px-2 py-0.5 bg-surface-400 text-sm")}>
           {estimate.retention} retention
         </span>
-        <span
-          className={cn(microLabel, "inline-flex items-center rounded-sm px-2 py-0.5 bg-landing-surface-500 text-sm")}
-        >
+        <span className={cn(microLabel, "inline-flex items-center rounded-sm px-2 py-0.5 bg-surface-400 text-sm")}>
           {estimate.support} support
         </span>
       </div>
@@ -208,7 +204,7 @@ function TierColumn({
 
 function EnterpriseTierColumn({ tooltip }: { tooltip?: string }) {
   return (
-    <div className="bg-landing-surface-550 h-full rounded p-5 space-y-4">
+    <div className="bg-surface-500 h-full rounded p-5 space-y-4">
       <TierHeader name="Enterprise" tooltip={tooltip} />
 
       <div className="space-y-2 text-sm">
@@ -216,17 +212,17 @@ function EnterpriseTierColumn({ tooltip }: { tooltip?: string }) {
           <span>Base</span>
           <span>Custom</span>
         </div>
-        <div className="flex justify-between text-landing-text-300">
+        <div className="flex justify-between text-foreground-300">
           <span>Additional data</span>
           <span>Custom</span>
         </div>
-        <div className="flex justify-between text-landing-text-300">
+        <div className="flex justify-between text-foreground-300">
           <span>Additional Signals steps processing</span>
           <span>Custom</span>
         </div>
       </div>
 
-      <div className="border-t pt-3 border-landing-surface-500">
+      <div className="border-t pt-3 border-surface-400">
         <div className={cn(subSection, "flex justify-between text-lg leading-6 text-white")}>
           <span>Total</span>
           <span>Custom</span>
@@ -234,10 +230,10 @@ function EnterpriseTierColumn({ tooltip }: { tooltip?: string }) {
       </div>
 
       <div className="flex flex-wrap gap-2">
-        <span className={cn(microLabel, "inline-flex items-center rounded-sm px-2 py-0.5 bg-landing-surface-500")}>
+        <span className={cn(microLabel, "inline-flex items-center rounded-sm px-2 py-0.5 bg-surface-400")}>
           {retentionLabel("enterprise")}
         </span>
-        <span className={cn(microLabel, "inline-flex items-center rounded-sm px-2 py-0.5 bg-landing-surface-500")}>
+        <span className={cn(microLabel, "inline-flex items-center rounded-sm px-2 py-0.5 bg-surface-400")}>
           Dedicated support
         </span>
       </div>
@@ -294,7 +290,7 @@ export default function PricingCalculator() {
 
   const tokensValue = (
     <>
-      {formatTokens(tokens)} <span className="text-sm text-landing-text-300">≈ {formatDataSize(dataGB)}</span>
+      {formatTokens(tokens)} <span className="text-sm text-foreground-300">≈ {formatDataSize(dataGB)}</span>
     </>
   );
 

--- a/frontend/components/landing/pricing/pricing-card.tsx
+++ b/frontend/components/landing/pricing/pricing-card.tsx
@@ -32,15 +32,15 @@ export default function PricingCard({
   ctaLabel,
   ctaHref,
 }: PricingCardProps) {
-  const featureColor = isAccent ? "text-white" : "text-landing-text-200";
-  const suffixColor = isAccent ? "text-white/70" : "text-landing-text-400";
-  const checkColor = isAccent ? "text-white/80" : "text-landing-text-300";
+  const featureColor = isAccent ? "text-white" : "text-foreground-200";
+  const suffixColor = isAccent ? "text-white/70" : "text-foreground-400";
+  const checkColor = isAccent ? "text-white/80" : "text-foreground-300";
 
   return (
     <div
       className={cn(
         "flex flex-col gap-6 rounded h-full p-5",
-        isAccent ? "bg-landing-primary-400" : "bg-landing-surface-550",
+        isAccent ? "bg-primary-400" : "bg-surface-500",
         className
       )}
     >
@@ -70,10 +70,7 @@ export default function PricingCard({
         <LandingButton
           variant={isAccent ? "solid" : "outline"}
           size="sm"
-          className={cn(
-            "w-full",
-            isAccent && "bg-white text-landing-primary-400 border border-white/40 hover:bg-white/90"
-          )}
+          className={cn("w-full", isAccent && "bg-white text-primary-400 border border-white/40 hover:bg-white/90")}
         >
           {ctaLabel}
         </LandingButton>

--- a/frontend/components/landing/pricing/pricing-table.tsx
+++ b/frontend/components/landing/pricing/pricing-table.tsx
@@ -22,15 +22,15 @@ export default function PricingTable() {
         style={{ gridTemplateColumns: `1.4fr repeat(${TIER_COLUMNS.length}, 1fr)` }}
       >
         {/* Header row — sticky on md+ */}
-        <div className="sticky top-0 z-10 bg-landing-surface-700 after:content-[''] after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-gradient-to-b after:from-landing-surface-700 after:to-transparent after:pointer-events-none" />
+        <div className="sticky top-0 z-10 bg-surface-700 after:content-[''] after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-gradient-to-b after:from-surface-700 after:to-transparent after:pointer-events-none" />
         {TIER_COLUMNS.map((tier) => (
           <div
             key={tier.id}
-            className="sticky top-0 z-10 bg-landing-surface-700 after:content-[''] after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-gradient-to-b after:from-landing-surface-700 after:to-transparent after:pointer-events-none relative px-5 pt-6 pb-5 flex flex-col items-start gap-3"
+            className="sticky top-0 z-10 bg-surface-700 after:content-[''] after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-gradient-to-b after:from-surface-700 after:to-transparent after:pointer-events-none relative px-5 pt-6 pb-5 flex flex-col items-start gap-3"
           >
             <div className="flex flex-col gap-1">
               <p className={cn(subSection, "text-white")}>{tier.name}</p>
-              <p className="font-sans text-sm text-landing-text-300">
+              <p className="font-sans text-sm text-foreground-300">
                 <span className="text-white">{tier.price}</span>
                 {tier.priceSuffix ? ` ${tier.priceSuffix}` : ""}
               </p>
@@ -65,11 +65,9 @@ function FeatureGroupRows({ group }: { group: FeatureGroup }) {
 function FeatureRowCells({ row }: { row: FeatureGroup["rows"][number] }) {
   return (
     <>
-      <div className="pl-0 pr-5 py-3 text-sm text-landing-text-200 border-t border-landing-surface-500/50">
-        {row.label}
-      </div>
+      <div className="pl-0 pr-5 py-3 text-sm text-foreground-200 border-t border-surface-400/50">{row.label}</div>
       {TIER_COLUMNS.map((tier) => (
-        <div key={tier.id} className="px-5 py-3 text-sm text-white border-t border-landing-surface-500/50">
+        <div key={tier.id} className="px-5 py-3 text-sm text-white border-t border-surface-400/50">
           <FeatureCell value={row.values[tier.id]} />
         </div>
       ))}
@@ -78,7 +76,7 @@ function FeatureRowCells({ row }: { row: FeatureGroup["rows"][number] }) {
 }
 
 function FeatureCell({ value }: { value: FeatureValue }) {
-  if (value === true) return <Check className="size-4 text-landing-text-100" strokeWidth={2.5} />;
-  if (value === false || value === null) return <Minus className="size-4 text-landing-text-500" />;
+  if (value === true) return <Check className="size-4 text-foreground-50" strokeWidth={2.5} />;
+  if (value === false || value === null) return <Minus className="size-4 text-foreground-500" />;
   return <span>{value}</span>;
 }

--- a/frontend/components/landing/sections/built-for-production/index.tsx
+++ b/frontend/components/landing/sections/built-for-production/index.tsx
@@ -13,7 +13,7 @@ import LearnMoreLink from "../two-lines-to-integrate/learn-more-link";
 const BuiltForProduction = () => (
   <section className="flex flex-col items-start w-full">
     <div className="flex flex-col gap-10 w-full">
-      <p className="font-sans-landing font-medium text-landing-text-100 text-[48px] leading-[60px] tracking-[-0.02em]">
+      <p className="font-sans-landing font-medium text-foreground-50 text-[48px] leading-[60px] tracking-[-0.02em]">
         20x more efficient storage
       </p>
 
@@ -28,7 +28,7 @@ const BuiltForProduction = () => (
 
         <div className="flex flex-col gap-1 items-start w-full md:flex-1 md:min-w-0">
           <motion.div
-            className="flex h-11 items-center justify-end px-5 overflow-hidden whitespace-nowrap w-full rounded-sm bg-landing-surface-500 text-landing-text-100"
+            className="flex h-11 items-center justify-end px-5 overflow-hidden whitespace-nowrap w-full rounded-sm bg-surface-400 text-foreground-50"
             initial={{ width: 0 }}
             whileInView={{ width: "100%" }}
             viewport={{ once: true, amount: 0.6 }}
@@ -38,13 +38,13 @@ const BuiltForProduction = () => (
           </motion.div>
           <div className="flex items-center gap-3 h-11 w-full">
             <motion.div
-              className="flex h-full items-center justify-end px-5 overflow-hidden whitespace-nowrap rounded-sm bg-landing-primary-300 text-background"
+              className="flex h-full items-center justify-end px-5 overflow-hidden whitespace-nowrap rounded-sm bg-primary-300 text-background"
               initial={{ width: 0 }}
               whileInView={{ width: "5%" }}
               viewport={{ once: true, amount: 0.6 }}
               transition={{ duration: 0.3, ease: "easeOut" }}
             />
-            <p className="text-landing-text-100">Laminar</p>
+            <p className="text-foreground-50">Laminar</p>
           </div>
         </div>
       </div>

--- a/frontend/components/landing/sections/claude-fix-my-agent/claude-code-session-mock.tsx
+++ b/frontend/components/landing/sections/claude-fix-my-agent/claude-code-session-mock.tsx
@@ -38,9 +38,7 @@ const DIFF_MS = 90;
 //   6..11: diff lines (one per stage)
 const TOTAL_STAGES = 6 + DIFF_LINES.length;
 
-const Cursor = () => (
-  <span className="inline-block w-1.5 h-3.5 bg-landing-text-300 ml-0.5 align-middle animate-pulse" />
-);
+const Cursor = () => <span className="inline-block w-1.5 h-3.5 bg-foreground-300 ml-0.5 align-middle animate-pulse" />;
 
 // Faithful port of the Claude Code session card from Figma (4054:7405),
 // with a line-by-line reveal that mimics a live session. Fixed-height
@@ -83,7 +81,7 @@ const ClaudeCodeSessionMock = ({ className }: Props) => {
     <div
       ref={ref}
       className={cn(
-        "w-[600px] h-[450px] rounded-md border border-landing-surface-500 bg-landing-surface-700 px-5 py-4 flex flex-col gap-[18px]",
+        "w-[600px] h-[450px] rounded-md border border-surface-400 bg-surface-700 px-5 py-4 flex flex-col gap-[18px]",
         className
       )}
     >
@@ -92,19 +90,19 @@ const ClaudeCodeSessionMock = ({ className }: Props) => {
           anything past the top edge (reads as a longer session). */}
       <div className="flex-1 min-h-0 overflow-hidden flex flex-col justify-end gap-[18px]">
         {stage >= 1 && (
-          <p className={cn(monoBase, "text-landing-text-300")}>
-            <span className="text-landing-primary-300">&gt;</span> {USER_PROMPT}
+          <p className={cn(monoBase, "text-foreground-300")}>
+            <span className="text-primary-300">&gt;</span> {USER_PROMPT}
           </p>
         )}
 
         {stage >= 2 && (
           <div className="flex flex-col gap-0.5">
-            <p className={cn(monoBase, "text-landing-text-200")}>
-              <span className="text-landing-primary-300">●</span>
+            <p className={cn(monoBase, "text-foreground-200")}>
+              <span className="text-primary-300">●</span>
               {` `}laminar - query_laminar_sql(query: &quot;SELECT trace_id, output_chars FROM refine_report …&quot;)
             </p>
             {stage >= 3 && (
-              <p className={cn(monoBase, "text-landing-text-400")}>
+              <p className={cn(monoBase, "text-foreground-400")}>
                 {"  └─ Returned 5 rows · avg output: 612 chars (target ≤ 300)"}
               </p>
             )}
@@ -112,16 +110,16 @@ const ClaudeCodeSessionMock = ({ className }: Props) => {
         )}
 
         {stage >= 4 && (
-          <p className={cn(monoBase, "text-landing-text-300")}>
-            <span className="text-landing-primary-300">✻</span> {` `}The prompt says &quot;a few sentences&quot; but
-            never enforces a length — I&apos;ll make it explicit.
+          <p className={cn(monoBase, "text-foreground-300")}>
+            <span className="text-primary-300">✻</span> {` `}The prompt says &quot;a few sentences&quot; but never
+            enforces a length — I&apos;ll make it explicit.
           </p>
         )}
 
         {stage >= 5 && (
           <div className="flex flex-col gap-0.5">
-            <p className={cn(monoBase, "text-landing-text-200")}>
-              <span className="text-landing-primary-300">●</span> Update(refine-report.ts)
+            <p className={cn(monoBase, "text-foreground-200")}>
+              <span className="text-primary-300">●</span> Update(refine-report.ts)
             </p>
             <div className="h-1.5" />
             {DIFF_LINES.slice(0, diffShown).map((line, i) => (
@@ -129,20 +127,20 @@ const ClaudeCodeSessionMock = ({ className }: Props) => {
                 key={i}
                 className={cn(
                   "flex items-center pl-1 pr-2",
-                  line.kind === "removed" && "bg-landing-surface-500/60",
-                  line.kind === "added" && "bg-landing-primary-400/10"
+                  line.kind === "removed" && "bg-surface-400/60",
+                  line.kind === "added" && "bg-primary-400/10"
                 )}
               >
-                <span className={cn(monoBase, "w-7 text-right pr-2 text-landing-text-500 select-none shrink-0")}>
+                <span className={cn(monoBase, "w-7 text-right pr-2 text-foreground-500 select-none shrink-0")}>
                   {i + 1}
                 </span>
                 <span
                   className={cn(
                     monoBase,
                     "w-4 text-center shrink-0",
-                    line.kind === "added" && "text-landing-primary-300",
-                    line.kind === "removed" && "text-landing-text-400",
-                    line.kind === "context" && "text-landing-text-500"
+                    line.kind === "added" && "text-primary-300",
+                    line.kind === "removed" && "text-foreground-400",
+                    line.kind === "context" && "text-foreground-500"
                   )}
                 >
                   {line.kind === "added" ? "+" : line.kind === "removed" ? "-" : ""}
@@ -151,9 +149,9 @@ const ClaudeCodeSessionMock = ({ className }: Props) => {
                   className={cn(
                     monoBase,
                     "whitespace-pre",
-                    line.kind === "added" && "text-landing-primary-300",
-                    line.kind === "removed" && "text-landing-text-400",
-                    line.kind === "context" && "text-landing-text-300"
+                    line.kind === "added" && "text-primary-300",
+                    line.kind === "removed" && "text-foreground-400",
+                    line.kind === "context" && "text-foreground-300"
                   )}
                 >
                   {line.text}
@@ -167,16 +165,16 @@ const ClaudeCodeSessionMock = ({ className }: Props) => {
       {/* Footer — input + status. Input shows the user typing during stage 0
           then clears once the prompt is "submitted" (stage ≥ 1). */}
       <div className="shrink-0 flex flex-col gap-1.5">
-        <div className="flex items-center gap-2 rounded-md border border-landing-surface-500 bg-landing-surface-600 px-3 py-2.5">
-          <span className={cn(monoBase, "font-medium text-landing-primary-300")}>&gt;</span>
-          <span className={cn(monoBase, "text-landing-text-200")}>
+        <div className="flex items-center gap-2 rounded-md border border-surface-400 bg-surface-600 px-3 py-2.5">
+          <span className={cn(monoBase, "font-medium text-primary-300")}>&gt;</span>
+          <span className={cn(monoBase, "text-foreground-200")}>
             {isTyping ? typed : ""}
             {isTyping && <Cursor />}
           </span>
         </div>
         <div className="flex items-center justify-between px-1">
-          <span className={cn("font-mono text-xs leading-[18px] text-landing-text-600")}>? for shortcuts</span>
-          <span className={cn("font-mono text-xs leading-[18px] text-landing-text-600")}>
+          <span className={cn("font-mono text-xs leading-[18px] text-foreground-600")}>? for shortcuts</span>
+          <span className={cn("font-mono text-xs leading-[18px] text-foreground-600")}>
             claude-opus-4-7 · 1M context
           </span>
         </div>

--- a/frontend/components/landing/sections/claude-fix-my-agent/index.tsx
+++ b/frontend/components/landing/sections/claude-fix-my-agent/index.tsx
@@ -6,7 +6,7 @@ import ClaudeCodeSessionMock from "./claude-code-session-mock";
 import RotatingAgentName from "./rotating-agent-name";
 
 // Vertical stack: title + subtitle on top, terminal session mock centered
-// inside a landing-surface-550 panel with a footnote pinned to the bottom.
+// inside a surface-500 panel with a footnote pinned to the bottom.
 const ClaudeFixMyAgent = () => (
   <section className="flex flex-col gap-10 items-start w-full">
     <div className="flex flex-col items-start">
@@ -21,7 +21,7 @@ const ClaudeFixMyAgent = () => (
           href="https://laminar.sh/docs/platform/mcp#mcp-server"
           target="_blank"
           rel="noopener noreferrer"
-          className="underline hover:text-landing-text-200"
+          className="underline hover:text-foreground-200"
         >
           MCP
         </a>{" "}
@@ -30,7 +30,7 @@ const ClaudeFixMyAgent = () => (
           href="https://laminar.sh/docs/platform/cli#cli"
           target="_blank"
           rel="noopener noreferrer"
-          className="underline hover:text-landing-text-200"
+          className="underline hover:text-foreground-200"
         >
           CLI
         </a>{" "}
@@ -38,7 +38,7 @@ const ClaudeFixMyAgent = () => (
         to confirm the fix worked.
       </p>
     </div>
-    <div className="bg-landing-surface-550 relative flex items-center w-full md:py-[40px] py-[30px] overflow-hidden px-8">
+    <div className="bg-surface-500 relative flex items-center w-full md:py-[40px] py-[30px] overflow-hidden px-8">
       <div className="shrink-0 mx-auto md:scale-none scale-[80%] origin-left sm:origin-center">
         <ClaudeCodeSessionMock />
       </div>

--- a/frontend/components/landing/sections/compliance.tsx
+++ b/frontend/components/landing/sections/compliance.tsx
@@ -35,8 +35,8 @@ const Compliance = () => (
               href={href}
               target="_blank"
               className={cn(
-                "flex items-center gap-3 h-14 w-full border-t border-landing-text-600",
-                "text-lg text-landing-text-300 no-underline"
+                "flex items-center gap-3 h-14 w-full border-t border-foreground-600",
+                "text-lg text-foreground-300 no-underline"
               )}
             >
               {label}

--- a/frontend/components/landing/sections/did-my-fix-work/index.tsx
+++ b/frontend/components/landing/sections/did-my-fix-work/index.tsx
@@ -5,7 +5,7 @@ import SectionFootnote from "../section-footnote";
 import EvalComparisonMock from "./eval-comparison-mock";
 
 // Vertical stack: title + subtitle on top, mock centered inside a
-// landing-surface-550 panel with a footnote pinned to the bottom.
+// surface-500 panel with a footnote pinned to the bottom.
 const DidMyFixWork = () => (
   <section className="flex flex-col gap-10 items-start w-full">
     <div className="flex flex-col items-start">
@@ -16,7 +16,7 @@ const DidMyFixWork = () => (
         regressions and iterate with confidence.
       </p>
     </div>
-    <div className="bg-landing-surface-550 relative flex items-center w-full md:py-[64px] py-[40px] overflow-hidden px-8">
+    <div className="bg-surface-500 relative flex items-center w-full md:py-[64px] py-[40px] overflow-hidden px-8">
       <div className="shrink-0 mx-auto md:scale-none scale-[80%] origin-left">
         <EvalComparisonMock className="w-[720px]" />
       </div>

--- a/frontend/components/landing/sections/divider.tsx
+++ b/frontend/components/landing/sections/divider.tsx
@@ -8,6 +8,6 @@ interface Props {
 // Horizontal divider line. Short variant separates "Did my fix work?" from
 // "Two lines to integrate"; full variant brackets Quote and Built for
 // production within the 880px column.
-const Divider = ({ className }: Props) => <div className={cn("h-px bg-landing-surface-500 w-full", className)} />;
+const Divider = ({ className }: Props) => <div className={cn("h-px bg-surface-400 w-full", className)} />;
 
 export default Divider;

--- a/frontend/components/landing/sections/features-for-every-step.tsx
+++ b/frontend/components/landing/sections/features-for-every-step.tsx
@@ -24,15 +24,15 @@ const Card = ({ Icon, title, description, href }: CardProps) => (
     target="_blank"
     aria-label={`Learn more about ${title}`}
     href={href}
-    className="bg-landing-surface-550 font-sans-landing flex flex-col h-[180px] px-5 py-4 justify-between rounded transition-all duration-300 hover:bg-landing-surface-400"
+    className="bg-surface-500 font-sans-landing flex flex-col h-[180px] px-5 py-4 justify-between rounded transition-all duration-300 hover:bg-surface-200"
   >
     <div className="flex items-start justify-between w-full">
-      <Icon className="size-6 text-landing-text-300" strokeWidth={1.5} />
-      <ArrowUpRight className="size-5 text-landing-text-300" strokeWidth={1.5} />
+      <Icon className="size-6 text-foreground-300" strokeWidth={1.5} />
+      <ArrowUpRight className="size-5 text-foreground-300" strokeWidth={1.5} />
     </div>
     <div className="flex flex-col gap-1">
       <p className="leading-6 text-white text-lg">{title}</p>
-      <p className="text-landing-text-200">{description}</p>
+      <p className="text-foreground-200">{description}</p>
     </div>
   </Link>
 );

--- a/frontend/components/landing/sections/has-this-issue/index.tsx
+++ b/frontend/components/landing/sections/has-this-issue/index.tsx
@@ -5,7 +5,7 @@ import SectionFootnote from "../section-footnote";
 import SignalEventClustersMock from "./signal-event-clusters-mock";
 
 // Vertical stack: title + subtitle on top, mock centered inside a
-// landing-surface-550 panel with a footnote pinned to the bottom.
+// surface-500 panel with a footnote pinned to the bottom.
 const HasThisIssue = () => (
   <section className="flex flex-col gap-10 items-start w-full">
     <div className="flex flex-col items-start">
@@ -16,7 +16,7 @@ const HasThisIssue = () => (
         stops recurring, Laminar resolves it — and reopens it if the issue returns.
       </p>
     </div>
-    <div className="bg-landing-surface-550 relative flex items-center w-full md:py-[120px] py-[70px] overflow-hidden px-8">
+    <div className="bg-surface-500 relative flex items-center w-full md:py-[120px] py-[70px] overflow-hidden px-8">
       {/* mx-auto centers the mock when it fits; when it doesn't (narrow
           viewports) the auto margins collapse to 0 so the mock sticks
           to the start edge instead of overflowing symmetrically.

--- a/frontend/components/landing/sections/open-source/index.tsx
+++ b/frontend/components/landing/sections/open-source/index.tsx
@@ -21,13 +21,13 @@ const FEATURES: Feature[] = [
 const FeatureRow = ({ label, href }: Feature) => {
   const inner = (
     <>
-      <p className="text-lg leading-6 text-landing-text-300">{label}</p>
-      {href && <ArrowUpRight className="size-4 text-landing-text-300 shrink-0" strokeWidth={2} />}
+      <p className="text-lg leading-6 text-foreground-300">{label}</p>
+      {href && <ArrowUpRight className="size-4 text-foreground-300 shrink-0" strokeWidth={2} />}
     </>
   );
-  const className = "flex items-center gap-3 h-14 w-full border-t border-landing-text-600";
+  const className = "flex items-center gap-3 h-14 w-full border-t border-foreground-600";
   return href ? (
-    <Link href={href} target="_blank" className={`${className} hover:text-landing-text-100 transition-colors`}>
+    <Link href={href} target="_blank" className={`${className} hover:text-foreground-50 transition-colors`}>
       {inner}
     </Link>
   ) : (
@@ -50,9 +50,9 @@ const OpenSource = () => (
           overflows left-anchored otherwise (same pattern as did-my-fix). On
           mobile the inner is scaled to 80% from the left edge so it fits
           tighter viewports without horizontal scrolling. */}
-      <div className="w-full md:flex-1 md:min-w-0 bg-landing-surface-550 flex items-center p-5 overflow-hidden h-[400px]">
+      <div className="w-full md:flex-1 md:min-w-0 bg-surface-500 flex items-center p-5 overflow-hidden h-[400px]">
         <div className="shrink-0 mx-auto md:scale-none scale-[80%] origin-left">
-          <div className="bg-landing-surface-700 rounded w-[420px] px-6 py-5">
+          <div className="bg-surface-700 rounded w-[420px] px-6 py-5">
             <Terminal />
           </div>
         </div>

--- a/frontend/components/landing/sections/open-source/terminal.tsx
+++ b/frontend/components/landing/sections/open-source/terminal.tsx
@@ -50,9 +50,7 @@ const SPINNER_MS = 80;
 
 type Phase = "type1" | "git" | "type2" | "compose" | "ready";
 
-const Cursor = () => (
-  <span className="inline-block w-1.5 h-3.5 bg-landing-text-300 ml-0.5 align-middle animate-pulse" />
-);
+const Cursor = () => <span className="inline-block w-1.5 h-3.5 bg-foreground-300 ml-0.5 align-middle animate-pulse" />;
 
 const Terminal = () => {
   const ref = useRef<HTMLDivElement>(null);
@@ -123,32 +121,32 @@ const Terminal = () => {
 
   return (
     <div ref={ref} className="font-mono text-xs leading-5 flex flex-col gap-0.5">
-      <p className="text-landing-text-300 whitespace-pre-wrap">
-        <span className="text-landing-primary-300">~ $</span> {typed1}
+      <p className="text-foreground-300 whitespace-pre-wrap">
+        <span className="text-primary-300">~ $</span> {typed1}
         {phase === "type1" && <Cursor />}
       </p>
       {GIT_LINES.slice(0, gitLines).map((line, i) => (
-        <p key={`git-${i}`} className="text-landing-text-400 whitespace-pre-wrap">
+        <p key={`git-${i}`} className="text-foreground-400 whitespace-pre-wrap">
           {line}
         </p>
       ))}
 
       {(phase === "type2" || phase === "compose" || phase === "ready") && (
-        <p className="text-landing-text-300 whitespace-pre-wrap mt-1">
-          <span className="text-landing-primary-300">~/lmnr $</span> {typed2}
+        <p className="text-foreground-300 whitespace-pre-wrap mt-1">
+          <span className="text-primary-300">~/lmnr $</span> {typed2}
           {phase === "type2" && <Cursor />}
         </p>
       )}
 
       {(phase === "compose" || phase === "ready") && (
         <>
-          <p className="text-landing-primary-300 whitespace-pre">
+          <p className="text-primary-300 whitespace-pre">
             [+] Running {ticked}/{ROWS.length}
           </p>
           {ROWS.slice(0, spawned).map((r, i) => {
             const isTicked = i < ticked;
             return (
-              <p key={r.name} className="text-landing-text-400 whitespace-pre">
+              <p key={r.name} className="text-foreground-400 whitespace-pre">
                 {isTicked ? " ✔" : ` ${SPINNER[spinnerFrame]}`} {r.name}
                 {isTicked ? `${r.verb}   ${r.elapsed}` : PRESENT_TENSE[r.verb]}
               </p>
@@ -159,7 +157,7 @@ const Terminal = () => {
 
       {phase === "ready" && (
         <>
-          <p className="text-landing-primary-300 whitespace-pre">▶ Ready on http://localhost:5667</p>
+          <p className="text-primary-300 whitespace-pre">▶ Ready on http://localhost:5667</p>
         </>
       )}
     </div>

--- a/frontend/components/landing/sections/quote.tsx
+++ b/frontend/components/landing/sections/quote.tsx
@@ -13,7 +13,7 @@ const Quote = () => (
       <br className="hidden md:inline" /> Laminar’s trace view is the first place we look”
     </p>
     <div className="flex flex-col items-start gap-0.5 shrink-0 pt-1.5">
-      <p className="font-sans-landing text-landing-text-300 text-lg leading-6">Magnus Müller, CEO</p>
+      <p className="font-sans-landing text-foreground-300 text-lg leading-6">Magnus Müller, CEO</p>
       <Image src={browserUseFullLogo} alt="Browser Use" height={28} className="h-7 w-auto" />
     </div>
   </section>

--- a/frontend/components/landing/sections/section-footnote.tsx
+++ b/frontend/components/landing/sections/section-footnote.tsx
@@ -13,7 +13,7 @@ interface Props {
 // Absolutely-positioned label that sits at the bottom of a mock panel
 // (a surface-550 wrapper). The parent must be `relative`. Pattern:
 //
-//   <div className="bg-landing-surface-550 relative ...">
+//   <div className="bg-surface-500 relative ...">
 //     <Mock />
 //     <SectionFootnote name="Evals" href="..." />
 //   </div>
@@ -29,7 +29,7 @@ const SectionFootnote = ({ name, href }: Props) => (
     <Link
       href={href}
       target="_blank"
-      className="inline-flex items-center gap-1 hover:text-landing-text-200 transition-colors"
+      className="inline-flex items-center gap-1 hover:text-foreground-200 transition-colors"
     >
       Learn more
       <ArrowUpRight className="size-4.5 translate-y-[1.5px]" strokeWidth={1.5} />

--- a/frontend/components/landing/sections/section-footnote.tsx
+++ b/frontend/components/landing/sections/section-footnote.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 // Absolutely-positioned label that sits at the bottom of a mock panel
-// (a surface-550 wrapper). The parent must be `relative`. Pattern:
+// (a surface-500 wrapper). The parent must be `relative`. Pattern:
 //
 //   <div className="bg-surface-500 relative ...">
 //     <Mock />

--- a/frontend/components/landing/sections/signal-event-card.tsx
+++ b/frontend/components/landing/sections/signal-event-card.tsx
@@ -42,14 +42,14 @@ interface SpanChipProps {
 const SpanChip = ({ iconBg, icon, label, spanId, flashSpanId, onClick }: SpanChipProps) => {
   const isFlashing = !!spanId && flashSpanId === spanId;
   const className = cn(
-    "inline-flex items-center gap-1 rounded border border-landing-text-200/15 bg-landing-text-200/15 pl-0.5 pr-1.5 py-0.5 align-middle transition-colors",
-    onClick && "cursor-pointer hover:bg-landing-text-200/25",
+    "inline-flex items-center gap-1 rounded border border-foreground-200/15 bg-foreground-200/15 pl-0.5 pr-1.5 py-0.5 align-middle transition-colors",
+    onClick && "cursor-pointer hover:bg-foreground-200/25",
     isFlashing && "signal-span-flash"
   );
   const inner = (
     <>
       <span className={cn("inline-flex items-center justify-center size-4 rounded", iconBg)}>{icon}</span>
-      <span className="text-landing-text-200 text-xs leading-none">{label}</span>
+      <span className="text-foreground-200 text-xs leading-none">{label}</span>
     </>
   );
   if (onClick && spanId) {
@@ -90,26 +90,26 @@ export const SignalContent = ({ onSpanClick, flashSpanId, onClose }: SignalConte
         {/* (cube, label, arrow) is decorative — signals the row would be
             clickable in the real product. The wrapper gets the X's flex
             sibling treatment so X stays pinned right via justify-between. */}
-        <div className="flex items-center gap-1.5 min-w-0 rounded-full border border-landing-text-600 px-2 py-1">
-          <Box className="size-3.5 shrink-0 text-landing-primary-200" strokeWidth={2} />
+        <div className="flex items-center gap-1.5 min-w-0 rounded-full border border-foreground-600 px-2 py-1">
+          <Box className="size-3.5 shrink-0 text-primary-200" strokeWidth={2} />
           <span className="text-white text-xs leading-none whitespace-nowrap">Agent run hit avoidable failures</span>
-          <ArrowUpRight className="size-3.5 shrink-0 text-landing-text-300" strokeWidth={2} />
+          <ArrowUpRight className="size-3.5 shrink-0 text-foreground-300" strokeWidth={2} />
         </div>
         {onClose ? (
           <button
             type="button"
             onClick={onClose}
-            className="shrink-0 rounded p-0.5 text-landing-text-300 hover:text-landing-text-200 transition-colors"
+            className="shrink-0 rounded p-0.5 text-foreground-300 hover:text-foreground-200 transition-colors"
             aria-label="Close signal panel"
           >
             <X className="size-4" strokeWidth={1.5} />
           </button>
         ) : (
-          <X className="size-4 shrink-0 text-landing-text-300" strokeWidth={1.5} />
+          <X className="size-4 shrink-0 text-foreground-300" strokeWidth={1.5} />
         )}
       </div>
 
-      <p className="text-landing-text-300 text-xs leading-5">
+      <p className="text-foreground-300 text-xs leading-5">
         Agent run flagged 4 issues. In one{" "}
         <SpanChip
           iconBg="bg-llm"
@@ -119,8 +119,8 @@ export const SignalContent = ({ onSpanClick, flashSpanId, onClose }: SignalConte
           onClick={chipProps.onSpanClick}
           flashSpanId={chipProps.flashSpanId}
         />{" "}
-        the agent decided to run <code className="text-landing-text-200">python</code> (macOS only ships{" "}
-        <code className="text-landing-text-200">python3</code>),{" "}
+        the agent decided to run <code className="text-foreground-200">python</code> (macOS only ships{" "}
+        <code className="text-foreground-200">python3</code>),{" "}
         <SpanChip
           iconBg="bg-tool"
           icon={<Bolt className="size-3 text-white" strokeWidth={2} />}
@@ -129,7 +129,7 @@ export const SignalContent = ({ onSpanClick, flashSpanId, onClose }: SignalConte
           onClick={chipProps.onSpanClick}
           flashSpanId={chipProps.flashSpanId}
         />{" "}
-        then hit <code className="text-landing-text-200">command not found</code> three times before recovering, a
+        then hit <code className="text-foreground-200">command not found</code> three times before recovering, a
         parallel{" "}
         <SpanChip
           iconBg="bg-tool"
@@ -148,7 +148,7 @@ export const SignalContent = ({ onSpanClick, flashSpanId, onClose }: SignalConte
           onClick={chipProps.onSpanClick}
           flashSpanId={chipProps.flashSpanId}
         />{" "}
-        missed when the shell CWD drifted after a <code className="text-landing-text-200">cd</code>.
+        missed when the shell CWD drifted after a <code className="text-foreground-200">cd</code>.
       </p>
     </div>
   );

--- a/frontend/components/landing/sections/slack-notification-card.tsx
+++ b/frontend/components/landing/sections/slack-notification-card.tsx
@@ -1,19 +1,19 @@
 import { cn } from "@/lib/utils";
 
-const SLACK_BORDER = "rgb(37 37 38)";
-const SLACK_BG = "rgb(22 22 23)";
+const SLACK_BORDER = "rgb(38 38 38)"; // surface-400
+const SLACK_BG = "rgb(23 23 23)"; // surface-700
 
 // Slack notification inner content. No outer frame — callers wrap it in a
 // frame (static border/bg here, animated wrapper in slack-to-signal-morph).
 export const SlackContent = () => (
   <div className="flex gap-3 items-start w-full px-3 pt-2 pb-3">
-    <div className="shrink-0 size-8 bg-landing-surface-800 rounded flex items-center justify-center overflow-hidden">
+    <div className="shrink-0 size-8 bg-surface-900 rounded flex items-center justify-center overflow-hidden">
       <svg width="16" height="16" viewBox="0 0 76 76" fill="none" className="size-4">
         <path
           fillRule="evenodd"
           clipRule="evenodd"
           d="M1.32507 73.4886C0.00220402 72.0863 0.0802819 69.9867 0.653968 68.1462C3.57273 58.7824 5.14534 48.8249 5.14534 38.5C5.14534 27.8899 3.48464 17.6677 0.408998 8.0791C-0.129499 6.40029 -0.266346 4.50696 0.811824 3.11199C2.27491 1.21902 4.56777 0 7.14535 0H37.1454C58.1322 0 75.1454 17.0132 75.1454 38C75.1454 58.9868 58.1322 76 37.1454 76H7.14535C4.85185 76 2.78376 75.0349 1.32507 73.4886Z"
-          fill="var(--color-landing-text-400)"
+          fill="var(--color-foreground-400)"
         />
       </svg>
     </div>
@@ -21,33 +21,33 @@ export const SlackContent = () => (
     <div className="flex flex-1 flex-col gap-3 items-start min-w-0 overflow-hidden">
       <div className="flex flex-col gap-1 w-full">
         <div className="flex items-center gap-1 w-full whitespace-nowrap font-sans text-xs">
-          <p className="text-landing-text-200">Laminar</p>
-          <div className="bg-landing-surface-500 rounded px-1 py-0.5 flex items-center justify-center">
-            <p className="text-[8px] leading-none text-landing-text-200">APP</p>
+          <p className="text-foreground-200">Laminar</p>
+          <div className="bg-surface-400 rounded px-1 py-0.5 flex items-center justify-center">
+            <p className="text-[8px] leading-none text-foreground-200">APP</p>
           </div>
-          <p className="text-landing-text-300">3:18 pm</p>
+          <p className="text-foreground-300">3:18 pm</p>
         </div>
 
         <div className="flex gap-0.5 items-center font-sans text-xs">
-          <div className="bg-muted border border-landing-surface-400 rounded px-1.5 py-px">
-            <p className="text-landing-primary-400/60 whitespace-nowrap">Failure</p>
+          <div className="bg-muted border border-surface-200 rounded px-1.5 py-px">
+            <p className="text-primary-400/60 whitespace-nowrap">Failure</p>
           </div>
-          <p className="text-landing-text-200 whitespace-nowrap">: New Event</p>
+          <p className="text-foreground-200 whitespace-nowrap">: New Event</p>
         </div>
       </div>
 
-      <p className="font-sans text-xs leading-relaxed text-landing-text-200 w-full">
+      <p className="font-sans text-xs leading-relaxed text-foreground-200 w-full">
         Agent run flagged 4 issues. In one anthropic.messages the agent decided to run <code>python</code> (macOS only
         ships <code>python3</code>), Bash then hit <code>command not found</code> three times before recovering, a
         parallel Bash pair cascade-cancelled, and Read missed when the shell CWD drifted after a <code>cd</code>.
       </p>
 
       <div className="flex flex-row gap-2 items-center">
-        <div className="bg-landing-surface-500 px-2 py-1 rounded">
-          <p className="font-sans text-xs text-landing-text-200">View Trace</p>
+        <div className="bg-surface-400 px-2 py-1 rounded">
+          <p className="font-sans text-xs text-foreground-200">View Trace</p>
         </div>
-        <div className="bg-landing-surface-500 px-2 py-1 rounded">
-          <p className="font-sans text-xs text-landing-text-200">View similar events</p>
+        <div className="bg-surface-400 px-2 py-1 rounded">
+          <p className="font-sans text-xs text-foreground-200">View similar events</p>
         </div>
       </div>
     </div>

--- a/frontend/components/landing/sections/slack-to-signal-morph.tsx
+++ b/frontend/components/landing/sections/slack-to-signal-morph.tsx
@@ -26,15 +26,15 @@ interface Props {
 
 // Outer card colors at the two endpoints. Framer interpolates rgb/hex
 // strings, but NOT CSS `var(...)` references — must use literal color
-// values here. FLAG: if you ever update --color-landing-surface-* tokens
+// values here. FLAG: if you ever update --color-surface-* tokens
 // in globals.css, sync these constants by hand (or this morph will drift
 // from the rest of the page).
-const SLACK_BORDER = "rgb(37 37 38)"; // landing-surface-500
-const SLACK_BG = "rgb(22 22 23)"; // landing-surface-700 (was mis-commented)
+const SLACK_BORDER = "rgb(38 38 38)"; // surface-400
+const SLACK_BG = "rgb(23 23 23)"; // surface-700
 const SIGNAL_BORDER = "rgb(49 134 255 / 0.6)";
 const SIGNAL_BG = "rgb(49 134 255 / 0.12)";
-// Midpoint background — exact hex of --color-landing-surface-600.
-const MIDPOINT_BG = "#1b1b1c44";
+// Midpoint background — exact hex of --color-surface-600.
+const MIDPOINT_BG = "#1c1c1c44";
 
 // Morphs from a Slack notification (progress=0) to a Signal event card
 // (progress=1). The content swaps at the midpoint; the wrapper's height is

--- a/frontend/components/landing/sections/two-lines-to-integrate/integrations-grid.tsx
+++ b/frontend/components/landing/sections/two-lines-to-integrate/integrations-grid.tsx
@@ -85,7 +85,7 @@ const IntegrationsGrid = ({ className }: Props) => (
             className={cn("size-4 object-contain", integration.iconClassName)}
           />
         </div>
-        <p className="font-sans-landing text-lg font-[480] text-landing-text-200 transition-colors group-hover:text-white">
+        <p className="font-sans-landing text-lg font-[480] text-foreground-200 transition-colors group-hover:text-white">
           {integration.alt}
         </p>
       </Link>

--- a/frontend/components/landing/sections/two-lines-to-integrate/learn-more-link.tsx
+++ b/frontend/components/landing/sections/two-lines-to-integrate/learn-more-link.tsx
@@ -17,7 +17,7 @@ const LearnMoreLink = ({ label, href, className }: Props) => (
     target={href.startsWith("http") ? "_blank" : undefined}
     className={cn(
       microLabel,
-      "inline-flex text-base items-center gap-2 hover:text-landing-text-200 transition-colors",
+      "inline-flex text-base items-center gap-2 hover:text-foreground-200 transition-colors",
       className
     )}
   >

--- a/frontend/components/landing/sections/understand-why-trace-view/ask-ai.tsx
+++ b/frontend/components/landing/sections/understand-why-trace-view/ask-ai.tsx
@@ -87,10 +87,10 @@ const SpanChip = ({ kind, label, onClick }: { kind: "tool" | "llm"; label: strin
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1 rounded border border-landing-text-200/15 bg-landing-text-200/15 pl-0.5 pr-1.5 py-0.5 align-middle hover:bg-landing-text-200/25 transition-colors"
+      className="inline-flex items-center gap-1 rounded border border-foreground-200/15 bg-foreground-200/15 pl-0.5 pr-1.5 py-0.5 align-middle hover:bg-foreground-200/25 transition-colors"
     >
       <span className={cn("inline-flex items-center justify-center size-4 rounded", iconBg)}>{icon}</span>
-      <span className="text-landing-text-200 text-xs leading-none font-mono">{label}</span>
+      <span className="text-foreground-200 text-xs leading-none font-mono">{label}</span>
     </button>
   );
 };

--- a/frontend/components/landing/sections/understand-why-trace-view/index.tsx
+++ b/frontend/components/landing/sections/understand-why-trace-view/index.tsx
@@ -85,7 +85,7 @@ const TimelineBodyLink = ({ spanId, label }: { spanId: string; label: string }) 
     <button
       type="button"
       onClick={() => selectAndRevealSpan(spanId)}
-      className="underline underline-offset-2 decoration-landing-text-400 hover:text-landing-text-100 hover:decoration-landing-text-200 transition-colors cursor-pointer"
+      className="underline underline-offset-2 decoration-foreground-400 hover:text-foreground-50 hover:decoration-foreground-200 transition-colors cursor-pointer"
     >
       {label}
     </button>
@@ -197,7 +197,7 @@ const UnderstandWhyTraceView = () => {
               <div className="sticky top-0 h-screen overflow-hidden flex flex-col justify-center items-center">
                 <div className="h-[760px] w-full overflow-hidden relative">
                   {/* Top gradient — text fades into page bg at top of viewport */}
-                  <div className="absolute top-0 left-0 right-0 z-10 bg-gradient-to-b from-landing-surface-700 to-transparent pointer-events-none h-[100px]" />
+                  <div className="absolute top-0 left-0 right-0 z-10 bg-gradient-to-b from-surface-700 to-transparent pointer-events-none h-[100px]" />
 
                   {/* Stack wrapper — vertically centered in viewport via flex
                   items-center. Inner motion.div uses `style={{ y }}` with
@@ -229,7 +229,7 @@ const UnderstandWhyTraceView = () => {
                   </div>
 
                   {/* Bottom gradient — text fades into page bg at bottom of viewport */}
-                  <div className="absolute bottom-0 left-0 right-0 z-10 bg-gradient-to-t from-landing-surface-700 to-transparent pointer-events-none h-[120px]" />
+                  <div className="absolute bottom-0 left-0 right-0 z-10 bg-gradient-to-t from-surface-700 to-transparent pointer-events-none h-[120px]" />
                 </div>
               </div>
             </div>
@@ -240,14 +240,14 @@ const UnderstandWhyTraceView = () => {
               overflows (the inner grows past parent's content area, and
               `justify-end` on outer pins its right edge).
               Top + bottom gradient fades mirror the LEFT column, but
-              fade INTO the rectangle's own bg (`landing-surface-550`)
+              fade INTO the rectangle's own bg (`surface-500`)
               rather than the page bg. z-10 puts gradients above the
               bento (z-0) and below the footnote (z-20 inside
               SectionFootnote), so the footnote stays legible over the
               bottom gradient. */}
             <div className="relative">
               <div className="sticky top-0 left-0 flex justify-center items-center h-screen">
-                <div className="w-[480px] h-[760px] rounded-sm bg-landing-surface-550 overflow-hidden flex items-center justify-end px-5 relative">
+                <div className="w-[480px] h-[760px] rounded-sm bg-surface-500 overflow-hidden flex items-center justify-end px-5 relative">
                   <div className="min-w-full shrink-0 flex items-center justify-center">
                     <TraceBento phase={phase} morphProgress={morphProgress} trace={trace} spans={spans ?? []} />
                   </div>
@@ -255,11 +255,11 @@ const UnderstandWhyTraceView = () => {
                   {/* Left gradient — only in the Ask AI phase, where chat content
                     bleeds toward the left edge and needs the fade. */}
                   {phase === 4 && (
-                    <div className="absolute bottom-0 left-0 top-0 z-10 bg-gradient-to-r from-landing-surface-550/80 to-transparent pointer-events-none w-[80px]" />
+                    <div className="absolute bottom-0 left-0 top-0 z-10 bg-gradient-to-r from-surface-500/80 to-transparent pointer-events-none w-[80px]" />
                   )}
 
                   {/* Bottom gradient */}
-                  <div className="absolute bottom-0 left-0 right-0 z-10 bg-gradient-to-t from-landing-surface-550 to-transparent pointer-events-none h-[120px]" />
+                  <div className="absolute bottom-0 left-0 right-0 z-10 bg-gradient-to-t from-surface-500 to-transparent pointer-events-none h-[120px]" />
 
                   <SectionFootnote name={activeBand.name} href={activeBand.learnMoreHref} />
                 </div>

--- a/frontend/components/landing/sections/understand-why-trace-view/mobile.tsx
+++ b/frontend/components/landing/sections/understand-why-trace-view/mobile.tsx
@@ -35,7 +35,7 @@ const UnderstandWhyTraceViewMobile = () => {
             }
           </p>
         </div>
-        <div className="bg-landing-surface-550 relative w-full overflow-hidden h-[280px] px-5 py-4 flex flex-col justify-center">
+        <div className="bg-surface-500 relative w-full overflow-hidden h-[280px] px-5 py-4 flex flex-col justify-center">
           <SlackNotificationCard className="w-[600px] max-w-[600px] shrink-0" />
           <SectionFootnote name="Signals" href="https://laminar.sh/docs/signals/introduction" />
         </div>
@@ -48,7 +48,7 @@ const UnderstandWhyTraceViewMobile = () => {
           <h2 className={subSection}>{"Understand why\nin seconds."}</h2>
           <p className={bodyMedium}>{"Go from issue description to the\nexact step that caused it."}</p>
         </div>
-        <div className="bg-landing-surface-550 relative w-full overflow-hidden h-[280px] px-5 py-4 flex flex-col justify-center">
+        <div className="bg-surface-500 relative w-full overflow-hidden h-[280px] px-5 py-4 flex flex-col justify-center">
           <SignalEventCard className="w-[600px] max-w-[600px] shrink-0" />
           <SectionFootnote name="Signals" href="https://laminar.sh/docs/signals/introduction" />
         </div>
@@ -63,12 +63,12 @@ const UnderstandWhyTraceViewMobile = () => {
             in a readable transcript and timeline.
           </p>
         </div>
-        <div className="bg-landing-surface-550 relative w-full overflow-hidden h-[360px]">
+        <div className="bg-surface-500 relative w-full overflow-hidden h-[360px]">
           {/* Centering pattern (see has-this-issue): flex + `mx-auto shrink-0`
               centers the card when there's room and left-overflows when not. */}
           <div ref={transcriptRef} className="absolute inset-0 flex px-8">
             <div
-              className="border-[0.5px] border-landing-surface-500 rounded-lg overflow-hidden shrink-0 mx-auto h-full"
+              className="border-[0.5px] border-surface-400 rounded-lg overflow-hidden shrink-0 mx-auto h-full"
               style={{ width: 480 }}
             >
               <motion.img
@@ -78,9 +78,9 @@ const UnderstandWhyTraceViewMobile = () => {
                 className="pointer-events-none select-none"
               />
             </div>
-            <div className="absolute top-0 left-0 right-0 h-[40px] bg-gradient-to-b from-landing-surface-550/80 to-transparent pointer-events-none z-10" />
+            <div className="absolute top-0 left-0 right-0 h-[40px] bg-gradient-to-b from-surface-500/80 to-transparent pointer-events-none z-10" />
           </div>
-          <div className="absolute bottom-0 left-0 right-0 h-[160px] bg-gradient-to-t from-landing-surface-550 to-transparent pointer-events-none z-10" />
+          <div className="absolute bottom-0 left-0 right-0 h-[160px] bg-gradient-to-t from-surface-500 to-transparent pointer-events-none z-10" />
           <SectionFootnote name="Transcript view" href="https://laminar.sh/docs/platform/viewing-traces" />
         </div>
       </div>
@@ -98,9 +98,9 @@ const UnderstandWhyTraceViewMobile = () => {
             that you can jump to directly.
           </p>
         </div>
-        <div className="bg-landing-surface-550 relative w-full overflow-hidden h-[360px] flex items-end justify-end px-8 pt-4 pb-12">
+        <div className="bg-surface-500 relative w-full overflow-hidden h-[360px] flex items-end justify-end px-8 pt-4 pb-12">
           <div
-            className="border-[0.5px] border-landing-surface-400 rounded-lg overflow-hidden shrink-0 mx-auto relative origin-bottom-right scale-80"
+            className="border-[0.5px] border-surface-200 rounded-lg overflow-hidden shrink-0 mx-auto relative origin-bottom-right scale-80"
             style={{ width: 480, height: 491 }}
           >
             <Image
@@ -111,7 +111,7 @@ const UnderstandWhyTraceViewMobile = () => {
               className="object-cover object-right-bottom pointer-events-none select-none"
             />
           </div>
-          <div className="absolute top-0 left-0 right-0 h-[40px] bg-gradient-to-b from-landing-surface-550/80 to-transparent pointer-events-none z-10" />
+          <div className="absolute top-0 left-0 right-0 h-[40px] bg-gradient-to-b from-surface-500/80 to-transparent pointer-events-none z-10" />
           <SectionFootnote name="Ask AI" href="https://laminar.sh/docs/platform/viewing-traces#chat-with-trace" />
         </div>
       </div>

--- a/frontend/components/landing/sections/understand-why-trace-view/trace-bento.tsx
+++ b/frontend/components/landing/sections/understand-why-trace-view/trace-bento.tsx
@@ -271,12 +271,12 @@ const TraceBento = ({ phase, morphProgress, trace, spans, onAllPanelsOpenChange 
   return (
     <motion.div
       initial={{
-        borderColor: "rgb(37 37 38 / 0)",
+        borderColor: "rgb(38 38 38 / 0)",
         backgroundColor: "rgb(10 10 10 / 0)",
         height: 0,
       }}
       animate={{
-        borderColor: phase >= 2 ? "rgb(37 37 38)" : "rgb(37 37 38 / 0)",
+        borderColor: phase >= 2 ? "rgb(38 38 38)" : "rgb(38 38 38 / 0)",
         backgroundColor: phase >= 2 ? "rgb(10 10 10)" : "rgb(10 10 10 / 0)",
         height: phase >= 2 ? BENTO_HEIGHT : headerHeight,
       }}

--- a/frontend/components/onboarding/steps/plan-step/plan-card.tsx
+++ b/frontend/components/onboarding/steps/plan-step/plan-card.tsx
@@ -26,8 +26,8 @@ export default function PlanCard({ plan, selected, onSelect, disabled = false, i
       aria-pressed={selected}
       aria-disabled={disabled}
       className={cn(
-        "relative flex flex-col gap-3 2xl:gap-4 rounded-md p-4 xl:p-5 2xl:p-6 text-left transition-all bg-landing-surface-550",
-        !disabled && "hover:bg-landing-surface-500",
+        "relative flex flex-col gap-3 2xl:gap-4 rounded-md p-4 xl:p-5 2xl:p-6 text-left transition-all bg-surface-500",
+        !disabled && "hover:bg-surface-400",
         selected && "ring-1 ring-inset ring-primary",
         disabled && "opacity-50 cursor-not-allowed"
       )}
@@ -42,7 +42,7 @@ export default function PlanCard({ plan, selected, onSelect, disabled = false, i
       <div className="flex items-center justify-between gap-2">
         <span className="text-sm xl:text-base 2xl:text-lg text-white">{plan.name}</span>
         {isCurrent ? (
-          <span className="text-[10px] 2xl:text-xs px-1.5 py-0.5 rounded-full bg-landing-surface-400 text-white font-medium">
+          <span className="text-[10px] 2xl:text-xs px-1.5 py-0.5 rounded-full bg-surface-200 text-white font-medium">
             Current
           </span>
         ) : (
@@ -58,17 +58,17 @@ export default function PlanCard({ plan, selected, onSelect, disabled = false, i
         <span className="font-sans-landing font-medium text-2xl xl:text-3xl 2xl:text-4xl leading-none text-white tracking-[-0.02em]">
           {plan.price}
         </span>
-        <span className="text-xs 2xl:text-sm text-landing-text-400">{plan.priceSubtext}</span>
+        <span className="text-xs 2xl:text-sm text-foreground-400">{plan.priceSubtext}</span>
       </p>
 
       <ul className="flex flex-col gap-1.5 2xl:gap-2 flex-1">
         {plan.features.map((f) => (
           <li key={f.label} className="flex flex-col gap-0.5">
             <div className="flex items-start gap-2">
-              <Check className="h-3 w-3 2xl:h-4 2xl:w-4 mt-0.5 shrink-0 text-landing-text-300" strokeWidth={2.5} />
-              <span className="text-sm text-landing-text-200">{f.label}</span>
+              <Check className="h-3 w-3 2xl:h-4 2xl:w-4 mt-0.5 shrink-0 text-foreground-300" strokeWidth={2.5} />
+              <span className="text-sm text-foreground-200">{f.label}</span>
             </div>
-            {f.sub && <span className="text-xs text-landing-text-400 ml-[22px] 2xl:ml-[24px]">{f.sub}</span>}
+            {f.sub && <span className="text-xs text-foreground-400 ml-[22px] 2xl:ml-[24px]">{f.sub}</span>}
           </li>
         ))}
       </ul>

--- a/frontend/components/onboarding/steps/plan-step/plan-card.tsx
+++ b/frontend/components/onboarding/steps/plan-step/plan-card.tsx
@@ -14,7 +14,7 @@ interface PlanCardProps {
 }
 
 // Styled to match the regular (non-accent) pricing-page tier columns: a flat
-// surface-550 panel, no border, no divider under the price, landing fonts.
+// surface-500 panel, no border, no divider under the price, landing fonts.
 // Selection uses an INSET ring (drawn inside the box) so the ScrollArea's overflow
 // can't clip it the way an outset ring/border at the grid edge would be.
 export default function PlanCard({ plan, selected, onSelect, disabled = false, isCurrent = false }: PlanCardProps) {

--- a/frontend/components/onboarding/steps/signals-step.tsx
+++ b/frontend/components/onboarding/steps/signals-step.tsx
@@ -71,7 +71,7 @@ export default function SignalsStep({ stepIndex, totalSteps, onAdvance }: Signal
                     aria-pressed={isSelected}
                     className={cn(
                       "flex items-start gap-3 text-left rounded-md p-3 transition-colors h-full pb-4 xl:pb-8 pt-4",
-                      isSelected ? "border border-primary/50 bg-primary/5" : "bg-landing-surface-800"
+                      isSelected ? "border border-primary/50 bg-primary/5" : "bg-surface-900"
                     )}
                   >
                     <div className="mt-0.5 flex items-center gap-2 shrink-0">

--- a/frontend/components/onboarding/steps/slack-step.tsx
+++ b/frontend/components/onboarding/steps/slack-step.tsx
@@ -63,7 +63,7 @@ export default function SlackStep({ stepIndex, totalSteps, onAdvance, onBack }: 
       onBack={onBack}
       isSubmitting={isSubmitting}
     >
-      <div className="flex items-start gap-3 rounded-lg border border-border bg-landing-surface-600 px-4 py-3">
+      <div className="flex items-start gap-3 rounded-lg border border-border bg-surface-600 px-4 py-3">
         <div className="my-auto">
           <Image src={slackLogo} alt="Slack" className="mt-0.5 shrink-0 h-7.5 w-7.5 2xl:h-8 2xl:w-8" />
         </div>

--- a/frontend/components/traces/trace-view/condensed-timeline/index.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/index.tsx
@@ -239,11 +239,11 @@ function CondensedTimeline() {
               }}
             >
               <div className="absolute top-0 h-6 flex items-center -translate-x-1/2 z-[34]">
-                <div className="size-5 bg-landing-text-500 text-primary-foreground rounded-full flex items-center justify-center">
+                <div className="size-5 bg-foreground-500 text-primary-foreground rounded-full flex items-center justify-center">
                   <PlayIcon className="w-3 h-3" />
                 </div>
               </div>
-              <div className="absolute top-[6px] bottom-[-60px] w-px bg-landing-text-500" />
+              <div className="absolute top-[6px] bottom-[-60px] w-px bg-foreground-500" />
             </div>
           )}
 

--- a/frontend/components/traces/trace-view/condensed-timeline/selection-indicator.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/selection-indicator.tsx
@@ -12,7 +12,7 @@ const SelectionIndicator = ({ selectedCount, onClear }: SelectionIndicatorProps)
     <div className="absolute bottom-1.5 left-1/2 -translate-x-1/2 z-40">
       <button
         onClick={onClear}
-        className="flex items-center gap-1.5 px-2 h-[24px] bg-landing-surface-500 border border-landing-text-600 text-landing-text-200 text-xs rounded-full shadow-md hover:bg-landing-surface-400"
+        className="flex items-center gap-1.5 px-2 h-[24px] bg-surface-400 border border-foreground-600 text-foreground-200 text-xs rounded-full shadow-md hover:bg-surface-200"
         aria-label={`Clear selection of ${selectedCount} spans`}
       >
         <span>Clear selection ({selectedCount})</span>

--- a/frontend/components/traces/trace-view/span-reference/index.tsx
+++ b/frontend/components/traces/trace-view/span-reference/index.tsx
@@ -49,7 +49,7 @@ function SpanChip({
         e.preventDefault();
         onClick();
       }}
-      className="inline-flex items-center gap-1 rounded px-1 py-0.25 align-middle bg-landing-text-300/20 hover:bg-landing-text-300/30 transition-colors cursor-pointer"
+      className="inline-flex items-center gap-1 rounded px-1 py-0.25 align-middle bg-foreground-300/20 hover:bg-foreground-300/30 transition-colors cursor-pointer"
     >
       <span
         className="inline-flex items-center justify-center rounded size-4 shrink-0"


### PR DESCRIPTION
## Summary

Consolidates the duplicated landing/platform palettes into three shared, OKLCH-expressed color ramps in `frontend/app/globals.css`, and removes the `landing-*` color token family entirely.

- **Surface ramp** (`surface-200`…`1000`) and **foreground/text ramp** (`foreground-50`…`600`) added as neutral, dark-theme scales. Semantic tokens — `background`, `card`, `secondary`, `popover`, `muted`, `accent`, `border`, and the `*-foreground` text tokens — now reference these ramps.
- **Dropped** `landing-surface-*`, `landing-text-*`, and `landing-primary-*` tokens; all usages rewritten onto the unified `surface`/`foreground`/`primary` scales via a nearest-color remap.
- **`--color-primary`** now maps to the canonical brand orange (`primary-400`) — same hue as the old `hsl(18 59% 55%)`, so no visual shift.
- All three ramps are expressed in **OKLCH**, with source hex/rgb retained as comments.

## Notes

- Neutral ramps came out as pure `oklch(L 0 0)`; the primary ramp carries real chroma/hue (the brand orange).
- A few literal mirror constants used by Framer Motion animations (`slack-to-signal-morph`, `slack-notification-card`, `trace-bento`) were kept as `rgb(...)` and synced to the new values, since Framer can't interpolate `var()`/`oklch()`.
- The orphaned `--primary`/`--primary-foreground` HSL vars in `:root` were left in place (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad visual refactor across marketing and product UI; intentional nearest-step remaps may cause subtle contrast or hover differences, and Framer rgb constants can drift from CSS if ramps change without manual sync.
> 
> **Overview**
> **Unifies marketing and app styling** by replacing the separate `landing-surface-*`, `landing-text-*`, and `landing-primary-*` token families with shared **`surface`**, **`foreground`**, and **`primary`** ramps defined in OKLCH in `globals.css`.
> 
> Semantic Tailwind/shadcn tokens (`background`, `card`, `secondary`, `muted`, `border`, `primary`, etc.) now point at those ramps instead of legacy HSL-only values, so dashboard and marketing surfaces draw from one palette. Usages across auth, onboarding, blog, pricing, landing sections, trace/debugger UI, and shared class-name helpers are updated to the new utilities (e.g. `bg-surface-700`, `text-foreground-200`, `bg-primary-200`).
> 
> Framer Motion paths that cannot tween CSS variables keep **hard-coded `rgb(...)`** literals aligned to the new ramp values (Slack→signal morph, trace bento borders). Scrollbars, text selection, and blog table styles reference the unified tokens. Legacy `:root` HSL variables are left in place but are no longer what `@theme` maps to for the main semantic colors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb13c04fa9df4519be7cc3808117c6ed31832b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->