### PR TITLE
don't generate tool call id, serde default fields that have skip_seri…

### DIFF
--- a/app-server/src/llm/models.rs
+++ b/app-server/src/llm/models.rs
@@ -14,7 +14,7 @@ pub enum ModelSize {
 #[serde(rename_all = "camelCase")]
 pub struct ProviderRequestItem {
     pub request: ProviderRequest,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
 }
 
@@ -22,11 +22,11 @@ pub struct ProviderRequestItem {
 #[serde(rename_all = "camelCase")]
 pub struct ProviderRequest {
     pub contents: Vec<ProviderContent>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_instruction: Option<ProviderContent>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<ProviderTool>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub generation_config: Option<ProviderGenerationConfig>,
     /// Inference service tier (e.g. `"flex"`). Only honored by the Gemini
     /// provider (https://ai.google.dev/gemini-api/docs/flex-inference);
@@ -42,24 +42,24 @@ pub struct ProviderRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderGenerationConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub top_k: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_output_tokens: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking_config: Option<ProviderThinkingConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderThinkingConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub include_thoughts: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking_level: Option<ProviderThinkingLevel>,
 }
 
@@ -78,20 +78,20 @@ pub enum ProviderThinkingLevel {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderContent {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parts: Option<Vec<ProviderPart>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderPart {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub function_call: Option<ProviderFunctionCall>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub function_response: Option<ProviderFunctionResponse>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thought: Option<bool>,
@@ -102,17 +102,17 @@ pub struct ProviderPart {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderFunctionCall {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub args: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderFunctionResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub name: String,
     pub response: serde_json::Value,
@@ -141,11 +141,11 @@ pub struct ProviderBatchOutput {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderInlineResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response: Option<ProviderResponse>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<ProviderErrorInfo>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
 }
 
@@ -162,20 +162,20 @@ pub enum ProviderStreamChunk {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub candidates: Option<Vec<ProviderCandidate>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage_metadata: Option<ProviderUsageMetadata>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_version: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderCandidate {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<ProviderContent>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finish_reason: Option<ProviderFinishReason>,
 }
 
@@ -217,15 +217,15 @@ pub struct ProviderErrorInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderUsageMetadata {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_token_count: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub candidates_token_count: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_token_count: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_read_input_tokens: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_creation_input_tokens: Option<i32>,
 }
 
@@ -246,9 +246,9 @@ pub struct ProviderBatchOperation {
     pub name: String,
     #[serde(default)]
     pub done: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response: Option<ProviderBatchOutput>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<ProviderErrorInfo>,
     #[serde(skip)]
     pub state: Option<ProviderBatchState>,

--- a/app-server/src/llm/openai/conversions.rs
+++ b/app-server/src/llm/openai/conversions.rs
@@ -277,7 +277,7 @@ pub fn parse_openai_response(value: Value) -> Result<ProviderResponse, OpenAIErr
                     .and_then(|s| serde_json::from_str::<Value>(s).ok())
                     .or_else(|| {
                         // Some gateways pre-parse `arguments` into an object.
-                        func.and_then(|f| f.get("arguments")).cloned(),
+                        func.and_then(|f| f.get("arguments")).cloned()
                     });
                 parts.push(ProviderPart {
                     function_call: Some(ProviderFunctionCall { id, name, args }),

--- a/app-server/src/llm/openai/conversions.rs
+++ b/app-server/src/llm/openai/conversions.rs
@@ -275,10 +275,10 @@ pub fn parse_openai_response(value: Value) -> Result<ProviderResponse, OpenAIErr
                     .and_then(|f| f.get("arguments"))
                     .and_then(|a| a.as_str())
                     .and_then(|s| serde_json::from_str::<Value>(s).ok())
-                    .or(
+                    .or_else( || {
                         // Some gateways pre-parse `arguments` into an object.
                         func.and_then(|f| f.get("arguments")).cloned(),
-                    );
+                    });
                 parts.push(ProviderPart {
                     function_call: Some(ProviderFunctionCall { id, name, args }),
                     ..Default::default()

--- a/app-server/src/llm/openai/conversions.rs
+++ b/app-server/src/llm/openai/conversions.rs
@@ -275,7 +275,7 @@ pub fn parse_openai_response(value: Value) -> Result<ProviderResponse, OpenAIErr
                     .and_then(|f| f.get("arguments"))
                     .and_then(|a| a.as_str())
                     .and_then(|s| serde_json::from_str::<Value>(s).ok())
-                    .or_else( || {
+                    .or_else(|| {
                         // Some gateways pre-parse `arguments` into an object.
                         func.and_then(|f| f.get("arguments")).cloned(),
                     });

--- a/app-server/src/llm/openai/conversions.rs
+++ b/app-server/src/llm/openai/conversions.rs
@@ -158,8 +158,7 @@ fn append_content_as_messages(content: &ProviderContent, out: &mut Vec<Value>) {
         }
         if let Some(fr) = part.function_response {
             let tool_call_id = fr.id.unwrap_or_default();
-            let content_str =
-                serde_json::to_string(&fr.response).unwrap_or_else(|_| "".to_string());
+            let content_str = serde_json::to_string(&fr.response).unwrap_or("".to_string());
             tool_results.push(json!({
                 "role": "tool",
                 "tool_call_id": tool_call_id,
@@ -168,9 +167,9 @@ fn append_content_as_messages(content: &ProviderContent, out: &mut Vec<Value>) {
             continue;
         }
         if let Some(fc) = part.function_call {
-            let id = fc.id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            let id = fc.id.unwrap_or_default();
             let args = fc.args.unwrap_or(Value::Object(Default::default()));
-            let arguments_str = serde_json::to_string(&args).unwrap_or_else(|_| "{}".to_string());
+            let arguments_str = serde_json::to_string(&args).unwrap_or("{}".to_string());
             tool_calls.push(json!({
                 "id": id,
                 "type": "function",
@@ -276,10 +275,10 @@ pub fn parse_openai_response(value: Value) -> Result<ProviderResponse, OpenAIErr
                     .and_then(|f| f.get("arguments"))
                     .and_then(|a| a.as_str())
                     .and_then(|s| serde_json::from_str::<Value>(s).ok())
-                    .or_else(|| {
+                    .or(
                         // Some gateways pre-parse `arguments` into an object.
-                        func.and_then(|f| f.get("arguments")).cloned()
-                    });
+                        func.and_then(|f| f.get("arguments")).cloned(),
+                    );
                 parts.push(ProviderPart {
                     function_call: Some(ProviderFunctionCall { id, name, args }),
                     ..Default::default()


### PR DESCRIPTION
…alizing

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stopping UUID synthesis for tool call IDs can break OpenAI tool round-trips when upstream requires non-empty `id`/`tool_call_id` values.
> 
> **Overview**
> Adds **`#[serde(default)]`** alongside **`skip_serializing_if = "Option::is_none"`** on optional fields across the internal provider request/response types in `models.rs`, so omitted JSON keys deserialize as `None` instead of failing.
> 
> In the OpenAI request converter, **missing `function_call` / `function_response` IDs** are no longer filled with a generated UUID—they use **`unwrap_or_default()`** (empty string) for `tool_calls[].id` and `tool_call_id`. JSON serialization fallbacks there are simplified to **`unwrap_or`** instead of **`unwrap_or_else`**.
> 
> **Note:** `missing_tool_call_id_gets_uuid` in `conversions.rs` still asserts a UUID-shaped id unless updated elsewhere; behavior for id-less tool calls is now an empty id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6304125aa383ad55d88b2f2b8037c11918a99f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->