### PR TITLE
Fix Anthropic cache-aware LLM cost calculation

### DIFF
--- a/app-server/src/traces/spans.rs
+++ b/app-server/src/traces/spans.rs
@@ -24,7 +24,11 @@ use crate::{
     },
     opentelemetry_proto::opentelemetry_proto_trace_v1::Span as OtelSpan,
     traces::{
-        span_attributes::{GEN_AI_CACHE_READ_INPUT_TOKENS, GEN_AI_CACHE_WRITE_INPUT_TOKENS},
+        span_attributes::{
+            GEN_AI_CACHE_READ_INPUT_TOKENS, GEN_AI_CACHE_WRITE_INPUT_TOKENS,
+            GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_1H_TOKENS,
+            GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_5M_TOKENS,
+        },
         utils::{convert_any_value_to_json_value, serialize_indexmap},
     },
     utils::{estimate_json_size, json_value_to_string},
@@ -54,6 +58,7 @@ const AISDK_OPERATION_PREFIXES: &[&str] = &[
     "streamObject",
 ];
 
+const AI_RESPONSE_PROVIDER_METADATA: &str = "ai.response.providerMetadata";
 const INPUT_ATTRIBUTE_NAME: &str = "lmnr.span.input";
 const OUTPUT_ATTRIBUTE_NAME: &str = "lmnr.span.output";
 /// If this attribute is set to true, the parent span will be overridden with
@@ -230,36 +235,36 @@ impl SpanAttributes {
             GEN_AI_CACHE_WRITE_INPUT_TOKENS,
         );
 
-        let Some(prefix) = self.detect_aisdk_operation_prefix() else {
-            return;
-        };
+        if let Some(prefix) = self.detect_aisdk_operation_prefix() {
+            // Usage attributes
+            self.normalize_if_absent(&format!("{prefix}.usage.inputTokens"), GEN_AI_INPUT_TOKENS);
+            self.normalize_if_absent(
+                &format!("{prefix}.usage.outputTokens"),
+                GEN_AI_OUTPUT_TOKENS,
+            );
+            self.normalize_if_absent(
+                &format!("{prefix}.usage.cachedInputTokens"),
+                GEN_AI_CACHE_READ_INPUT_TOKENS,
+            );
+            self.normalize_if_absent(
+                &format!("{prefix}.usage.inputTokenDetails.cacheReadTokens"),
+                GEN_AI_CACHE_READ_INPUT_TOKENS,
+            );
+            self.normalize_if_absent(
+                &format!("{prefix}.usage.inputTokenDetails.cacheWriteTokens"),
+                GEN_AI_CACHE_WRITE_INPUT_TOKENS,
+            );
 
-        // Usage attributes
-        self.normalize_if_absent(&format!("{prefix}.usage.inputTokens"), GEN_AI_INPUT_TOKENS);
-        self.normalize_if_absent(
-            &format!("{prefix}.usage.outputTokens"),
-            GEN_AI_OUTPUT_TOKENS,
-        );
-        self.normalize_if_absent(
-            &format!("{prefix}.usage.cachedInputTokens"),
-            GEN_AI_CACHE_READ_INPUT_TOKENS,
-        );
-        self.normalize_if_absent(
-            &format!("{prefix}.usage.inputTokenDetails.cacheReadTokens"),
-            GEN_AI_CACHE_READ_INPUT_TOKENS,
-        );
-        self.normalize_if_absent(
-            &format!("{prefix}.usage.inputTokenDetails.cacheWriteTokens"),
-            GEN_AI_CACHE_WRITE_INPUT_TOKENS,
-        );
+            self.normalize_if_absent(&format!("{prefix}.prompt.messages"), "ai.prompt.messages");
+            self.normalize_if_absent(&format!("{prefix}.response.text"), "ai.response.text");
+            self.normalize_if_absent(
+                &format!("{prefix}.response.toolCalls"),
+                "ai.response.toolCalls",
+            );
+            self.normalize_if_absent(&format!("{prefix}.response.object"), "ai.response.object");
+        }
 
