### PR TITLE
exclude signals internal project id from input extraction too

### DIFF
--- a/app-server/src/traces/input_extraction/producer.rs
+++ b/app-server/src/traces/input_extraction/producer.rs
@@ -112,6 +112,13 @@ pub async fn process_user_task_candidates(
         return;
     }
 
+    #[cfg(feature = "signals")]
+    if std::env::var(crate::env::private::signals::INTERNAL_PROJECT_ID)
+        .is_ok_and(|internal_project_id_str| internal_project_id_str == project_id.to_string())
+    {
+        return;
+    }
+
     if candidates.is_empty()
         || !is_feature_enabled(Feature::InputExtraction)
         || !llm_client_available()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, feature-gated guard on an already-skipped internal project path; no change to normal customer project extraction.
> 
> **Overview**
> Extends the **input extraction producer** early-exit so it no longer processes spans for the signals self-tracing project, in addition to the existing user-task internal project guard.
> 
> When the `signals` feature is enabled, `process_user_task_candidates` compares `project_id` to `INTERNAL_PROJECT_ID` from env and returns immediately on match—same pattern as `USER_TASK_INTERNAL_PROJECT_ID`—so LLM input extraction does not run on signals internal traces and recurse through ingest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee0f564e90ad16731c7dcd02e9f8adc8b9586ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

