### PR TITLE
add a switch so sql API requests >N bytes do direct disk read

### DIFF
--- a/app-server/src/env/sql.rs
+++ b/app-server/src/env/sql.rs
@@ -13,3 +13,18 @@ pub const MAX_RESULT_BYTES: StringEnv = StringEnv::new("SQL_QUERY_MAX_RESULT_BYT
 /// unlimited, so self-hosters are unrestricted unless they opt in; cloud sets a
 /// concrete cap (e.g. a few GB) via env.
 pub const MAX_MEMORY_USAGE: StringEnv = StringEnv::new("SQL_QUERY_MAX_MEMORY_USAGE", "0");
+/// `min_bytes_to_use_direct_io` forces the query to directly read from disk
+/// skipping the page cache if the number of bytes to read exceeds
+/// the value. Default `0` = no enforcement.
+///
+/// Large reads may cause huge chunks of data to be read via OS page cache.
+/// An offending repeated query from API may cause significant slowdown to the
+/// rest of the read paths if the page cache is busy serving API requests.
+/// This setting is a kill switch to re-route offending API queries to read
+/// directly from disk, thus greatly slowing them down, but unblocking the
+/// rest of critical functionality. Reference:
+/// https://presentations.clickhouse.com/2021-meetup53/optimizations/?full#13
+
+// TODO: find more fine-grained controls for this
+pub const MIN_BYTES_TO_USE_DIRECT_IO: StringEnv =
+    StringEnv::new("SQL_QUERY_MIN_BYTES_TO_USE_DIRECT_IO", "0");

--- a/app-server/src/env/sql.rs
+++ b/app-server/src/env/sql.rs
@@ -13,6 +13,7 @@ pub const MAX_RESULT_BYTES: StringEnv = StringEnv::new("SQL_QUERY_MAX_RESULT_BYT
 /// unlimited, so self-hosters are unrestricted unless they opt in; cloud sets a
 /// concrete cap (e.g. a few GB) via env.
 pub const MAX_MEMORY_USAGE: StringEnv = StringEnv::new("SQL_QUERY_MAX_MEMORY_USAGE", "0");
+// TODO: find more fine-grained controls for this
 /// `min_bytes_to_use_direct_io` forces the query to directly read from disk
 /// skipping the page cache if the number of bytes to read exceeds
 /// the value. Default `0` = no enforcement.
@@ -24,7 +25,5 @@ pub const MAX_MEMORY_USAGE: StringEnv = StringEnv::new("SQL_QUERY_MAX_MEMORY_USA
 /// directly from disk, thus greatly slowing them down, but unblocking the
 /// rest of critical functionality. Reference:
 /// https://presentations.clickhouse.com/2021-meetup53/optimizations/?full#13
-
-// TODO: find more fine-grained controls for this
 pub const MIN_BYTES_TO_USE_DIRECT_IO: StringEnv =
     StringEnv::new("SQL_QUERY_MIN_BYTES_TO_USE_DIRECT_IO", "0");

--- a/app-server/src/sql/ch.rs
+++ b/app-server/src/sql/ch.rs
@@ -46,6 +46,11 @@ pub async fn query(
         if max_memory_usage != "0" {
             clickhouse_query = clickhouse_query.with_setting("max_memory_usage", max_memory_usage);
         }
+        let min_bytes_direct_io = env::sql::MIN_BYTES_TO_USE_DIRECT_IO.get();
+        if min_bytes_direct_io != "0" {
+            clickhouse_query =
+                clickhouse_query.with_setting("min_bytes_to_use_direct_io", min_bytes_direct_io);
+        }
     }
 
     for (key, value) in parameters {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Opt-in env default disables the behavior; only affects public ad-hoc SQL query settings, not the trusted frontend.
> 
> **Overview**
> Adds an **operator-controlled kill switch** for public `/v1/sql` traffic: when `SQL_QUERY_MIN_BYTES_TO_USE_DIRECT_IO` is set to a non-zero byte threshold, those queries get ClickHouse’s `min_bytes_to_use_direct_io` setting so large scans bypass the OS page cache and read from disk instead.
> 
> Default remains **`0` (no enforcement)**, matching the existing public-only guard pattern used for `max_memory_usage`; the trusted frontend path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45213b2c23b14ca02115274964aee8fc33a899c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

