### PR TITLE
feat: Generate custom render templates

### DIFF
--- a/frontend/app/api/projects/[projectId]/render-templates/generate/route.ts
+++ b/frontend/app/api/projects/[projectId]/render-templates/generate/route.ts
@@ -2,10 +2,25 @@ import { type NextRequest } from "next/server";
 import { prettifyError, ZodError } from "zod/v4";
 
 import { generateTemplate } from "@/lib/actions/render-template/generate";
+import { getServerSession } from "@/lib/auth-session";
+import { isUserMemberOfProject } from "@/lib/authorization";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = await params;
+
+  // Defense-in-depth auth gate (also enforced by proxy.ts middleware): this route
+  // runs a billable LLM agent, so verify session + project membership before
+  // invoking generation. 401/403 JSON, matching other project-scoped routes.
+  const session = await getServerSession();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!(await isUserMemberOfProject(projectId, userId))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   try {
-    const { projectId } = await params;
     const body = await request.json();
 
     const result = await generateTemplate({ ...body, projectId });

--- a/frontend/app/api/projects/[projectId]/render-templates/generate/route.ts
+++ b/frontend/app/api/projects/[projectId]/render-templates/generate/route.ts
@@ -16,7 +16,10 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (!userId) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
-  if (!(await isUserMemberOfProject(projectId, userId))) {
+  // skipCache: a billable LLM run is security-sensitive — force a fresh membership
+  // read so a since-removed user can't ride the 30-day positive-membership cache
+  // (same convention as CLI key-mint in lib/actions/cli-auth).
+  if (!(await isUserMemberOfProject(projectId, userId, { skipCache: true }))) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/frontend/app/api/projects/[projectId]/render-templates/generate/route.ts
+++ b/frontend/app/api/projects/[projectId]/render-templates/generate/route.ts
@@ -2,26 +2,10 @@ import { type NextRequest } from "next/server";
 import { prettifyError, ZodError } from "zod/v4";
 
 import { generateTemplate } from "@/lib/actions/render-template/generate";
-import { getServerSession } from "@/lib/auth-session";
-import { isUserMemberOfProject } from "@/lib/authorization";
 
+// Auth/membership is enforced by proxy.ts middleware for all /api/projects/* routes.
 export async function POST(request: NextRequest, { params }: { params: Promise<{ projectId: string }> }) {
   const { projectId } = await params;
-
-  // Defense-in-depth auth gate (also enforced by proxy.ts middleware): this route
-  // runs a billable LLM agent, so verify session + project membership before
-  // invoking generation. 401/403 JSON, matching other project-scoped routes.
-  const session = await getServerSession();
-  const userId = session?.user?.id;
-  if (!userId) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  // skipCache: a billable LLM run is security-sensitive — force a fresh membership
-  // read so a since-removed user can't ride the 30-day positive-membership cache
-  // (same convention as CLI key-mint in lib/actions/cli-auth).
-  if (!(await isUserMemberOfProject(projectId, userId, { skipCache: true }))) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
-  }
 
   try {
     const body = await request.json();

--- a/frontend/app/api/projects/[projectId]/render-templates/generate/route.ts
+++ b/frontend/app/api/projects/[projectId]/render-templates/generate/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest } from "next/server";
+import { prettifyError, ZodError } from "zod/v4";
+
+import { generateTemplate } from "@/lib/actions/render-template/generate";
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ projectId: string }> }) {
+  try {
+    const { projectId } = await params;
+    const body = await request.json();
+
+    const result = await generateTemplate({ ...body, projectId });
+
+    return Response.json(result);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return Response.json({ error: prettifyError(error) }, { status: 400 });
+    }
+
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Failed to generate template." },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/components/sql/sql-editor.tsx
+++ b/frontend/components/sql/sql-editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type Extension } from "@codemirror/state";
 import CodeMirror from "@uiw/react-codemirror";
 import { motion } from "framer-motion";
 import { Loader2, Sparkles } from "lucide-react";
