### PR TITLE
Revert "Merge pull request #2055 from lmnr-ai/fix/extend-user-fp-to-md"

### DIFF
--- a/app-server/src/traces/input_extraction/fingerprint.rs
+++ b/app-server/src/traces/input_extraction/fingerprint.rs
@@ -1,8 +1,6 @@
 //! Structural fingerprinting of user messages: the sequence of
-//! top-level XML-like scaffolding tags plus the ordered sequence of
-//! markdown headings (h1-h3), used as part of the regex cache key so
-//! traces with the same scaffolding shape share a cached regex. The
-//! fingerprint is only ever hashed, so headings are kept verbatim.
+//! top-level XML-like scaffolding tags, used as part of the regex cache
+//! key so traces with the same scaffolding shape share a cached regex.
 
 use std::sync::LazyLock;
 
@@ -13,47 +11,10 @@ use fancy_regex::Regex;
 static TOP_LEVEL_TAG: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"<([a-zA-Z_][\w-]*)\b[^>]*>[\s\S]*?</\1\s*>").unwrap());
 
-/// ATX-style markdown heading, levels 1-3 only (`#`/`##`/`###`). Up to 3
-/// leading spaces are allowed (CommonMark); a 4th makes it a code block,
-/// not a heading. `(?!#)` after the level group rejects h4+
-/// (`####...`). The heading text is optional (a bare `###` still
-/// counts), but when text is present it must be separated by whitespace
-/// — CommonMark treats `###foo` (no space) as a paragraph, not a
-/// heading.
-static MARKDOWN_HEADING: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^ {0,3}(#{1,3})(?!#)(?:[ \t]+.*)?$").unwrap());
-
-/// Ordered sequence of markdown headings (verbatim, `#` markers and text
-/// included) found in the message, scanned line by line over the raw
-/// input (including text inside XML-like tag bodies). Unlike XML tags,
-/// headings have no closing marker, so — unlike tag names — order here
-/// is significant and is preserved as encountered, not sorted or
-/// deduplicated.
-fn heading_sequence(input: &str) -> Vec<&str> {
-    input
-        .lines()
-        .filter(|line| matches!(MARKDOWN_HEADING.is_match(line), Ok(true)))
-        .map(str::trim)
-        .collect()
-}
-
 /// Structural fingerprint of a user message: the sequence of top-level
-/// XML-like tags (nested tags are swallowed by the lazy body match, and
-/// tag order doesn't affect the fingerprint), or `"plain"` for messages
-/// with no balanced tags — followed by `|` and the order-sensitive
-/// sequence of verbatim markdown headings, when any are present.
+/// XML-like tags (nested tags are swallowed by the lazy body match), or
+/// `"plain"` for messages with no balanced tags.
 pub fn fingerprint_user_message(input: &str) -> String {
-    let tag_fingerprint = fingerprint_tags(input);
-    let headings = heading_sequence(input);
-    if headings.is_empty() {
-        tag_fingerprint
-    } else {
-        format!("{tag_fingerprint}|{}", headings.join("\n"))
-    }
-}
-
-/// Tag-only half of the fingerprint. See `fingerprint_user_message`.
-fn fingerprint_tags(input: &str) -> String {
     let mut parts: Vec<String> = Vec::new();
     let mut rest = input;
 
@@ -172,79 +133,5 @@ mod tests {
         assert_eq!(fingerprint_user_message("<ENV>x</ENV>"), "env,/env");
         // Prose on both sides of an unmatched region stays one "plain".
         assert_eq!(fingerprint_user_message("a <br oken b"), "plain");
-    }
-
-    #[test]
-    fn fingerprint_no_headings_unaffected() {
-        assert_eq!(fingerprint_user_message("just some prose"), "plain");
-        assert_eq!(fingerprint_user_message("<env>x</env>"), "env,/env");
-    }
-
-    #[test]
-    fn fingerprint_headings_verbatim() {
-        assert_eq!(fingerprint_user_message("# Title"), "plain|# Title");
-        assert_eq!(fingerprint_user_message("## Title"), "plain|## Title");
-        assert_eq!(fingerprint_user_message("### Title"), "plain|### Title");
-    }
-
-    #[test]
-    fn fingerprint_headings_ignore_h4_plus() {
-        assert_eq!(fingerprint_user_message("#### Title"), "plain");
-        assert_eq!(fingerprint_user_message("###### Title"), "plain");
-    }
-
-    #[test]
-    fn fingerprint_headings_order_matters() {
-        // Unlike tags, heading order is preserved, not sorted.
-        let a = fingerprint_user_message("# One\ntext\n## Two\ntext\n### Three");
-        let b = fingerprint_user_message("### Three\ntext\n## Two\ntext\n# One");
-        assert_eq!(a, "plain|# One\n## Two\n### Three");
-        assert_eq!(b, "plain|### Three\n## Two\n# One");
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn fingerprint_headings_repeated_not_deduped() {
-        assert_eq!(
-            fingerprint_user_message("# A\n# B\n## C"),
-            "plain|# A\n# B\n## C"
-        );
-    }
-
-    #[test]
-    fn fingerprint_headings_combine_with_tags() {
-        assert_eq!(
-            fingerprint_user_message("<env>x</env>\n# Title\nbody"),
-            "env,/env,plain|# Title"
-        );
-    }
-
-    #[test]
-    fn fingerprint_headings_bare_hash_counts() {
-        // A heading marker with no text still counts as a heading.
-        assert_eq!(fingerprint_user_message("###"), "plain|###");
-        assert_eq!(fingerprint_user_message("###\nbody"), "plain|###");
-    }
-
-    #[test]
-    fn fingerprint_headings_require_leading_whitespace_for_text() {
-        // No space after the hashes: not a heading per CommonMark, so no
-        // "|..." suffix is appended.
-        assert_eq!(fingerprint_user_message("###notaheading"), "plain");
-    }
-
-    #[test]
-    fn fingerprint_headings_leading_spaces_allowed() {
-        assert_eq!(fingerprint_user_message("   # Title"), "plain|# Title");
-        // 4+ leading spaces makes it a code block, not a heading.
-        assert_eq!(fingerprint_user_message("    # Title"), "plain");
-    }
-
-    #[test]
-    fn fingerprint_headings_inside_tag_body_are_detected() {
-        assert_eq!(
-            fingerprint_user_message("<context>\n# Heading\nbody\n</context>"),
-            "context,/context|# Heading"
-        );
     }
 }


### PR DESCRIPTION
cost has grown manyfold. Reverting in prod, investigating in the background

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache-key semantics for trace input extraction, so heading-only differences may share regexes again; behavior is intentional for cost but can affect extraction consistency until a cheaper approach lands.
> 
> **Overview**
> Reverts the extension of `fingerprint_user_message` that appended an order-sensitive markdown heading sequence (`h1`–`h3`) after a `|` suffix on the regex cache key.
> 
> The fingerprint again depends only on top-level XML-like tag scaffolding (plus `plain`), with tag logic inlined in `fingerprint_user_message` and the `MARKDOWN_HEADING` regex, `heading_sequence`, and `fingerprint_tags` helper removed. All heading-related unit tests are dropped.
> 
> **Effect:** traces that differ only in markdown headings will share the same cache key again, which is intended to reduce regex-cache fragmentation and the production cost spike called out in the revert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ce6da534b83981369ef2881121d29488e38acd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

