### PR TITLE
feat: span input token breakdown tooltip (LAM-1924)

### DIFF
--- a/frontend/components/traces/stats-shields.tsx
+++ b/frontend/components/traces/stats-shields.tsx
@@ -219,16 +219,14 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
         </TooltipTrigger>
         <TooltipPortal>
           <TooltipContent side="bottom" className="p-2 border bg-surface-700">
-            <div className="flex-col space-y-2">
-              {span ? (
-                <InputTokenBreakdown span={span} />
-              ) : (
-                <Label className="flex text-xs gap-1">
-                  <span className="text-secondary-foreground">{label("input tokens")}</span>{" "}
-                  {numberFormat.format(stats.inputTokens)}
+            {span ? (
+              <InputTokenBreakdown span={span} />
+            ) : (
+              <div className="flex-col space-y-1">
+                <Label className="flex justify-between text-xs gap-4">
+                  <span className="text-secondary-foreground">{label("input tokens")}</span>
+                  <span>{numberFormat.format(stats.inputTokens)}</span>
                 </Label>
-              )}
-              <div className="flex-col space-y-1 border-t pt-2">
                 <Label className="flex justify-between text-xs gap-4">
                   <span className="text-secondary-foreground">{label("output tokens")}</span>
                   <span>{numberFormat.format(stats.outputTokens)}</span>
@@ -239,14 +237,14 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
                     <span>{numberFormat.format(stats.reasoningTokens)}</span>
                   </Label>
                 )}
-                {!span && !!stats.cacheReadInputTokens && (
+                {!!stats.cacheReadInputTokens && (
                   <Label className="flex justify-between text-xs gap-4 text-success-bright">
                     <span>{label("cache input tokens")}</span>
                     <span>{numberFormat.format(stats.cacheReadInputTokens)}</span>
                   </Label>
                 )}
               </div>
-            </div>
+            )}
           </TooltipContent>
         </TooltipPortal>
       </Tooltip>

--- a/frontend/components/traces/stats-shields.tsx
+++ b/frontend/components/traces/stats-shields.tsx
@@ -6,7 +6,7 @@ import { memo, useMemo } from "react";
 import { InputTokenBreakdown } from "@/components/traces/token-breakdown";
 import { type TraceViewSpan, type TraceViewTrace } from "@/components/traces/trace-view/store";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { type Span, type TraceRow } from "@/lib/traces/types.ts";
+import { type Span, SpanType, type TraceRow } from "@/lib/traces/types.ts";
 import { cn, getDurationString } from "@/lib/utils";
 
 import { Label } from "../ui/label";
@@ -219,7 +219,7 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
         </TooltipTrigger>
         <TooltipPortal>
           <TooltipContent side="bottom" className="p-2 border bg-surface-700">