-        self.normalize_if_absent(&format!("{prefix}.prompt.messages"), "ai.prompt.messages");
-        self.normalize_if_absent(&format!("{prefix}.response.text"), "ai.response.text");
-        self.normalize_if_absent(
-            &format!("{prefix}.response.toolCalls"),
-            "ai.response.toolCalls",
-        );
-        self.normalize_if_absent(&format!("{prefix}.response.object"), "ai.response.object");
+        self.normalize_anthropic_provider_metadata();
     }
 
     fn detect_aisdk_operation_prefix(&self) -> Option<&'static str> {
@@ -295,6 +300,98 @@ impl SpanAttributes {
             if let Some(value) = self.raw_attributes.get(source_key).cloned() {
                 self.raw_attributes.insert(target_key.to_string(), value);
             }
+        }
+    }
+
+    fn normalize_anthropic_provider_metadata(&mut self) {
+        let Some(provider_metadata) = self.provider_metadata_value() else {
+            return;
+        };
+        let Some(usage) = provider_metadata
+            .get("anthropic")
+            .and_then(|anthropic| anthropic.get("usage"))
+        else {
+            return;
+        };
+
+        let cache_creation = usage.get("cache_creation");
+        let cache_creation_5m_tokens =
+            Self::json_i64(cache_creation.and_then(|v| v.get("ephemeral_5m_input_tokens")));
+        let cache_creation_1h_tokens =
+            Self::json_i64(cache_creation.and_then(|v| v.get("ephemeral_1h_input_tokens")));
+        let cache_read_tokens = Self::json_i64(usage.get("cache_read_input_tokens"));
+        let cache_creation_tokens = Self::json_i64(usage.get("cache_creation_input_tokens"))
+            .or_else(|| {
+                let inferred =
+                    cache_creation_5m_tokens.unwrap_or(0) + cache_creation_1h_tokens.unwrap_or(0);
+                (inferred > 0).then_some(inferred)
+            });
+
+        if let Some(tokens) = cache_read_tokens {
+            self.insert_if_absent(GEN_AI_CACHE_READ_INPUT_TOKENS, json!(tokens));
+        }
+        if let Some(tokens) = cache_creation_tokens {
+            self.insert_if_absent(GEN_AI_CACHE_WRITE_INPUT_TOKENS, json!(tokens));
+        }
+        if let Some(tokens) = cache_creation_5m_tokens {
+            self.insert_if_absent(
+                GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_5M_TOKENS,
+                json!(tokens),
+            );
+        }
+        if let Some(tokens) = cache_creation_1h_tokens {
+            self.insert_if_absent(
+                GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_1H_TOKENS,
+                json!(tokens),
+            );
+        }
+
+        if !self.raw_attributes.contains_key(GEN_AI_INPUT_TOKENS)
+            && !self.raw_attributes.contains_key(GEN_AI_PROMPT_TOKENS)
+        {
+            let regular_input_tokens = Self::json_i64(usage.get("input_tokens")).unwrap_or(0);
+            let total_input_tokens = regular_input_tokens
+                + self.int_attr(GEN_AI_CACHE_WRITE_INPUT_TOKENS).unwrap_or(0)
+                + self.int_attr(GEN_AI_CACHE_READ_INPUT_TOKENS).unwrap_or(0);
+            if total_input_tokens > 0 {
+                self.insert_if_absent(GEN_AI_INPUT_TOKENS, json!(total_input_tokens));
+            }
+        }
+
+        if let Some(output_tokens) = Self::json_i64(usage.get("output_tokens")) {
+            self.insert_if_absent(GEN_AI_OUTPUT_TOKENS, json!(output_tokens));
+        }
+    }
+
+    fn provider_metadata_value(&self) -> Option<Value> {
+        match self.raw_attributes.get(AI_RESPONSE_PROVIDER_METADATA)? {
+            Value::String(metadata) => {
+                let mut value = serde_json::from_str::<Value>(metadata).ok()?;
+                loop {
+                    match value {
+                        Value::String(inner) => {
+                            value = serde_json::from_str::<Value>(&inner).ok()?;
+                        }
+                        other => return Some(other),
+                    }
+                }
+            }
+            Value::Object(_) => self
+                .raw_attributes
+                .get(AI_RESPONSE_PROVIDER_METADATA)
+                .cloned(),
+            _ => None,
+        }
+    }
+
+    fn json_i64(value: Option<&Value>) -> Option<i64> {
+        match value? {
+            Value::Number(number) => number
+                .as_i64()
+                .or_else(|| number.as_u64().and_then(|n| i64::try_from(n).ok()))
+                .filter(|n| *n >= 0),
+            Value::String(value) => value.parse::<i64>().ok().filter(|n| *n >= 0),
+            _ => None,
         }
     }
 
