### PR TITLE
Add MiniMax to playground providers

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -135,6 +135,7 @@ services:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      MINIMAX_BASE_URL: ${MINIMAX_BASE_URL}
       AEAD_SECRET_KEY: ${AEAD_SECRET_KEY}
       QUICKWIT_SEARCH_URL: http://quickwit:7280
       # LLM provider for frontend AI features (chat-with-trace, SQL-with-AI).

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -128,6 +128,7 @@ services:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      MINIMAX_BASE_URL: ${MINIMAX_BASE_URL}
       AEAD_SECRET_KEY: ${AEAD_SECRET_KEY}
       QUICKWIT_SEARCH_URL: http://quickwit:7280
       # LLM provider for frontend AI features (chat-with-trace, SQL-with-AI).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       CLICKHOUSE_RO_USER: ${CLICKHOUSE_RO_USER}
       CLICKHOUSE_RO_PASSWORD: ${CLICKHOUSE_RO_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      MINIMAX_BASE_URL: ${MINIMAX_BASE_URL}
       AEAD_SECRET_KEY: ${AEAD_SECRET_KEY}
       QUICKWIT_SEARCH_URL: http://quickwit:7280
       # LLM provider for frontend AI features (chat-with-trace, SQL-with-AI).

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -50,6 +50,14 @@ S3_TRACE_PAYLOADS_BUCKET=
 REDIS_URL=
 OPENAI_API_KEY=
 
+# MiniMax Playground requests default to the global OpenAI-compatible API.
+# Set one of these Base URLs to select another official region or protocol:
+# https://api.minimax.io/v1
+# https://api.minimaxi.com/v1
+# https://api.minimax.io/anthropic
+# https://api.minimaxi.com/anthropic
+# MINIMAX_BASE_URL=https://api.minimax.io/v1
+
 # AI features (chat-with-trace, SQL generation, span previews, signals, etc.)
 # Pick one provider: openai | gemini | bedrock. LLM_MODEL_* overrides are
 # optional — per-provider defaults apply when unset.

--- a/frontend/components/playground/types.ts
+++ b/frontend/components/playground/types.ts
@@ -233,6 +233,11 @@ export const providers: { provider: Provider; models: LanguageModel[] }[] = [
         name: "MiniMax-M3",
         label: "MiniMax-M3",
       },
+      {
+        id: "minimax:MiniMax-M2.7",
+        name: "MiniMax-M2.7",
+        label: "MiniMax-M2.7",
+      },
     ],
   },
   {

--- a/frontend/components/playground/types.ts
+++ b/frontend/components/playground/types.ts
@@ -6,7 +6,7 @@ export type LanguageModel = {
   label: string;
 };
 
-export type Provider = "openai" | "anthropic" | "gemini" | "groq" | "mistral" | "bedrock" | "openai-azure";
+export type Provider = "openai" | "anthropic" | "gemini" | "groq" | "mistral" | "bedrock" | "openai-azure" | "minimax";
 
 export const providerToApiKey: Record<Provider, EnvVars> = {
   openai: EnvVars.OPENAI_API_KEY,
@@ -16,6 +16,7 @@ export const providerToApiKey: Record<Provider, EnvVars> = {
   mistral: EnvVars.MISTRAL_API_KEY,
   bedrock: EnvVars.AWS_ACCESS_KEY_ID,
   "openai-azure": EnvVars.AWS_ACCESS_KEY_ID,
+  minimax: EnvVars.MINIMAX_API_KEY,
 } as const;
 
 export const apiKeyToProvider: Partial<Record<EnvVars, Provider>> = {
@@ -24,6 +25,7 @@ export const apiKeyToProvider: Partial<Record<EnvVars, Provider>> = {
   [EnvVars.GEMINI_API_KEY]: "gemini",
   [EnvVars.GROQ_API_KEY]: "groq",
   [EnvVars.MISTRAL_API_KEY]: "mistral",
+  [EnvVars.MINIMAX_API_KEY]: "minimax",
   [EnvVars.AWS_ACCESS_KEY_ID]: "bedrock",
   [EnvVars.AWS_SECRET_ACCESS_KEY]: "bedrock",
   [EnvVars.AWS_REGION]: "bedrock",
@@ -220,6 +222,16 @@ export const providers: { provider: Provider; models: LanguageModel[] }[] = [
         id: "gemini:gemini-3.1-pro-preview",
         name: "gemini-3.1-pro-preview",
         label: "Gemini 3.1 Pro Preview",
+      },
+    ],
+  },
+  {
+    provider: "minimax",
+    models: [
+      {
+        id: "minimax:MiniMax-M3",
+        name: "MiniMax-M3",
+        label: "MiniMax-M3",
       },
     ],
   },

--- a/frontend/components/playground/utils.tsx
+++ b/frontend/components/playground/utils.tsx
@@ -26,6 +26,7 @@ export const providerIconMap: Record<Provider, ReactNode> = {
   gemini: <IconGemini />,
   groq: <IconGroq />,
   mistral: <IconMistral />,
+  minimax: <IconOpenAI />,
   bedrock: <IconAmazonBedrock />,
   "openai-azure": <IconAzure />,
 };
@@ -36,6 +37,7 @@ export const providerNameMap: Record<Provider, string> = {
   gemini: "Gemini",
   groq: "Groq",
   mistral: "Mistral",
+  minimax: "MiniMax",
   bedrock: "Amazon Bedrock",
   "openai-azure": "Azure",
 };
@@ -46,6 +48,7 @@ export const envVarsToIconMap: Record<EnvVars, ReactNode> = {
   [EnvVars.GROQ_API_KEY]: <IconGroq />,
   [EnvVars.ANTHROPIC_API_KEY]: <IconAnthropic />,
   [EnvVars.MISTRAL_API_KEY]: <IconMistral />,
+  [EnvVars.MINIMAX_API_KEY]: <IconOpenAI />,
   [EnvVars.OPENAI_AZURE_API_KEY]: <IconAzure />,
   [EnvVars.OPENAI_AZUURE_DEPLOYMENT_NAME]: <IconAzure />,
   [EnvVars.OPENAI_AZUURE_RESOURCE_ID]: <IconAzure />,

--- a/frontend/lib/env/utils.ts
+++ b/frontend/lib/env/utils.ts
@@ -4,6 +4,7 @@ export enum EnvVars {
   GROQ_API_KEY = "GROQ_API_KEY",
   ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY",
   MISTRAL_API_KEY = "MISTRAL_API_KEY",
+  MINIMAX_API_KEY = "MINIMAX_API_KEY",
   OPENAI_AZURE_API_KEY = "AZURE_API_KEY",
   OPENAI_AZUURE_DEPLOYMENT_NAME = "OPENAI_AZURE_DEPLOYMENT_NAME",
   OPENAI_AZUURE_RESOURCE_ID = "OPENAI_AZURE_RESOURCE_ID",
@@ -20,6 +21,7 @@ export enum LLMModelProviders {
   GROQ = "groq",
   ANTHROPIC = "anthropic",
   MISTRAL = "mistral",
+  MINIMAX = "minimax",
   OPENAI_AZURE = "openai-azure",
   BEDROCK = "bedrock",
 }
@@ -31,6 +33,7 @@ export const MODEL_PROVIDER_TO_API_KEYS: Record<string, string[]> = {
   [LLMModelProviders.GROQ]: [EnvVars.GROQ_API_KEY],
   [LLMModelProviders.ANTHROPIC]: [EnvVars.ANTHROPIC_API_KEY],
   [LLMModelProviders.MISTRAL]: [EnvVars.MISTRAL_API_KEY],
+  [LLMModelProviders.MINIMAX]: [EnvVars.MINIMAX_API_KEY],
   [LLMModelProviders.OPENAI_AZURE]: [
     EnvVars.OPENAI_AZURE_API_KEY,
     EnvVars.OPENAI_AZUURE_DEPLOYMENT_NAME,
@@ -44,6 +47,7 @@ export const ENV_VAR_TO_ISSUER_URL: Record<string, string> = {
   [EnvVars.GROQ_API_KEY]: "https://console.groq.com/keys",
   [EnvVars.ANTHROPIC_API_KEY]: "https://console.anthropic.com/settings/keys",
   [EnvVars.MISTRAL_API_KEY]: "https://console.mistral.ai/api-keys/",
+  [EnvVars.MINIMAX_API_KEY]: "https://platform.minimax.io/user-center/basic-information/interface-key",
   [EnvVars.GOOGLE_SEARCH_ENGINE_ID]: "https://developers.google.com/custom-search/v1/overview",
   [EnvVars.GOOGLE_SEARCH_API_KEY]: "https://developers.google.com/custom-search/v1/overview",
 };

--- a/frontend/lib/playground/providersRegistry.ts
+++ b/frontend/lib/playground/providersRegistry.ts
@@ -15,6 +15,7 @@ const providersInstanceMap = {
   anthropic: createAnthropic,
   groq: createGroq,
   bedrock: createAmazonBedrock,
+  minimax: createOpenAI,
   ["openai-azure"]: createAzure,
 };
 
@@ -32,7 +33,8 @@ export const getModel = <P extends Provider, K extends string>(key: `${P}:${K}`,
   }
 
   try {
-    const providerInstance = createProvider({ apiKey });
+    const providerConfig = provider === "minimax" ? { apiKey, baseURL: "https://api.minimax.io/v1" } : { apiKey };
+    const providerInstance = createProvider(providerConfig);
     return providerInstance(model);
   } catch (error) {
     throw new Error(`Failed to initialize model ${key}`, {

--- a/frontend/lib/playground/providersRegistry.ts
+++ b/frontend/lib/playground/providersRegistry.ts
@@ -8,6 +8,21 @@ import { createOpenAI } from "@ai-sdk/openai";
 
 import { type Provider } from "@/components/playground/types";
 
+const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
+
+const createMiniMax = ({ apiKey }: { apiKey: string }) => {
+  const configuredBaseURL = process.env.MINIMAX_BASE_URL?.trim() || DEFAULT_MINIMAX_BASE_URL;
+  const baseURL = configuredBaseURL.replace(/\/+$/, "");
+
+  if (baseURL.endsWith("/anthropic")) {
+    const provider = createAnthropic({ apiKey, baseURL: `${baseURL}/v1` });
+    return (model: string) => provider(model);
+  }
+
+  const provider = createOpenAI({ apiKey, baseURL });
+  return (model: string) => provider.chat(model);
+};
+
 const providersInstanceMap = {
   openai: createOpenAI,
   gemini: createGoogleGenerativeAI,
@@ -15,7 +30,7 @@ const providersInstanceMap = {
   anthropic: createAnthropic,
   groq: createGroq,
   bedrock: createAmazonBedrock,
-  minimax: createOpenAI,
+  minimax: createMiniMax,
   ["openai-azure"]: createAzure,
 };
 
@@ -34,8 +49,8 @@ export const getModel = <P extends Provider, K extends string>(key: `${P}:${K}`,
 
   try {
     if (provider === "minimax") {
-      const providerInstance = createOpenAI({ apiKey, baseURL: "https://api.minimax.io/v1" });
-      return providerInstance.chat(model);
+      const providerInstance = providersInstanceMap.minimax({ apiKey });
+      return providerInstance(model);
     }
 
     const providerConfig = { apiKey };

--- a/frontend/lib/playground/providersRegistry.ts
+++ b/frontend/lib/playground/providersRegistry.ts
@@ -33,7 +33,12 @@ export const getModel = <P extends Provider, K extends string>(key: `${P}:${K}`,
   }
 
   try {
-    const providerConfig = provider === "minimax" ? { apiKey, baseURL: "https://api.minimax.io/v1" } : { apiKey };
+    if (provider === "minimax") {
+      const providerInstance = createOpenAI({ apiKey, baseURL: "https://api.minimax.io/v1" });
+      return providerInstance.chat(model);
+    }
+
+    const providerConfig = { apiKey };
     const providerInstance = createProvider(providerConfig);
     return providerInstance(model);
   } catch (error) {

--- a/frontend/tests/test-minimax-playground-provider.test.ts
+++ b/frontend/tests/test-minimax-playground-provider.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { generateText } from "ai";
+
+import { getModel } from "@/lib/playground/providersRegistry";
+
+const originalFetch = globalThis.fetch;
+const originalBaseURL = process.env.MINIMAX_BASE_URL;
+
+const modelIds = ["MiniMax-M3", "MiniMax-M2.7"] as const;
+const endpointCases = [
+  {
+    name: "global OpenAI",
+    baseURL: "https://api.minimax.io/v1",
+    requestURL: "https://api.minimax.io/v1/chat/completions",
+    protocol: "openai",
+  },
+  {
+    name: "China OpenAI",
+    baseURL: "https://api.minimaxi.com/v1",
+    requestURL: "https://api.minimaxi.com/v1/chat/completions",
+    protocol: "openai",
+  },
+  {
+    name: "global Anthropic",
+    baseURL: "https://api.minimax.io/anthropic",
+    requestURL: "https://api.minimax.io/anthropic/v1/messages",
+    protocol: "anthropic",
+  },
+  {
+    name: "China Anthropic",
+    baseURL: "https://api.minimaxi.com/anthropic",
+    requestURL: "https://api.minimaxi.com/anthropic/v1/messages",
+    protocol: "anthropic",
+  },
+] as const;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalBaseURL === undefined) {
+    delete process.env.MINIMAX_BASE_URL;
+  } else {
+    process.env.MINIMAX_BASE_URL = originalBaseURL;
+  }
+});
+
+for (const endpoint of endpointCases) {
+  for (const modelId of modelIds) {
+    test(`${modelId} uses the ${endpoint.name} endpoint`, async () => {
+      process.env.MINIMAX_BASE_URL = endpoint.baseURL;
+
+      let capturedRequest: Request | undefined;
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        capturedRequest = new Request(input, init);
+
+        const responseBody =
+          endpoint.protocol === "anthropic"
+            ? {
+                id: "msg_test",
+                type: "message",
+                role: "assistant",
+                model: modelId,
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                stop_sequence: null,
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }
+            : {
+                id: "chatcmpl-test",
+                object: "chat.completion",
+                created: 0,
+                model: modelId,
+                choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              };
+
+        return new Response(JSON.stringify(responseBody), {
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      const result = await generateText({
+        model: getModel(`minimax:${modelId}`, "test-api-key"),
+        prompt: "Hello",
+      });
+
+      assert.equal(result.text, "ok");
+      assert.ok(capturedRequest);
+      assert.equal(capturedRequest.url, endpoint.requestURL);
+
+      const body = (await capturedRequest.json()) as { model: string };
+      assert.equal(body.model, modelId);
+      assert.equal(
+        capturedRequest.headers.get(endpoint.protocol === "anthropic" ? "x-api-key" : "authorization"),
+        endpoint.protocol === "anthropic" ? "test-api-key" : "Bearer test-api-key"
+      );
+    });
+  }
+}


### PR DESCRIPTION
Reason: The playground provider catalog is maintained as a static list across the Provider union, model catalog, AI SDK registry, and display/API-key mappings. MiniMax was missing from that catalog and therefore unavailable in LlmSelect.

## Summary
- Add MiniMax-M3 and MiniMax-M2.7 to the playground provider catalog and API-key mappings.
- Default to the global OpenAI-compatible API while allowing global or China OpenAI/Anthropic endpoints through `MINIMAX_BASE_URL`.
- Document the endpoint configuration, pass it through Docker Compose, and cover both models across all four endpoints with request-capture tests.

## Checks
- `git diff --check`
- `corepack pnpm -C frontend exec tsx --test tests/test-minimax-playground-provider.test.ts` (8 passed)
- `corepack pnpm -C frontend test` (142 passed)
- `corepack pnpm -C frontend type-check`
- `corepack pnpm -C frontend exec eslint lib/playground/providersRegistry.ts tests/test-minimax-playground-provider.test.ts`
- `corepack pnpm -C frontend exec prettier --check lib/playground/providersRegistry.ts tests/test-minimax-playground-provider.test.ts`
- `corepack pnpm -C frontend build`
- `docker compose -f <compose-file> config --quiet` for all three changed Compose files



