### PR TITLE
remove signals feature on backend test action

### DIFF
--- a/.github/workflows/backend-build-and-test.yml
+++ b/.github/workflows/backend-build-and-test.yml
@@ -53,4 +53,4 @@ jobs:
           # compiled (target/release). A debug `cargo test` reads target/debug,
           # which is empty, so it recompiles the whole dependency tree from
           # scratch — the recompile that was blowing past the 30 min timeout.
-          docker run --rm -t app-server-test:latest cargo test --release --features signals -- --nocapture
+          docker run --rm -t app-server-test:latest cargo test --release -- --nocapture


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Signals-gated code and tests are no longer compiled in this PR workflow, so regressions in that optional feature may slip through unless covered elsewhere.
> 
> **Overview**
> Updates the **Backend build and test** workflow so the in-container `cargo test` no longer passes **`--features signals`**.
> 
> PR CI now exercises the default **app-server** feature set (no optional `signals` deps such as ONNX/tokenizers), while still using **`--release`** to reuse the Docker builder artifacts and avoid full debug recompiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd11a181b6368feb562c46b8475b90cbcac8d370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->