@@ -25,6 +26,8 @@ export interface SQLEditorProps {
   inputPlaceholder?: string;
   projectId?: string;
   aiButtonVariant?: "icon" | "full";
+  /** Extra CodeMirror extensions appended per-usage (e.g. scroll margins). */
+  extraExtensions?: Extension[];
 }
 
 export default function SQLEditor({
@@ -39,13 +42,17 @@ export default function SQLEditor({
   inputPlaceholder = "e.g. Get top 10 most expensive traces from last 24 hours",
   projectId,
   aiButtonVariant = "icon",
+  extraExtensions,
 }: SQLEditorProps) {
   const [isAiDialogOpen, setIsAiDialogOpen] = useState(false);
   const [isAiLoading, setIsAiLoading] = useState(false);
   const [aiPrompt, setAiPrompt] = useState("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  const extensions = useMemo(() => createExtensions(schema), [schema]);
+  const extensions = useMemo(
+    () => [...createExtensions(schema), ...(extraExtensions ?? [])],
+    [schema, extraExtensions]
+  );
 
   const handleAiGenerate = useCallback(async () => {
     const prompt = aiPrompt.trim();

--- a/frontend/components/traces/trace-view/custom-view/index.tsx
+++ b/frontend/components/traces/trace-view/custom-view/index.tsx
@@ -2,6 +2,7 @@ import { Loader2 } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
+import { useTraceViewStore } from "@/components/traces/trace-view/store";
 import { TemplatePickerPreview, useTemplatePicker } from "@/components/ui/template-renderer/template-picker";
 
 /** Renders the selected trace template. Template selection lives in the trace
@@ -19,6 +20,7 @@ export default function CustomView({
 }) {
   const { projectId } = useParams();
   const { selectedTemplate, isManaging } = useTemplatePicker();
+  const selectSpanById = useTraceViewStore((s) => s.selectSpanById);
 
   // Outcome keyed by fetch inputs. Effects run after paint, so a keyed result
   // (rather than bare isFetching/error flags) prevents one paint from showing
@@ -81,7 +83,7 @@ export default function CustomView({
         </div>
       ) : (
         <div className="flex flex-1 min-h-0 flex-col overflow-y-auto">
-          <TemplatePickerPreview data={renderData} />
+          <TemplatePickerPreview data={renderData} onSelectSpan={selectSpanById} />
         </div>
       )}
     </div>

--- a/frontend/components/traces/trace-view/template-view-toggle.tsx
+++ b/frontend/components/traces/trace-view/template-view-toggle.tsx
@@ -1,5 +1,16 @@
-import { Check, ChevronDown, Eye, EyeOff, LayoutTemplate, List, ListTree, type LucideIcon, Plus } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import {
+  Check,
+  ChevronDown,
+  Eye,
+  EyeOff,
+  LayoutTemplate,
+  List,
+  ListTree,
+  type LucideIcon,
+  PencilIcon,
+  Plus,
+} from "lucide-react";
+import { type MouseEvent, useCallback, useMemo, useState } from "react";
 
 import { type ViewTab } from "@/components/traces/trace-view/view-toggle";
 import {
@@ -44,7 +55,7 @@ export default function TemplateViewToggle({
   onToggleContent,
   viewTabs,
 }: TemplateViewToggleProps) {
-  const { templates, selectedTemplate, selectTemplate, openCreate } = useTemplatePicker();
+  const { templates, selectedTemplate, selectTemplate, openCreate, openEdit } = useTemplatePicker();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
 
@@ -88,6 +99,20 @@ export default function TemplateViewToggle({
     openCreate();
     setOpen(false);
   }, [openCreate]);
+
+  // Editing loads the template into the shared form first (the manage dialog
+  // reads it via useFormContext), so edit implies selecting it. Don't open edit
+  // on a failed load — fetchTemplate already toasted.
+  const handleEditTemplate = useCallback(
+    async (e: MouseEvent, id: string) => {
+      e.stopPropagation();
+      e.preventDefault();
+      setOpen(false);
+      if (selectedTemplate?.id !== id && !(await selectTemplate(id))) return;
+      openEdit();
+    },
+    [selectedTemplate, selectTemplate, openEdit]
+  );
 
   return (
     <div className="flex items-center min-w-0">
@@ -147,10 +172,20 @@ export default function TemplateViewToggle({
                           key={t.id}
                           value={`template:${t.id}`}
                           onSelect={() => handlePickTemplate(t.id)}
-                          className="text-xs"
+                          className="group text-xs"
                         >
                           <span className="flex-1 truncate">{t.name}</span>
-                          {active && <Check className="ml-2 size-3.5 shrink-0" />}
+                          <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
+                            <button
+                              type="button"
+                              aria-label={`Edit ${t.name}`}
+                              onClick={(e) => handleEditTemplate(e, t.id)}
+                              className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
+                            >
+                              <PencilIcon className="size-2.5" />
+                            </button>
+                            {active && <Check className="size-3.5" />}
+                          </div>
                         </CommandItem>
                       );
                     })

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -68,7 +68,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold text-left leading-none tracking-tight", className)}
+    className={cn("text-lg font-semibold text-left leading-none", className)}
     {...props}
   />
 ));

--- a/frontend/components/ui/template-renderer/index.tsx
+++ b/frontend/components/ui/template-renderer/index.tsx
@@ -26,15 +26,9 @@ export type ManageTemplateForm = z.infer<typeof manageTemplateSchema>;
 
 export const defaultTemplateValues: ManageTemplateForm = {
   name: "",
-  code: `function({ data }) {
-  // This template uses HTML syntax for data rendering
-
-  return (
-    <div>
-      Data {JSON.stringify(data)}
-    </div>
-  );
-}`,
+  // Empty by default — create starts with no code; the user either generates or
+  // pastes their own. The disabled-when-no-code CTA guards submit.
+  code: "",
   scope: "span",
   whereClause: null,
   testData: "",

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -7,6 +7,7 @@ import { normalizeTemplateCode } from "./normalize";
 import { LAMINAR_IFRAME_THEME, laminarIframeThemeJson } from "./theme";
 
 const MESSAGE_TYPE = "__TEMPLATE_DATA_UPDATE__";
+const SELECT_SPAN_MESSAGE_TYPE = "__TEMPLATE_SELECT_SPAN__";
 
 const createIframeContent = (templateCode: string): string => {
   const escapedTemplateCode = templateCode
@@ -82,6 +83,9 @@ const createIframeContent = (templateCode: string): string => {
     const parentOrigin = window.origin;
     const LAMINAR_THEME = ${themeJson};
 
+    // Lets templates request a span selection in the parent trace view.
+    const selectSpan = (spanId) => { if (typeof spanId === 'string' && spanId) window.parent.postMessage({ type: '${SELECT_SPAN_MESSAGE_TYPE}', spanId }, parentOrigin); };
+
     class TemplateRenderer {
       constructor() {
         this.root = document.getElementById('root');
@@ -147,9 +151,9 @@ const createIframeContent = (templateCode: string): string => {
         const { useState, useEffect, useMemo, useRef, useCallback, useContext } = preactHooks;
         
         const templateFunction = new Function(
-          'h', 'Fragment', 'useState', 'useEffect', 'useMemo', 'useRef', 'useCallback', 'useContext',
+          'h', 'Fragment', 'useState', 'useEffect', 'useMemo', 'useRef', 'useCallback', 'useContext', 'selectSpan',
           'return ' + this.compiledCode
-        )(h, Fragment, useState, useEffect, useMemo, useRef, useCallback, useContext);
+        )(h, Fragment, useState, useEffect, useMemo, useRef, useCallback, useContext, selectSpan);
         
         if (typeof templateFunction !== 'function') {
           throw new Error('Template must be a function');
@@ -236,21 +240,41 @@ interface JsxRendererProps {
   data: any;
   className?: string;
   autoHeight?: boolean;
+  onSelectSpan?: (spanId: string) => void;
 }
 
-const JsxRenderer = ({ code, data, className, autoHeight = false }: JsxRendererProps) => {
+const JsxRenderer = ({ code, data, className, autoHeight = false, onSelectSpan }: JsxRendererProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const pendingDataRef = useRef<any>(null);
   const iframeReadyRef = useRef(false);
+  // Latest data, read by the [code] effect when the iframe (re)initializes so a
+  // freshly-mounted iframe (e.g. after the empty-state → populated transition)
+  // gets queued data even when `data` itself didn't change.
+  const latestDataRef = useRef(data);
+
+  // Keep the latest callback + data available to the [code]-keyed message
+  // listener. Declared before the [code] effect so it runs first on each commit.
+  const onSelectSpanRef = useRef(onSelectSpan);
+  useEffect(() => {
+    onSelectSpanRef.current = onSelectSpan;
+    latestDataRef.current = data;
+  });
 
   useEffect(() => {
     const iframe = iframeRef.current;
     if (!iframe) return;
 
     iframeReadyRef.current = false;
+    // Queue current data for this (re)initialized iframe's READY. The [data]
+    // effect only fires on data change, so it misses the empty→populated mount.
+    pendingDataRef.current = parseData(latestDataRef.current);
 
     const handleReady = (event: MessageEvent) => {
       if (event.source !== iframe.contentWindow) return;
+      if (event.data?.type === SELECT_SPAN_MESSAGE_TYPE && typeof event.data.spanId === "string") {
+        onSelectSpanRef.current?.(event.data.spanId);
+        return;
+      }
       if (event.data?.type !== `${MESSAGE_TYPE}_READY`) return;
       iframeReadyRef.current = true;
 

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -1,7 +1,9 @@
+import { Eye } from "lucide-react";
 import { useEffect, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 
+import { normalizeTemplateCode } from "./normalize";
 import { LAMINAR_IFRAME_THEME, laminarIframeThemeJson } from "./theme";
 
 const MESSAGE_TYPE = "__TEMPLATE_DATA_UPDATE__";
@@ -221,21 +223,6 @@ const createErrorContent = (message: string): string => `
 </body>
 </html>`;
 
-const normalizeTemplateCode = (code: string): string => {
-  const trimmedCode = code.trim();
-
-  const functionMatch = trimmedCode.match(/^function\s*\((.*?)\)\s*{([\s\S]*)}$/);
-  if (functionMatch) {
-    return `(${functionMatch[1]}) => {${functionMatch[2]}}`;
-  }
-
-  if (!trimmedCode.startsWith("(") && !trimmedCode.startsWith("function")) {
-    return `({ data }) => {${trimmedCode}}`;
-  }
-
-  return trimmedCode;
-};
-
 const parseData = (data: any): any => {
   try {
     return typeof data === "string" ? JSON.parse(data) : data;
@@ -334,6 +321,19 @@ const JsxRenderer = ({ code, data, className, autoHeight = false }: JsxRendererP
       observer?.disconnect();
     };
   }, [autoHeight]);
+
+  // Nothing generated / written yet — show an empty state instead of a blank iframe.
+  if (!code?.trim()) {
+    return (
+      <div className={cn("flex h-full w-full flex-col items-center justify-center gap-2 p-6 text-center", className)}>
+        <Eye className="size-6 text-muted-foreground" />
+        <h3 className="text-sm font-medium text-secondary-foreground">Nothing to preview yet</h3>
+        <p className="max-w-xs text-xs text-muted-foreground">
+          Generate a template or write your own in the Code tab to see a live preview.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <iframe

--- a/frontend/components/ui/template-renderer/jsx-renderer.tsx
+++ b/frontend/components/ui/template-renderer/jsx-renderer.tsx
@@ -71,7 +71,7 @@ const createIframeContent = (templateCode: string): string => {
     *::-webkit-scrollbar-thumb { background: ${LAMINAR_IFRAME_THEME.colors.border}; border-radius: 10px; }
     *::-webkit-scrollbar-thumb:hover { background: ${LAMINAR_IFRAME_THEME.colors.border}CC; }
     html, body { scrollbar-color: ${LAMINAR_IFRAME_THEME.colors.border} ${LAMINAR_IFRAME_THEME.colors.border}33; }
-    .error { color: ${LAMINAR_IFRAME_THEME.colors.destructive.DEFAULT}; }
+    .error { color: ${LAMINAR_IFRAME_THEME.colors["destructive-bright"]}; padding: 1rem; font-size: 0.875rem; }
     .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
   </style>
 </head>
@@ -212,7 +212,7 @@ const createErrorContent = (message: string): string => `
   <meta charset="utf-8">
   <style>
     body { margin: 0; padding: 1rem; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: ${LAMINAR_IFRAME_THEME.colors.background}; color: ${LAMINAR_IFRAME_THEME.colors.foreground}; }
-    .error { color: ${LAMINAR_IFRAME_THEME.colors.destructive.DEFAULT}; background: rgba(204, 51, 51, 0.08); padding: 1rem; border-radius: 0.375rem; border: 1px solid ${LAMINAR_IFRAME_THEME.colors.border}; }
+    .error { color: ${LAMINAR_IFRAME_THEME.colors["destructive-bright"]}; background: rgba(204, 51, 51, 0.08); padding: 1rem; border-radius: 0.375rem; border: 1px solid ${LAMINAR_IFRAME_THEME.colors.border}; font-size: 0.875rem; }
   </style>
 </head>
 <body>

--- a/frontend/components/ui/template-renderer/manage-template-dialog/data-panel.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/data-panel.tsx
@@ -43,7 +43,7 @@ const DataPanel = () => {
   };
 
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col gap-2 p-3">
+    <div className="flex h-full min-h-0 min-w-0 flex-col gap-2">
       <span className="text-xs text-muted-foreground">
         Sample data passed to the template as <code className="font-mono">data</code>.
       </span>

--- a/frontend/components/ui/template-renderer/manage-template-dialog/fetch-render-data.ts
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/fetch-render-data.ts
@@ -1,0 +1,29 @@
+export interface RenderData {
+  spans?: unknown[];
+  truncated?: boolean;
+}
+
+// Runs the trace's span WHERE clause via the render-data endpoint. Shared by the
+// SpanFilter "Test" button and the auto-fetch that follows a trace generation.
+// Throws with the server error message on failure so each caller renders it its way.
+export async function fetchRenderData(
+  projectId: string,
+  traceId: string,
+  whereClause: string | null,
+  signal?: AbortSignal
+): Promise<RenderData> {
+  const res = await fetch(`/api/projects/${projectId}/traces/${traceId}/render-data`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    signal,
+    body: JSON.stringify({ whereClause: whereClause ?? null }),
+  });
+  if (!res.ok) {
+    const errMessage = await res
+      .json()
+      .then((d) => d?.error)
+      .catch(() => null);
+    throw new Error(errMessage ?? "Failed to run the filter");
+  }
+  return res.json();
+}

--- a/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
@@ -222,14 +222,20 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
 
         <form onSubmit={handleSubmit(submit)} className="flex h-full w-full flex-col overflow-hidden">
           <div className="flex h-14 shrink-0 items-center justify-between border-b px-5">
-            <DialogTitle className="text-base font-normal text-foreground">{title}</DialogTitle>
+            <DialogTitle className="text-base font-medium text-foreground">{title}</DialogTitle>
             <div className="flex items-center gap-2">
-              <Button type="button" variant="outline" size="md" onClick={handleCancel} className="rounded px-4 text-xs">
+              <Button
+                type="button"
+                variant="outline"
+                size="default"
+                onClick={handleCancel}
+                className="rounded px-4 text-xs"
+              >
                 Cancel
               </Button>
               <Button
                 type="submit"
-                size="md"
+                size="default"
                 disabled={isSaving || isGenerating || !code?.trim()}
                 className="gap-1.5 rounded px-4 text-xs"
               >

--- a/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import useSWR, { useSWRConfig } from "swr";
 
@@ -42,16 +42,36 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
   const [describeText, setDescribeText] = useState("");
   const [activeTab, setActiveTab] = useState("preview");
 
+  // In-flight generate request. The dialog never unmounts, so a request that
+  // resolves after the user cancels must NOT write back into the (now restored)
+  // form — abort it on close and bail on `aborted`.
+  const generateAbortRef = useRef<AbortController | null>(null);
+
+  // Reset transient UI state each time the dialog opens. Because the component
+  // stays mounted across open/close, a stale `activeTab` (e.g. the trace-only
+  // "filter" tab) would otherwise leave a span dialog's panel blank.
+  useEffect(() => {
+    if (mode !== null) {
+      setActiveTab("preview");
+      setDescribeText("");
+      setIsGenerating(false);
+    }
+  }, [mode]);
+
   const handleGenerate = useCallback(async () => {
     if (!describeText.trim()) {
       toast({ variant: "destructive", title: "Describe what you want the template to render first." });
       return;
     }
+    generateAbortRef.current?.abort();
+    const controller = new AbortController();
+    generateAbortRef.current = controller;
     setIsGenerating(true);
     try {
       const res = await fetch(`/api/projects/${projectId}/render-templates/generate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        signal: controller.signal,
         body: JSON.stringify({
           scope: effectiveScope,
           description: describeText,
@@ -73,6 +93,8 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
         return;
       }
       const result = (await res.json()) as { code: string; whereClause?: string };
+      // Cancelled mid-resolve — the form was already restored; don't clobber it.
+      if (controller.signal.aborted) return;
       setValue("code", result.code, { shouldDirty: true });
       if (effectiveScope === "trace" && result.whereClause !== undefined) {
         setValue("whereClause", result.whereClause, { shouldDirty: true });
@@ -80,15 +102,28 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
       setDescribeText("");
       setActiveTab("preview");
     } catch (e) {
+      // Aborted by cancel — silent, whoever cancelled owns the next state.
+      if (controller.signal.aborted) return;
       toast({
         variant: "destructive",
         title: "Error",
         description: e instanceof Error ? e.message : "Failed to generate template",
       });
     } finally {
-      setIsGenerating(false);
+      // Only the current request may clear the flag/ref — a newer one owns them.
+      if (generateAbortRef.current === controller) {
+        generateAbortRef.current = null;
+        setIsGenerating(false);
+      }
     }
   }, [projectId, effectiveScope, describeText, getValues, setValue, spanOutline, toast]);
+
+  // Abort any in-flight generate before delegating to the parent's cancel — used
+  // by both close affordances (overlay/escape and the panel's X button).
+  const handleCancel = useCallback(() => {
+    generateAbortRef.current?.abort();
+    onCancel();
+  }, [onCancel]);
 
   const submit = useCallback(
     async (data: ManageTemplateForm) => {
@@ -142,9 +177,9 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      if (!next) onCancel();
+      if (!next) handleCancel();
     },
-    [onCancel]
+    [handleCancel]
   );
 
   const title = `${mode === "edit" ? "Edit" : "Create a"} custom render template`;
@@ -176,7 +211,7 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
             spanOutline={spanOutline}
             activeTab={activeTab}
             onTabChange={setActiveTab}
-            onCancel={onCancel}
+            onCancel={handleCancel}
             isSaving={isSaving}
             canSave={!!code?.trim()}
           />

--- a/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
@@ -50,6 +50,11 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
   // form — abort it on close and bail on `aborted`.
   const generateAbortRef = useRef<AbortController | null>(null);
 
+  // Laminar session for grouping generations. Editing uses the template id
+  // (stable across sessions); creating has no id yet, so we mint a per-open
+  // draft id so a create session's iterative "Request changes" runs group.
+  const draftSessionIdRef = useRef<string>("");
+
   // Reset transient UI state each time the dialog opens. Because the component
   // stays mounted across open/close, a stale `activeTab` (e.g. the trace-only
   // "filter" tab) would otherwise leave a span dialog's panel blank.
@@ -58,6 +63,7 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
       setActiveTab("preview");
       setDescribeText("");
       setIsGenerating(false);
+      draftSessionIdRef.current = `render-template-draft:${crypto.randomUUID()}`;
     }
   }, [mode]);
 
@@ -78,6 +84,8 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
         body: JSON.stringify({
           scope: effectiveScope,
           description: describeText,
+          // Group by template id when editing; fall back to the per-open draft id.
+          sessionId: getValues("id") ?? draftSessionIdRef.current,
           currentCode: getValues("code"),
           ...(effectiveScope === "trace"
             ? {

--- a/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
@@ -1,14 +1,17 @@
+import { Loader2 } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import useSWR, { useSWRConfig } from "swr";
 
+import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { useToast } from "@/lib/hooks/use-toast";
 import { swrFetcher } from "@/lib/utils";
 
 import { type ManageTemplateForm, type Template, type TemplateScope } from "../index";
 import { type ManageTemplateMode } from "../template-picker";
+import { fetchRenderData } from "./fetch-render-data";
 import LeftColumn from "./left-column";
 import RightPanel from "./right-panel";
 
@@ -96,11 +99,25 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
       // Cancelled mid-resolve — the form was already restored; don't clobber it.
       if (controller.signal.aborted) return;
       setValue("code", result.code, { shouldDirty: true });
+      const nextWhereClause =
+        result.whereClause !== undefined ? result.whereClause : (getValues("whereClause") ?? null);
       if (effectiveScope === "trace" && result.whereClause !== undefined) {
         setValue("whereClause", result.whereClause, { shouldDirty: true });
       }
       setDescribeText("");
       setActiveTab("preview");
+      // Auto-fetch the trace's spans against the (possibly new) filter and pipe
+      // them into testData so the preview renders real data immediately. Best-
+      // effort: a failure leaves the prior sample data in place, preview still shows.
+      if (effectiveScope === "trace" && traceId) {
+        try {
+          const renderData = await fetchRenderData(projectId as string, traceId, nextWhereClause, controller.signal);
+          if (controller.signal.aborted) return;
+          setValue("testData", JSON.stringify(renderData, null, 2), { shouldDirty: false });
+        } catch {
+          // Non-fatal — generation succeeded; the data fetch just didn't refresh.
+        }
+      }
     } catch (e) {
       // Aborted by cancel — silent, whoever cancelled owns the next state.
       if (controller.signal.aborted) return;
@@ -116,7 +133,7 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
         setIsGenerating(false);
       }
     }
-  }, [projectId, effectiveScope, describeText, getValues, setValue, spanOutline, toast]);
+  }, [projectId, effectiveScope, traceId, describeText, getValues, setValue, spanOutline, toast]);
 
   // Abort any in-flight generate before delegating to the parent's cancel — used
   // by both close affordances (overlay/escape and the panel's X button).
@@ -187,34 +204,48 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
   return (
     <Dialog open={mode !== null} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="flex h-[600px] w-[960px] max-w-none overflow-hidden rounded-lg border p-0 outline-0"
+        className="flex h-[700px] w-[1000px] max-w-none flex-col overflow-hidden rounded-lg border p-0 outline-0 2xl:h-[840px] 2xl:w-[1280px]"
         onPointerDownOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
-        {/* Visually-hidden a11y title/description — the visible header lives in LeftColumn. */}
-        <DialogTitle className="sr-only">{title}</DialogTitle>
         <DialogDescription className="sr-only">
           Generate or write custom JSX to render your data however you want.
         </DialogDescription>
 
-        <form onSubmit={handleSubmit(submit)} className="flex h-full w-full overflow-hidden">
-          <LeftColumn
-            title={title}
-            isGenerating={isGenerating}
-            describeText={describeText}
-            onDescribeChange={setDescribeText}
-            onGenerate={handleGenerate}
-          />
-          <RightPanel
-            scope={effectiveScope}
-            traceId={traceId}
-            spanOutline={spanOutline}
-            activeTab={activeTab}
-            onTabChange={setActiveTab}
-            onCancel={handleCancel}
-            isSaving={isSaving}
-            canSave={!!code?.trim()}
-          />
+        <form onSubmit={handleSubmit(submit)} className="flex h-full w-full flex-col overflow-hidden">
+          <div className="flex h-14 shrink-0 items-center justify-between border-b px-5">
+            <DialogTitle className="text-base font-normal text-foreground">{title}</DialogTitle>
+            <div className="flex items-center gap-2">
+              <Button type="button" variant="outline" size="md" onClick={handleCancel} className="rounded px-4 text-xs">
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                size="md"
+                disabled={isSaving || !code?.trim()}
+                className="gap-1.5 rounded px-4 text-xs"
+              >
+                {isSaving && <Loader2 className="size-3.5 animate-spin" />}
+                Save
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex min-h-0 flex-1 overflow-hidden">
+            <LeftColumn
+              isGenerating={isGenerating}
+              describeText={describeText}
+              onDescribeChange={setDescribeText}
+              onGenerate={handleGenerate}
+            />
+            <RightPanel
+              scope={effectiveScope}
+              traceId={traceId}
+              spanOutline={spanOutline}
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+            />
+          </div>
         </form>
       </DialogContent>
     </Dialog>

--- a/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
@@ -1,25 +1,16 @@
-import { Loader2, Play, Sparkles, X } from "lucide-react";
 import { useParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
-import { Controller, useFormContext } from "react-hook-form";
+import { useCallback, useState } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 import useSWR, { useSWRConfig } from "swr";
 
-import SQLEditor from "@/components/sql/sql-editor";
-import { Button } from "@/components/ui/button";
-import { CopyButton } from "@/components/ui/copy-button";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { buildRenderTemplatePrompt, buildTraceRenderTemplatePrompt } from "@/lib/actions/render-template/prompts";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { useToast } from "@/lib/hooks/use-toast";
 import { swrFetcher } from "@/lib/utils";
 
 import { type ManageTemplateForm, type Template, type TemplateScope } from "../index";
-import JsxRenderer from "../jsx-renderer";
 import { type ManageTemplateMode } from "../template-picker";
-import CodeEditor from "./code-editor";
-import DataPanel from "./data-panel";
+import LeftColumn from "./left-column";
+import RightPanel from "./right-panel";
 
 interface Props {
   mode: ManageTemplateMode;
@@ -35,63 +26,69 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
   const { toast } = useToast();
   const { mutate } = useSWRConfig();
 
+  const { control, handleSubmit, reset, getValues, setValue } = useFormContext<ManageTemplateForm>();
+  const effectiveScope = useWatch({ control, name: "scope" }) ?? scope;
+  const code = useWatch({ control, name: "code" });
+
   const { data: spanOutline } = useSWR<unknown[]>(
-    mode !== null && scope === "trace" && traceId ? `/api/projects/${projectId}/traces/${traceId}/span-outline` : null,
+    mode !== null && effectiveScope === "trace" && traceId
+      ? `/api/projects/${projectId}/traces/${traceId}/span-outline`
+      : null,
     swrFetcher
   );
 
-  const {
-    control,
-    handleSubmit,
-    watch,
-    reset,
-    getValues,
-    setValue,
-    formState: { errors },
-  } = useFormContext<ManageTemplateForm>();
-
   const [isSaving, setIsSaving] = useState(false);
-  const [isTesting, setIsTesting] = useState(false);
-  const [testResult, setTestResult] = useState<
-    { ok: true; count: number; truncated: boolean } | { ok: false; error: string } | null
-  >(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [describeText, setDescribeText] = useState("");
+  const [activeTab, setActiveTab] = useState("preview");
 
-  // The dialog stays mounted across open/close — drop the previous session's result.
-  useEffect(() => {
-    setTestResult(null);
-  }, [mode]);
-
-  const testWhereClause = useCallback(async () => {
-    if (!traceId) return;
-    setIsTesting(true);
-    setTestResult(null);
+  const handleGenerate = useCallback(async () => {
+    if (!describeText.trim()) {
+      toast({ variant: "destructive", title: "Describe what you want the template to render first." });
+      return;
+    }
+    setIsGenerating(true);
     try {
-      const res = await fetch(`/api/projects/${projectId}/traces/${traceId}/render-data`, {
+      const res = await fetch(`/api/projects/${projectId}/render-templates/generate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ whereClause: getValues("whereClause") ?? null }),
+        body: JSON.stringify({
+          scope: effectiveScope,
+          description: describeText,
+          currentCode: getValues("code"),
+          ...(effectiveScope === "trace"
+            ? {
+                currentWhereClause: getValues("whereClause") ?? null,
+                traceOutline: spanOutline ? JSON.stringify(spanOutline) : undefined,
+              }
+            : { sampleData: getValues("testData") }),
+        }),
       });
       if (!res.ok) {
         const errMessage = await res
           .json()
           .then((d) => d?.error)
           .catch(() => null);
-        setTestResult({ ok: false, error: errMessage ?? "Failed to run the filter" });
+        toast({ variant: "destructive", title: "Error", description: errMessage ?? "Failed to generate template" });
         return;
       }
-      const data = await res.json();
-      setValue("testData", JSON.stringify(data, null, 2), { shouldDirty: false });
-      setTestResult({
-        ok: true,
-        count: Array.isArray(data?.spans) ? data.spans.length : 0,
-        truncated: !!data?.truncated,
+      const result = (await res.json()) as { code: string; whereClause?: string };
+      setValue("code", result.code, { shouldDirty: true });
+      if (effectiveScope === "trace" && result.whereClause !== undefined) {
+        setValue("whereClause", result.whereClause, { shouldDirty: true });
+      }
+      setDescribeText("");
+      setActiveTab("preview");
+    } catch (e) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: e instanceof Error ? e.message : "Failed to generate template",
       });
-    } catch {
-      setTestResult({ ok: false, error: "Failed to run the filter" });
     } finally {
-      setIsTesting(false);
+      setIsGenerating(false);
     }
-  }, [projectId, traceId, getValues, setValue]);
+  }, [projectId, effectiveScope, describeText, getValues, setValue, spanOutline, toast]);
 
   const submit = useCallback(
     async (data: ManageTemplateForm) => {
@@ -143,18 +140,6 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
     [projectId, mutate, toast, reset, onSaved, scope]
   );
 
-  const effectiveScope = watch("scope") ?? scope;
-
-  const promptHintSuffix =
-    effectiveScope === "trace"
-      ? spanOutline
-        ? " + this trace's outline"
-        : ""
-      : watch("testData")?.trim()
-        ? " + your test data"
-        : "";
-  const promptHint = `Generate with your AI tool - prompt includes Laminar style guide${promptHintSuffix}`;
-
   const handleOpenChange = useCallback(
     (next: boolean) => {
       if (!next) onCancel();
@@ -162,160 +147,39 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
     [onCancel]
   );
 
+  const title = `${mode === "edit" ? "Edit" : "Create a"} custom render template`;
+
   return (
     <Dialog open={mode !== null} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="flex h-full w-full max-h-[92vh] max-w-[92vw] lg:max-w-[80vw] flex-col gap-0 overflow-hidden p-0 outline-0"
+        className="flex h-[600px] w-[960px] max-w-none overflow-hidden rounded-lg border p-0 outline-0"
         onPointerDownOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
-        <form onSubmit={handleSubmit(submit)} className="flex flex-1 flex-col overflow-hidden">
-          <DialogHeader className="relative space-y-0.5 border-b px-5 py-3 pr-12">
-            <DialogTitle className="text-base">Render template</DialogTitle>
-            <p className="text-xs text-muted-foreground">
-              Write JSX that renders your data, or copy the AI prompt for a head start.
-            </p>
-            <button
-              type="button"
-              onClick={onCancel}
-              aria-label="Close"
-              className="absolute right-3 top-3 inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <X className="size-4" />
-            </button>
-          </DialogHeader>
+        {/* Visually-hidden a11y title/description — the visible header lives in LeftColumn. */}
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <DialogDescription className="sr-only">
+          Generate or write custom JSX to render your data however you want.
+        </DialogDescription>
 
-          <div className="grid flex-1 grid-cols-[minmax(360px,1fr)_minmax(0,1.4fr)] gap-4 overflow-hidden">
-            <div className="flex min-h-0 min-w-0 flex-col gap-3 pl-4 py-4">
-              <div>
-                <Label htmlFor="template-name" className="text-xs tracking-wide text-muted-foreground">
-                  Name
-                </Label>
-                <Controller
-                  rules={{ required: "Template name is required" }}
-                  name="name"
-                  control={control}
-                  render={({ field }) => (
-                    <Input
-                      id="template-name"
-                      className="mt-1 h-8 w-full"
-                      placeholder="e.g. Trace summary card"
-                      autoFocus
-                      {...field}
-                    />
-                  )}
-                />
-                {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name.message}</p>}
-              </div>
-
-              {effectiveScope === "trace" && (
-                <div>
-                  <Label className="text-xs tracking-wide text-muted-foreground">Span filter (SQL WHERE)</Label>
-                  <div className="mt-1 flex items-start gap-2">
-                    <div className="h-16 min-w-0 flex-1 overflow-hidden rounded-md border">
-                      <Controller
-                        name="whereClause"
-                        control={control}
-                        render={({ field }) => (
-                          <SQLEditor
-                            value={field.value ?? ""}
-                            onChange={field.onChange}
-                            placeholder="e.g. span_type = 'LLM' AND name LIKE 'agent%'"
-                            schema={{ tables: ["spans"] }}
-                          />
-                        )}
-                      />
-                    </div>
-                    {traceId && (
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        className="h-8 shrink-0 text-xs"
-                        disabled={isTesting}
-                        onClick={testWhereClause}
-                      >
-                        {isTesting ? (
-                          <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                        ) : (
-                          <Play className="mr-1.5 size-3.5" />
-                        )}
-                        Test
-                      </Button>
-                    )}
-                  </div>
-                  {testResult &&
-                    (testResult.ok ? (
-                      <p className="mt-1 text-xs text-success">
-                        Matched {testResult.count} {testResult.count === 1 ? "span" : "spans"}
-                        {testResult.truncated ? " (truncated to 256)" : ""} — preview and data updated.
-                      </p>
-                    ) : (
-                      <p className="mt-1 text-xs text-destructive">{testResult.error}</p>
-                    ))}
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Appended to{" "}
-                    <code className="font-mono">SELECT * FROM spans WHERE trace_id = &lt;trace&gt; AND (...)</code>.
-                    Leave empty to include all spans.{traceId ? " Test runs it against this trace." : ""}
-                  </p>
-                </div>
-              )}
-
-              <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg border bg-card">
-                <div className="flex items-start justify-between gap-2 border-b px-3 py-2">
-                  <div className="flex min-w-0 items-start gap-1.5 text-xs text-muted-foreground">
-                    <Sparkles className="mt-0.5 size-3.5 shrink-0 text-primary" />
-                    <span title={promptHint}>{promptHint}</span>
-                  </div>
-                  <CopyButton
-                    type="button"
-                    variant="secondaryLight"
-                    text={
-                      effectiveScope === "trace"
-                        ? buildTraceRenderTemplatePrompt(spanOutline ? JSON.stringify(spanOutline, null, 2) : undefined)
-                        : buildRenderTemplatePrompt(watch("testData"))
-                    }
-                    className="shrink-0 text-xs"
-                    iconClassName="size-3"
-                  >
-                    Copy prompt
-                  </CopyButton>
-                </div>
-                <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-                  <CodeEditor />
-                </div>
-              </div>
-            </div>
-
-            <div className="flex min-h-0 min-w-0 flex-col pr-4 py-4">
-              <Tabs
-                defaultValue="preview"
-                className="flex min-h-0 min-w-0 flex-1 flex-col gap-0 overflow-hidden rounded-lg border bg-muted/30"
-              >
-                <TabsList className="m-2 self-start">
-                  <TabsTrigger value="preview">Preview</TabsTrigger>
-                  <TabsTrigger value="data">Data</TabsTrigger>
-                </TabsList>
-                <TabsContent value="preview" className="flex min-h-0 min-w-0 flex-col border-t outline-none">
-                  <div className="min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
-                    <JsxRenderer code={watch("code")} data={watch("testData")} />
-                  </div>
-                </TabsContent>
-                <TabsContent value="data" className="flex min-h-0 min-w-0 flex-col border-t outline-none">
-                  <DataPanel />
-                </TabsContent>
-              </Tabs>
-            </div>
-          </div>
-
-          <DialogFooter className="border-t px-5 py-3">
-            <Button type="button" variant="secondary" onClick={onCancel} disabled={isSaving}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isSaving}>
-              {isSaving && <Loader2 className="mr-2 size-4 animate-spin" />}
-              {mode === "edit" ? "Save" : "Create"}
-            </Button>
-          </DialogFooter>
+        <form onSubmit={handleSubmit(submit)} className="flex h-full w-full overflow-hidden">
+          <LeftColumn
+            title={title}
+            isGenerating={isGenerating}
+            describeText={describeText}
+            onDescribeChange={setDescribeText}
+            onGenerate={handleGenerate}
+          />
+          <RightPanel
+            scope={effectiveScope}
+            traceId={traceId}
+            spanOutline={spanOutline}
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            onCancel={onCancel}
+            isSaving={isSaving}
+            canSave={!!code?.trim()}
+          />
         </form>
       </DialogContent>
     </Dialog>

--- a/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
@@ -204,7 +204,7 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
   return (
     <Dialog open={mode !== null} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="flex h-[700px] w-[1000px] max-w-none flex-col overflow-hidden rounded-lg border p-0 outline-0 2xl:h-[840px] 2xl:w-[1280px]"
+        className="flex h-[85vh] max-h-[900px] w-[90vw] max-w-[1400px] flex-col overflow-hidden rounded-lg border p-0 outline-0"
         onPointerDownOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >

--- a/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/index.tsx
@@ -230,7 +230,7 @@ const ManageTemplateDialog = ({ mode, scope = "span", traceId, onCancel, onSaved
               <Button
                 type="submit"
                 size="md"
-                disabled={isSaving || !code?.trim()}
+                disabled={isSaving || isGenerating || !code?.trim()}
                 className="gap-1.5 rounded px-4 text-xs"
               >
                 {isSaving && <Loader2 className="size-3.5 animate-spin" />}

--- a/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
@@ -65,7 +65,9 @@ const LeftColumn = ({ title, isGenerating, describeText, onDescribeChange, onGen
           size="md"
         >
           <Sparkles className="size-3" />
-          <span className={cn(isGenerating && "shimmer")}>{isGenerating ? "Generating" : "Generate"}</span>
+          <span className={cn(isGenerating && "shimmer")}>
+            {isGenerating ? "Generating" : code?.trim() ? "Request changes" : "Generate"}
+          </span>
         </Button>
       </div>
     </div>

--- a/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
@@ -1,0 +1,75 @@
+import { Sparkles } from "lucide-react";
+import { Controller, useFormContext, useWatch } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+import { type ManageTemplateForm } from "../index";
+
+interface Props {
+  title: string;
+  isGenerating: boolean;
+  describeText: string;
+  onDescribeChange: (value: string) => void;
+  onGenerate: () => void;
+}
+
+const LeftColumn = ({ title, isGenerating, describeText, onDescribeChange, onGenerate }: Props) => {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<ManageTemplateForm>();
+  const code = useWatch({ control, name: "code" });
+
+  return (
+    <div className="flex h-full w-[387px] shrink-0 flex-col gap-4 px-6 pb-4 pt-6 border-r">
+      <div className="flex min-h-0 flex-1 flex-col gap-6">
+        <div className="flex flex-col gap-1 py-0.5">
+          <p className="text-base text-foreground">{title}</p>
+          <p className="max-w-[278px] text-sm text-secondary-foreground">
+            Generate or write custom JSX to render your data however you want.
+          </p>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-3">
+          <Controller
+            rules={{ required: "Template name is required" }}
+            name="name"
+            control={control}
+            render={({ field }) => (
+              <Input size="sm" className="rounded border-border" placeholder="Template name" autoFocus {...field} />
+            )}
+          />
+
+          <Textarea
+            value={describeText}
+            onChange={(e) => onDescribeChange(e.target.value)}
+            disabled={isGenerating}
+            className="min-h-0 flex-1 resize-none rounded border border-border px-4 py-3 text-sm text-foreground outline-none focus:border-primary disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder={
+              code?.trim() ? "Describe changes to your custom render template" : "Describe your custom render template"
+            }
+          />
+          {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          onClick={onGenerate}
+          disabled={isGenerating}
+          className="gap-1 rounded px-4 text-xs"
+          size="md"
+        >
+          <Sparkles className="size-3" />
+          <span className={cn(isGenerating && "shimmer")}>{isGenerating ? "Generating" : "Generate"}</span>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default LeftColumn;

--- a/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
@@ -37,17 +37,36 @@ const LeftColumn = ({ isGenerating, describeText, onDescribeChange, onGenerate }
           {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
         </div>
 
-        <Textarea
-          value={describeText}
-          onChange={(e) => onDescribeChange(e.target.value)}
-          disabled={isGenerating}
-          className="min-h-0 flex-1 resize-none rounded border border-border px-4 py-3 text-sm text-foreground outline-none focus:border-primary disabled:cursor-not-allowed disabled:opacity-50"
-          placeholder={
-            code?.trim()
-              ? "Describe changes to your custom render template"
-              : "Generate custom JSX to render your data however you want."
-          }
-        />
+        {/* Native <textarea> text can't take background-clip:text, so during
+            generation we hide the real text and overlay a shimmering copy that
+            mirrors its padding/typography. */}
+        <div className="relative flex min-h-0 flex-1 flex-col">
+          <Textarea
+            value={describeText}
+            onChange={(e) => onDescribeChange(e.target.value)}
+            disabled={isGenerating}
+            className={cn(
+              "min-h-0 flex-1 resize-none rounded border border-border px-4 py-3 text-sm text-foreground outline-none focus:border-primary disabled:cursor-not-allowed disabled:opacity-50",
+              isGenerating && "text-transparent disabled:opacity-100"
+            )}
+            placeholder={
+              code?.trim()
+                ? "Describe changes to your custom render template"
+                : "Generate custom JSX to render your data however you want."
+            }
+          />
+          {isGenerating && describeText && (
+            <div
+              aria-hidden
+              // Muted greys, not bright white: base = muted-foreground (currentColor),
+              // highlight pinned to the lighter secondary-foreground. Setting
+              // shimmer-color also bypasses tw-shimmer's dark-mode brighten-to-white.
+              className="shimmer shimmer-color-secondary-foreground pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-4 py-3 text-sm text-muted-foreground"
+            >
+              {describeText}
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="flex justify-end">

--- a/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
@@ -9,14 +9,13 @@ import { cn } from "@/lib/utils";
 import { type ManageTemplateForm } from "../index";
 
 interface Props {
-  title: string;
   isGenerating: boolean;
   describeText: string;
   onDescribeChange: (value: string) => void;
   onGenerate: () => void;
 }
 
-const LeftColumn = ({ title, isGenerating, describeText, onDescribeChange, onGenerate }: Props) => {
+const LeftColumn = ({ isGenerating, describeText, onDescribeChange, onGenerate }: Props) => {
   const {
     control,
     formState: { errors },
@@ -24,43 +23,37 @@ const LeftColumn = ({ title, isGenerating, describeText, onDescribeChange, onGen
   const code = useWatch({ control, name: "code" });
 
   return (
-    <div className="flex h-full w-[387px] shrink-0 flex-col gap-4 px-6 pb-4 pt-6 border-r">
-      <div className="flex min-h-0 flex-1 flex-col gap-6">
-        <div className="flex flex-col gap-1 py-0.5">
-          <p className="text-base text-foreground">{title}</p>
-          <p className="max-w-[278px] text-sm text-secondary-foreground">
-            Generate or write custom JSX to render your data however you want.
-          </p>
-        </div>
-
-        <div className="flex min-h-0 flex-1 flex-col gap-3">
-          <div className="flex flex-col gap-1">
-            <Controller
-              rules={{ required: "Template name is required" }}
-              name="name"
-              control={control}
-              render={({ field }) => (
-                <Input size="sm" className="rounded border-border" placeholder="Template name" autoFocus {...field} />
-              )}
-            />
-            {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
-          </div>
-
-          <Textarea
-            value={describeText}
-            onChange={(e) => onDescribeChange(e.target.value)}
-            disabled={isGenerating}
-            className="min-h-0 flex-1 resize-none rounded border border-border px-4 py-3 text-sm text-foreground outline-none focus:border-primary disabled:cursor-not-allowed disabled:opacity-50"
-            placeholder={
-              code?.trim() ? "Describe changes to your custom render template" : "Describe your custom render template"
-            }
+    <div className="flex h-full w-[387px] shrink-0 flex-col gap-4 px-5 pb-4 pt-4 border-r">
+      <div className="flex min-h-0 flex-1 flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <Controller
+            rules={{ required: "Template name is required" }}
+            name="name"
+            control={control}
+            render={({ field }) => (
+              <Input size="sm" className="rounded border-border" placeholder="Template name" autoFocus {...field} />
+            )}
           />
+          {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
         </div>
+
+        <Textarea
+          value={describeText}
+          onChange={(e) => onDescribeChange(e.target.value)}
+          disabled={isGenerating}
+          className="min-h-0 flex-1 resize-none rounded border border-border px-4 py-3 text-sm text-foreground outline-none focus:border-primary disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder={
+            code?.trim()
+              ? "Describe changes to your custom render template"
+              : "Generate custom JSX to render your data however you want."
+          }
+        />
       </div>
 
       <div className="flex justify-end">
         <Button
           type="button"
+          variant="outline"
           onClick={onGenerate}
           disabled={isGenerating}
           className="gap-1 rounded px-4 text-xs"

--- a/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/left-column.tsx
@@ -34,14 +34,17 @@ const LeftColumn = ({ title, isGenerating, describeText, onDescribeChange, onGen
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col gap-3">
-          <Controller
-            rules={{ required: "Template name is required" }}
-            name="name"
-            control={control}
-            render={({ field }) => (
-              <Input size="sm" className="rounded border-border" placeholder="Template name" autoFocus {...field} />
-            )}
-          />
+          <div className="flex flex-col gap-1">
+            <Controller
+              rules={{ required: "Template name is required" }}
+              name="name"
+              control={control}
+              render={({ field }) => (
+                <Input size="sm" className="rounded border-border" placeholder="Template name" autoFocus {...field} />
+              )}
+            />
+            {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
+          </div>
 
           <Textarea
             value={describeText}
@@ -52,7 +55,6 @@ const LeftColumn = ({ title, isGenerating, describeText, onDescribeChange, onGen
               code?.trim() ? "Describe changes to your custom render template" : "Describe your custom render template"
             }
           />
-          {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
         </div>
       </div>
 

--- a/frontend/components/ui/template-renderer/manage-template-dialog/right-panel.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/right-panel.tsx
@@ -40,9 +40,9 @@ const RightPanel = ({ scope, traceId, spanOutline, activeTab, onTabChange, onCan
         <div className="flex w-full items-start justify-between">
           <TabsList>
             <TabsTrigger value="preview">Preview</TabsTrigger>
+            <TabsTrigger value="code">Code</TabsTrigger>
             {scope === "trace" && <TabsTrigger value="filter">Span filter</TabsTrigger>}
             <TabsTrigger value="data">Sample data</TabsTrigger>
-            <TabsTrigger value="code">Code</TabsTrigger>
           </TabsList>
           <Button
             type="button"
@@ -60,18 +60,6 @@ const RightPanel = ({ scope, traceId, spanOutline, activeTab, onTabChange, onCan
           className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border bg-background outline-none"
         >
           <JsxRenderer code={code} data={testData} />
-        </TabsContent>
-
-        {scope === "trace" && (
-          <TabsContent value="filter" className="flex min-h-0 flex-1 flex-col outline-none">
-            <SpanFilter traceId={traceId} />
-          </TabsContent>
-        )}
-
-        <TabsContent value="data" className="flex min-h-0 flex-1 flex-col outline-none">
-          <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-            <DataPanel />
-          </div>
         </TabsContent>
 
         <TabsContent value="code" className="flex min-h-0 flex-1 flex-col gap-3 outline-none">
@@ -92,6 +80,18 @@ const RightPanel = ({ scope, traceId, spanOutline, activeTab, onTabChange, onCan
           </div>
           <div className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-md border border-border">
             <CodeEditor />
+          </div>
+        </TabsContent>
+
+        {scope === "trace" && (
+          <TabsContent value="filter" className="flex min-h-0 flex-1 flex-col outline-none">
+            <SpanFilter traceId={traceId} />
+          </TabsContent>
+        )}
+
+        <TabsContent value="data" className="flex min-h-0 flex-1 flex-col outline-none">
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+            <DataPanel />
           </div>
         </TabsContent>
       </Tabs>

--- a/frontend/components/ui/template-renderer/manage-template-dialog/right-panel.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/right-panel.tsx
@@ -1,0 +1,109 @@
+import { Loader2, Sparkles, X } from "lucide-react";
+import { useFormContext, useWatch } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { buildRenderTemplatePrompt, buildTraceRenderTemplatePrompt } from "@/lib/actions/render-template/prompts";
+
+import { type ManageTemplateForm, type TemplateScope } from "../index";
+import JsxRenderer from "../jsx-renderer";
+import CodeEditor from "./code-editor";
+import DataPanel from "./data-panel";
+import SpanFilter from "./span-filter";
+
+interface Props {
+  scope: TemplateScope;
+  traceId?: string;
+  /** Span outline that enriches the copied AI prompt (trace scope only). */
+  spanOutline?: unknown[];
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+  onCancel: () => void;
+  isSaving: boolean;
+  canSave: boolean;
+}
+
+const RightPanel = ({ scope, traceId, spanOutline, activeTab, onTabChange, onCancel, isSaving, canSave }: Props) => {
+  const { control } = useFormContext<ManageTemplateForm>();
+  const code = useWatch({ control, name: "code" });
+  const testData = useWatch({ control, name: "testData" });
+
+  const copyPromptText =
+    scope === "trace"
+      ? buildTraceRenderTemplatePrompt(spanOutline ? JSON.stringify(spanOutline, null, 2) : undefined)
+      : buildRenderTemplatePrompt(testData);
+
+  return (
+    <div className="flex h-full min-w-0 flex-1 flex-col gap-4 px-6 pb-4 pt-6 ">
+      <Tabs value={activeTab} onValueChange={onTabChange} className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
+        <div className="flex w-full items-start justify-between">
+          <TabsList>
+            <TabsTrigger value="preview">Preview</TabsTrigger>
+            {scope === "trace" && <TabsTrigger value="filter">Span filter</TabsTrigger>}
+            <TabsTrigger value="data">Sample data</TabsTrigger>
+            <TabsTrigger value="code">Code</TabsTrigger>
+          </TabsList>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onCancel}
+            aria-label="Close"
+            className="size-6 shrink-0 rounded-md p-0 text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+
+        <TabsContent
+          value="preview"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border bg-background outline-none"
+        >
+          <JsxRenderer code={code} data={testData} />
+        </TabsContent>
+
+        {scope === "trace" && (
+          <TabsContent value="filter" className="flex min-h-0 flex-1 flex-col outline-none">
+            <SpanFilter traceId={traceId} />
+          </TabsContent>
+        )}
+
+        <TabsContent value="data" className="flex min-h-0 flex-1 flex-col outline-none">
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+            <DataPanel />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="code" className="flex min-h-0 flex-1 flex-col gap-3 outline-none">
+          <div className="flex shrink-0 items-center justify-between gap-2 rounded-md border border-border bg-card px-3 py-2">
+            <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+              <Sparkles className="size-3.5 shrink-0 text-primary" />
+              <span>Generate with your AI tool and paste here</span>
+            </div>
+            <CopyButton
+              type="button"
+              variant="secondaryLight"
+              text={copyPromptText}
+              className="shrink-0 text-xs"
+              iconClassName="size-3"
+            >
+              Copy prompt
+            </CopyButton>
+          </div>
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-md border border-border">
+            <CodeEditor />
+          </div>
+        </TabsContent>
+      </Tabs>
+
+      <div className="flex justify-end">
+        <Button type="submit" disabled={isSaving || !canSave} className="h-8 gap-1.5 rounded px-4 text-xs">
+          {isSaving && <Loader2 className="size-3.5 animate-spin" />}
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default RightPanel;

--- a/frontend/components/ui/template-renderer/manage-template-dialog/right-panel.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/right-panel.tsx
@@ -1,7 +1,6 @@
-import { Loader2, Sparkles, X } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { useFormContext, useWatch } from "react-hook-form";
 
-import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { buildRenderTemplatePrompt, buildTraceRenderTemplatePrompt } from "@/lib/actions/render-template/prompts";
@@ -19,12 +18,9 @@ interface Props {
   spanOutline?: unknown[];
   activeTab: string;
   onTabChange: (tab: string) => void;
-  onCancel: () => void;
-  isSaving: boolean;
-  canSave: boolean;
 }
 
-const RightPanel = ({ scope, traceId, spanOutline, activeTab, onTabChange, onCancel, isSaving, canSave }: Props) => {
+const RightPanel = ({ scope, traceId, spanOutline, activeTab, onTabChange }: Props) => {
   const { control } = useFormContext<ManageTemplateForm>();
   const code = useWatch({ control, name: "code" });
   const testData = useWatch({ control, name: "testData" });
@@ -35,31 +31,28 @@ const RightPanel = ({ scope, traceId, spanOutline, activeTab, onTabChange, onCan
       : buildRenderTemplatePrompt(testData);
 
   return (
-    <div className="flex h-full min-w-0 flex-1 flex-col gap-4 px-6 pb-4 pt-6 ">
+    <div className="flex h-full min-w-0 flex-1 flex-col gap-4 px-5 pb-4 pt-4">
       <Tabs value={activeTab} onValueChange={onTabChange} className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
-        <div className="flex w-full items-start justify-between">
-          <TabsList>
-            <TabsTrigger value="preview">Preview</TabsTrigger>
-            <TabsTrigger value="code">Code</TabsTrigger>
-            {scope === "trace" && <TabsTrigger value="filter">Span filter</TabsTrigger>}
-            <TabsTrigger value="data">Sample data</TabsTrigger>
-          </TabsList>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={onCancel}
-            aria-label="Close"
-            className="size-6 shrink-0 rounded-md p-0 text-muted-foreground hover:text-foreground"
-          >
-            <X className="size-4" />
-          </Button>
-        </div>
+        <TabsList className="self-start">
+          <TabsTrigger value="preview">Preview</TabsTrigger>
+          <TabsTrigger value="data">Sample data</TabsTrigger>
+          <TabsTrigger value="code">Code</TabsTrigger>
+        </TabsList>
 
         <TabsContent
           value="preview"
           className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border bg-background outline-none"
         >
           <JsxRenderer code={code} data={testData} />
+        </TabsContent>
+
+        {/* Sample data owns both the trace-scope span filter (which populates the
+            data) and the JSON editor that the preview renders from. */}
+        <TabsContent value="data" className="flex min-h-0 flex-1 flex-col gap-4 outline-none">
+          {scope === "trace" && <SpanFilter traceId={traceId} />}
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+            <DataPanel />
+          </div>
         </TabsContent>
 
         <TabsContent value="code" className="flex min-h-0 flex-1 flex-col gap-3 outline-none">
@@ -82,26 +75,7 @@ const RightPanel = ({ scope, traceId, spanOutline, activeTab, onTabChange, onCan
             <CodeEditor />
           </div>
         </TabsContent>
-
-        {scope === "trace" && (
-          <TabsContent value="filter" className="flex min-h-0 flex-1 flex-col outline-none">
-            <SpanFilter traceId={traceId} />
-          </TabsContent>
-        )}
-
-        <TabsContent value="data" className="flex min-h-0 flex-1 flex-col outline-none">
-          <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-            <DataPanel />
-          </div>
-        </TabsContent>
       </Tabs>
-
-      <div className="flex justify-end">
-        <Button type="submit" disabled={isSaving || !canSave} className="h-8 gap-1.5 rounded px-4 text-xs">
-          {isSaving && <Loader2 className="size-3.5 animate-spin" />}
-          Save
-        </Button>
-      </div>
     </div>
   );
 };

--- a/frontend/components/ui/template-renderer/manage-template-dialog/span-filter.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/span-filter.tsx
@@ -1,11 +1,11 @@
+import { EditorView } from "@uiw/react-codemirror";
 import { Loader2, Play } from "lucide-react";
 import { useParams } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
 import SQLEditor from "@/components/sql/sql-editor";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 
 import { type ManageTemplateForm } from "../index";
 
@@ -57,29 +57,38 @@ const SpanFilter = ({ traceId }: Props) => {
     }
   }, [projectId, traceId, getValues, setValue]);
 
+  // Reserve space below the cursor so the floating Test button never covers the
+  // active line when the editor scrolls (bottom-2 + h-7 button ≈ 36px).
+  const editorExtensions = useMemo(() => [EditorView.scrollMargins.of(() => ({ bottom: 44 }))], []);
+
   return (
-    <div>
-      <Label className="text-xs tracking-wide text-muted-foreground">Span filter (SQL WHERE)</Label>
-      <div className="mt-1 flex items-start gap-2">
-        <div className="h-16 min-w-0 flex-1 overflow-hidden rounded-md border">
-          <Controller
-            name="whereClause"
-            control={control}
-            render={({ field }) => (
-              <SQLEditor
-                value={field.value ?? ""}
-                onChange={field.onChange}
-                placeholder="e.g. span_type = 'LLM' AND name LIKE 'agent%'"
-                schema={{ tables: ["spans"] }}
-              />
-            )}
-          />
-        </div>
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+        <p>Filter out unneeded spans from custom renderer to improve rendering performance.</p>
+        <p>
+          Appended to <code className="font-mono">SELECT * FROM spans WHERE trace_id = &lt;trace&gt; AND (...)</code>.
+        </p>
+      </div>
+
+      <div className="relative h-32 min-w-0 overflow-hidden rounded-md border">
+        <Controller
+          name="whereClause"
+          control={control}
+          render={({ field }) => (
+            <SQLEditor
+              value={field.value ?? ""}
+              onChange={field.onChange}
+              placeholder="e.g. span_type = 'LLM' AND name LIKE 'agent%'"
+              schema={{ tables: ["spans"] }}
+              extraExtensions={editorExtensions}
+            />
+          )}
+        />
         {traceId && (
           <Button
             type="button"
             variant="secondary"
-            className="h-8 shrink-0 text-xs"
+            className="absolute bottom-2 right-2 z-10 h-7 text-xs shadow-md"
             disabled={isTesting}
             onClick={testWhereClause}
           >
@@ -88,19 +97,16 @@ const SpanFilter = ({ traceId }: Props) => {
           </Button>
         )}
       </div>
+
       {testResult &&
         (testResult.ok ? (
-          <p className="mt-1 text-xs text-success">
+          <p className="text-xs text-success-bright">
             Matched {testResult.count} {testResult.count === 1 ? "span" : "spans"}
             {testResult.truncated ? " (truncated to 256)" : ""} — preview and data updated.
           </p>
         ) : (
-          <p className="mt-1 text-xs text-destructive">{testResult.error}</p>
+          <p className="text-xs text-destructive">{testResult.error}</p>
         ))}
-      <p className="mt-1 text-xs text-muted-foreground">
-        Appended to <code className="font-mono">SELECT * FROM spans WHERE trace_id = &lt;trace&gt; AND (...)</code>.
-        Leave empty to include all spans.{traceId ? " Test runs it against this trace." : ""}
-      </p>
     </div>
   );
 };

--- a/frontend/components/ui/template-renderer/manage-template-dialog/span-filter.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/span-filter.tsx
@@ -1,8 +1,8 @@
 import { EditorView } from "@uiw/react-codemirror";
 import { Loader2, Play } from "lucide-react";
 import { useParams } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
-import { Controller, useFormContext } from "react-hook-form";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Controller, useFormContext, useWatch } from "react-hook-form";
 
 import SQLEditor from "@/components/sql/sql-editor";
 import { Button } from "@/components/ui/button";
@@ -19,11 +19,19 @@ interface Props {
 const SpanFilter = ({ traceId }: Props) => {
   const { projectId } = useParams();
   const { control, getValues, setValue } = useFormContext<ManageTemplateForm>();
+  const whereClause = useWatch({ control, name: "whereClause" });
 
   const [isTesting, setIsTesting] = useState(false);
   const [testResult, setTestResult] = useState<
     { ok: true; count: number; truncated: boolean } | { ok: false; error: string } | null
   >(null);
+
+  // Drop a prior "Matched N" / error once the filter is edited — it must never
+  // describe a clause the user has since changed. (Testing reads whereClause but
+  // doesn't mutate it, so this won't clear the result the test just set.)
+  useEffect(() => {
+    setTestResult(null);
+  }, [whereClause]);
 
   const testWhereClause = useCallback(async () => {
     if (!traceId) return;

--- a/frontend/components/ui/template-renderer/manage-template-dialog/span-filter.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/span-filter.tsx
@@ -1,0 +1,108 @@
+import { Loader2, Play } from "lucide-react";
+import { useParams } from "next/navigation";
+import { useCallback, useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+
+import SQLEditor from "@/components/sql/sql-editor";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+import { type ManageTemplateForm } from "../index";
+
+interface Props {
+  /** Trace whose spans the WHERE clause is tested against. */
+  traceId?: string;
+}
+
+// Trace-scope span selector: a SQL WHERE fragment plus a Test button that runs it
+// against the current trace and pipes the result into the form's testData.
+const SpanFilter = ({ traceId }: Props) => {
+  const { projectId } = useParams();
+  const { control, getValues, setValue } = useFormContext<ManageTemplateForm>();
+
+  const [isTesting, setIsTesting] = useState(false);
+  const [testResult, setTestResult] = useState<
+    { ok: true; count: number; truncated: boolean } | { ok: false; error: string } | null
+  >(null);
+
+  const testWhereClause = useCallback(async () => {
+    if (!traceId) return;
+    setIsTesting(true);
+    setTestResult(null);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/traces/${traceId}/render-data`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ whereClause: getValues("whereClause") ?? null }),
+      });
+      if (!res.ok) {
+        const errMessage = await res
+          .json()
+          .then((d) => d?.error)
+          .catch(() => null);
+        setTestResult({ ok: false, error: errMessage ?? "Failed to run the filter" });
+        return;
+      }
+      const data = await res.json();
+      setValue("testData", JSON.stringify(data, null, 2), { shouldDirty: false });
+      setTestResult({
+        ok: true,
+        count: Array.isArray(data?.spans) ? data.spans.length : 0,
+        truncated: !!data?.truncated,
+      });
+    } catch {
+      setTestResult({ ok: false, error: "Failed to run the filter" });
+    } finally {
+      setIsTesting(false);
+    }
+  }, [projectId, traceId, getValues, setValue]);
+
+  return (
+    <div>
+      <Label className="text-xs tracking-wide text-muted-foreground">Span filter (SQL WHERE)</Label>
+      <div className="mt-1 flex items-start gap-2">
+        <div className="h-16 min-w-0 flex-1 overflow-hidden rounded-md border">
+          <Controller
+            name="whereClause"
+            control={control}
+            render={({ field }) => (
+              <SQLEditor
+                value={field.value ?? ""}
+                onChange={field.onChange}
+                placeholder="e.g. span_type = 'LLM' AND name LIKE 'agent%'"
+                schema={{ tables: ["spans"] }}
+              />
+            )}
+          />
+        </div>
+        {traceId && (
+          <Button
+            type="button"
+            variant="secondary"
+            className="h-8 shrink-0 text-xs"
+            disabled={isTesting}
+            onClick={testWhereClause}
+          >
+            {isTesting ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : <Play className="mr-1.5 size-3.5" />}
+            Test
+          </Button>
+        )}
+      </div>
+      {testResult &&
+        (testResult.ok ? (
+          <p className="mt-1 text-xs text-success">
+            Matched {testResult.count} {testResult.count === 1 ? "span" : "spans"}
+            {testResult.truncated ? " (truncated to 256)" : ""} — preview and data updated.
+          </p>
+        ) : (
+          <p className="mt-1 text-xs text-destructive">{testResult.error}</p>
+        ))}
+      <p className="mt-1 text-xs text-muted-foreground">
+        Appended to <code className="font-mono">SELECT * FROM spans WHERE trace_id = &lt;trace&gt; AND (...)</code>.
+        Leave empty to include all spans.{traceId ? " Test runs it against this trace." : ""}
+      </p>
+    </div>
+  );
+};
+
+export default SpanFilter;

--- a/frontend/components/ui/template-renderer/manage-template-dialog/span-filter.tsx
+++ b/frontend/components/ui/template-renderer/manage-template-dialog/span-filter.tsx
@@ -8,6 +8,7 @@ import SQLEditor from "@/components/sql/sql-editor";
 import { Button } from "@/components/ui/button";
 
 import { type ManageTemplateForm } from "../index";
+import { fetchRenderData } from "./fetch-render-data";
 
 interface Props {
   /** Trace whose spans the WHERE clause is tested against. */
@@ -38,28 +39,15 @@ const SpanFilter = ({ traceId }: Props) => {
     setIsTesting(true);
     setTestResult(null);
     try {
-      const res = await fetch(`/api/projects/${projectId}/traces/${traceId}/render-data`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ whereClause: getValues("whereClause") ?? null }),
-      });
-      if (!res.ok) {
-        const errMessage = await res
-          .json()
-          .then((d) => d?.error)
-          .catch(() => null);
-        setTestResult({ ok: false, error: errMessage ?? "Failed to run the filter" });
-        return;
-      }
-      const data = await res.json();
+      const data = await fetchRenderData(projectId as string, traceId, getValues("whereClause") ?? null);
       setValue("testData", JSON.stringify(data, null, 2), { shouldDirty: false });
       setTestResult({
         ok: true,
         count: Array.isArray(data?.spans) ? data.spans.length : 0,
         truncated: !!data?.truncated,
       });
-    } catch {
-      setTestResult({ ok: false, error: "Failed to run the filter" });
+    } catch (e) {
+      setTestResult({ ok: false, error: e instanceof Error ? e.message : "Failed to run the filter" });
     } finally {
       setIsTesting(false);
     }

--- a/frontend/components/ui/template-renderer/normalize.ts
+++ b/frontend/components/ui/template-renderer/normalize.ts
@@ -1,0 +1,18 @@
+// Normalizes a user/AI-authored template into an arrow-function expression.
+// Shared by the iframe renderer (jsx-renderer.tsx) and server-side validation
+// (lib/actions/render-template/validate.ts) so the two never diverge on what
+// shape counts as a valid template. Pure — no React, safe to import server-side.
+export const normalizeTemplateCode = (code: string): string => {
+  const trimmedCode = code.trim();
+
+  const functionMatch = trimmedCode.match(/^function\s*\((.*?)\)\s*{([\s\S]*)}$/);
+  if (functionMatch) {
+    return `(${functionMatch[1]}) => {${functionMatch[2]}}`;
+  }
+
+  if (!trimmedCode.startsWith("(") && !trimmedCode.startsWith("function")) {
+    return `({ data }) => {${trimmedCode}}`;
+  }
+
+  return trimmedCode;
+};

--- a/frontend/components/ui/template-renderer/template-picker.tsx
+++ b/frontend/components/ui/template-renderer/template-picker.tsx
@@ -1,7 +1,16 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Check, ChevronDown, Loader2, PencilIcon, Plus } from "lucide-react";
 import { useParams } from "next/navigation";
-import { createContext, type PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  type MouseEvent,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import useSWR from "swr";
 
@@ -237,7 +246,7 @@ const GROUP_CLASS =
 const formatLabel = (m: string) => (m.toLowerCase() === "messages" ? "LLM Messages" : m);
 
 export const TemplatePickerView = ({ mode, onModeChange, modes, triggerClassName }: TemplatePickerViewProps) => {
-  const { templates, selectedTemplate, selectTemplate, openCreate } = useTemplatePicker();
+  const { templates, selectedTemplate, selectTemplate, openCreate, openEdit } = useTemplatePicker();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
 
@@ -281,6 +290,21 @@ export const TemplatePickerView = ({ mode, onModeChange, modes, triggerClassName
     openCreate();
     setOpen(false);
   }, [openCreate]);
+
+  // Editing a template must load it into the shared form first (the manage
+  // dialog reads it via useFormContext), so edit implies selecting it.
+  const handleEditTemplate = useCallback(
+    async (e: MouseEvent, id: string) => {
+      e.stopPropagation();
+      e.preventDefault();
+      setOpen(false);
+      if (selectedTemplate?.id !== id) {
+        await selectTemplate(id);
+      }
+      openEdit();
+    },
+    [selectedTemplate, selectTemplate, openEdit]
+  );
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -340,10 +364,20 @@ export const TemplatePickerView = ({ mode, onModeChange, modes, triggerClassName
                         key={t.id}
                         value={`template:${t.id}`}
                         onSelect={() => handlePickTemplate(t.id)}
-                        className="text-xs"
+                        className="group text-xs"
                       >
                         <span className="flex-1 truncate">{t.name}</span>
-                        {active && <Check className="ml-2 size-3.5 shrink-0" />}
+                        <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
+                          <button
+                            type="button"
+                            aria-label={`Edit ${t.name}`}
+                            onClick={(e) => handleEditTemplate(e, t.id)}
+                            className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+                          >
+                            <PencilIcon className="size-3" />
+                          </button>
+                          {active && <Check className="size-3.5" />}
+                        </div>
                       </CommandItem>
                     );
                   })

--- a/frontend/components/ui/template-renderer/template-picker.tsx
+++ b/frontend/components/ui/template-renderer/template-picker.tsx
@@ -53,7 +53,8 @@ interface TemplatePickerContextValue {
   /** True while the manage dialog is open — selectedTemplate then reflects
    *  unsaved draft form values, so consumers should hold off side effects. */
   isManaging: boolean;
-  selectTemplate: (templateId: string) => Promise<void>;
+  /** Loads a template into the form. Resolves `true` only when the fetch succeeded and hydrated. */
+  selectTemplate: (templateId: string) => Promise<boolean>;
   openCreate: () => void;
   openEdit: () => void;
 }
@@ -154,14 +155,16 @@ export const TemplatePickerProvider = ({
   }, [presetKey, templates, getPresetTemplate, fetchTemplate, reset]);
 
   const selectTemplate = useCallback(
-    async (templateId: string) => {
+    async (templateId: string): Promise<boolean> => {
       const t = templates?.find((x) => x.id === templateId);
-      if (!t) return;
+      if (!t) return false;
       if (presetKey) setPresetTemplate(presetKey, templateId);
       setIsLoadingTemplate(true);
       try {
         const full = await fetchTemplate(templateId);
-        if (full) reset({ ...full, scope, testData });
+        if (!full) return false;
+        reset({ ...full, scope, testData });
+        return true;
       } finally {
         setIsLoadingTemplate(false);
       }
@@ -298,8 +301,10 @@ export const TemplatePickerView = ({ mode, onModeChange, modes, triggerClassName
       e.stopPropagation();
       e.preventDefault();
       setOpen(false);
-      if (selectedTemplate?.id !== id) {
-        await selectTemplate(id);
+      // Don't open edit on a failed load — fetchTemplate already toasted, and
+      // openEdit would otherwise snapshot stale/empty form values.
+      if (selectedTemplate?.id !== id && !(await selectTemplate(id))) {
+        return;
       }
       openEdit();
     },

--- a/frontend/components/ui/template-renderer/template-picker.tsx
+++ b/frontend/components/ui/template-renderer/template-picker.tsx
@@ -377,7 +377,7 @@ export const TemplatePickerView = ({ mode, onModeChange, modes, triggerClassName
                             type="button"
                             aria-label={`Edit ${t.name}`}
                             onClick={(e) => handleEditTemplate(e, t.id)}
-                            className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+                            className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
                           >
                             <PencilIcon className="size-3" />
                           </button>
@@ -425,9 +425,10 @@ export const TemplatePickerActions = ({ className }: { className?: string }) => 
 interface TemplatePickerPreviewProps {
   data: string;
   className?: string;
+  onSelectSpan?: (spanId: string) => void;
 }
 
-export const TemplatePickerPreview = ({ data, className }: TemplatePickerPreviewProps) => {
+export const TemplatePickerPreview = ({ data, className, onSelectSpan }: TemplatePickerPreviewProps) => {
   const { selectedTemplate, openCreate, templates, isLoadingTemplate } = useTemplatePicker();
 
   if (isLoadingTemplate) {
@@ -454,5 +455,13 @@ export const TemplatePickerPreview = ({ data, className }: TemplatePickerPreview
     );
   }
 
-  return <JsxRenderer className={cn("rounded-none", className)} code={selectedTemplate.code} data={data} autoHeight />;
+  return (
+    <JsxRenderer
+      className={cn("rounded-none", className)}
+      code={selectedTemplate.code}
+      data={data}
+      autoHeight
+      onSelectSpan={onSelectSpan}
+    />
+  );
 };

--- a/frontend/components/ui/template-renderer/template-picker.tsx
+++ b/frontend/components/ui/template-renderer/template-picker.tsx
@@ -23,7 +23,6 @@ import { cn, swrFetcher } from "@/lib/utils";
 
 import {
   defaultTemplateValues,
-  defaultTraceTemplateCode,
   type ManageTemplateForm,
   manageTemplateSchema,
   type Template,
@@ -165,7 +164,6 @@ export const TemplatePickerProvider = ({
     setBackup(getValues());
     reset({
       ...defaultTemplateValues,
-      ...(scope === "trace" && { code: defaultTraceTemplateCode }),
       scope,
       testData,
     });

--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -321,13 +321,12 @@ export async function register() {
       console.log("Local DB is not enabled, skipping migrations and initial data");
     }
     if (process.env.LMNR_PROJECT_API_KEY) {
-      const { Laminar, LaminarAiSdkTelemetry } = await import("@lmnr-ai/lmnr");
+      const { LaminarAiSdkTelemetry } = await import("@lmnr-ai/lmnr");
       const { registerTelemetry } = await import("ai");
       console.log("Initializing Laminar");
-      // registerTelemetry alone routes spans through getTracer(), which resolves
-      // to the no-op global provider until Laminar.initialize() installs the
-      // OTLP exporter — without this, generateText/observe spans export nowhere.
-      Laminar.initialize({ projectApiKey: process.env.LMNR_PROJECT_API_KEY });
+      // LaminarAiSdkTelemetry's constructor calls Laminar.initialize() itself
+      // (reading projectApiKey from LMNR_PROJECT_API_KEY), so no explicit init.
+      // The env-var guard stays: without a key that self-init would throw.
       registerTelemetry(new LaminarAiSdkTelemetry());
     }
 

--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -321,9 +321,13 @@ export async function register() {
       console.log("Local DB is not enabled, skipping migrations and initial data");
     }
     if (process.env.LMNR_PROJECT_API_KEY) {
-      const { LaminarAiSdkTelemetry } = await import("@lmnr-ai/lmnr");
+      const { Laminar, LaminarAiSdkTelemetry } = await import("@lmnr-ai/lmnr");
       const { registerTelemetry } = await import("ai");
       console.log("Initializing Laminar");
+      // registerTelemetry alone routes spans through getTracer(), which resolves
+      // to the no-op global provider until Laminar.initialize() installs the
+      // OTLP exporter — without this, generateText/observe spans export nowhere.
+      Laminar.initialize({ projectApiKey: process.env.LMNR_PROJECT_API_KEY });
       registerTelemetry(new LaminarAiSdkTelemetry());
     }
 

--- a/frontend/lib/actions/render-template/generate.ts
+++ b/frontend/lib/actions/render-template/generate.ts
@@ -1,0 +1,92 @@
+import { observe } from "@lmnr-ai/lmnr";
+import { stepCountIs, ToolLoopAgent } from "ai";
+import { z } from "zod";
+
+import { getLanguageModel } from "@/lib/ai/model";
+
+import { buildGenerateInstructions } from "./prompts";
+import { createVfsTools, FILTER_FILE, TEMPLATE_FILE, type Vfs } from "./tools";
+import { validateTemplateCode } from "./validate";
+
+const GenerateSchema = z.object({
+  projectId: z.guid(),
+  scope: z.enum(["span", "trace"]),
+  description: z.string().min(1, "Description is required"),
+  /** Existing template code when editing; empty/absent when creating. */
+  currentCode: z.string().optional(),
+  /** Existing WHERE clause when editing a trace template. */
+  currentWhereClause: z.string().nullish(),
+  /** Sample `data` (span scope) — JSON string shown to the agent for context. */
+  sampleData: z.string().optional(),
+  /** Trace outline (trace scope) — JSON string of representative spans. */
+  traceOutline: z.string().optional(),
+});
+
+export type GenerateTemplateInput = z.infer<typeof GenerateSchema>;
+
+export interface GenerateTemplateResult {
+  code: string;
+  /** Only present for trace scope. */
+  whereClause?: string;
+}
+
+// Runaway guard — the agent should finish in a handful of steps (write → validate → fix).
+const MAX_STEPS = 12;
+
+const buildUserPrompt = (input: GenerateTemplateInput): string => {
+  const parts: string[] = [];
+  parts.push(
+    input.currentCode?.trim() ? "Modify the existing template per this request:" : "Create a template for this request:"
+  );
+  parts.push(`<request>\n${input.description.trim()}\n</request>`);
+  if (input.scope === "trace" && input.traceOutline?.trim()) {
+    parts.push(`<trace_outline>\n${input.traceOutline.trim()}\n</trace_outline>`);
+  }
+  if (input.scope === "span" && input.sampleData?.trim()) {
+    parts.push(`<sample_data>\n${input.sampleData.trim()}\n</sample_data>`);
+  }
+  return parts.join("\n\n");
+};
+
+/**
+ * In-platform render-template generation. Runs an AI SDK v7 ToolLoopAgent that
+ * edits a virtual filesystem (template.jsx, + filter.sql for trace) and
+ * syntax-validates before finishing. Returns whatever ended up in the VFS —
+ * the modal drops it into the editor + preview. Matches the mock's signature.
+ */
+export const generateTemplate = async (input: GenerateTemplateInput): Promise<GenerateTemplateResult> => {
+  const parsed = GenerateSchema.parse(input);
+  const { projectId, scope } = parsed;
+
+  const vfs: Vfs = { [TEMPLATE_FILE]: parsed.currentCode ?? "" };
+  const allowedPaths = [TEMPLATE_FILE];
+  if (scope === "trace") {
+    vfs[FILTER_FILE] = parsed.currentWhereClause ?? "";
+    allowedPaths.push(FILTER_FILE);
+  }
+
+  await observe({ name: "generateRenderTemplate", input: { projectId, scope } }, async () => {
+    const agent = new ToolLoopAgent({
+      model: getLanguageModel("medium"),
+      instructions: buildGenerateInstructions(scope),
+      tools: createVfsTools(vfs, allowedPaths),
+      stopWhen: stepCountIs(MAX_STEPS),
+    });
+    await agent.generate({ prompt: buildUserPrompt(parsed) });
+  });
+
+  const code = (vfs[TEMPLATE_FILE] ?? "").trim();
+  if (!code) {
+    throw new Error("Generation produced no template code. Please try again with a clearer description.");
+  }
+
+  // Best-effort: the agent is instructed to validate before finishing, but on step
+  // exhaustion it may stop with a syntax error. Surface it rather than silently
+  // returning broken code the preview can't render.
+  const validation = validateTemplateCode(code);
+  if (!validation.ok) {
+    throw new Error(`Generated template has a syntax error: ${validation.error}`);
+  }
+
+  return scope === "trace" ? { code, whereClause: (vfs[FILTER_FILE] ?? "").trim() } : { code };
+};

--- a/frontend/lib/actions/render-template/generate.ts
+++ b/frontend/lib/actions/render-template/generate.ts
@@ -69,7 +69,12 @@ export const generateTemplate = async (input: GenerateTemplateInput): Promise<Ge
   }
 
   await observe(
-    { name: "generateRenderTemplate", sessionId: parsed.sessionId, input: { projectId, scope } },
+    {
+      name: "generateRenderTemplate",
+      sessionId: parsed.sessionId,
+      metadata: { feature: "render-template" },
+      input: { projectId, scope },
+    },
     async () => {
       const agent = new ToolLoopAgent({
         model: getLanguageModel("medium"),

--- a/frontend/lib/actions/render-template/generate.ts
+++ b/frontend/lib/actions/render-template/generate.ts
@@ -12,6 +12,9 @@ const GenerateSchema = z.object({
   projectId: z.guid(),
   scope: z.enum(["span", "trace"]),
   description: z.string().min(1, "Description is required"),
+  /** Groups every generation of one template into a single Laminar session.
+   *  Editing → the template id; creating → an ephemeral per-dialog draft id. */
+  sessionId: z.string().optional(),
   /** Existing template code when editing; empty/absent when creating. */
   currentCode: z.string().optional(),
   /** Existing WHERE clause when editing a trace template. */
@@ -65,15 +68,18 @@ export const generateTemplate = async (input: GenerateTemplateInput): Promise<Ge
     allowedPaths.push(FILTER_FILE);
   }
 
-  await observe({ name: "generateRenderTemplate", input: { projectId, scope } }, async () => {
-    const agent = new ToolLoopAgent({
-      model: getLanguageModel("medium"),
-      instructions: buildGenerateInstructions(scope),
-      tools: createVfsTools(vfs, allowedPaths),
-      stopWhen: stepCountIs(MAX_STEPS),
-    });
-    await agent.generate({ prompt: buildUserPrompt(parsed) });
-  });
+  await observe(
+    { name: "generateRenderTemplate", sessionId: parsed.sessionId, input: { projectId, scope } },
+    async () => {
+      const agent = new ToolLoopAgent({
+        model: getLanguageModel("medium"),
+        instructions: buildGenerateInstructions(scope),
+        tools: createVfsTools(vfs, allowedPaths),
+        stopWhen: stepCountIs(MAX_STEPS),
+      });
+      await agent.generate({ prompt: buildUserPrompt(parsed) });
+    }
+  );
 
   const code = (vfs[TEMPLATE_FILE] ?? "").trim();
   if (!code) {

--- a/frontend/lib/actions/render-template/prompts.ts
+++ b/frontend/lib/actions/render-template/prompts.ts
@@ -238,3 +238,106 @@ ${outlineBlock}
 
 ${TRACE_WHAT_TO_RENDER}`;
 };
+
+// ---------------------------------------------------------------------------
+// In-platform generation agent (ToolLoopAgent) — system instructions.
+// Reuses the same STYLE_GUIDE / OUTPUT_CONTRACT as the copy-prompt flow so the
+// generated code matches what the sandbox expects, then layers on the agent's
+// tool + gate contract (edit files in a virtual FS, validate before finishing).
+// ---------------------------------------------------------------------------
+
+const AGENT_INTRO = `You are an agent that authors a JSX render template for Laminar, an open-source observability platform for AI agents. The template renders a JSON payload inside a sandboxed iframe using Preact + Tailwind, with Tailwind wired to Laminar's semantic design tokens.
+
+You work by editing files in a virtual filesystem with the provided tools — you do NOT reply with the code in prose. When you are done, your final message is ignored; only the file contents are used.`;
+
+const AGENT_TOOL_CONTRACT = `<tools_and_workflow>
+You have these tools:
+- \`readFile({ path })\` — read a file's current contents.
+- \`writeFile({ path, content })\` — overwrite a file.
+- \`strReplace({ path, oldStr, newStr })\` — replace the first exact occurrence of \`oldStr\`. \`oldStr\` must appear exactly once.
+- \`validate()\` — syntax-check \`template.jsx\`. Returns \`{ ok, error }\`.
+
+Files:
+- \`template.jsx\` — the template function (ALWAYS edit this). It may be pre-seeded with an existing template you must MODIFY per the request, or empty for a fresh template.
+{{FILTER_FILE_DOC}}
+
+Workflow:
+1. \`readFile\` the current file(s).
+2. \`writeFile\` / \`strReplace\` to implement the user's request.
+3. \`validate()\` — if it returns \`ok: false\`, fix the reported error and validate again.
+4. Only finish once \`validate()\` returns \`ok: true\` AND you have fully addressed the user's request. Do NOT finish with a failing validation.
+</tools_and_workflow>`;
+
+const FILTER_FILE_DOC = `- \`filter.sql\` — a ClickHouse SQL WHERE fragment selecting which spans to render (see the span filter contract). Edit this when the request implies which spans matter; leave it empty to render all spans.`;
+
+// Agent output contracts. Deliberately SEPARATE from the copy-prompt
+// OUTPUT_CONTRACT / TRACE_OUTPUT_CONTRACT: those tell the model to REPLY with
+// fenced code blocks, but the agent must DELIVER via the file tools. Reusing the
+// copy-prompt contracts made the model answer in prose and never call writeFile
+// (empty VFS -> "no template code"). Keep all "reply with a fenced block"
+// delivery language OUT of these. The hard-rules text is intentionally
+// duplicated from OUTPUT_CONTRACT rather than shared, so editing the copy-prompt
+// flow can never silently change the agent's contract (and vice versa).
+const AGENT_JSX_SHAPE = `function({ data }) {
+  return (
+    <div className="w-full min-h-full p-4 text-sm text-foreground bg-background">
+      {/* JSX here */}
+    </div>
+  );
+}`;
+
+const AGENT_JSX_HARD_RULES = `- Use HTML/JSX syntax (no TypeScript, no imports, no exports).
+- The function receives a single argument \`{ data }\`. Always destructure as \`function({ data })\`.
+- Return ONE root JSX element. Use Tailwind classes via \`className\`.
+- Prefer pure, static JSX. Reach for \`useState\` ONLY when the UI is genuinely interactive (e.g. an expand/collapse toggle, a tab switcher). \`useState\` is in scope. Do NOT use \`useEffect\`, \`useMemo\`, \`useCallback\`, \`useRef\`, or \`useContext\`. Do NOT import any hook.
+- \`Fragment\` is in scope. When rendering siblings in a list, give each iteration a stable \`key\`. Never emit \`<>\`/\`</>\` inside an \`Array.map\`.
+- You may use \`JSON.stringify\`, \`Array.isArray\`, \`Object.entries\`, \`Object.keys\`, \`String\`, \`Number\`, \`Boolean\`.
+- Be defensive: \`data\` may be \`undefined\`, \`null\`, a primitive, an array, or an object. Guard every access.
+- Do NOT call \`fetch\`, \`XMLHttpRequest\`, \`WebSocket\`, \`EventSource\`, \`navigator.sendBeacon\`, \`window.open\`, \`document.cookie\`, \`localStorage\`, or any other I/O API. They are blocked in the sandbox and will throw.
+- Do NOT reference external URLs, \`<script>\`, \`<iframe>\`, \`<style>\`, \`<link>\`, inline event handlers on strings, or \`dangerouslySetInnerHTML\`.
+- Do NOT use \`import\`, \`require\`, \`eval\`, \`new Function\`, or top-level \`await\`.`;
+
+const AGENT_SPAN_OUTPUT = `<template_contract>
+Write the finished template to \`template.jsx\` using the writeFile / strReplace tools. Do NOT reply with the code in prose — only the file contents are used. The file must contain exactly this shape:
+
+${AGENT_JSX_SHAPE}
+
+Hard rules:
+${AGENT_JSX_HARD_RULES}
+</template_contract>`;
+
+const AGENT_TRACE_OUTPUT = `<template_contract>
+Write your work to the files using the tools — do NOT reply with the code in prose, only the file contents are used:
+- \`filter.sql\` — the ClickHouse WHERE fragment (leave empty to render all spans).
+- \`template.jsx\` — the template function, which must contain exactly this shape:
+
+${AGENT_JSX_SHAPE}
+
+Hard rules:
+${AGENT_JSX_HARD_RULES}
+- Span \`input\`/\`output\`/\`attributes\` may be objects, arrays, strings, or null; the outline shows TRUNCATED values, so always truncate/wrap long strings in the layout.
+</template_contract>`;
+
+export const buildGenerateInstructions = (scope: "span" | "trace"): string => {
+  if (scope === "trace") {
+    return `${AGENT_INTRO}
+
+${AGENT_TOOL_CONTRACT.replace("{{FILTER_FILE_DOC}}", FILTER_FILE_DOC)}
+
+${SPAN_FILTER_CONTRACT}
+
+${TRACE_DATA_SHAPE}
+
+${STYLE_GUIDE}
+
+${AGENT_TRACE_OUTPUT}`;
+  }
+
+  return `${AGENT_INTRO}
+
+${AGENT_TOOL_CONTRACT.replace("\n{{FILTER_FILE_DOC}}", "")}
+
+${STYLE_GUIDE}
+
+${AGENT_SPAN_OUTPUT}`;
+};

--- a/frontend/lib/actions/render-template/prompts.ts
+++ b/frontend/lib/actions/render-template/prompts.ts
@@ -206,6 +206,7 @@ Hard rules for the jsx block:
 - \`Fragment\` is in scope. When rendering siblings in a list, give each iteration a stable \`key\`. Never emit \`<>\`/\`</>\` inside an \`Array.map\`.
 - You may use \`JSON.stringify\`, \`Array.isArray\`, \`Object.entries\`, \`Object.keys\`, \`String\`, \`Number\`, \`Boolean\`.
 - Be defensive: guard every access (\`data?.spans\`, \`Array.isArray(data?.spans) ? data.spans : []\`). Span \`input\`/\`output\`/\`attributes\` may be objects, arrays, strings, or null. The outline below shows TRUNCATED values — real values are longer, so always truncate/wrap long strings in the layout.
+- A \`selectSpan(spanId)\` function is in scope. To make an element select a span in the trace view when clicked, add an onClick handler, e.g. \`onClick={() => selectSpan(span.spanId)}\`. Each span in \`data.spans\` has a \`spanId\`.
 - Do NOT call \`fetch\`, \`XMLHttpRequest\`, \`WebSocket\`, \`EventSource\`, \`navigator.sendBeacon\`, \`window.open\`, \`document.cookie\`, \`localStorage\`, or any other I/O API. They are blocked in the sandbox and will throw.
 - Do NOT reference external URLs, \`<script>\`, \`<iframe>\`, \`<style>\`, \`<link>\`, inline event handlers on strings, or \`dangerouslySetInnerHTML\`.
 - Do NOT use \`import\`, \`require\`, \`eval\`, \`new Function\`, or top-level \`await\`.
@@ -316,6 +317,7 @@ ${AGENT_JSX_SHAPE}
 Hard rules:
 ${AGENT_JSX_HARD_RULES}
 - Span \`input\`/\`output\`/\`attributes\` may be objects, arrays, strings, or null; the outline shows TRUNCATED values, so always truncate/wrap long strings in the layout.
+- A \`selectSpan(spanId)\` function is in scope. To make an element select a span in the trace view when clicked, add an onClick handler, e.g. \`onClick={() => selectSpan(span.spanId)}\`. Each span in \`data.spans\` has a \`spanId\`.
 </template_contract>`;
 
 export const buildGenerateInstructions = (scope: "span" | "trace"): string => {

--- a/frontend/lib/actions/render-template/tools.ts
+++ b/frontend/lib/actions/render-template/tools.ts
@@ -1,0 +1,71 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { validateTemplateCode } from "./validate";
+
+export const TEMPLATE_FILE = "template.jsx";
+export const FILTER_FILE = "filter.sql";
+
+/** In-memory virtual filesystem the generation agent edits. One entry per file. */
+export type Vfs = Record<string, string>;
+
+/**
+ * Builds the tool set the ToolLoopAgent uses to read/edit the virtual files and
+ * syntax-check the template. Tools close over `vfs` (single per-request object),
+ * so no `toolsContext` plumbing is needed. `allowedPaths` scopes writes to the
+ * files the agent is allowed to touch (template.jsx, and filter.sql for trace).
+ */
+export const createVfsTools = (vfs: Vfs, allowedPaths: string[]) => {
+  const assertPath = (path: string): string | null =>
+    allowedPaths.includes(path) ? null : `Unknown file "${path}". Editable files: ${allowedPaths.join(", ")}.`;
+
+  return {
+    readFile: tool({
+      description: "Read the current contents of a file.",
+      inputSchema: z.object({ path: z.string() }),
+      execute: async ({ path }) => {
+        const err = assertPath(path);
+        if (err) return { ok: false, error: err };
+        return { ok: true, content: vfs[path] ?? "" };
+      },
+    }),
+
+    writeFile: tool({
+      description: "Overwrite a file with new contents.",
+      inputSchema: z.object({ path: z.string(), content: z.string() }),
+      execute: async ({ path, content }) => {
+        const err = assertPath(path);
+        if (err) return { ok: false, error: err };
+        vfs[path] = content;
+        return { ok: true };
+      },
+    }),
+
+    strReplace: tool({
+      description:
+        "Replace the first exact occurrence of oldStr with newStr in a file. oldStr must appear exactly once.",
+      inputSchema: z.object({ path: z.string(), oldStr: z.string(), newStr: z.string() }),
+      execute: async ({ path, oldStr, newStr }) => {
+        const err = assertPath(path);
+        if (err) return { ok: false, error: err };
+        const current = vfs[path] ?? "";
+        const first = current.indexOf(oldStr);
+        if (first === -1) return { ok: false, error: "oldStr not found in file." };
+        if (current.indexOf(oldStr, first + oldStr.length) !== -1) {
+          return {
+            ok: false,
+            error: "oldStr is ambiguous (appears more than once). Include more surrounding context.",
+          };
+        }
+        vfs[path] = current.slice(0, first) + newStr + current.slice(first + oldStr.length);
+        return { ok: true };
+      },
+    }),
+
+    validate: tool({
+      description: "Syntax-check template.jsx. Returns { ok, error }. Call this before finishing.",
+      inputSchema: z.object({}),
+      execute: async () => validateTemplateCode(vfs[TEMPLATE_FILE] ?? ""),
+    }),
+  };
+};

--- a/frontend/lib/actions/render-template/validate.ts
+++ b/frontend/lib/actions/render-template/validate.ts
@@ -1,0 +1,42 @@
+import { parseExpression } from "@babel/parser";
+
+import { normalizeTemplateCode } from "@/components/ui/template-renderer/normalize";
+
+export interface TemplateValidationResult {
+  ok: boolean;
+  /** Human-readable syntax error (with 1-based line:col when available), or undefined when ok. */
+  error?: string;
+}
+
+// Plan A: SYNTAX-ONLY validation. We parse the normalized template as a JSX
+// arrow-function expression and confirm it IS a function. We deliberately do NOT
+// execute the code (no server-side eval / vm) — runtime errors against real data
+// are surfaced by the iframe preview instead. This parser mirrors the iframe's
+// @babel transpile (jsx-renderer.tsx), so "parses here" == "parses in the sandbox".
+export const validateTemplateCode = (code: string): TemplateValidationResult => {
+  const trimmed = code?.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Template code is empty." };
+  }
+
+  const normalized = normalizeTemplateCode(trimmed);
+
+  try {
+    const node = parseExpression(normalized, {
+      plugins: ["jsx"],
+      errorRecovery: false,
+    });
+
+    if (node.type !== "ArrowFunctionExpression" && node.type !== "FunctionExpression") {
+      return { ok: false, error: "Template must be a function of the shape function({ data }) { ... }." };
+    }
+
+    return { ok: true };
+  } catch (e) {
+    // @babel/parser throws SyntaxError with a `.loc` { line, column } (0-based col).
+    const err = e as { message?: string; loc?: { line: number; column: number } };
+    const location = err.loc ? ` (line ${err.loc.line}, column ${err.loc.column + 1})` : "";
+    const message = (err.message ?? "Invalid JSX syntax").replace(/\s*\(\d+:\d+\)\s*$/, "");
+    return { ok: false, error: `${message}${location}` };
+  }
+};

--- a/frontend/lib/actions/sessions/extract-input.ts
+++ b/frontend/lib/actions/sessions/extract-input.ts
@@ -78,6 +78,7 @@ export async function extractInputsForGroup(
   await observe(
     {
       name: "traces:extract-inputs",
+      metadata: { feature: "input-extraction" },
       input: { projectId, systemHash, fingerprint, traceCount: traces.length, cacheKey },
     },
     async () => {

--- a/frontend/lib/actions/spans/previews/agent-names.ts
+++ b/frontend/lib/actions/spans/previews/agent-names.ts
@@ -14,7 +14,7 @@ export type AgentNamesResult = Record<string, string | null>;
 
 async function generateAgentName(systemPrompt: string): Promise<string | null> {
   try {
-    const { text } = await observe({ name: "generate-agent-name" }, async () =>
+    const { text } = await observe({ name: "generate-agent-name", metadata: { feature: "span-previews" } }, async () =>
       generateText({
         model: getLanguageModel("small"),
         system:

--- a/frontend/lib/actions/spans/previews/resolve.ts
+++ b/frontend/lib/actions/spans/previews/resolve.ts
@@ -386,6 +386,7 @@ export async function resolvePreviews(
   return observe(
     {
       name: "previews:resolve",
+      metadata: { feature: "span-previews" },
       input: { projectId, spanCount: spanIds.length, rawSpanCount: rawSpans.length, skipGeneration },
     },
     async () => {

--- a/frontend/lib/actions/sql/generate.ts
+++ b/frontend/lib/actions/sql/generate.ts
@@ -25,7 +25,7 @@ export async function generateSql(input: z.infer<typeof GenerateSchema>): Promis
   const prompts = getGenerationPrompts(mode, currentQuery);
 
   const { output } = await observe(
-    { name: "generateSql", input: { projectId, mode } },
+    { name: "generateSql", metadata: { feature: "sql-generation" }, input: { projectId, mode } },
     async () =>
       await generateText({
         model: getLanguageModel("medium"),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "@ai-sdk/provider": "4.0.2",
     "@ai-sdk/react": "4.0.16",
     "@aws-sdk/client-s3": "^3.1053.0",
+    "@babel/parser": "^8.0.0",
     "@clickhouse/client": "^1.12.1",
     "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/lang-html": "^6.4.9",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1053.0
         version: 3.1054.0
+      '@babel/parser':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@clickhouse/client':
         specifier: ^1.12.1
         version: 1.12.1
@@ -703,6 +706,10 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
@@ -710,6 +717,10 @@ packages:
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.2':
+    resolution: {integrity: sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
@@ -722,6 +733,11 @@ packages:
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.0':
+    resolution: {integrity: sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/runtime@7.28.3':
@@ -743,6 +759,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.0':
+    resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@better-auth/core@1.6.14':
     resolution: {integrity: sha512-12cA7tnR4Wyb3nLpPmeq/Id7QNB+4OhjbzuX7sIhqglgXGjyT5iiNpe2lx/8FF532sHC450Yx1850salCYbkzw==}
@@ -7315,9 +7335,13 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
+  '@babel/helper-string-parser@8.0.0': {}
+
   '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-identifier@8.0.2': {}
 
   '@babel/helper-validator-option@7.29.7': {}
 
@@ -7329,6 +7353,10 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/parser@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.0
 
   '@babel/runtime@7.28.3': {}
 
@@ -7356,6 +7384,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@8.0.0':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.2
 
   '@better-auth/core@1.6.14(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:


### PR DESCRIPTION
## Summary
Adds in-dialog AI generation for custom render templates and rebuilds the manage-template modal.

- **Generation agent** (`lib/actions/render-template`): AI SDK v7 `ToolLoopAgent` editing a virtual FS (`template.jsx` + trace-only `filter.sql`) via `readFile`/`writeFile`/`strReplace`/`validate` tools. Syntax-only validation via `@babel/parser`. Laminar-instrumented (`observe` + global AI-SDK telemetry).
- **Prompt fix**: agent output contracts are separate from the copy-prompt contracts so the model delivers via file tools instead of replying with fenced code blocks (the previous reuse made it answer in prose and write nothing).
- **Modal redesign**: fixed two-column layout (form left, tabs + Save right), segmented Preview / Span filter / Sample data / Code tabs, previewer no-data state, conditional describe placeholder.
- **Route**: `POST /api/projects/[id]/render-templates/generate`.

## Testing
- Verified end-to-end against a live LLM provider: agent calls tools, writes valid JSX, syntax-validates.
- `pnpm type-check` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New server-side LLM agent path and user-authored JSX/SQL still run in existing sandbox and render-data endpoints; generation is abort-guarded but adds LLM cost and dependency on provider availability.
> 
> **Overview**
> Adds **in-product AI generation** for custom render templates via `POST /api/projects/[projectId]/render-templates/generate`, backed by an AI SDK `ToolLoopAgent` that edits a per-request virtual FS (`template.jsx`, and `filter.sql` for trace scope) with `readFile` / `writeFile` / `strReplace` / `validate` tools. Agent prompts are **split from the copy-prompt flow** so the model writes files instead of replying with fenced blocks; results are syntax-checked with `@babel/parser` and shared `normalizeTemplateCode` before returning.
> 
> The **manage-template dialog** is rebuilt: describe-on-the-left with Generate / Request changes (abort-safe, Laminar `sessionId`), Preview / Sample data / Code tabs on the right, Save disabled until code exists, and trace flows auto-refresh sample data after generation via shared `fetchRenderData`. Span SQL filtering moves into a **SpanFilter** panel with a floating Test button; new templates start with **empty code** (preview empty state) instead of a default stub.
> 
> **Trace custom views** can wire template clicks to the span tree through `selectSpan(spanId)` in the sandbox iframe (`postMessage` → `selectSpanById`). Template pickers gain **inline edit** actions and `selectTemplate` success booleans so edit never opens on a failed load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f65a34b87a46db21d0659bd40bbf7c226929e4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

