### PR TITLE
fix(playground): handle legacy string message content

### DIFF
--- a/frontend/lib/playground/utils.ts
+++ b/frontend/lib/playground/utils.ts
@@ -1,8 +1,14 @@
 import { type ModelMessage, type SystemModelMessage, type ToolModelMessage } from "ai";
 
-import { type Message } from "@/lib/playground/types";
+import { type Message, type TextPart } from "@/lib/playground/types";
 
 import { tryParseJson } from "../utils";
+
+// Legacy rows (pre AI SDK v5) stored message content as a plain string instead
+// of a parts array. Normalize those into a single text part so the editor —
+// and the .map() below — always see an array.
+const toContentParts = (content: Message["content"]): Message["content"] =>
+  Array.isArray(content) ? content : [{ type: "text", text: String(content ?? "") } as TextPart];
 
 export const parseSystemMessages = (messages: Message[]): ModelMessage[] =>
   messages.map((message) => {
@@ -31,7 +37,7 @@ export const parseSystemMessages = (messages: Message[]): ModelMessage[] =>
 export const transformFromLegacy = (messages: Message[]): Message[] =>
   messages.map((message) => ({
     ...message,
-    content: message.content.map((part: any) => {
+    content: toContentParts(message.content).map((part: any) => {
       switch (part.type) {
         case "tool-call":
           // V4 format: { type: "tool-call", toolCallId, toolName, args }

--- a/frontend/lib/playground/utils.ts
+++ b/frontend/lib/playground/utils.ts
@@ -7,7 +7,7 @@ import { tryParseJson } from "../utils";
 // Legacy rows (pre AI SDK v5) stored message content as a plain string instead
 // of a parts array. Normalize those into a single text part so the editor —
 // and the .map() below — always see an array.
-const toContentParts = (content: Message["content"]): Message["content"] =>
+const toContentParts = (content: Message["content"] | string | null | undefined): Message["content"] =>
   Array.isArray(content) ? content : [{ type: "text", text: String(content ?? "") } as TextPart];
 
 export const parseSystemMessages = (messages: Message[]): ModelMessage[] =>

--- a/frontend/tests/playground-transform-legacy.test.ts
+++ b/frontend/tests/playground-transform-legacy.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { type Message } from "@/lib/playground/types";
+import { transformFromLegacy } from "@/lib/playground/utils";
+
+test("transformFromLegacy normalizes legacy string content into a text part", () => {
+  // Pre AI SDK v5 rows stored content as a plain string.
+  const legacy = [{ role: "user", content: "hello world" }] as unknown as Message[];
+
+  const result = transformFromLegacy(legacy);
+
+  assert.deepEqual(result[0].content, [{ type: "text", text: "hello world" }]);
+});
+
+test("transformFromLegacy preserves array content and upgrades v4 tool-call/result parts", () => {
+  const messages = [
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "hi" },
+        { type: "tool-call", toolCallId: "1", toolName: "t", args: '{"a":1}' },
+        { type: "tool-result", toolCallId: "1", toolName: "t", result: "ok" },
+      ],
+    },
+  ] as unknown as Message[];
+
+  const result = transformFromLegacy(messages);
+  const parts = result[0].content as any[];
+
+  assert.deepEqual(parts[0], { type: "text", text: "hi" });
+  assert.deepEqual(parts[1], { type: "tool-call", toolCallId: "1", toolName: "t", input: { a: 1 } });
+  assert.deepEqual(parts[2], {
+    type: "tool-result",
+    toolCallId: "1",
+    toolName: "t",
+    output: { type: "text", value: "ok" },
+  });
+});
+
+test("transformFromLegacy handles nullish legacy content without throwing", () => {
+  const legacy = [{ role: "assistant", content: null }] as unknown as Message[];
+
+  const result = transformFromLegacy(legacy);
+
+  assert.deepEqual(result[0].content, [{ type: "text", text: "" }]);
+});


### PR DESCRIPTION
## Summary

- Playgrounds saved before the AI SDK v5 migration store message `content` as a plain **string**, but `transformFromLegacy` assumed an array and called `.map` on it.
- Opening any such playground crashed with `message.content.map is not a function`.
- Fix: normalize non-array (legacy string / nullish) `content` into a single `text` part before mapping, so the editor and the v4→v5 part upgrade always see an array.

Fixes #1905

## Verification

```
$ npx tsx --test tests/playground-transform-legacy.test.ts
# tests 3
# pass 3
# fail 0
```

- New regression test covers legacy string content, preserved array content (v4 tool-call/tool-result upgrade), and nullish content.
- `tsc --noEmit` clean on changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized playground load-path fix with regression tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes a crash when opening playgrounds saved before the AI SDK v5 migration, where message `content` was stored as a **plain string** (or null) instead of a parts array. `transformFromLegacy` called `.map` on that value and threw **`message.content.map is not a function`**.
> 
> The change introduces **`toContentParts`**, which leaves array content unchanged and wraps non-array values in a single `{ type: "text", text: ... }` part (empty string for null/undefined). **`transformFromLegacy`** runs that normalization before the existing v4→v5 part upgrade logic.
> 
> Adds **`playground-transform-legacy.test.ts`** covering legacy string content, array + tool-call/result upgrade, and nullish content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c99ccda94bdaf7accfc9d3c208264b000ea5fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->