### PR TITLE
fix: expose output col, fix aggregation of score

### DIFF
--- a/frontend/components/evaluation/evaluation.tsx
+++ b/frontend/components/evaluation/evaluation.tsx
@@ -268,10 +268,7 @@ function EvaluationContent({ evaluations, evaluationId }: EvaluationProps) {
     [setSort]
   );
 
-  const visibleColumnDefs = useMemo(
-    () => selectVisibleColumnDefs(columnDefs, isComparison),
-    [columnDefs, isComparison]
-  );
+  const visibleColumnDefs = useMemo(() => selectVisibleColumnDefs(columnDefs), [columnDefs]);
 
   const onDeleteCustomColumn = useCallback(
     (columnId: string) => removeCustomColumn(columnId.replace("custom:", "")),

--- a/frontend/components/evaluation/store.tsx
+++ b/frontend/components/evaluation/store.tsx
@@ -52,10 +52,8 @@ export interface EvalStoreState {
   addScoreName: (name: string) => void;
 }
 
-export const selectVisibleColumnDefs = (
-  columnDefs: ColumnDef<EvalRow>[],
-  isComparison: boolean
-): ColumnDef<EvalRow>[] => columnDefs.filter((c) => !c.meta?.hidden && !(isComparison && c.id === "output"));
+export const selectVisibleColumnDefs = (columnDefs: ColumnDef<EvalRow>[]): ColumnDef<EvalRow>[] =>
+  columnDefs.filter((c) => !c.meta?.hidden);
 
 export function buildColumnDefs({
   scoreNames,

--- a/frontend/components/shared/evaluation/shared-evaluation.tsx
+++ b/frontend/components/shared/evaluation/shared-evaluation.tsx
@@ -170,7 +170,7 @@ function SharedEvaluationContent({ evaluationId, evaluationName }: SharedEvaluat
     [searchParams, push, pathName]
   );
 
-  const visibleColumnDefs = useMemo(() => selectVisibleColumnDefs(columnDefs, false), [columnDefs]);
+  const visibleColumnDefs = useMemo(() => selectVisibleColumnDefs(columnDefs), [columnDefs]);
   const { width: defaultTraceViewWidth, handleResizeStop } = useResizableTraceViewWidth();
 
   return (

--- a/frontend/lib/actions/evaluation/utils.ts
+++ b/frontend/lib/actions/evaluation/utils.ts
@@ -54,14 +54,18 @@ export function calculateScoreDistribution(
   const lowerBound = Math.min(minScore, DEFAULT_LOWER_BOUND);
   const upperBound = maxScore;
 
-  // If all scores are the same, put everything in the last bucket
+  // All scores are the same value. This branch only fires when that value sits
+  // at the lower bound (<= 0, since lowerBound = min(value, 0)), e.g. a binary
+  // score filtered to `= 0`. Put the mass in the FIRST bucket — the last bucket
+  // is the "positive"/high end, so dumping all-zero rows there makes
+  // `binaryCounts` report a 100% positive rate instead of 0%.
   if (lowerBound === upperBound) {
     const buckets: EvaluationScoreDistributionBucket[] = Array.from({ length: DEFAULT_BUCKET_COUNT }, () => ({
       lowerBound,
       upperBound,
       heights: [0],
     }));
-    buckets[DEFAULT_BUCKET_COUNT - 1].heights = [scores.length];
+    buckets[0].heights = [scores.length];
     return buckets;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI and stats-bucketing fixes in evaluation views; no auth or data-path changes.
> 
> **Overview**
> **Comparison eval tables** no longer force-hide the **output** column: `selectVisibleColumnDefs` drops the `isComparison` branch and only respects `meta.hidden`, so output can appear when comparing runs (still off by default via column visibility).
> 
> **Score distribution** for the degenerate case where every value is the same and at the lower bound (e.g. binary scores filtered to `= 0`) now assigns all counts to the **first** bucket instead of the last. That aligns with `binaryCounts` (first = negative, last = positive), so run-level binary pass rates show **0%** instead of incorrectly **100%**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a86e0d98417c408d1570a2c3f9b820b6d2fe6cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->