### PR TITLE
pin clickhouse to latest known working version

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -18,11 +18,7 @@ services:
       retries: 3
 
   clickhouse:
-    # Version 26.3 will break queries on the spans_v0 view, if they are
-    # not filtered by trace_id and/or ordered by start_time. This is a
-    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
-    # We will pin to the earliest stable version once this is fixed
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.5
     pull_policy: always
     container_name: clickhouse
     volumes:

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -16,11 +16,7 @@ services:
       retries: 3
 
   clickhouse:
-    # Version 26.3 will break queries on the spans_v0 view, if they are
-    # not filtered by trace_id and/or ordered by start_time. This is a
-    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
-    # We will pin to the earliest stable version once this is fixed
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.5
     pull_policy: always
     container_name: clickhouse
     volumes:

--- a/docker-compose-local-dev-full.yml
+++ b/docker-compose-local-dev-full.yml
@@ -19,11 +19,7 @@ services:
       retries: 3
 
   clickhouse:
-    # Version 26.3 will break queries on the spans_v0 view, if they are
-    # not filtered by trace_id and/or ordered by start_time. This is a
-    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
-    # We will pin to the earliest stable version once this is fixed
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.5
     pull_policy: always
     container_name: clickhouse
     ports:

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -25,11 +25,7 @@ services:
       retries: 5
 
   clickhouse:
-    # Version 26.3 will break queries on the spans_v0 view, if they are
-    # not filtered by trace_id and/or ordered by start_time. This is a
-    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
-    # We will pin to the earliest stable version once this is fixed
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.5
     pull_policy: always
     container_name: clickhouse
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,11 +25,7 @@ services:
       retries: 5
 
   clickhouse:
-    # Version 26.3 will break queries on the spans_v0 view, if they are
-    # not filtered by trace_id and/or ordered by start_time. This is a
-    # known bug, tracking https://github.com/ClickHouse/ClickHouse/pull/101218.
-    # We will pin to the earliest stable version once this is fixed
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.5
     container_name: clickhouse
     pull_policy: always
     volumes:


### PR DESCRIPTION
Clickhouse 26.6 breaks with an issue.

26.5 is a known good working version. Pin to it, while we wait for clickhouse to fix upstream. Maybe we can keep this version until we need newer versions' features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compose-only image tag change with no application code; main risk is environments that already upgraded to a broken `latest` needing a deliberate image downgrade.
> 
> **Overview**
> Pins the ClickHouse service image from **`clickhouse/clickhouse-server:latest`** to **`clickhouse/clickhouse-server:26.5`** across all five compose variants (`docker-compose.yml`, `docker-compose-full.yml`, and the local dev/build stacks).
> 
> This avoids pulling **ClickHouse 26.6**, which is reported to break the stack, while **26.5** is treated as the last known good version. The old inline comments about a **26.3** `spans_v0` query issue and waiting for an upstream fix are removed as part of the pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4944e81f19951f865787ea85d1c8b75b3c06f2b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