@@ -3902,6 +3999,150 @@ mod tests {
         assert_eq!(
             attrs.raw_attributes.get(GEN_AI_CACHE_READ_INPUT_TOKENS),
             Some(&json!(100))
+        );
+    }
+
+    #[test]
+    fn test_anthropic_provider_metadata_cache_tokens_normalize_to_legacy_keys() {
+        let attributes = HashMap::from([
+            ("gen_ai.usage.input_tokens".to_string(), json!(10261)),
+            ("gen_ai.usage.output_tokens".to_string(), json!(179)),
+            (
+                "ai.response.providerMetadata".to_string(),
+                json!(
+                    r#"{"anthropic":{"usage":{"input_tokens":1,"output_tokens":179,"cache_creation_input_tokens":3421,"cache_read_input_tokens":6839,"cache_creation":{"ephemeral_5m_input_tokens":3421}}}}"#
+                ),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_READ_INPUT_TOKENS),
+            Some(&json!(6839))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_WRITE_INPUT_TOKENS),
+            Some(&json!(3421))
+        );
+        assert_eq!(
+            attrs
+                .raw_attributes
+                .get(GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_5M_TOKENS),
+            Some(&json!(3421))
+        );
+
+        let input_tokens = attrs.input_tokens();
+        assert_eq!(input_tokens.regular_input_tokens, 1);
+        assert_eq!(input_tokens.cache_write_tokens, 3421);
+        assert_eq!(input_tokens.cache_read_tokens, 6839);
+        assert_eq!(input_tokens.total(), 10261);
+    }
+
+    #[test]
+    fn test_anthropic_provider_metadata_reconstructs_missing_total_input_tokens() {
+        let attributes = HashMap::from([(
+            "ai.response.providerMetadata".to_string(),
+            json!({
+                "anthropic": {
+                    "usage": {
+                        "input_tokens": 3,
+                        "output_tokens": 233,
+                        "cache_creation_input_tokens": 6839,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation": {
+                            "ephemeral_5m_input_tokens": 6839
+                        }
+                    }
+                }
+            }),
+        )]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_INPUT_TOKENS),
+            Some(&json!(6842))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_OUTPUT_TOKENS),
+            Some(&json!(233))
+        );
+    }
+
+    #[test]
+    fn test_anthropic_provider_metadata_does_not_overwrite_existing_canonical_attrs() {
+        let attributes = HashMap::from([
+            ("gen_ai.usage.input_tokens".to_string(), json!(500)),
+            (
+                "gen_ai.usage.cache_read_input_tokens".to_string(),
+                json!(100),
+            ),
+            (
+                "gen_ai.usage.cache_creation_input_tokens".to_string(),
+                json!(50),
+            ),
+            (
+                "ai.response.providerMetadata".to_string(),
+                json!({
+                    "anthropic": {
+                        "usage": {
+                            "input_tokens": 1,
+                            "output_tokens": 20,
+                            "cache_creation_input_tokens": 300,
+                            "cache_read_input_tokens": 400
+                        }
+                    }
+                }),
+            ),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_INPUT_TOKENS),
+            Some(&json!(500))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_READ_INPUT_TOKENS),
+            Some(&json!(100))
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_CACHE_WRITE_INPUT_TOKENS),
+            Some(&json!(50))
+        );
+    }
+
+    #[test]
+    fn test_malformed_provider_metadata_is_ignored() {
+        let attributes = HashMap::from([
+            (
+                "ai.response.providerMetadata".to_string(),
+                json!("{not-valid-json"),
+            ),
+            ("gen_ai.usage.input_tokens".to_string(), json!(10)),
+            ("gen_ai.usage.output_tokens".to_string(), json!(20)),
+        ]);
+
+        let mut attrs = SpanAttributes::new(attributes);
+        attrs.normalize_aisdk_attributes();
+
+        assert!(
+            !attrs
+                .raw_attributes
+                .contains_key(GEN_AI_CACHE_READ_INPUT_TOKENS)
+        );
+        assert!(
+            !attrs
+                .raw_attributes
+                .contains_key(GEN_AI_CACHE_WRITE_INPUT_TOKENS)
+        );
+        assert_eq!(
+            attrs.raw_attributes.get(GEN_AI_INPUT_TOKENS),
+            Some(&json!(10))
         );
     }
 

