### PR TITLE
fix: add Starveri model costs

### DIFF
--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -50,18 +50,48 @@ export async function register() {
 
       const PRICES_URL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 
+      const costPerToken = (costPerMillionTokens: number) => costPerMillionTokens / 1_000_000;
+      const starveriCosts = (input: number, output: number, cachedInput: number) => ({
+        litellm_provider: "starveri",
+        source: "https://api.starveri.net/models",
+        input_cost_per_token: costPerToken(input),
+        output_cost_per_token: costPerToken(output),
+        cache_read_input_token_cost: costPerToken(cachedInput),
+      });
+
+      const STARVERI_MODEL_COSTS: Record<string, Record<string, unknown>> = {
+        "starveri/gpt-5.1-codex": starveriCosts(0.4166666666666667, 3.3333333333333335, 0.041666666666666664),
+        "starveri/gpt-5.3-codex-spark": starveriCosts(0.3333333333333333, 0.6666666666666666, 0.0033333333333333335),
+        "starveri/gpt-5.3-codex": starveriCosts(0.16666666666666666, 0.3333333333333333, 0.016666666666666666),
+        "starveri/gpt-5.4": starveriCosts(0.3333333333333333, 1.6666666666666667, 0.03333333333333333),
+        "starveri/gpt-5.4-mini": starveriCosts(0.25, 1.1666666666666667, 0.025),
+        "starveri/gpt-5.5": starveriCosts(0.8333333333333334, 2.5, 0.08333333333333333),
+      };
+
       const SHORT_NAME_PREFIXES = ["mistral", "xai", "minimax", "moonshot"];
 
       const initializeModelCosts = async (): Promise<boolean> => {
         try {
-          const response = await fetch(PRICES_URL, { signal: AbortSignal.timeout(30000) });
-          if (!response.ok) {
-            throw new Error(`Failed to fetch model prices: ${response.status} ${response.statusText}`);
+          let data: Record<string, unknown> = {};
+          try {
+            const response = await fetch(PRICES_URL, { signal: AbortSignal.timeout(30000) });
+            if (!response.ok) {
+              throw new Error(`Failed to fetch model prices: ${response.status} ${response.statusText}`);
+            }
+            data = await response.json();
+          } catch (error) {
+            console.error("Failed to fetch LiteLLM model prices:", error);
+            console.log("Continuing with bundled model costs only...");
           }
-          const data: Record<string, unknown> = await response.json();
+          const modelCostsData = { ...data };
+          for (const [modelName, costs] of Object.entries(STARVERI_MODEL_COSTS)) {
+            if (!(modelName in modelCostsData)) {
+              modelCostsData[modelName] = costs;
+            }
+          }
 
           const rows = new Map<string, unknown>();
-          for (const [modelName, info] of Object.entries(data)) {
+          for (const [modelName, info] of Object.entries(modelCostsData)) {
             if (modelName === "sample_spec") continue;
             const lowerName = modelName.toLowerCase();
             rows.set(lowerName, info);

--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -83,12 +83,10 @@ export async function register() {
             console.error("Failed to fetch LiteLLM model prices:", error);
             console.log("Continuing with bundled model costs only...");
           }
-          const modelCostsData = { ...data };
-          for (const [modelName, costs] of Object.entries(STARVERI_MODEL_COSTS)) {
-            if (!(modelName in modelCostsData)) {
-              modelCostsData[modelName] = costs;
-            }
-          }
+          // Bundled Starveri rows always win: if LiteLLM later publishes a
+          // stale or incorrect starveri/* entry, the source-backed local
+          // mapping takes precedence rather than being silently overwritten.
+          const modelCostsData = { ...data, ...STARVERI_MODEL_COSTS };
 
           const rows = new Map<string, unknown>();
           for (const [modelName, info] of Object.entries(modelCostsData)) {


### PR DESCRIPTION
## Summary

Adds default cost rows for Starveri's OpenAI-compatible model IDs so spans reported with `gen_ai.system=starveri` can resolve provider-specific pricing instead of falling back to unknown or unrelated model prices.

What changed:

- Seeds six `starveri/<model>` rows in the existing model-cost initialization path.
- Converts Starveri's published USD-per-1M-token prices into Laminar's existing per-token fields: `input_cost_per_token`, `output_cost_per_token`, and `cache_read_input_token_cost`.
- Keeps the rows provider-specific so they do not override OpenAI's own `gpt-*` pricing.
- Still upserts bundled Starveri rows if the LiteLLM price fetch fails.
- Lets bundled Starveri rows win if LiteLLM later publishes colliding `starveri/<model>` keys, so the explicit source-backed Starveri mapping remains stable.

I left tool/unit pricing such as web search or code interpreter out because the current calculator handles token pricing, not separate per-tool charges.

Fixes #1880.

## Test plan

- `pnpm exec prettier --check instrumentation.ts`
- `pnpm exec eslint instrumentation.ts` (passes with existing `no-explicit-any` warnings in this file)
- `pnpm type-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to startup pricing seeding in `instrumentation.ts`; no auth or data-path changes, with only localized impact if bundled rates drift from Starveri’s published prices.
> 
> **Overview**
> **Starveri spans** (`starveri/<model>` IDs) now get explicit per-token pricing at boot instead of missing or wrong LiteLLM rows.
> 
> `initializeModelCosts` in `instrumentation.ts` adds six bundled Starveri entries (input, output, cache-read) sourced from Starveri’s API docs, merged **after** the LiteLLM JSON so local rows override any colliding `starveri/*` keys from upstream.
> 
> LiteLLM price fetch failures no longer abort initialization: the outer flow logs the error and continues with bundled costs (including Starveri) when the remote file is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc6d83495a7dd363fdc4e15e0f3682c3d855efe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->