### PR TITLE
feat: mirror private impl

### DIFF
--- a/frontend/lib/actions/slack/webhook.ts
+++ b/frontend/lib/actions/slack/webhook.ts
@@ -76,24 +76,16 @@ export async function processSlackEvent(input: z.infer<typeof ProcessSlackEventS
 /**
  * Forward a signature-verified Slack event to app-server's internal `/api/v1/slack/process`. Body is
  * the RAW verified bytes (never re-encoded). No auth header — app-server is cluster-internal.
- *
- * Best-effort: failures are logged, never thrown. The channel-agent endpoint is signals-gated, so on
- * OSS / non-signals builds it returns 404 — we must still ack Slack with 200, otherwise Slack treats
- * the 5xx as a delivery failure and retries the same `app_mention` repeatedly.
  */
 async function forwardSlackEventToBackend(rawBody: string): Promise<void> {
-  try {
-    const res = await fetch(`${process.env.BACKEND_URL}/api/v1/slack/process`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: rawBody,
-      cache: "no-store",
-    });
+  const res = await fetch(`${process.env.BACKEND_URL}/api/v1/slack/process`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: rawBody,
+    cache: "no-store",
+  });
 
-    if (!res.ok) {
-      console.error(`Forwarding Slack event to app-server failed: ${res.status}`);
-    }
-  } catch (error) {
-    console.error("Forwarding Slack event to app-server failed:", error);
+  if (!res.ok) {
+    throw new Error(`Forwarding Slack event to app-server failed: ${res.status}`);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Slack Events API ack behavior: backend forward failures surface as 5xx and can trigger Slack retries, unlike the prior always-ack pattern for missing/disabled channel-agent endpoints.
> 
> **Overview**
> **`forwardSlackEventToBackend`** no longer swallows failures when posting verified events to app-server **`/api/v1/slack/process`**. The previous best-effort **`try/catch`** (log-only, always succeed) and comments about acking Slack with 200 on 404/OSS builds are removed.
> 
> Non-OK HTTP responses now **`throw`**, and fetch/network errors propagate instead of being logged and ignored. For **`app_mention`**, that means the Slack webhook route can return **5xx** instead of always **200**, so Slack may retry failed deliveries when backend forwarding fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d3b137b65d906de21bfd7174526e123203c8c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->