### PR TITLE
migrate clickhouse so that clusterer can record centroids at naming time

### DIFF
--- a/frontend/lib/clickhouse/migrations/52_clusters_centroid_at_naming.sql
+++ b/frontend/lib/clickhouse/migrations/52_clusters_centroid_at_naming.sql
@@ -1,0 +1,7 @@
+-- Record the centroid a cluster had at the moment it was (re)named, so we
+-- can measure how far it has drifted since and decide when to rename.
+-- DEFAULT centroid seeds existing rows with their current centroid; the
+-- column is written explicitly at naming time and never overwritten as the
+-- centroid shifts afterward. CODEC(NONE) matches the `centroid` column.
+ALTER TABLE signal_event_clusters ADD COLUMN centroid_at_naming Array(BFloat16) DEFAULT centroid CODEC(NONE);
+ALTER TABLE signal_event_clusters ADD CONSTRAINT signal_event_clusters_centroid_at_naming_dim_768 CHECK length(centroid_at_naming) = 768;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive schema-only migration with a backfill default; no auth or query-path changes in this diff.
> 
> **Overview**
> Adds ClickHouse migration **52** so the clusterer can snapshot each cluster’s embedding when a name is assigned.
> 
> **`signal_event_clusters`** gains **`centroid_at_naming`** (`Array(BFloat16)`, `CODEC(NONE)` like **`centroid`**), with **`DEFAULT centroid`** so existing rows backfill from their current centroid. Application code is expected to set this explicitly on (re)name and leave it fixed while **`centroid`** drifts, enabling drift-based rename decisions.
> 
> A **`CHECK length(centroid_at_naming) = 768`** constraint aligns with the 768-dim centroid schema from migration 48.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cff339d80b96b819905cae643295ca9d83f93d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