--- a/app-server/src/traces/utils.rs
+++ b/app-server/src/traces/utils.rs
@@ -12,7 +12,7 @@ use crate::{
     cache::Cache,
     db::{DB, spans::Span, trace::Trace},
     language_model::costs::{
-        ModelInfo, SpanCostInput, calculate_span_cost, get_model_costs_for_project,
+        ModelCosts, ModelInfo, SpanCostInput, calculate_span_cost, get_model_costs_for_project,
     },
     traces::prompt_hash::{extract_system_message, structural_skeleton_hash},
 };
@@ -25,7 +25,7 @@ use super::span_attributes::{
     GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_5M_TOKENS, GEN_AI_USAGE_REASONING_TOKENS,
     OPENAI_REQUEST_SERVICE_TIER, OPENAI_RESPONSE_SERVICE_TIER, SPAN_PROMPT_HASH,
 };
-use super::spans::{SpanAttributes, SpanUsage};
+use super::spans::{InputTokens, SpanAttributes, SpanUsage};
 
 static SKIP_SPAN_NAME_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^Runnable[A-Z][A-Za-z]*(?:<[A-Za-z_,]+>)*\.task$").unwrap());
@@ -46,6 +46,7 @@ pub async fn get_llm_usage_for_span(
     let input_cost = attributes.input_cost();
     let output_cost = attributes.output_cost();
     let total_cost = attributes.total_cost();
+    let has_incoming_positive_cost = has_positive_cost(input_cost, output_cost, total_cost);
     let response_model = attributes.response_model();
     let request_model = attributes.request_model();
     let mut model_name = response_model.clone().or(request_model.clone());
@@ -57,10 +58,13 @@ pub async fn get_llm_usage_for_span(
     // Transform the model name and provider names for universal model pricing lookup
     (model_name, provider_name) = tranform_model_and_provider(model_name, provider_name);
 
-    if input_cost.is_some_and(|c| c > 0.0)
-        || output_cost.is_some_and(|c| c > 0.0)
-        || total_cost.is_some_and(|c| c > 0.0)
-    {
+    if should_use_provided_cost(
+        input_cost,
+        output_cost,
+        total_cost,
+        attributes,
+        &input_tokens,
+    ) {
         return SpanUsage {
             input_tokens: input_tokens.total(),
             output_tokens,
@@ -92,12 +96,19 @@ pub async fn get_llm_usage_for_span(
         )
         .await
         {
-            let span_cost_input: SpanCostInput =
-                build_span_cost_input(attributes, &input_tokens, output_tokens);
-            let cost_entry = calculate_span_cost(&model_costs, &span_cost_input);
-            input_cost = cost_entry.input_cost;
-            output_cost = cost_entry.output_cost;
-            total_cost = input_cost + output_cost;
+            if should_calculate_model_cost(
+                &model_costs,
+                has_incoming_positive_cost,
+                attributes,
+                &input_tokens,
+            ) {
+                let span_cost_input: SpanCostInput =
+                    build_span_cost_input(attributes, &input_tokens, output_tokens);
+                let cost_entry = calculate_span_cost(&model_costs, &span_cost_input);
+                input_cost = cost_entry.input_cost;
+                output_cost = cost_entry.output_cost;
+                total_cost = input_cost + output_cost;
+            }
         }
     } else if let Some(provider) = attributes
         .raw_attributes
@@ -124,6 +135,71 @@ pub async fn get_llm_usage_for_span(
         request_model,
         provider_name,
     }
+}
+
+fn should_use_provided_cost(
+    input_cost: Option<f64>,
+    output_cost: Option<f64>,
+    total_cost: Option<f64>,
+    attributes: &SpanAttributes,
+    input_tokens: &InputTokens,
+) -> bool {
+    has_positive_cost(input_cost, output_cost, total_cost)
+        && !has_cache_token_breakdown(attributes, input_tokens)
+}
+
+fn has_positive_cost(
+    input_cost: Option<f64>,
+    output_cost: Option<f64>,
+    total_cost: Option<f64>,
+) -> bool {
+    input_cost.is_some_and(|c| c > 0.0)
+        || output_cost.is_some_and(|c| c > 0.0)
+        || total_cost.is_some_and(|c| c > 0.0)
+}
+
+fn has_cache_token_breakdown(attributes: &SpanAttributes, input_tokens: &InputTokens) -> bool {
+    input_tokens.cache_read_tokens > 0
+        || input_tokens.cache_write_tokens > 0
+        || attributes
+            .int_attr(GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_5M_TOKENS)
+            .is_some_and(|tokens| tokens > 0)
+        || attributes
+            .int_attr(GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_1H_TOKENS)
+            .is_some_and(|tokens| tokens > 0)
+}
+
+fn should_calculate_model_cost(
+    model_costs: &ModelCosts,
+    has_incoming_positive_cost: bool,
+    attributes: &SpanAttributes,
+    input_tokens: &InputTokens,
+) -> bool {
+    if has_incoming_positive_cost && has_cache_token_breakdown(attributes, input_tokens) {
+        return has_cache_pricing_for_breakdown(model_costs, attributes, input_tokens);
+    }
+
+    true
+}
+
+fn has_cache_pricing_for_breakdown(
+    model_costs: &ModelCosts,
+    attributes: &SpanAttributes,
+    input_tokens: &InputTokens,
+) -> bool {
+    let costs = &model_costs.0;
+    let has_cost = |key: &str| costs.get(key).and_then(Value::as_f64).is_some();
+
+    let needs_cache_read_pricing = input_tokens.cache_read_tokens > 0;
+    let cache_creation_1h_tokens = attributes
+        .int_attr(GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_1H_TOKENS)
+        .unwrap_or(0);
+    let needs_cache_creation_pricing =
+        input_tokens.cache_write_tokens > 0 || cache_creation_1h_tokens > 0;
+
+    (!needs_cache_read_pricing || has_cost("cache_read_input_token_cost"))
+        && (!needs_cache_creation_pricing || has_cost("cache_creation_input_token_cost"))
+        && (cache_creation_1h_tokens <= 0 || has_cost("cache_creation_input_token_cost_above_1hr"))
 }
 
 /// Build SpanCostInput from span attributes
@@ -379,6 +455,117 @@ fn tranform_model_and_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_float_eq(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-12,
+            "expected {actual} to equal {expected}"
+        );
+    }
+
+    #[test]
+    fn provided_cost_is_authoritative_without_cache_tokens() {
+        let attributes = SpanAttributes::new(HashMap::new());
+        let input_tokens = InputTokens {
+            regular_input_tokens: 100,
+            cache_write_tokens: 0,
+            cache_read_tokens: 0,
+        };
+
+        assert!(should_use_provided_cost(
+            Some(0.1),
+            Some(0.2),
+            Some(0.3),
+            &attributes,
+            &input_tokens
+        ));
+    }
+
+    #[test]
+    fn provided_cost_does_not_bypass_model_pricing_with_cache_tokens() {
+        let attributes = SpanAttributes::new(HashMap::new());
+        let input_tokens = InputTokens {
+            regular_input_tokens: 1,
+            cache_write_tokens: 3421,
+            cache_read_tokens: 6839,
+        };
+
+        assert!(!should_use_provided_cost(
+            Some(0.051305),
+            Some(0.004475),
+            Some(0.05578),
+            &attributes,
+            &input_tokens
+        ));
+    }
+
+    #[test]
+    fn ephemeral_cache_tokens_count_as_cache_breakdown() {
+        let attributes = SpanAttributes::new(HashMap::from([(
+            GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_5M_TOKENS.to_string(),
+            json!(3421),
+        )]));
+        let input_tokens = InputTokens {
+            regular_input_tokens: 1,
+            cache_write_tokens: 0,
+            cache_read_tokens: 0,
+        };
+
+        assert!(!should_use_provided_cost(
+            Some(0.051305),
+            Some(0.004475),
+            Some(0.05578),
+            &attributes,
+            &input_tokens
+        ));
+    }
+
+    #[test]
+    fn accounting_review_cache_shape_uses_cache_aware_model_cost() {
+        let attributes = SpanAttributes::new(HashMap::from([(
+            GEN_AI_USAGE_CACHE_CREATION_EPHEMERAL_5M_TOKENS.to_string(),
+            json!(3421),
+        )]));
+        let input_tokens = InputTokens {
+            regular_input_tokens: 1,
+            cache_write_tokens: 3421,
+            cache_read_tokens: 6839,
+        };
+        let span_cost_input = build_span_cost_input(&attributes, &input_tokens, 179);
+        let model_costs = ModelCosts(json!({
+            "input_cost_per_token": 0.000005,
+            "output_cost_per_token": 0.000025,
+            "cache_read_input_token_cost": 0.0000005,
+            "cache_creation_input_token_cost": 0.00000625
+        }));
+
+        let cost_entry = calculate_span_cost(&model_costs, &span_cost_input);
+
+        assert_float_eq(cost_entry.input_cost, 0.02480575);
+        assert_float_eq(cost_entry.output_cost, 0.004475);
+        assert!(cost_entry.input_cost < 10261.0 * 0.000005);
+    }
+
+    #[test]
+    fn cache_bearing_span_with_incomplete_cache_pricing_keeps_provided_cost() {
+        let attributes = SpanAttributes::new(HashMap::new());
+        let input_tokens = InputTokens {
+            regular_input_tokens: 1,
+            cache_write_tokens: 3421,
+            cache_read_tokens: 6839,
+        };
+        let model_costs = ModelCosts(json!({
+            "input_cost_per_token": 0.000005,
+            "output_cost_per_token": 0.000025
+        }));
+
+        assert!(!should_calculate_model_cost(
+            &model_costs,
+            true,
+            &attributes,
+            &input_tokens
+        ));
+    }
 
     #[test]
     fn prompt_hash_stable_across_cc_versions() {


### PR DESCRIPTION
## Summary

- Normalize Anthropic cache usage from `ai.response.providerMetadata` into Laminar's canonical cache token attributes.
- Recompute model cost for cache-bearing spans when cache-aware model pricing is available, instead of trusting naive incoming `gen_ai.usage.cost`.
- Preserve incoming costs when cache pricing is unavailable, and keep existing provided-cost behavior for non-cache spans.

## Testing

- `rustfmt --edition 2024 app-server/src/traces/spans.rs app-server/src/traces/utils.rs`
- `cargo test anthropic_provider_metadata -- --nocapture`
- `cargo test malformed_provider_metadata -- --nocapture`
- `cargo test provided_cost -- --nocapture`
- `cargo test cache_breakdown -- --nocapture`
- `cargo test accounting_review_cache_shape -- --nocapture`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

