### PR TITLE
fix(playground): handle legacy string content in transformFromLegacy

### DIFF
--- a/frontend/lib/playground/utils.ts
+++ b/frontend/lib/playground/utils.ts
@@ -29,39 +29,48 @@ export const parseSystemMessages = (messages: Message[]): ModelMessage[] =>
   });
 
 export const transformFromLegacy = (messages: Message[]): Message[] =>
-  messages.map((message) => ({
-    ...message,
-    content: message.content.map((part: any) => {
-      switch (part.type) {
-        case "tool-call":
-          // V4 format: { type: "tool-call", toolCallId, toolName, args }
-          // V5 format: { type: "tool-call", toolCallId, toolName, input }
-          if ("args" in part && !("input" in part)) {
-            const { args, ...rest } = part;
-            return {
-              ...rest,
-              input: typeof args === "string" ? tryParseJson(args || "{}") : args || {},
-            };
-          }
-          return part;
+  messages.map((message) => {
+    // Legacy rows (saved before the AI SDK v5 migration) store content as a
+    // plain string instead of a parts array. Normalize so the mapping below
+    // doesn't crash on `.map`.
+    const rawContent = message.content as unknown;
+    const content: Message["content"] =
+      typeof rawContent === "string" ? [{ type: "text", text: rawContent }] : (rawContent as Message["content"]);
 
-        case "tool-result":
-          // V4 format: { type: "tool-result", toolCallId, toolName, result }
-          // V5 format: { type: "tool-result", toolCallId, toolName, output: { type, value } }
-          if ("result" in part && !("output" in part)) {
-            const { result, ...rest } = part;
-            return {
-              ...rest,
-              output: {
-                type: "text",
-                value: result,
-              },
-            };
-          }
-          return part;
+    return {
+      ...message,
+      content: content.map((part: any) => {
+        switch (part.type) {
+          case "tool-call":
+            // V4 format: { type: "tool-call", toolCallId, toolName, args }
+            // V5 format: { type: "tool-call", toolCallId, toolName, input }
+            if ("args" in part && !("input" in part)) {
+              const { args, ...rest } = part;
+              return {
+                ...rest,
+                input: typeof args === "string" ? tryParseJson(args || "{}") : args || {},
+              };
+            }
+            return part;
 
-        default:
-          return part;
-      }
-    }),
-  }));
+          case "tool-result":
+            // V4 format: { type: "tool-result", toolCallId, toolName, result }
+            // V5 format: { type: "tool-result", toolCallId, toolName, output: { type, value } }
+            if ("result" in part && !("output" in part)) {
+              const { result, ...rest } = part;
+              return {
+                ...rest,
+                output: {
+                  type: "text",
+                  value: result,
+                },
+              };
+            }
+            return part;
+
+          default:
+            return part;
+        }
+      }),
+    };
+  });

--- a/frontend/tests/test-playground-transform-from-legacy.test.ts
+++ b/frontend/tests/test-playground-transform-from-legacy.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { type Message } from "@/lib/playground/types";
+import { transformFromLegacy } from "@/lib/playground/utils";
+
+describe("transformFromLegacy", () => {
+  it("normalizes legacy plain-string content into a text part", () => {
+    // Rows saved before the AI SDK v5 migration store content as a string.
+    const messages = [{ role: "user", content: "hello world" }] as unknown as Message[];
+
+    const result = transformFromLegacy(messages);
+
+    assert.deepStrictEqual(result, [
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello world" }],
+      },
+    ]);
+  });
+
+  it("leaves array content untouched and upgrades V4 tool parts", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "calling a tool" },
+          { type: "tool-call", toolCallId: "1", toolName: "search", args: '{"q":"x"}' },
+        ],
+      },
+    ] as unknown as Message[];
+
+    const result = transformFromLegacy(messages);
+
+    assert.deepStrictEqual(result, [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "calling a tool" },
+          { type: "tool-call", toolCallId: "1", toolName: "search", input: { q: "x" } },
+        ],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

Opening a playground that was saved **before the AI SDK v5 migration** crashes the playground panel with:

```
message.content.map is not a function
```

Those legacy rows store the message `content` as a plain string, but `transformFromLegacy` in `frontend/lib/playground/utils.ts` assumes `content` is always a parts array and calls `.map` on it directly.

Fixes #1905

## Repro

Open any playground saved before the AI SDK v5 migration (a row whose `content` is a string rather than an array of parts).

## Fix

Normalize string `content` into a single `text` part before mapping, so the existing V4→V5 part-upgrade logic runs unchanged for arrays:

```ts
const rawContent = message.content as unknown;
const content: Message["content"] =
  typeof rawContent === "string" ? [{ type: "text", text: rawContent }] : (rawContent as Message["content"]);
```

The cast through `unknown` is needed because `Message["content"]` is typed as an array, but legacy DB rows violate that at runtime.

## Tests

Added `frontend/tests/test-playground-transform-from-legacy.test.ts`:
- legacy plain-string content is normalized into a `text` part
- array content is left untouched and V4 tool-call parts are still upgraded to V5

Verification:
- `pnpm test` — 117/117 pass (2 new)
- `pnpm type-check` — 0 errors
- `pnpm lint` — clean on changed files

## AI disclosure

This change was produced with **Claude Code** (model: Claude Opus). The diff, the root-cause analysis, and the tests were reviewed by a human before submission.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized backward-compatibility fix in playground message loading with unit tests; no auth, security, or data-write path changes.
> 
> **Overview**
> Fixes a crash when loading **pre–AI SDK v5** playgrounds whose messages store `content` as a plain string instead of a parts array (`message.content.map is not a function`).
> 
> **`transformFromLegacy`** now normalizes string `content` into a single `{ type: "text", text: ... }` part before running the existing V4→V5 part upgrades (`args`→`input`, `result`→`output`). Array-shaped messages behave as before.
> 
> Adds **`test-playground-transform-from-legacy.test.ts`** covering string normalization and unchanged V4 tool-call upgrading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 443bb19ea4d4e63db24ed8d642da458442e283e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->