### PR TITLE
feat: auth cookie caching

### DIFF
--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -153,6 +153,13 @@ const getGenericOAuthConfig = () => {
 export const auth = betterAuth({
   secret: AUTH_SECRET,
   baseURL: AUTH_URL,
+  session: {
+    // Verify session from a signed cookie instead of the DB; revocation lags up to maxAge.
+    cookieCache: {
+      enabled: true,
+      maxAge: 5 * 60,
+    },
+  },
   // Reuse the existing `users` row id (uuid, DB default). Generating a uuid here
   // keeps every Better-Auth-managed id (session/account/verification/jwks, all
   // `text`) valid for the `uuid` users.id column and its FKs across the schema.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication session resolution; logout and server-side revocation may not take effect immediately for up to five minutes while the cookie cache is valid.
> 
> **Overview**
> **Session validation** for Better Auth now uses a **signed cookie cache** so routine `getSession` checks can skip the database, with **`maxAge` set to 5 minutes** (`5 * 60` seconds).
> 
> The inline comment documents the tradeoff: **revoked or deleted sessions may still be accepted until the cache entry expires**, up to that window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc9496e5b4f725ed9349d10a8ab9cb8f8db1117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->