### PR TITLE
fix: mobile logos sizes

### DIFF
--- a/frontend/components/landing/hero/logo-strip.tsx
+++ b/frontend/components/landing/hero/logo-strip.tsx
@@ -13,23 +13,43 @@ interface Props {
 }
 
 const LOGOS = [
-  { id: "browser-use", Component: LogoBrowserUse, className: "w-32 h-8", href: "https://browser-use.com" },
-  { id: "openhands", Component: LogoOpenHands, className: "w-28 h-7", href: "https://www.all-hands.dev" },
-  { id: "rye", Component: LogoRye, className: "w-16 h-5", href: "https://rye.com" },
-  { id: "axion-ray", Component: LogoAxionRay, className: "w-24 h-8", href: "https://www.axionray.com" },
-  { id: "passionfroot", Component: LogoPassionfroot, className: "w-28 h-7", href: "https://www.passionfroot.me" },
-  { id: "knot", Component: LogoKnot, className: "w-[54px] h-5", href: "https://www.knotapi.com" },
+  {
+    id: "browser-use",
+    Component: LogoBrowserUse,
+    className: "w-[102px] h-[26px] sm:w-32 sm:h-8",
+    href: "https://browser-use.com",
+  },
+  {
+    id: "openhands",
+    Component: LogoOpenHands,
+    className: "w-[90px] h-[22px] sm:w-28 sm:h-7",
+    href: "https://www.all-hands.dev",
+  },
+  { id: "rye", Component: LogoRye, className: "w-[51px] h-4 sm:w-16 sm:h-5", href: "https://rye.com" },
+  {
+    id: "axion-ray",
+    Component: LogoAxionRay,
+    className: "w-[77px] h-[26px] sm:w-24 sm:h-8",
+    href: "https://www.axionray.com",
+  },
+  {
+    id: "passionfroot",
+    Component: LogoPassionfroot,
+    className: "w-[90px] h-[22px] sm:w-28 sm:h-7",
+    href: "https://www.passionfroot.me",
+  },
+  { id: "knot", Component: LogoKnot, className: "w-[43px] h-4 sm:w-[54px] sm:h-5", href: "https://www.knotapi.com" },
 ];
 
 const LogoStrip = ({ className }: Props) => (
-  <div className={cn("grid grid-cols-3 md:grid-cols-6 gap-2 w-full max-w-[960px]", className)}>
+  <div className={cn("grid grid-cols-3 md:grid-cols-6 gap-1 sm:gap-2 w-full max-w-[960px]", className)}>
     {LOGOS.map(({ id, Component, className: logoClassName, href }) => (
       <a
         key={id}
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="group flex items-center justify-center h-13 rounded bg-surface-500 transition-colors hover:bg-surface-400"
+        className="group flex items-center justify-center h-10 sm:h-13 rounded bg-surface-500 transition-colors hover:bg-surface-400"
       >
         <Component className={cn("opacity-50 scale-90 transition-opacity group-hover:opacity-80", logoClassName)} />
       </a>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS changes in the landing hero logo strip with no logic, API, or data impact.
> 
> **Overview**
> Tightens the landing hero **logo strip** layout on small viewports while keeping existing `sm:`+ sizing.
> 
> Each partner logo now uses **mobile-specific width/height** with **`sm:` breakpoints** restoring the previous dimensions. Logo cells use **`h-10`** instead of **`h-13`**, and the grid uses **`gap-1`** on mobile (**`sm:gap-2`** unchanged from before on larger screens).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0c5ee6c51fa7e78a99cff97b940b1718a2dfd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->