### PR TITLE
fix(realtime): scope SSE CORS to an origin allow-list

### DIFF
--- a/app-server/.env.example
+++ b/app-server/.env.example
@@ -51,3 +51,8 @@ QUICKWIT_SPANS_INDEX_ID=spans_v2
 
 # Optional, set this to the public URL of the frontend for the links in slack/email notifications
 # NEXT_PUBLIC_URL=https://laminar-fe.mywebsite.com
+
+# Optional, comma-separated extra origins allowed to open realtime SSE connections.
+# NEXT_PUBLIC_URL is always allowed; only set this if a different origin must reach
+# the SSE endpoint. Unset restricts realtime CORS to the frontend origin.
+# SSE_ALLOWED_ORIGINS=https://app.mywebsite.com,https://admin.mywebsite.com

--- a/app-server/src/env/server.rs
+++ b/app-server/src/env/server.rs
@@ -14,3 +14,10 @@ pub const CONSUMER_PORT: NumEnv<u16> = NumEnv::new("CONSUMER_PORT", 8002);
 pub const HTTP_PAYLOAD_LIMIT: NumEnv<usize> = NumEnv::new("HTTP_PAYLOAD_LIMIT", 5_242_880);
 /// Max gRPC request payload in bytes. Default 25 MB.
 pub const GRPC_PAYLOAD_LIMIT: NumEnv<usize> = NumEnv::new("GRPC_PAYLOAD_LIMIT", 26_214_400);
+
+/// Comma-separated extra origins allowed to open realtime SSE connections.
+/// The frontend origin (`NEXT_PUBLIC_URL`) is always allowed implicitly, so
+/// this only needs setting when a different origin must reach the SSE
+/// endpoint. Empty (default) restricts CORS to the frontend origin. Parsed at
+/// the call site, hence a bare name rather than a typed descriptor.
+pub const SSE_ALLOWED_ORIGINS: &str = "SSE_ALLOWED_ORIGINS";

--- a/app-server/src/realtime/mod.rs
+++ b/app-server/src/realtime/mod.rs
@@ -6,29 +6,47 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 use tokio::sync::mpsc;
+use url::Url;
 use uuid::Uuid;
 
 use crate::pubsub::{PubSub, PubSubTrait, SseChannel, keys::SSE_CHANNEL_PATTERN};
 
 /// Origins permitted to open SSE connections. The frontend origin
 /// (`NEXT_PUBLIC_URL`) is always included; additional origins come from the
-/// comma-separated `SSE_ALLOWED_ORIGINS`. A trailing slash is normalized away
-/// so `https://app.example.com/` and `https://app.example.com` compare equal.
+/// comma-separated `SSE_ALLOWED_ORIGINS`. Each value is reduced to its origin
+/// (`scheme://host[:port]`) so it compares equal to the browser's `Origin`
+/// header regardless of a trailing slash or path component.
 static ALLOWED_SSE_ORIGINS: LazyLock<HashSet<String>> = LazyLock::new(|| {
     let frontend = std::env::var(crate::env::notifications::NEXT_PUBLIC_URL).unwrap_or_default();
     let extra = std::env::var(crate::env::server::SSE_ALLOWED_ORIGINS).unwrap_or_default();
     build_allowed_origins(&frontend, &extra)
 });
 
+/// Reduce a configured URL to the origin form a browser sends in the `Origin`
+/// header: `scheme://host[:port]`, with no trailing slash or path. So a value
+/// like `https://app.example.com/path` is canonicalized to
+/// `https://app.example.com` and still matches. Falls back to a trailing-slash
+/// trim when the value can't be parsed as an absolute URL (or has an opaque
+/// origin), preserving the previous best-effort behaviour.
+fn canonicalize_origin(raw: &str) -> String {
+    Url::parse(raw)
+        .ok()
+        .map(|url| url.origin().ascii_serialization())
+        .filter(|origin| origin != "null")
+        .unwrap_or_else(|| raw.trim_end_matches('/').to_string())
+}
+
 /// Build the allow-list from the frontend origin plus a comma-separated list.
