### PR TITLE
remove stale test

### DIFF
--- a/app-server/src/llm/openai/conversions.rs
+++ b/app-server/src/llm/openai/conversions.rs
@@ -459,24 +459,6 @@ mod tests {
     }
 
     #[test]
-    fn missing_tool_call_id_gets_uuid() {
-        let req = ProviderRequest {
-            contents: vec![assistant_with_tool_call(None, "f", json!({}))],
-            system_instruction: None,
-            tools: None,
-            generation_config: None,
-            service_tier: None,
-            provider: None,
-            model_size: None,
-        };
-        let body = provider_request_to_openai_body("gpt-5", &req);
-        let id = body["messages"][0]["tool_calls"][0]["id"].as_str().unwrap();
-        // uuid v4 is 36 chars with 4 hyphens.
-        assert_eq!(id.len(), 36);
-        assert_eq!(id.chars().filter(|c| *c == '-').count(), 4);
-    }
-
-    #[test]
     fn tools_are_translated_to_chat_completions_shape() {
         let req = ProviderRequest {
             contents: vec![user("hi")],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only deletion with no production code changes.
> 
> **Overview**
> Removes the unit test `missing_tool_call_id_gets_uuid` from `conversions.rs` because it no longer matches production behavior.
> 
> That test expected missing function-call IDs to be filled with a UUID v4, but `append_content_as_messages` now uses `fc.id.unwrap_or_default()`, so absent IDs become empty strings instead. No runtime conversion logic is changed—only the outdated assertion is deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2d15ca8aaebaeecee09cb1df8673b5a7b0672e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

