### PR TITLE
fix(sql): fall back to main ClickHouse creds for the read-only client

### DIFF
--- a/app-server/.env.example
+++ b/app-server/.env.example
@@ -15,6 +15,8 @@ RABBITMQ_URL=amqp://admin:adminpasswd@localhost:5672/%2f
 CLICKHOUSE_URL=http://localhost:8123
 CLICKHOUSE_USER=ch_user
 CLICKHOUSE_PASSWORD=ch_passwd
+# Optional dedicated read-only credentials for the SQL editor / dashboards.
+# When unset, the read-only client falls back to CLICKHOUSE_USER / CLICKHOUSE_PASSWORD.
 CLICKHOUSE_RO_USER=ch_user
 CLICKHOUSE_RO_PASSWORD=ch_passwd
 

--- a/app-server/src/features/mod.rs
+++ b/app-server/src/features/mod.rs
@@ -48,8 +48,12 @@ pub fn is_feature_enabled(feature: Feature) -> bool {
         Feature::RabbitMQ => std::env::var(env::mq::URL).is_ok(),
         Feature::SqlQueryEngine => std::env::var(env::connections::QUERY_ENGINE_URL).is_ok(),
         Feature::ClickhouseReadOnly => {
-            std::env::var(env::clickhouse::RO_USER).is_ok()
-                && std::env::var(env::clickhouse::RO_PASSWORD).is_ok()
+            // Enabled whenever ClickHouse is configured. Dedicated read-only
+            // credentials (CLICKHOUSE_RO_USER / CLICKHOUSE_RO_PASSWORD) are used
+            // when present; otherwise the read-only client falls back to the main
+            // ClickHouse credentials (see main.rs), so self-hosted deployments get
+            // a working SQL editor and dashboards out of the box.
+            std::env::var(env::clickhouse::URL).is_ok()
         }
         Feature::Tracing => {
             std::env::var(env::observability::SENTRY_DSN).is_ok()

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -914,7 +914,7 @@ fn main() -> anyhow::Result<()> {
     let clickhouse_password = std::env::var(env::clickhouse::PASSWORD);
     let clickhouse_client = clickhouse::Client::default()
         .with_url(clickhouse_url.clone())
-        .with_user(clickhouse_user)
+        .with_user(clickhouse_user.clone())
         .with_database("default")
         // Validation switches the write format from RowBinary to RowBinaryWithNamesAndTypes.
         // https://clickhouse.com/docs/interfaces/formats/RowBinaryWithNamesAndTypes
@@ -937,8 +937,8 @@ fn main() -> anyhow::Result<()> {
         .with_setting("async_insert", "1")
         .with_setting("wait_for_async_insert", "1");
 
-    let clickhouse = match clickhouse_password {
-        Ok(password) => clickhouse_client.with_password(password),
+    let clickhouse = match &clickhouse_password {
+        Ok(password) => clickhouse_client.with_password(password.clone()),
         _ => {
             log::warn!("CLICKHOUSE_PASSWORD not set, using without password");
             clickhouse_client
@@ -947,10 +947,16 @@ fn main() -> anyhow::Result<()> {
 
     // == Clickhouse Read-Only Client ==
     let clickhouse_readonly_client = if is_feature_enabled(Feature::ClickhouseReadOnly) {
-        let clickhouse_ro_user =
-            std::env::var(env::clickhouse::RO_USER).expect("CLICKHOUSE_RO_USER must be set");
+        // Dedicated read-only credentials are optional: when CLICKHOUSE_RO_USER /
+        // CLICKHOUSE_RO_PASSWORD aren't set, fall back to the main ClickHouse
+        // credentials so the SQL editor and dashboards work on self-hosted
+        // deployments without extra configuration. The public SQL path is still
+        // guarded by the query-engine validator and per-query limits, not by a
+        // privileged read-only ClickHouse user.
+        let clickhouse_ro_user = std::env::var(env::clickhouse::RO_USER)
+            .unwrap_or_else(|_| clickhouse_user.clone());
         let clickhouse_ro_password = std::env::var(env::clickhouse::RO_PASSWORD)
-            .expect("CLICKHOUSE_RO_PASSWORD must be set");
+            .unwrap_or_else(|_| clickhouse_password.clone().unwrap_or_default());
 
         Some(Arc::new(crate::sql::ClickhouseReadonlyClient::new(
             clickhouse_url,


### PR DESCRIPTION
## Problem

On self-hosted deployments, the SQL editor and every dashboard chart fail with:

```
ClickHouse client is not configured.
```

even though ClickHouse itself is up and `CLICKHOUSE_URL` / `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` are set correctly.

Root cause: the read-only ClickHouse client (used by `/v1/sql/query`, dashboards, MCP SQL, dataset exports) is only built when the **separate** `CLICKHOUSE_RO_USER` / `CLICKHOUSE_RO_PASSWORD` vars are set. `Feature::ClickhouseReadOnly` is off otherwise, so `clickhouse_readonly_client` is `None` and those routes return the error. These extra vars aren't part of a normal quickstart, so SQL/dashboards silently don't work out of the box.

Refs #832

## Fix

- Enable `Feature::ClickhouseReadOnly` whenever ClickHouse is configured (`CLICKHOUSE_URL` set).
- When `CLICKHOUSE_RO_USER` / `CLICKHOUSE_RO_PASSWORD` are absent, the read-only client falls back to the main `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD`. Operators who want a restricted user can still set the dedicated vars.
- Document the vars as optional in `.env.example`.

## Why this is safe

The "read-only" client is a plain ClickHouse client with its own credentials — it does **not** rely on a privileged read-only ClickHouse user to enforce safety. The public SQL path is already guarded by the query-engine validator (which strips mutations and inline `SETTINGS`) plus the per-query `max_execution_time` / `max_result_bytes` / `max_memory_usage` caps. So reusing the main credentials when no dedicated read-only user exists doesn't change the security posture; it just removes a config foot-gun. `.env.example` already shipped `CLICKHOUSE_RO_USER == CLICKHOUSE_USER`, so this matches the project's own defaults.

## Scope

This fixes the headline "ClickHouse client is not configured" symptom from #832. The separate issue of older dashboard charts using stale enum encodings (`span_type = 1` / `trace_type = 0`) noted in the thread is out of scope here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small boot-time config change; SQL safety still relies on the query engine validator and limits, not RO ClickHouse users alone.
> 
> **Overview**
> Fixes self-hosted setups where SQL editor and dashboards error with **"ClickHouse client is not configured"** despite valid `CLICKHOUSE_URL` / user / password.
> 
> **`Feature::ClickhouseReadOnly`** now turns on when `CLICKHOUSE_URL` is set, instead of requiring separate `CLICKHOUSE_RO_USER` / `CLICKHOUSE_RO_PASSWORD`. The read-only client still uses dedicated RO env vars when present; otherwise it **falls back** to `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` (with small `main.rs` refactors so those values can be reused). **`.env.example`** notes that RO credentials are optional.
> 
> Dedicated read-only ClickHouse users remain supported for operators who want them; app-layer query validation and limits are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28ad67c50f194d830f2bb5f0b39325b5e7eeaa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->