-/// Trailing slashes are normalized away and blanks dropped so the set holds
-/// canonical origins. Pure so the parsing is unit-testable without env state.
+/// Each entry is canonicalized to a bare origin and blanks dropped so the set
+/// holds values comparable to a browser `Origin` header. Pure so the parsing
+/// is unit-testable without env state.
 fn build_allowed_origins(frontend_url: &str, extra_csv: &str) -> HashSet<String> {
     std::iter::once(frontend_url)
         .chain(extra_csv.split(','))
-        .map(|raw| raw.trim().trim_end_matches('/'))
+        .map(str::trim)
+        .filter(|raw| !raw.is_empty())
+        .map(canonicalize_origin)
         .filter(|origin| !origin.is_empty())
-        .map(str::to_string)
         .collect()
 }
 
@@ -40,12 +58,12 @@ fn resolve_cors_origin(request_origin: Option<&str>) -> Option<String> {
     match_allowed_origin(request_origin, &ALLOWED_SSE_ORIGINS)
 }
 
-/// Pure matcher: returns the original origin string when its slash-normalized
+/// Pure matcher: returns the original origin string when its canonicalized
 /// form is in `allowed`. Split out from `resolve_cors_origin` so the matching
 /// rule can be tested without touching the env-backed global allow-list.
 fn match_allowed_origin(request_origin: Option<&str>, allowed: &HashSet<String>) -> Option<String> {
     let origin = request_origin?;
-    if allowed.contains(origin.trim_end_matches('/')) {
+    if allowed.contains(&canonicalize_origin(origin)) {
         Some(origin.to_string())
     } else {
         None
@@ -338,6 +356,30 @@ mod tests {
     fn build_allowed_origins_empty_inputs_yield_empty_set() {
         assert!(build_allowed_origins("", "").is_empty());
         assert!(build_allowed_origins("", ",  ,").is_empty());
+    }
+
+    #[test]
+    fn build_allowed_origins_strips_path_and_port() {
+        // A NEXT_PUBLIC_URL with a path must canonicalize to a bare origin so it
+        // matches the browser's Origin header (which carries no path).
+        let set = build_allowed_origins(
+            "https://app.example.com/some/path",
+            "https://dash.example.com:8443/x",
+        );
+        assert!(set.contains("https://app.example.com"));
+        assert!(set.contains("https://dash.example.com:8443"));
+        // Default port is dropped, matching how browsers send the Origin header.
+        let https = build_allowed_origins("https://app.example.com:443", "");
+        assert!(https.contains("https://app.example.com"));
+    }
+
+    #[test]
+    fn match_accepts_origin_when_config_has_path() {
+        let set = build_allowed_origins("https://app.example.com/dashboard", "");
+        assert_eq!(
+            match_allowed_origin(Some("https://app.example.com"), &set),
+            Some("https://app.example.com".to_string())
+        );
     }
 
     #[test]

--- a/app-server/src/realtime/mod.rs
+++ b/app-server/src/realtime/mod.rs
@@ -3,11 +3,54 @@ use async_stream::stream;
 use dashmap::DashMap;
 use futures_util::stream::Stream;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::collections::HashSet;
+use std::sync::{Arc, LazyLock};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::pubsub::{PubSub, PubSubTrait, SseChannel, keys::SSE_CHANNEL_PATTERN};
+
+/// Origins permitted to open SSE connections. The frontend origin
+/// (`NEXT_PUBLIC_URL`) is always included; additional origins come from the
+/// comma-separated `SSE_ALLOWED_ORIGINS`. A trailing slash is normalized away
+/// so `https://app.example.com/` and `https://app.example.com` compare equal.
+static ALLOWED_SSE_ORIGINS: LazyLock<HashSet<String>> = LazyLock::new(|| {
+    let frontend = std::env::var(crate::env::notifications::NEXT_PUBLIC_URL).unwrap_or_default();
+    let extra = std::env::var(crate::env::server::SSE_ALLOWED_ORIGINS).unwrap_or_default();
+    build_allowed_origins(&frontend, &extra)
+});
+
+/// Build the allow-list from the frontend origin plus a comma-separated list.
+/// Trailing slashes are normalized away and blanks dropped so the set holds
+/// canonical origins. Pure so the parsing is unit-testable without env state.
+fn build_allowed_origins(frontend_url: &str, extra_csv: &str) -> HashSet<String> {
+    std::iter::once(frontend_url)
+        .chain(extra_csv.split(','))
+        .map(|raw| raw.trim().trim_end_matches('/'))
+        .filter(|origin| !origin.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Echo the request's `Origin` back only when it is on the allow-list.
+/// Returns `None` (no `Access-Control-Allow-Origin` header) otherwise — the
+/// SSE endpoint must never reply with a wildcard `*`, which would let any site
+/// read a project's realtime trace data.
+fn resolve_cors_origin(request_origin: Option<&str>) -> Option<String> {
+    match_allowed_origin(request_origin, &ALLOWED_SSE_ORIGINS)
+}
+
+/// Pure matcher: returns the original origin string when its slash-normalized
+/// form is in `allowed`. Split out from `resolve_cors_origin` so the matching
+/// rule can be tested without touching the env-backed global allow-list.
+fn match_allowed_origin(request_origin: Option<&str>, allowed: &HashSet<String>) -> Option<String> {
+    let origin = request_origin?;
+    if allowed.contains(origin.trim_end_matches('/')) {
+        Some(origin.to_string())
+    } else {
+        None
+    }
+}
 
 /// Connection with unique ID for tracking
 #[derive(Clone)]
@@ -54,6 +97,7 @@ pub fn create_sse_response(
     subscription_key: SubscriptionKey,
     connections: SseConnectionMap,
     initial_message: Option<SseMessage>,
+    request_origin: Option<String>,
 ) -> ActixResult<HttpResponse> {
     let (sender, receiver) = mpsc::unbounded_channel();
     let connection_id = Uuid::new_v4();
@@ -139,14 +183,21 @@ pub fn create_sse_response(
 
     let stream = create_sse_stream(receiver);
 
-    Ok(HttpResponse::Ok()
+    let mut response = HttpResponse::Ok();
+    response
         .insert_header(("Content-Type", "text/event-stream"))
         .insert_header(("Cache-Control", "no-cache"))
         .insert_header(("Connection", "keep-alive"))
         .insert_header(("X-Accel-Buffering", "no"))
-        .insert_header(("Access-Control-Allow-Origin", "*"))
         .insert_header(("Access-Control-Allow-Headers", "Cache-Control"))
-        .streaming(stream))
+        // Response varies by Origin since the ACAO header is reflected per-origin.
+        .insert_header(("Vary", "Origin"));
+
+    if let Some(allowed_origin) = resolve_cors_origin(request_origin.as_deref()) {
+        response.insert_header(("Access-Control-Allow-Origin", allowed_origin));
+    }
+
+    Ok(response.streaming(stream))
 }
 
 /// Send message to local SSE connections only (used by Redis subscriber)
@@ -260,4 +311,55 @@ pub async fn start_redis_subscriber(
         })
         .await
         .map_err(|e| anyhow::anyhow!("Redis subscriber failed: {:?}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allowed() -> HashSet<String> {
+        build_allowed_origins(
+            "https://app.example.com/",
+            "https://dash.example.com, https://extra.example.com/ ,",
+        )
+    }
+
+    #[test]
+    fn build_allowed_origins_normalizes_and_drops_blanks() {
+        let set = allowed();
+        assert!(set.contains("https://app.example.com")); // trailing slash stripped
+        assert!(set.contains("https://dash.example.com")); // whitespace trimmed
+        assert!(set.contains("https://extra.example.com")); // slash + whitespace
+        assert!(!set.contains("")); // empty trailing csv entry dropped
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn build_allowed_origins_empty_inputs_yield_empty_set() {
+        assert!(build_allowed_origins("", "").is_empty());
+        assert!(build_allowed_origins("", ",  ,").is_empty());
+    }
+
+    #[test]
+    fn match_reflects_allowed_origin_verbatim() {
+        let set = allowed();
+        // Reflected with its original (un-normalized) form so the browser's
+        // exact Origin is echoed back.
+        assert_eq!(
+            match_allowed_origin(Some("https://app.example.com"), &set),
+            Some("https://app.example.com".to_string())
+        );
+        assert_eq!(
+            match_allowed_origin(Some("https://app.example.com/"), &set),
+            Some("https://app.example.com/".to_string())
+        );
+    }
+
+    #[test]
+    fn match_rejects_unlisted_origin() {
+        let set = allowed();
+        assert_eq!(match_allowed_origin(Some("https://evil.example.com"), &set), None);
+        // No wildcard fallback: an absent Origin header yields no ACAO header.
+        assert_eq!(match_allowed_origin(None, &set), None);
+    }
 }

--- a/app-server/src/routes/realtime.rs
+++ b/app-server/src/routes/realtime.rs
@@ -1,5 +1,5 @@
 use actix_web::{
-    HttpResponse, Result as ActixResult, get,
+    HttpRequest, HttpResponse, Result as ActixResult, get,
     web::{Data, Path, Query},
 };
 use serde::Deserialize;
@@ -16,16 +16,24 @@ pub struct RealtimeQuery {
 // SSE Endpoint on the main HTTP server (producer mode)
 #[get("realtime")]
 pub async fn sse_endpoint(
+    req: HttpRequest,
     path: Path<Uuid>,
     query: Query<RealtimeQuery>,
     connections: Data<SseConnectionMap>,
 ) -> ActixResult<HttpResponse> {
     let project_id = path.into_inner();
 
+    let request_origin = req
+        .headers()
+        .get(actix_web::http::header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+        .map(|origin| origin.to_string());
+
     create_sse_response(
         project_id,
         query.key.clone(),
         connections.get_ref().clone(),
         None,
+        request_origin,
     )
 }


### PR DESCRIPTION
## Problem

The realtime SSE endpoint (`CONSUMER_PORT`, default 8002) responded with `Access-Control-Allow-Origin: *`. Combined with a valid session, any web page could open an `EventSource` to it and stream a project's realtime trace/span/signal data cross-origin.

Closes #1873

## Fix

- Reflect the request `Origin` only when it is on an allow-list; never emit a wildcard.
- Allow-list = the frontend `NEXT_PUBLIC_URL` plus an optional comma-separated `SSE_ALLOWED_ORIGINS` for extra trusted origins.
- When the origin is not allowed, no `Access-Control-Allow-Origin` header is sent at all, so the browser blocks the cross-origin read.
- Added `Vary: Origin` since the response now depends on the request origin.

## Notes

- `SSE_ALLOWED_ORIGINS` documented in `.env.example`; empty by default, so existing single-frontend deployments keep working with just `NEXT_PUBLIC_URL`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive CORS behavior on the realtime SSE path; misconfigured `NEXT_PUBLIC_URL` or `SSE_ALLOWED_ORIGINS` could block legitimate clients or leave overly permissive setups if env is wrong.
> 
> **Overview**
> **Replaces** `Access-Control-Allow-Origin: *` on realtime SSE responses with a reflected origin only when the request is allowed, closing cross-origin reads of project trace data from arbitrary sites.
> 
> The allow-list is built from `NEXT_PUBLIC_URL` plus optional comma-separated `SSE_ALLOWED_ORIGINS` (documented in `.env.example` and `env/server.rs`). Origins are canonicalized to `scheme://host[:port]` so config paths/slashes still match browser `Origin` headers. Unlisted or missing origins get **no** `Access-Control-Allow-Origin`; responses add `Vary: Origin`. The realtime route passes the request `Origin` into `create_sse_response`, and unit tests cover parsing and matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e46ca23d67f2b3b726436b9096cfaca2ac9b0202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->