-            {span ? (
+            {span && (span.spanType === SpanType.LLM || span.spanType === SpanType.CACHED) ? (
               <InputTokenBreakdown span={span} />
             ) : (
               <div className="flex-col space-y-1">

--- a/frontend/components/traces/stats-shields.tsx
+++ b/frontend/components/traces/stats-shields.tsx
@@ -3,6 +3,7 @@ import { pick } from "lodash";
 import { CircleDollarSign, Clock3, Coins } from "lucide-react";
 import { memo, useMemo } from "react";
 
+import { InputTokenBreakdown } from "@/components/traces/token-breakdown";
 import { type TraceViewSpan, type TraceViewTrace } from "@/components/traces/trace-view/store";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { type Span, type TraceRow } from "@/lib/traces/types.ts";
@@ -185,9 +186,12 @@ interface StatsShieldsProps {
   className?: string;
   variant?: "filled" | "outline";
   labelPrefix?: string;
+  // When present (single LLM/CACHED span), the tokens tooltip shows an
+  // estimated input-token breakdown bar; trace/session shields omit it.
+  span?: Span;
 }
 
-export function StatsShields({ stats, className, variant = "filled", labelPrefix }: StatsShieldsProps) {
+export function StatsShields({ stats, className, variant = "filled", labelPrefix, span }: StatsShieldsProps) {
   const label = (text: string) =>
     labelPrefix ? `${labelPrefix} ${text}` : text.charAt(0).toUpperCase() + text.slice(1);
   const durationContent = (
@@ -214,27 +218,34 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
           </div>
         </TooltipTrigger>
         <TooltipPortal>
-          <TooltipContent side="bottom" className="p-2 border">
-            <div className="flex-col space-y-1">
-              <Label className="flex text-xs gap-1">
-                <span className="text-secondary-foreground">{label("input tokens")}</span>{" "}
-                {numberFormat.format(stats.inputTokens)}
-              </Label>
-              <Label className="flex text-xs gap-1">
-                <span className="text-secondary-foreground">{label("output tokens")}</span>{" "}
-                {numberFormat.format(stats.outputTokens)}
-              </Label>
-              {!!stats.cacheReadInputTokens && (
-                <Label className="flex text-xs gap-1 text-success-bright">
-                  <span>{label("cache input tokens")}</span> {numberFormat.format(stats.cacheReadInputTokens)}
-                </Label>
-              )}
-              {!!stats.reasoningTokens && (
+          <TooltipContent side="bottom" className="p-2 border bg-surface-700">
+            <div className="flex-col space-y-2">
+              {span ? (
+                <InputTokenBreakdown span={span} />
+              ) : (
                 <Label className="flex text-xs gap-1">
-                  <span className="text-secondary-foreground">{label("reasoning tokens")}</span>{" "}
-                  {numberFormat.format(stats.reasoningTokens)}
+                  <span className="text-secondary-foreground">{label("input tokens")}</span>{" "}
+                  {numberFormat.format(stats.inputTokens)}
                 </Label>
               )}
+              <div className="flex-col space-y-1 border-t pt-2">
+                <Label className="flex justify-between text-xs gap-4">
+                  <span className="text-secondary-foreground">{label("output tokens")}</span>
+                  <span>{numberFormat.format(stats.outputTokens)}</span>
+                </Label>
+                {!!stats.reasoningTokens && (
+                  <Label className="flex justify-between text-xs gap-4">
+                    <span className="text-secondary-foreground">{label("reasoning tokens")}</span>
+                    <span>{numberFormat.format(stats.reasoningTokens)}</span>
+                  </Label>
+                )}
+                {!span && !!stats.cacheReadInputTokens && (
+                  <Label className="flex justify-between text-xs gap-4 text-success-bright">
+                    <span>{label("cache input tokens")}</span>
+                    <span>{numberFormat.format(stats.cacheReadInputTokens)}</span>
+                  </Label>
+                )}
+              </div>
             </div>
           </TooltipContent>
         </TooltipPortal>
@@ -254,7 +265,7 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
           </div>
         </TooltipTrigger>
         <TooltipPortal>
-          <TooltipContent side="bottom" className="p-2 border">
+          <TooltipContent side="bottom" className="p-2 border bg-surface-700">
             <div className="flex-col space-y-1">
               <Label className="flex text-xs gap-1">
                 <span className="text-secondary-foreground">{label("total cost")}</span>{" "}
@@ -341,6 +352,7 @@ const SpanStatsShields = ({ span, className, variant }: SpanStatsShieldsProps) =
     ])}
     className={className}
     variant={variant}
+    span={span}
   />
 );
 

--- a/frontend/components/traces/token-breakdown.tsx
+++ b/frontend/components/traces/token-breakdown.tsx
@@ -146,10 +146,19 @@ export const InputTokenBreakdown = ({ span }: { span: Span }) => {
   const data = useMemo(() => getTokenBreakdown(span), [span]);
 
   if (!data) {
+    const cacheReadFallback = span.cacheReadInputTokens ?? 0;
     return (
-      <div className="flex justify-between text-xs gap-4">
-        <span className="text-secondary-foreground">Input tokens</span>
-        <span className="tabular-nums">{numberFormat.format(span.inputTokens || 0)}</span>
+      <div className="flex flex-col gap-1">
+        <div className="flex justify-between text-xs gap-4">
+          <span className="text-secondary-foreground">Input tokens</span>
+          <span className="tabular-nums">{numberFormat.format(span.inputTokens || 0)}</span>
+        </div>
+        {cacheReadFallback > 0 && (
+          <div className="flex justify-between text-xs gap-4 text-success-bright">
+            <span>Cache input tokens</span>
+            <span className="tabular-nums">{numberFormat.format(cacheReadFallback)}</span>
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/components/traces/token-breakdown.tsx
+++ b/frontend/components/traces/token-breakdown.tsx
@@ -1,0 +1,179 @@
+import { useMemo } from "react";
+
+import { getRoleColors } from "@/components/traces/span-view/common";
+import { resolveTools } from "@/components/traces/tool-list";
+import { Label } from "@/components/ui/label";
+import { normalizeToMessages } from "@/lib/spans/types";
+import { type Span, SpanType } from "@/lib/traces/types";
+
+const numberFormat = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
+
+type BucketKey = "system" | "tools" | "user" | "history";
+
+interface Bucket {
+  key: BucketKey;
+  label: string;
+  color: string;
+  tokens: number;
+}
+
+const BUCKET_META: Record<BucketKey, { label: string; role: string }> = {
+  // Reuse the span-view role palette so segments match the transcript colors.
+  system: { label: "System prompt", role: "system" },
+  tools: { label: "Tool definitions", role: "tool" },
+  user: { label: "User messages", role: "user" },
+  history: { label: "History", role: "assistant" },
+};
+
+// Char count of a message's content only (role/keys excluded) — a rough proxy
+// for that message's token weight. Non-string content is stringified.
+const contentChars = (msg: unknown): number => {
+  if (msg == null) return 0;
+  const content =
+    typeof msg === "object" && msg !== null && "content" in msg ? (msg as { content?: unknown }).content : msg;
+  if (content == null) return 0;
+  if (typeof content === "string") return content.length;
+  try {
+    return JSON.stringify(content).length;
+  } catch {
+    return 0;
+  }
+};
+
+// system → system, user/human → user, everything else (assistant, tool
+// results, model, prior turns) → history.
+const bucketForRole = (role: unknown): Exclude<BucketKey, "tools"> => {
+  const r = typeof role === "string" ? role.toLowerCase() : "";
+  if (r === "system" || r === "developer") return "system";
+  if (r === "user" || r === "human") return "user";
+  return "history";
+};
+
+// Distribute `total` across `weights` proportionally, guaranteeing the parts
+// sum EXACTLY to `total` via the largest-remainder method.
+const distribute = (weights: number[], total: number): number[] => {
+  const sum = weights.reduce((a, b) => a + b, 0);
+  if (sum <= 0 || total <= 0) return weights.map(() => 0);
+  const raw = weights.map((w) => (total * w) / sum);
+  const floored = raw.map(Math.floor);
+  let remainder = total - floored.reduce((a, b) => a + b, 0);
+  const order = raw.map((v, i) => ({ i, frac: v - Math.floor(v) })).sort((a, b) => b.frac - a.frac);
+  for (let k = 0; k < order.length && remainder > 0; k++, remainder--) {
+    floored[order[k].i] += 1;
+  }
+  return floored;
+};
+
+/**
+ * Estimate how a span's real `inputTokens` split across system prompt, tool
+ * definitions, user messages, and history (assistant + tool results + prior
+ * turns). We can't run the model's tokenizer, so we weight each category by
+ * character count and distribute the ACTUAL input-token total across all of
+ * them proportionally — history included, so system/user aren't inflated.
+ */
+export const estimateInputBreakdown = (span: Span): Bucket[] | null => {
+  if (span.spanType !== SpanType.LLM && span.spanType !== SpanType.CACHED) return null;
+  if (!span.inputTokens || span.inputTokens <= 0) return null;
+
+  const normalized = normalizeToMessages(span.input);
+  if (!Array.isArray(normalized)) return null;
+
+  const chars: Record<BucketKey, number> = { system: 0, tools: 0, user: 0, history: 0 };
+  for (const msg of normalized) {
+    chars[bucketForRole((msg as { role?: unknown } | null)?.role)] += contentChars(msg);
+  }
+
+  // Tool definitions ride the `tool_definitions` column (resolveTools prefers
+  // it, falls back to legacy attributes) — NOT the message array.
+  const tools = resolveTools(span);
+  if (tools.length > 0) {
+    chars.tools = JSON.stringify(tools).length;
+  }
+
+  const keys: BucketKey[] = ["system", "tools", "user", "history"];
+  const weights = keys.map((k) => chars[k]);
+  if (weights.every((w) => w === 0)) return null;
+
+  const tokens = distribute(weights, span.inputTokens);
+
+  return keys
+    .map((key, i) => ({
+      key,
+      label: BUCKET_META[key].label,
+      color: getRoleColors(BUCKET_META[key].role).badgeText,
+      tokens: tokens[i],
+    }))
+    .filter((b) => b.tokens > 0);
+};
+
+export const InputTokenBreakdown = ({ span }: { span: Span }) => {
+  const buckets = useMemo(() => estimateInputBreakdown(span), [span]);
+
+  if (!buckets || buckets.length === 0) {
+    return (
+      <Label className="flex text-xs gap-1">
+        <span className="text-secondary-foreground">Input tokens</span> {numberFormat.format(span.inputTokens || 0)}
+      </Label>
+    );
+  }
+
+  const total = span.inputTokens;
+  const cacheRead = span.cacheReadInputTokens ?? 0;
+  const uncached = Math.max(0, total - cacheRead);
+
+  return (
+    <div className="flex flex-col gap-3 min-w-[220px]">
+      <div className="flex justify-between text-xs">
+        <span className="text-secondary-foreground">Input tokens</span>
+        <span>{numberFormat.format(total)}</span>
+      </div>
+      {cacheRead > 0 && (
+        <div className="flex flex-col gap-2">
+          <div className="flex w-full h-1 gap-0.5 rounded-full bg-surface-200">
+            <div
+              className="h-full rounded-full bg-success-bright"
+              style={{ flex: cacheRead }}
+              title={`Cached: ${numberFormat.format(cacheRead)}`}
+            />
+            <div
+              className="h-full rounded-full"
+              style={{ flex: uncached }}
+              title={`Uncached: ${numberFormat.format(uncached)}`}
+            />
+          </div>
+          <div className="flex items-center justify-between text-xs gap-4">
+            <span className="flex items-center gap-1.5">
+              <span className="size-2 rounded-[2px] bg-success-bright" />
+              <span className="text-secondary-foreground">Cache input tokens</span>
+            </span>
+            <span>{numberFormat.format(cacheRead)}</span>
+          </div>
+        </div>
+      )}
+      <div className="flex flex-col gap-2">
+        {/* Proportional bar — estimated, colors match the span-view roles. */}
+        <div className="flex w-full h-1 gap-0.5">
+          {buckets.map((b) => (
+            <div
+              key={b.key}
+              className="h-full rounded-full"
+              style={{ flex: b.tokens, backgroundColor: b.color }}
+              title={`${b.label}: ${numberFormat.format(b.tokens)}`}
+            />
+          ))}
+        </div>
+        <div className="flex flex-col gap-1">
+          {buckets.map((b) => (
+            <div key={b.key} className="flex items-center justify-between text-xs gap-4">
+              <span className="flex items-center gap-1.5">
+                <span className="size-2 rounded-[2px]" style={{ backgroundColor: b.color }} />
+                <span className="text-secondary-foreground">{b.label}</span>
+              </span>
+              <span>{numberFormat.format(b.tokens)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/components/traces/token-breakdown.tsx
+++ b/frontend/components/traces/token-breakdown.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 
 import { getRoleColors } from "@/components/traces/span-view/common";
 import { resolveTools } from "@/components/traces/tool-list";
-import { Label } from "@/components/ui/label";
 import { normalizeToMessages } from "@/lib/spans/types";
 import { type Span, SpanType } from "@/lib/traces/types";
 
@@ -110,10 +109,22 @@ export const InputTokenBreakdown = ({ span }: { span: Span }) => {
   const buckets = useMemo(() => estimateInputBreakdown(span), [span]);
 
   if (!buckets || buckets.length === 0) {
+    // Estimation fell back (non-array/legacy input) — still surface the cache
+    // line so cached spans don't lose it (the parent hides its own once `span`).
+    const cacheReadFallback = span.cacheReadInputTokens ?? 0;
     return (
-      <Label className="flex text-xs gap-1">
-        <span className="text-secondary-foreground">Input tokens</span> {numberFormat.format(span.inputTokens || 0)}
-      </Label>
+      <div className="flex flex-col gap-1 min-w-[220px]">
+        <div className="flex justify-between text-xs gap-4">
+          <span className="text-secondary-foreground">Input tokens</span>
+          <span>{numberFormat.format(span.inputTokens || 0)}</span>
+        </div>
+        {cacheReadFallback > 0 && (
+          <div className="flex justify-between text-xs gap-4 text-success-bright">
+            <span>Cache input tokens</span>
+            <span>{numberFormat.format(cacheReadFallback)}</span>
+          </div>
+        )}
+      </div>
     );
   }
 

--- a/frontend/components/traces/token-breakdown.tsx
+++ b/frontend/components/traces/token-breakdown.tsx
@@ -147,12 +147,23 @@ export const InputTokenBreakdown = ({ span }: { span: Span }) => {
 
   if (!data) {
     const cacheReadFallback = span.cacheReadInputTokens ?? 0;
+    const reasoningFallback = span.reasoningTokens ?? 0;
     return (
       <div className="flex flex-col gap-1">
         <div className="flex justify-between text-xs gap-4">
           <span className="text-secondary-foreground">Input tokens</span>
           <span className="tabular-nums">{numberFormat.format(span.inputTokens || 0)}</span>
         </div>
+        <div className="flex justify-between text-xs gap-4">
+          <span className="text-secondary-foreground">Output tokens</span>
+          <span className="tabular-nums">{numberFormat.format(span.outputTokens || 0)}</span>
+        </div>
+        {reasoningFallback > 0 && (
+          <div className="flex justify-between text-xs gap-4">
+            <span className="text-secondary-foreground">Reasoning tokens</span>
+            <span className="tabular-nums">{numberFormat.format(reasoningFallback)}</span>
+          </div>
+        )}
         {cacheReadFallback > 0 && (
           <div className="flex justify-between text-xs gap-4 text-success-bright">
             <span>Cache input tokens</span>

--- a/frontend/components/traces/token-breakdown.tsx
+++ b/frontend/components/traces/token-breakdown.tsx
@@ -7,13 +7,38 @@ import { type Span, SpanType } from "@/lib/traces/types";
 
 const numberFormat = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
 
-type BucketKey = "system" | "tools" | "user" | "history";
+const pctOf = (part: number, total: number): number => (total > 0 ? Math.round((part / total) * 100) : 0);
 
-interface Bucket {
+/** Measured count — real provider numbers. */
+const MeasuredValue = ({ tokens, pct }: { tokens: number; pct: number }) => (
+  <span className="tabular-nums">
+    {numberFormat.format(tokens)} <span className="text-secondary-foreground">({pct}%)</span>
+  </span>
+);
+
+/** Estimated share of input — char-weighted guess, pct only. */
+const EstimatedValue = ({ pct }: { pct: number }) => (
+  <span className="tabular-nums text-secondary-foreground">{pct}%</span>
+);
+
+type BucketKey = "system" | "tools" | "user" | "assistant";
+
+export interface EstimatedBucket {
   key: BucketKey;
   label: string;
   color: string;
-  tokens: number;
+  /** Share of input tokens (parts sum to 100). */
+  pct: number;
+}
+
+export interface TokenBreakdownData {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cacheReadTokens: number;
+  reasoningTokens: number;
+  /** Char-weighted split of input; null when input isn't a message array. */
+  estimates: EstimatedBucket[] | null;
 }
 
 const BUCKET_META: Record<BucketKey, { label: string; role: string }> = {
@@ -21,8 +46,11 @@ const BUCKET_META: Record<BucketKey, { label: string; role: string }> = {
   system: { label: "System prompt", role: "system" },
   tools: { label: "Tool definitions", role: "tool" },
   user: { label: "User messages", role: "user" },
-  history: { label: "History", role: "assistant" },
+  // Catch-all for assistant/model turns and role:tool results (OpenAI-style).
+  assistant: { label: "Assistant messages", role: "assistant" },
 };
+
+const BUCKET_KEYS: BucketKey[] = ["system", "tools", "user", "assistant"];
 
 // Char count of a message's content only (role/keys excluded) — a rough proxy
 // for that message's token weight. Non-string content is stringified.
@@ -40,22 +68,21 @@ const contentChars = (msg: unknown): number => {
 };
 
 // system → system, user/human → user, everything else (assistant, tool
-// results, model, prior turns) → history.
+// results, model) → assistant.
 const bucketForRole = (role: unknown): Exclude<BucketKey, "tools"> => {
   const r = typeof role === "string" ? role.toLowerCase() : "";
   if (r === "system" || r === "developer") return "system";
   if (r === "user" || r === "human") return "user";
-  return "history";
+  return "assistant";
 };
 
-// Distribute `total` across `weights` proportionally, guaranteeing the parts
-// sum EXACTLY to `total` via the largest-remainder method.
-const distribute = (weights: number[], total: number): number[] => {
+// Distribute 100 across `weights` via largest-remainder so parts sum exactly.
+const distributePct = (weights: number[]): number[] => {
   const sum = weights.reduce((a, b) => a + b, 0);
-  if (sum <= 0 || total <= 0) return weights.map(() => 0);
-  const raw = weights.map((w) => (total * w) / sum);
+  if (sum <= 0) return weights.map(() => 0);
+  const raw = weights.map((w) => (100 * w) / sum);
   const floored = raw.map(Math.floor);
-  let remainder = total - floored.reduce((a, b) => a + b, 0);
+  let remainder = 100 - floored.reduce((a, b) => a + b, 0);
   const order = raw.map((v, i) => ({ i, frac: v - Math.floor(v) })).sort((a, b) => b.frac - a.frac);
   for (let k = 0; k < order.length && remainder > 0; k++, remainder--) {
     floored[order[k].i] += 1;
@@ -63,21 +90,13 @@ const distribute = (weights: number[], total: number): number[] => {
   return floored;
 };
 
-/**
- * Estimate how a span's real `inputTokens` split across system prompt, tool
- * definitions, user messages, and history (assistant + tool results + prior
- * turns). We can't run the model's tokenizer, so we weight each category by
- * character count and distribute the ACTUAL input-token total across all of
- * them proportionally — history included, so system/user aren't inflated.
- */
-export const estimateInputBreakdown = (span: Span): Bucket[] | null => {
-  if (span.spanType !== SpanType.LLM && span.spanType !== SpanType.CACHED) return null;
+const estimateShares = (span: Span): EstimatedBucket[] | null => {
   if (!span.inputTokens || span.inputTokens <= 0) return null;
 
   const normalized = normalizeToMessages(span.input);
   if (!Array.isArray(normalized)) return null;
 
-  const chars: Record<BucketKey, number> = { system: 0, tools: 0, user: 0, history: 0 };
+  const chars: Record<BucketKey, number> = { system: 0, tools: 0, user: 0, assistant: 0 };
   for (const msg of normalized) {
     chars[bucketForRole((msg as { role?: unknown } | null)?.role)] += contentChars(msg);
   }
@@ -89,101 +108,124 @@ export const estimateInputBreakdown = (span: Span): Bucket[] | null => {
     chars.tools = JSON.stringify(tools).length;
   }
 
-  const keys: BucketKey[] = ["system", "tools", "user", "history"];
-  const weights = keys.map((k) => chars[k]);
+  const weights = BUCKET_KEYS.map((k) => chars[k]);
   if (weights.every((w) => w === 0)) return null;
 
-  const tokens = distribute(weights, span.inputTokens);
+  const pcts = distributePct(weights);
+  return BUCKET_KEYS.map((key, i) => ({
+    key,
+    label: BUCKET_META[key].label,
+    color: getRoleColors(BUCKET_META[key].role).badgeText,
+    pct: pcts[i],
+  })).filter((b) => b.pct > 0);
+};
 
-  return keys
-    .map((key, i) => ({
-      key,
-      label: BUCKET_META[key].label,
-      color: getRoleColors(BUCKET_META[key].role).badgeText,
-      tokens: tokens[i],
-    }))
-    .filter((b) => b.tokens > 0);
+/**
+ * Measured token counts from the span, plus an optional char-weighted estimate
+ * of how input tokens split across system / tools / user / assistant.
+ */
+export const getTokenBreakdown = (span: Span): TokenBreakdownData | null => {
+  if (span.spanType !== SpanType.LLM && span.spanType !== SpanType.CACHED) return null;
+
+  const inputTokens = span.inputTokens || 0;
+  const outputTokens = span.outputTokens || 0;
+  const totalTokens = span.totalTokens || inputTokens + outputTokens;
+  if (totalTokens <= 0 && inputTokens <= 0) return null;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: totalTokens || inputTokens + outputTokens,
+    cacheReadTokens: span.cacheReadInputTokens ?? 0,
+    reasoningTokens: span.reasoningTokens ?? 0,
+    estimates: estimateShares(span),
+  };
 };
 
 export const InputTokenBreakdown = ({ span }: { span: Span }) => {
-  const buckets = useMemo(() => estimateInputBreakdown(span), [span]);
+  const data = useMemo(() => getTokenBreakdown(span), [span]);
 
-  if (!buckets || buckets.length === 0) {
-    // Estimation fell back (non-array/legacy input) — still surface the cache
-    // line so cached spans don't lose it (the parent hides its own once `span`).
-    const cacheReadFallback = span.cacheReadInputTokens ?? 0;
+  if (!data) {
     return (
-      <div className="flex flex-col gap-1 min-w-[220px]">
-        <div className="flex justify-between text-xs gap-4">
-          <span className="text-secondary-foreground">Input tokens</span>
-          <span>{numberFormat.format(span.inputTokens || 0)}</span>
-        </div>
-        {cacheReadFallback > 0 && (
-          <div className="flex justify-between text-xs gap-4 text-success-bright">
-            <span>Cache input tokens</span>
-            <span>{numberFormat.format(cacheReadFallback)}</span>
-          </div>
-        )}
+      <div className="flex justify-between text-xs gap-4">
+        <span className="text-secondary-foreground">Input tokens</span>
+        <span className="tabular-nums">{numberFormat.format(span.inputTokens || 0)}</span>
       </div>
     );
   }
 
-  const total = span.inputTokens;
-  const cacheRead = span.cacheReadInputTokens ?? 0;
-  const uncached = Math.max(0, total - cacheRead);
+  const { inputTokens, outputTokens, cacheReadTokens, reasoningTokens, estimates } = data;
+  const uncached = Math.max(0, inputTokens - cacheReadTokens);
 
   return (
     <div className="flex flex-col gap-3 min-w-[220px]">
-      <div className="flex justify-between text-xs">
-        <span className="text-secondary-foreground">Input tokens</span>
-        <span>{numberFormat.format(total)}</span>
-      </div>
-      {cacheRead > 0 && (
-        <div className="flex flex-col gap-2">
-          <div className="flex w-full h-1 gap-0.5 rounded-full bg-surface-200">
-            <div
-              className="h-full rounded-full bg-success-bright"
-              style={{ flex: cacheRead }}
-              title={`Cached: ${numberFormat.format(cacheRead)}`}
-            />
-            <div
-              className="h-full rounded-full"
-              style={{ flex: uncached }}
-              title={`Uncached: ${numberFormat.format(uncached)}`}
-            />
+      <div className="flex flex-col gap-1">
+        <div className="flex justify-between text-xs gap-4">
+          <span className="text-secondary-foreground">Input tokens</span>
+          <span className="tabular-nums">{numberFormat.format(inputTokens)}</span>
+        </div>
+        {cacheReadTokens > 0 && (
+          <div className="flex flex-col gap-2 pt-1">
+            <div className="flex w-full h-1 gap-0.5 rounded-full bg-surface-200">
+              <div
+                className="h-full rounded-full bg-success-bright"
+                style={{ flex: cacheReadTokens }}
+                title={`Cached: ${numberFormat.format(cacheReadTokens)} (${pctOf(cacheReadTokens, inputTokens)}%)`}
+              />
+              <div
+                className="h-full rounded-full"
+                style={{ flex: uncached }}
+                title={`Uncached: ${numberFormat.format(uncached)} (${pctOf(uncached, inputTokens)}%)`}
+              />
+            </div>
+            <div className="flex items-center justify-between text-xs gap-4">
+              <span className="flex items-center gap-1.5">
+                <span className="size-2 rounded-[2px] bg-success-bright" />
+                <span className="text-secondary-foreground">Cache input tokens</span>
+              </span>
+              <MeasuredValue tokens={cacheReadTokens} pct={pctOf(cacheReadTokens, inputTokens)} />
+            </div>
           </div>
-          <div className="flex items-center justify-between text-xs gap-4">
-            <span className="flex items-center gap-1.5">
-              <span className="size-2 rounded-[2px] bg-success-bright" />
-              <span className="text-secondary-foreground">Cache input tokens</span>
-            </span>
-            <span>{numberFormat.format(cacheRead)}</span>
+        )}
+      </div>
+
+      {estimates && estimates.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <div className="flex w-full h-1 gap-0.5">
+            {estimates.map((b) => (
+              <div
+                key={b.key}
+                className="h-full rounded-full"
+                style={{ flex: b.pct, backgroundColor: b.color }}
+                title={`${b.label}: ${b.pct}%`}
+              />
+            ))}
+          </div>
+          <div className="flex flex-col gap-1">
+            {estimates.map((b) => (
+              <div key={b.key} className="flex items-center justify-between text-xs gap-4">
+                <span className="flex items-center gap-1.5">
+                  <span className="size-2 rounded-[2px]" style={{ backgroundColor: b.color }} />
+                  <span className="text-secondary-foreground">{b.label}</span>
+                </span>
+                <EstimatedValue pct={b.pct} />
+              </div>
+            ))}
           </div>
         </div>
       )}
-      <div className="flex flex-col gap-2">
-        {/* Proportional bar — estimated, colors match the span-view roles. */}
-        <div className="flex w-full h-1 gap-0.5">
-          {buckets.map((b) => (
-            <div
-              key={b.key}
-              className="h-full rounded-full"
-              style={{ flex: b.tokens, backgroundColor: b.color }}
-              title={`${b.label}: ${numberFormat.format(b.tokens)}`}
-            />
-          ))}
+
+      <div className="flex flex-col gap-1 border-t pt-2">
+        <div className="flex justify-between text-xs gap-4">
+          <span className="text-secondary-foreground">Output tokens</span>
+          <MeasuredValue tokens={outputTokens} pct={pctOf(outputTokens, inputTokens)} />
         </div>
-        <div className="flex flex-col gap-1">
-          {buckets.map((b) => (
-            <div key={b.key} className="flex items-center justify-between text-xs gap-4">
-              <span className="flex items-center gap-1.5">
-                <span className="size-2 rounded-[2px]" style={{ backgroundColor: b.color }} />
-                <span className="text-secondary-foreground">{b.label}</span>
-              </span>
-              <span>{numberFormat.format(b.tokens)}</span>
-            </div>
-          ))}
-        </div>
+        {reasoningTokens > 0 && (
+          <div className="flex justify-between text-xs gap-4">
+            <span className="text-secondary-foreground">Reasoning tokens</span>
+            <MeasuredValue tokens={reasoningTokens} pct={pctOf(reasoningTokens, inputTokens)} />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds an estimated **input-token breakdown** bar to the tokens tooltip on the trace-view span shield. When hovering a single LLM/CACHED span's token stat, the tooltip now shows how that span's real `input_tokens` split across **System prompt**, **Tool definitions**, **User messages**, and **History**, plus the cached/uncached split.

The estimate weights each category by character count and distributes the span's actual `input_tokens` proportionally via the largest-remainder method, so the parts always sum exactly to the real total. Colors match the span-view role palette. Tool definitions are resolved from the dedup'd `tool_definitions` column (with the legacy-attributes fallback).

## Scope

Span-level only. The trace-level breakdown (server-side aggregate endpoint) is split into a follow-up branch (`feat/trace-token-breakdown`) so this PR stays focused.

## Notes / accepted caveats

This is a read-time **estimate**, not the model's tokenizer:
- Char count is a proxy for token weight (skews on code/CJK, UTF-16 units).
- Only message `content` chars count (roles/structure excluded); cache-read is shown separately but not excluded from the split.
- Role bucketing is coarse (assistant/tool-results/reasoning all collapse into History).
- Multimodal/image content is mis-weighted (base64 over-counts, URLs under-count).
- Falls back to the plain total (+ cache line) when input isn't a parseable message array.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI in the traces frontend with graceful fallback when input isn't parseable; no auth, billing, or API changes.
> 
> **Overview**
> **Span token tooltips** on the trace view now show a richer breakdown when you hover the token shield on a single **LLM** or **CACHED** span (`SpanStatsShields` passes the span through). Trace/session aggregates still use the plain totals list.
> 
> Adds **`InputTokenBreakdown`** in `token-breakdown.tsx`: measured input/output/reasoning counts, a **cached vs uncached** bar when cache-read tokens exist, and an **estimated** split of input across system prompt, tool definitions (from `resolveTools` / `tool_definitions`), user messages, and assistant/history—weighted by message `content` character counts and normalized with largest-remainder so percentages sum to 100. Segment colors align with span-view role colors.
> 
> **`StatsShields`** gains an optional `span` prop and switches the tokens tooltip body: breakdown UI for LLM/CACHED when `span` is set, otherwise the existing aggregate rows (now **justify-between** layout). Token and cost tooltips use **`bg-surface-700`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e034d990829fdc5f15e826a86c42244e6ce2e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->