### PR TITLE
remove slow tools check in default signal prompt

### DIFF
--- a/frontend/components/signals/prompts.ts
+++ b/frontend/components/signals/prompts.ts
@@ -14,8 +14,8 @@ const templates: EventTemplate[] = [
     icon: "alert-circle",
     description: "Spot errors, loops, wrong tool usage, and slow actions",
     prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
-loops or repeated calls, wrong tool selection, logic errors, \
-and abnormally slow or expensive spans. Only report problems visible in the trace data.`,
+loops or repeated calls, wrong tool selection, and logic errors. \
+Only report problems visible in the trace data.`,
     structuredOutputSchema: JSON.stringify(
       {
         type: "object",

--- a/frontend/components/signals/prompts.ts
+++ b/frontend/components/signals/prompts.ts
@@ -12,7 +12,7 @@ const templates: EventTemplate[] = [
     name: "Failure Detector",
     shortName: "Failure",
     icon: "alert-circle",
-    description: "Spot errors, loops, wrong tool usage, and slow actions",
+    description: "Spot errors, loops and wrong tool usage",
     prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
 loops or repeated calls, wrong tool selection, and logic errors. \
 Only report problems visible in the trace data.`,

--- a/frontend/lib/db/default-signals.ts
+++ b/frontend/lib/db/default-signals.ts
@@ -1,8 +1,8 @@
 export const DEFAULT_SIGNAL = {
   name: "Failure Detector",
   prompt: `Analyze this trace for concrete issues: tool call failures, API errors, \
-loops or repeated calls, wrong tool selection, logic errors, \
-and abnormally slow or expensive spans. Only report problems visible in the trace data.`,
+loops or repeated calls, wrong tool selection, and logic errors. \
+Only report problems visible in the trace data.`,
   structuredOutputSchema: {
     type: "object",
     required: ["description", "category"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only prompt changes for the default signal; no runtime logic, schema, or trigger changes.
> 
> **Overview**
> Narrows the **Failure Detector** default signal so it no longer asks the model to flag **abnormally slow or expensive spans**.
> 
> The template description in `prompts.ts` and the shared `DEFAULT_SIGNAL` prompt in `default-signals.ts` now focus on errors, loops, wrong tools, and logic issues only. Structured output schema and categories are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38814597399f8e87e9f47ed7a0aadfa3b6cf7d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->