### PR TITLE
fix(signals): allow free-tier users to access signal settings LAM-1818

### DIFF
--- a/frontend/components/signal/index.tsx
+++ b/frontend/components/signal/index.tsx
@@ -9,7 +9,6 @@ import { type ManageSignalForm, ManageSignalPanel } from "@/components/signals/c
 import { TraceViewSidePanel } from "@/components/traces/trace-view";
 import Header from "@/components/ui/header.tsx";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useProjectContext } from "@/contexts/project-context";
 import { track } from "@/lib/posthog";
 
 interface SignalProps {
@@ -24,7 +23,6 @@ function SignalContent({ slackClientId, slackRedirectUri, slackBrokerEnabled }: 
   const params = useParams<{ projectId: string }>();
   const { push } = useRouter();
   const searchParams = useSearchParams();
-  const { workspace } = useProjectContext();
 
   const activeTab = searchParams.get("tab") || "events";
 
@@ -39,8 +37,6 @@ function SignalContent({ slackClientId, slackRedirectUri, slackBrokerEnabled }: 
     setTraceId: state.setTraceId,
     setSpanId: state.setSpanId,
   }));
-
-  const isFreeTier = workspace?.tierName.toLowerCase().trim() === "free";
 
   const handleSuccess = useCallback(
     async (form: ManageSignalForm) => {
@@ -75,29 +71,25 @@ function SignalContent({ slackClientId, slackRedirectUri, slackBrokerEnabled }: 
             <TabsTrigger className="text-xs" value="events">
               Events
             </TabsTrigger>
-            {!isFreeTier && (
-              <TabsTrigger className="text-xs" value="settings">
-                Settings
-              </TabsTrigger>
-            )}
+            <TabsTrigger className="text-xs" value="settings">
+              Settings
+            </TabsTrigger>
           </TabsList>
         </div>
 
         <TabsContent value="events" className="flex flex-col overflow-hidden">
           <EventsTable />
         </TabsContent>
-        {!isFreeTier && (
-          <TabsContent value="settings" className="flex flex-col overflow-hidden">
-            <ManageSignalPanel
-              key={signal.id}
-              defaultValues={signal}
-              onSuccess={handleSuccess}
-              slackClientId={slackClientId}
-              slackRedirectUri={slackRedirectUri}
-              slackBrokerEnabled={slackBrokerEnabled}
-            />
-          </TabsContent>
-        )}
+        <TabsContent value="settings" className="flex flex-col overflow-hidden">
+          <ManageSignalPanel
+            key={signal.id}
+            defaultValues={signal}
+            onSuccess={handleSuccess}
+            slackClientId={slackClientId}
+            slackRedirectUri={slackRedirectUri}
+            slackBrokerEnabled={slackBrokerEnabled}
+          />
+        </TabsContent>
       </Tabs>
 
       {traceId && (


### PR DESCRIPTION
## What

Removes the free-tier gate on the signal page so **all tiers** (including Free) can access the **Settings** tab and the manage-signal panel.

Previously `frontend/components/signal/index.tsx` computed `isFreeTier` from `workspace.tierName` and hid both the Settings `TabsTrigger` and its `TabsContent` (the `ManageSignalPanel`) behind `{!isFreeTier && ...}`.

## Changes

- Removed the `isFreeTier` derivation and both `{!isFreeTier && ...}` wrappers
- Removed the now-unused `useProjectContext` import

Net: +13 / −21.

## Why it's safe

There is **no backend tier gate** on the signal-update path (no tier checks in `lib/actions/signals/` or the signals API route), so the UI was the only barrier — nothing server-side rejects a free-tier save.

## Verification

- `pnpm lint` → 0 errors; `pnpm type-check` → clean.
- Local dev only seeds the `unlimited` tier, so the visual difference isn't reproducible without temporarily creating a `Free` tier and assigning a workspace to it. Verified manually that way; the real effect lands on Cloud where Free-tier workspaces exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file UI change with no auth or API logic; aligns the UI with signal update paths that were not tier-gated server-side.
> 
> **Overview**
> **Free-tier workspaces can now open the signal Settings tab and use `ManageSignalPanel`**, matching behavior that paid tiers already had in the UI.
> 
> The change **drops** the `isFreeTier` check on `workspace.tierName` and the `{!isFreeTier && ...}` guards around the Settings tab trigger and content, and **removes** the unused `useProjectContext` import. Events tab behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f13373f522611c8486925987862612acd40fc366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->