### PR TITLE
flush internal tracer provider on pod termination

### DIFF
--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -189,7 +189,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     let internal_tracing_enabled = is_feature_enabled(Feature::InternalTracing);
-    let (_internal_tracer_provider, internal_ingest_deps) =
+    let (internal_tracer_provider, internal_ingest_deps) =
         instrumentation::setup_tracing_and_logging(
             is_feature_enabled(Feature::Tracing),
             internal_tracing_enabled,
@@ -1940,5 +1940,15 @@ fn main() -> anyhow::Result<()> {
         );
         handle.join().expect("thread is not panicking")?;
     }
+
+    // Servers have stopped (SIGTERM); the runtime + ingest deps are still alive here.
+    // Flush buffered internal spans so freshly-minted signal.run roots aren't lost on a
+    // rolling deploy, which would orphan their child spans ingested by surviving pods.
+    if let Some(provider) = internal_tracer_provider {
+        if let Err(e) = provider.force_flush() {
+            log::warn!("Failed to flush internal tracer provider on shutdown: {e:?}");
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small shutdown-path change in observability only; flush failures are logged and do not block exit.
> 
> **Overview**
> On pod termination, buffered **internal** OpenTelemetry spans could be dropped before export, which during rolling deploys can lose freshly created `signal.run` root spans and leave child spans ingested elsewhere orphaned.
> 
> The internal `SdkTracerProvider` is no longer discarded at startup (it was previously bound to `_`). After HTTP/gRPC/consumer threads finish on shutdown, the process calls **`force_flush()`** on that provider while the runtime and ingest deps are still alive, with a warn log if flush fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 042d2fed98eedaf0053e01ccf3697816a39c866c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->