### PR TITLE
fix: merge metadata on trace pre-agg as well, pg already does similar

### DIFF
--- a/app-server/src/ch/traces.rs
+++ b/app-server/src/ch/traces.rs
@@ -6,7 +6,7 @@ use clickhouse::insert::Insert;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::utils::chrono_to_nanoseconds;
+use super::utils::{chrono_to_nanoseconds, merge_json_objects};
 use super::{
     ClickhouseInsertable, DataPlaneBatch, SPANS_CH_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS, Table,
 };
@@ -240,11 +240,12 @@ impl TraceAggregation {
                     entry.status = Some(status.clone());
                 }
             }
-            if entry.metadata.is_none() {
-                if let Some(metadata) = span.attributes.metadata() {
-                    if let Ok(metadata_value) = serde_json::to_value(&metadata) {
-                        entry.metadata = Some(metadata_value);
-                    }
+            if let Some(metadata) = span.attributes.metadata() {
+                if let Ok(metadata_value) = serde_json::to_value(&metadata) {
+                    entry.metadata = Some(match entry.metadata.take() {
+                        Some(existing) => merge_json_objects(existing, metadata_value),
+                        None => metadata_value,
+                    });
                 }
             }
             if entry.trace_type == 0 {

--- a/app-server/src/ch/utils.rs
+++ b/app-server/src/ch/utils.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use serde_json::Value;
 
 pub fn chrono_to_nanoseconds(chrono_dt: DateTime<Utc>) -> i64 {
     let timestamp = chrono_dt.timestamp(); // seconds since the Unix epoch
@@ -8,4 +9,20 @@ pub fn chrono_to_nanoseconds(chrono_dt: DateTime<Utc>) -> i64 {
     let total_nanos = (timestamp as i64) * 1_000_000_000 + (nanos as i64);
 
     total_nanos
+}
+
+pub fn merge_json_objects(base: Value, incoming: Value) -> Value {
+    match (base, incoming) {
+        (Value::Object(mut base_map), Value::Object(incoming_map)) => {
+            for (k, v) in incoming_map {
+                let merged = match base_map.remove(&k) {
+                    Some(existing) => merge_json_objects(existing, v),
+                    None => v,
+                };
+                base_map.insert(k, merged);
+            }
+            Value::Object(base_map)
+        }
+        (_, incoming) => incoming,
+    }
 }


### PR DESCRIPTION
Pre-aggregation in memory replaces metadata across spans with no defined order. Postgres query then merges these pre-aggregated values. The semantics are inconsistent, so we merge everywhere now. Two considerations:

1. This change is breaking. Yes, people are likely to see more metadata than they used to, but existing behaviour is a bug - they likely see less than they expect to
2. Merge semantics is best-effort, i.e. same value different keys merging is undefined behaviour, because we don't control order in which spans arrive, even if we sort within the aggregation (most OTel SDKs already do), the postgres merge may ruin it.

Both of these tradeoffs are acceptable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trace metadata semantics on the ClickHouse aggregation path; users may see more or differently merged metadata, but no auth, security, or payment impact.
> 
> **Overview**
> **Trace metadata** during in-memory ClickHouse pre-aggregation (`TraceAggregation::from_spans`) no longer keeps only the first span’s metadata. Each span’s metadata is **deep-merged** into the running aggregate via new `merge_json_objects` in `ch/utils.rs`, matching Postgres upsert behavior (`metadata || EXCLUDED.metadata`).
> 
> This is a **behavior change**: traces can show **more** metadata than before when multiple spans contribute keys. Merge order is **best-effort** (span arrival order; conflicting values for the same key are undefined), which the PR treats as acceptable vs. the prior “last/first wins” bug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da58aa2201ae4b92f10c6f23dfcdd9d01f96168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->