### PR TITLE
fix array join queries in query engine

### DIFF
--- a/app-server/src/query_engine/validator.rs
+++ b/app-server/src/query_engine/validator.rs
@@ -472,6 +472,12 @@ impl QueryValidator {
         }
         let mut statement = statements.remove(0);
 
+        // ARRAY JOIN right-hand sides are array columns, not table references —
+        // identified by source span so they're skipped (not rewritten into
+        // `_v0(...)`) across all passes. The rewriter leaves these nodes intact,
+        // so the same spans stay valid for the post-rewrite check; compute once.
+        let array_join_spans = collect_array_join_spans(&statement);
+
         self.validate_security(&statement)?;
         // Reject CTEs that shadow an allowlisted physical table. CTE-name
         // collection (`collect_cte_names`) is global, not lexically scoped, so a
@@ -480,12 +486,9 @@ impl QueryValidator {
         // cross-tenant leak. Forbidding the collision keeps the invariant
         // "allowlisted name ⇒ always a physical table ⇒ always rewritten".
         self.validate_cte_names(&statement)?;
-        self.validate_tables_and_columns(&statement)?;
+        self.validate_tables_and_columns(&statement, &array_join_spans)?;
 
         let cte_names = collect_cte_names(&statement);
-        // ARRAY JOIN right-hand sides are array columns, not table references —
-        // skip them so they aren't rewritten into `_v0(...)` view functions.
-        let array_join_spans = collect_array_join_spans(&statement);
         let mut rewriter = ViewRewriter {
             registry: &self.registry,
             project_id,
@@ -506,7 +509,7 @@ impl QueryValidator {
         // function), and no blocked function may have been introduced. A
         // violation means a rewrite escape — fail closed rather than ship
         // unscoped SQL to ClickHouse.
-        self.validate_post_rewrite(&statement)?;
+        self.validate_post_rewrite(&statement, &array_join_spans)?;
 
         Ok(statement.to_string())
     }
@@ -525,20 +528,22 @@ impl QueryValidator {
 
     /// Re-scan the rewritten statement: assert every allowlisted physical table
     /// reference was rewritten away and no blocked function was introduced.
-    fn validate_post_rewrite(&self, statement: &Statement) -> Result<(), String> {
+    /// `array_join_spans` are exempt — those array-column relations are
+    /// intentionally left un-rewritten (they aren't tables).
+    fn validate_post_rewrite(
+        &self,
+        statement: &Statement,
+        array_join_spans: &HashSet<Span>,
+    ) -> Result<(), String> {
         let mut scan = BlockedScanner { blocked: None };
         let _ = statement.visit(&mut scan);
         if let Some(name) = scan.blocked {
             return Err(format!("Function '{name}' is not allowed"));
         }
 
-        // The rewriter leaves ARRAY JOIN array-column relations untouched (they
-        // aren't tables), so they're still recognisable by span and must be
-        // exempted from the "everything allowlisted was rewritten" assertion.
-        let array_join_spans = collect_array_join_spans(statement);
         let mut checker = PostRewriteChecker {
             registry: &self.registry,
-            array_join_spans: &array_join_spans,
+            array_join_spans,
             error: None,
         };
         let _ = statement.visit(&mut checker);
@@ -567,13 +572,16 @@ impl QueryValidator {
         Ok(())
     }
 
-    fn validate_tables_and_columns(&self, statement: &Statement) -> Result<(), String> {
+    fn validate_tables_and_columns(
+        &self,
+        statement: &Statement,
+        array_join_spans: &HashSet<Span>,
+    ) -> Result<(), String> {
         let cte_names = collect_cte_names(statement);
-        let array_join_spans = collect_array_join_spans(statement);
         let mut checker = TableColumnChecker {
             registry: &self.registry,
             cte_names: &cte_names,
-            array_join_spans: &array_join_spans,
+            array_join_spans,
             error: None,
         };
         let _ = statement.visit(&mut checker);

--- a/app-server/src/query_engine/validator.rs
+++ b/app-server/src/query_engine/validator.rs
@@ -11,14 +11,14 @@ use std::collections::{HashMap, HashSet};
 use std::ops::ControlFlow;
 
 use sqlparser::ast::{
-    Expr, FunctionArg, FunctionArgExpr, FunctionArgOperator, Ident, ObjectName, ObjectNamePart,
-    Query, Select, Statement, TableAlias, TableFactor, TableFunctionArgs, Value, ValueWithSpan,
-    Visit, VisitMut, Visitor, VisitorMut,
+    Expr, FunctionArg, FunctionArgExpr, FunctionArgOperator, Ident, JoinOperator, ObjectName,
+    ObjectNamePart, Query, Select, Statement, TableAlias, TableFactor, TableFunctionArgs, Value,
+    ValueWithSpan, Visit, VisitMut, Visitor, VisitorMut,
 };
 use sqlparser::dialect::ClickHouseDialect;
 use sqlparser::keywords::Keyword;
 use sqlparser::parser::Parser;
-use sqlparser::tokenizer::{Token, Tokenizer};
+use sqlparser::tokenizer::{Span, Token, TokenWithSpan, Tokenizer};
 
 const VIEW_VERSION: &str = "v0";
 
@@ -126,37 +126,40 @@ pub(crate) fn parse_clickhouse_sql(
     sql: &str,
 ) -> Result<Vec<Statement>, sqlparser::parser::ParserError> {
     let dialect = ClickHouseDialect {};
-    let tokens = Tokenizer::new(&dialect, sql).tokenize()?;
+    // Tokenize WITH locations: the validator later identifies ARRAY JOIN array
+    // columns by their source span, so spans must survive into the parsed AST.
+    let tokens = Tokenizer::new(&dialect, sql).tokenize_with_location()?;
     let tokens = wrap_in_placeholder_lists(tokens);
     Parser::new(&dialect)
-        .with_tokens(tokens)
+        .with_tokens_with_locations(tokens)
         .parse_statements()
 }
 
 /// Insert `(`/`)` tokens around a `{...}` placeholder group that immediately
 /// follows an `IN` keyword, so the `IN` parser accepts it. Operates purely on
-/// the token stream (comments/whitespace are dropped by `tokenize`, string
-/// literals are opaque `Token::SingleQuotedString` values), so a `{` inside a
-/// string or comment is never matched.
+/// the token stream (string literals are opaque `Token::SingleQuotedString`
+/// values, comments are `Token::Whitespace`), so a `{` inside a string or
+/// comment is never matched. The injected parens get empty spans — they don't
+/// correspond to source text and are never span-matched downstream.
 ///
 /// Workaround for sqlparser bug — `IN {placeholder}` rejected without parens:
 /// https://github.com/apache/datafusion-sqlparser-rs/issues/2384
-fn wrap_in_placeholder_lists(tokens: Vec<Token>) -> Vec<Token> {
+fn wrap_in_placeholder_lists(tokens: Vec<TokenWithSpan>) -> Vec<TokenWithSpan> {
     let is_in_keyword =
-        |t: &Token| matches!(t, Token::Word(w) if w.keyword == Keyword::IN);
+        |t: &TokenWithSpan| matches!(&t.token, Token::Word(w) if w.keyword == Keyword::IN);
 
-    let mut out: Vec<Token> = Vec::with_capacity(tokens.len() + 4);
+    let mut out: Vec<TokenWithSpan> = Vec::with_capacity(tokens.len() + 4);
     let mut i = 0;
     while i < tokens.len() {
-        // Find the index of the previous non-whitespace token already emitted.
-        let prev_significant = out.iter().rev().find(|t| !is_whitespace(t));
-        if matches!(&tokens[i], Token::LBrace)
+        // Find the previous non-whitespace token already emitted.
+        let prev_significant = out.iter().rev().find(|t| !is_whitespace(&t.token));
+        if matches!(&tokens[i].token, Token::LBrace)
             && prev_significant.is_some_and(is_in_keyword)
             && let Some(close) = matching_brace_end(&tokens, i)
         {
-            out.push(Token::LParen);
+            out.push(TokenWithSpan::wrap(Token::LParen));
             out.extend_from_slice(&tokens[i..=close]);
-            out.push(Token::RParen);
+            out.push(TokenWithSpan::wrap(Token::RParen));
             i = close + 1;
             continue;
         }
@@ -173,10 +176,10 @@ fn is_whitespace(t: &Token) -> bool {
 /// Given the index of an `LBrace`, return the index of its matching `RBrace`,
 /// honoring nesting (a placeholder type like `Array(Map(...))` has no braces,
 /// but nest defensively in case ClickHouse param syntax grows them).
-fn matching_brace_end(tokens: &[Token], open: usize) -> Option<usize> {
+fn matching_brace_end(tokens: &[TokenWithSpan], open: usize) -> Option<usize> {
     let mut depth = 0usize;
     for (idx, t) in tokens.iter().enumerate().skip(open) {
-        match t {
+        match t.token {
             Token::LBrace => depth += 1,
             Token::RBrace => {
                 depth -= 1;
@@ -480,10 +483,14 @@ impl QueryValidator {
         self.validate_tables_and_columns(&statement)?;
 
         let cte_names = collect_cte_names(&statement);
+        // ARRAY JOIN right-hand sides are array columns, not table references —
+        // skip them so they aren't rewritten into `_v0(...)` view functions.
+        let array_join_spans = collect_array_join_spans(&statement);
         let mut rewriter = ViewRewriter {
             registry: &self.registry,
             project_id,
             cte_names,
+            array_join_spans: &array_join_spans,
             where_stack: Vec::new(),
             error: None,
         };
@@ -525,8 +532,13 @@ impl QueryValidator {
             return Err(format!("Function '{name}' is not allowed"));
         }
 
+        // The rewriter leaves ARRAY JOIN array-column relations untouched (they
+        // aren't tables), so they're still recognisable by span and must be
+        // exempted from the "everything allowlisted was rewritten" assertion.
+        let array_join_spans = collect_array_join_spans(statement);
         let mut checker = PostRewriteChecker {
             registry: &self.registry,
+            array_join_spans: &array_join_spans,
             error: None,
         };
         let _ = statement.visit(&mut checker);
@@ -557,9 +569,11 @@ impl QueryValidator {
 
     fn validate_tables_and_columns(&self, statement: &Statement) -> Result<(), String> {
         let cte_names = collect_cte_names(statement);
+        let array_join_spans = collect_array_join_spans(statement);
         let mut checker = TableColumnChecker {
             registry: &self.registry,
             cte_names: &cte_names,
+            array_join_spans: &array_join_spans,
             error: None,
         };
         let _ = statement.visit(&mut checker);
@@ -609,6 +623,53 @@ fn collect_cte_names(statement: &Statement) -> HashSet<String> {
     c.names
 }
 
+/// Source-span of an `ObjectName`'s last identifier, used to uniquely identify a
+/// particular relation occurrence in the original SQL (two textually identical
+/// names at different positions have different spans).
+fn relation_name_span(name: &ObjectName) -> Option<Span> {
+    match name.0.last()? {
+        ObjectNamePart::Identifier(ident) => Some(ident.span),
+        _ => None,
+    }
+}
+
+/// Collect the source spans of every relation that is the right-hand side of a
+/// ClickHouse `ARRAY JOIN`. In `... ARRAY JOIN clusters AS cluster_id`, `clusters`
+/// is an **array column** of the left table, not a table reference — `sqlparser`
+/// nonetheless models it as a `TableFactor::Table`. We key by span so the
+/// table/column visitors can recognise and skip exactly that occurrence without
+/// affecting a genuine `FROM clusters` elsewhere in the query.
+fn collect_array_join_spans(statement: &Statement) -> HashSet<Span> {
+    struct ArrayJoinCollector {
+        spans: HashSet<Span>,
+    }
+    impl Visitor for ArrayJoinCollector {
+        type Break = ();
+        fn pre_visit_select(&mut self, select: &Select) -> ControlFlow<()> {
+            for twj in &select.from {
+                for join in &twj.joins {
+                    if matches!(
+                        join.join_operator,
+                        JoinOperator::ArrayJoin
+                            | JoinOperator::LeftArrayJoin
+                            | JoinOperator::InnerArrayJoin
+                    ) && let TableFactor::Table { name, .. } = &join.relation
+                        && let Some(span) = relation_name_span(name)
+                    {
+                        self.spans.insert(span);
+                    }
+                }
+            }
+            ControlFlow::Continue(())
+        }
+    }
+    let mut c = ArrayJoinCollector {
+        spans: HashSet::new(),
+    };
+    let _ = statement.visit(&mut c);
+    c.spans
+}
+
 struct BlockedScanner {
     blocked: Option<String>,
 }
@@ -640,6 +701,7 @@ impl Visitor for BlockedScanner {
 struct TableColumnChecker<'a> {
     registry: &'a TableRegistry,
     cte_names: &'a HashSet<String>,
+    array_join_spans: &'a HashSet<Span>,
     error: Option<String>,
 }
 
@@ -647,6 +709,11 @@ impl Visitor for TableColumnChecker<'_> {
     type Break = ();
 
     fn pre_visit_relation(&mut self, name: &ObjectName) -> ControlFlow<()> {
+        // An ARRAY JOIN right-hand side is an array column of the left table,
+        // not a table reference — don't validate it against the table allowlist.
+        if relation_name_span(name).is_some_and(|s| self.array_join_spans.contains(&s)) {
+            return ControlFlow::Continue(());
+        }
         let table = relation_table_name(name);
         if self.cte_names.contains(&table) {
             return ControlFlow::Continue(());
@@ -703,6 +770,7 @@ impl Visitor for TableColumnChecker<'_> {
 /// (one without table-function args) may remain.
 struct PostRewriteChecker<'a> {
     registry: &'a TableRegistry,
+    array_join_spans: &'a HashSet<Span>,
     error: Option<String>,
 }
 
@@ -711,6 +779,11 @@ impl Visitor for PostRewriteChecker<'_> {
 
     fn pre_visit_table_factor(&mut self, table_factor: &TableFactor) -> ControlFlow<()> {
         if let TableFactor::Table { name, args, .. } = table_factor {
+            // ARRAY JOIN array-column relations are intentionally left un-rewritten;
+            // they aren't tables, so don't flag them as "not project-scoped".
+            if relation_name_span(name).is_some_and(|s| self.array_join_spans.contains(&s)) {
+                return ControlFlow::Continue(());
+            }
             // A view function (`spans_v0(...)`) carries args; a bare allowlisted
             // relation does not. The latter escaped rewriting — fail closed.
             if args.is_none() {
@@ -731,6 +804,7 @@ struct ViewRewriter<'a> {
     registry: &'a TableRegistry,
     project_id: &'a str,
     cte_names: HashSet<String>,
+    array_join_spans: &'a HashSet<Span>,
     where_stack: Vec<Option<Expr>>,
     error: Option<String>,
 }
@@ -753,6 +827,14 @@ impl VisitorMut for ViewRewriter<'_> {
             name, alias, args, ..
         } = table_factor
         {
+            // An ARRAY JOIN right-hand side is an array column of the left table,
+            // not a table reference — leave it exactly as written. (sqlparser
+            // models it as a `TableFactor::Table`, so without this guard we'd
+            // rewrite e.g. `ARRAY JOIN clusters` into `clusters_v0(...)`.)
+            if relation_name_span(name).is_some_and(|s| self.array_join_spans.contains(&s)) {
+                return ControlFlow::Continue(());
+            }
+
             let table_name = relation_table_name(name);
 
             // An allowlisted table name presented as a table function (e.g.

--- a/app-server/src/query_engine/validator/tests.rs
+++ b/app-server/src/query_engine/validator/tests.rs
@@ -801,3 +801,124 @@ fn test_not_in_with_array_placeholder() {
         "got: {result}"
     );
 }
+
+#[test]
+fn test_array_join_column_not_rewritten() {
+    // `ARRAY JOIN clusters AS cluster_id` unnests the `clusters` ARRAY column of
+    // signal_events — `clusters` here is a column, NOT the `clusters` table, so
+    // it must be left untouched even though a `clusters` table exists. Only the
+    // real FROM table (`signal_events`) is rewritten to its scoped view.
+    let query = r#"
+        SELECT DISTINCT cluster_id
+        FROM signal_events
+        ARRAY JOIN clusters AS cluster_id
+        WHERE signal_id = {signalId: UUID}
+    "#;
+    let result = validate_ok(query);
+    assert!(
+        contains_ws(
+            &result,
+            &format!("FROM signal_events_v0(project_id = '{SAMPLE_PROJECT_ID}') AS signal_events")
+        ),
+        "got: {result}"
+    );
+    // The array column stays a bare `clusters`, NOT `clusters_v0(...)`.
+    assert!(
+        contains_ws(&result, "ARRAY JOIN clusters AS cluster_id"),
+        "got: {result}"
+    );
+    assert!(!result.contains("clusters_v0"), "got: {result}");
+}
+
+#[test]
+fn test_left_array_join_column_not_rewritten() {
+    let query = r#"
+        SELECT cluster_id
+        FROM signal_events
+        LEFT ARRAY JOIN clusters AS cluster_id
+        WHERE signal_id = {signalId: UUID}
+    "#;
+    let result = validate_ok(query);
+    assert!(
+        contains_ws(&result, "LEFT ARRAY JOIN clusters AS cluster_id"),
+        "got: {result}"
+    );
+    assert!(!result.contains("clusters_v0"), "got: {result}");
+}
+
+#[test]
+fn test_array_join_does_not_shadow_real_clusters_table() {
+    // A query that ARRAY JOINs the `clusters` column AND separately selects from
+    // the real `clusters` table: only the table reference is rewritten, the
+    // array-join column is left alone (span-keyed, so the two don't conflate).
+    let query = r#"
+        SELECT c.id
+        FROM clusters c
+        WHERE c.id IN (
+            SELECT cluster_id
+            FROM signal_events
+            ARRAY JOIN clusters AS cluster_id
+            WHERE signal_id = {signalId: UUID}
+        )
+    "#;
+    let result = validate_ok(query);
+    // The real FROM table is scoped...
+    assert!(
+        contains_ws(
+            &result,
+            &format!("FROM clusters_v0(project_id = '{SAMPLE_PROJECT_ID}') AS c")
+        ),
+        "got: {result}"
+    );
+    // ...while the array-join column is untouched.
+    assert!(
+        contains_ws(&result, "ARRAY JOIN clusters AS cluster_id"),
+        "got: {result}"
+    );
+    // Exactly one rewritten clusters view (the table), not two.
+    assert_eq!(result.matches("clusters_v0").count(), 1, "got: {result}");
+}
+
+#[test]
+fn test_full_clusters_emerging_query() {
+    // The exact shape from the frontend bug report (clusters table + ARRAY JOIN
+    // on the clusters column inside the subquery).
+    let query = r#"
+        SELECT
+          id,
+          name,
+          parent_id as parentId,
+          level
+        FROM clusters
+        WHERE signal_id = {signalId: UUID}
+          AND level != 0
+          AND id IN (
+            SELECT DISTINCT cluster_id
+            FROM signal_events
+            ARRAY JOIN clusters AS cluster_id
+            WHERE signal_id = {signalId: UUID}
+          )
+        ORDER BY num_signal_events DESC, level ASC, created_at ASC
+    "#;
+    let result = validate_ok(query);
+    assert!(
+        contains_ws(
+            &result,
+            &format!("FROM clusters_v0(project_id = '{SAMPLE_PROJECT_ID}') AS clusters")
+        ),
+        "got: {result}"
+    );
+    assert!(
+        contains_ws(
+            &result,
+            &format!("FROM signal_events_v0(project_id = '{SAMPLE_PROJECT_ID}') AS signal_events")
+        ),
+        "got: {result}"
+    );
+    assert!(
+        contains_ws(&result, "ARRAY JOIN clusters AS cluster_id"),
+        "got: {result}"
+    );
+    // Only the outer clusters TABLE is rewritten; the array-join column is not.
+    assert_eq!(result.matches("clusters_v0").count(), 1, "got: {result}");
+}


### PR DESCRIPTION
Clickhouse array join right hand side is not a table name, but is an array expression, so if it matches table name, we need not add the _v0 postfix to it

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the query-engine security validator and project-scoping rewrite path; the span-based exemption is narrow and covered by tests, but incorrect span matching could still mis-scope or skip real table references.
> 
> **Overview**
> Fixes queries where an **ARRAY JOIN** right-hand side shares a name with an allowlisted table (e.g. `ARRAY JOIN clusters` on `signal_events` while a `clusters` table exists). Those RHS names are array columns, not relations, but sqlparser models them as `TableFactor::Table`, so the validator was incorrectly rewriting them to `clusters_v0(project_id = ...)`.
> 
> Parsing now keeps **source spans** (`tokenize_with_location` / `with_tokens_with_locations`, including the `IN {placeholder}` shim). The validator collects spans for ARRAY JOIN / LEFT ARRAY JOIN / INNER ARRAY JOIN RHS identifiers and **skips** those occurrences in table allowlist checks, `_v0` view rewriting, and post-rewrite “bare table” verification—while real `FROM clusters` at a different position still gets project-scoped.
> 
> Adds regression tests for plain and left ARRAY JOIN, mixed table + array-join in one query, and the full clusters emerging query shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b95b210d1984536e3876b4d2773200aa8ac03e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->