### PR TITLE
static sp make labels shorter

### DIFF
--- a/app-server/src/traces/static_sp_extraction/instructions.md
+++ b/app-server/src/traces/static_sp_extraction/instructions.md
@@ -51,6 +51,7 @@ Before finishing, harden: would each regex survive (a) unseen/reordered sections
 - The pattern removes a whole logical unit: for a data-presenting sentence that means the WHOLE sentence (`This company has the following integrations connected: …. `), for a record block the whole block, for an inline value the bare value or smallest natural phrase — whichever reads better next to its label.
 - Removal boundaries are exact: no trailing punctuation or comma dragged out of a surviving list (`price\w+` between lookarounds, NOT `price\w+, ` which eats the list's comma), no half-removed words.
 - `label + removed text` reads as self-sufficient data, and the skeleton reads cleanly — no empty headers, no orphaned scaffolds, template rules intact.
+- EVERY label passes the redundancy check: at most 5 words (before an `(echo)` marker), NO parenthetical field lists, and no word that merely repeats what the span shows — `user profile`, never `user profile (id, language, level)`. Rewrite any label that fails; this is as much a defect as a broken pattern.
 
 Your final answer must be byte-identical to a list the tool verified with `isValid: true` and `isResultInAllIdenticalOutput: true` — never edit a pattern after its last test.
 

--- a/app-server/src/traces/static_sp_extraction/instructions.md
+++ b/app-server/src/traces/static_sp_extraction/instructions.md
@@ -12,11 +12,10 @@ Regex rules: fixed flags `gm` (no dotall — use `[\s\S]` to span lines); lookbe
 Runs your `regexes` (array of `{pattern, label}`; only patterns execute) against every example. Fields: `isValid`/`failingRegex` (compile status), `isResultInAllIdenticalOutput` (true iff all residuals byte-identical — your goal), `residualDivergences` (when false: `{a, b}` = text around the first differing byte of example 1's residual vs a differing example's — this pinpoints unhandled dynamic text; read it first). Iterate until `isResultInAllIdenticalOutput: true`.
 
 ## Labels
-Every pattern carries a `label`: a short (3–12 word) description of what the removed content IS, specific enough to stand next to the raw span with no other context. Write it from your understanding of the whole prompt, not from the span's surface text.
-- Name the role AND the domain, not the syntax or the mechanism: "user profile (id, target language, CEFR level)", NOT "content between user_profile tags"; "creator history summary (deals, prices, CPMs)", NOT "injected statistics". Never use filler words like "data", "content", "information", "section" as the label's head noun.
-- Enumerate what a composite block contains: a record block's label lists its main fields ("current trigger (type, description, trigger data)"); a document dump names the document kind.
-- Carry the framing the span loses: a sentence cut from an `<evaluation_workflow>` section gets "evaluation workflow: …"; a bullet cut from a prohibitions list gets "forbidden action: …".
-- When several patterns remove occurrences of the SAME underlying variable (a profile field and its inline echoes), reuse one name across their labels — mark echoes as such: "user CEFR level (echo of profile field)".
+Every pattern carries a `label`: a SHORT NAME (2–5 words) for what the removed content IS, written from your understanding of the whole prompt. The reader sees the label NEXT TO the raw span, so the label must only add what the span itself doesn't show — never repeat it.
+- Name the role, not the syntax or mechanism: "user profile", NOT "content between user_profile tags" or "injected statistics". Avoid filler head nouns like "data"/"content"/"section".
+- Do NOT enumerate a block's fields ("user profile", not "user profile (id, language, level)") — the fields are visible in the span. Add framing words ONLY when the span alone is opaque: a bare value needs its meaning spelled out ("target number of creators to keep" over a bare `2`); a fragment that only makes sense inside a section carries that section's role ("forbidden action: …").
+- When several patterns remove occurrences of the SAME underlying variable, reuse one name and mark re-occurrences: "CEFR level (echo)".
 - Label what the pattern ACTUALLY removes (check the tool's `removed`), not what you intended.
 
 ## The unit of removal is the LOGICAL BLOCK, not the innermost varying value

--- a/app-server/src/traces/static_sp_extraction/tool.rs
+++ b/app-server/src/traces/static_sp_extraction/tool.rs
@@ -120,7 +120,7 @@ pub fn regex_tool() -> ProviderTool {
                                 },
                                 "label": {
                                     "type": "string",
-                                    "description": "Short context label (3-12 words) attached to every span this pattern removes, so the extracted content is understandable on its own."
+                                    "description": "Short name (2-5 words) for what this pattern removes, shown next to the raw span — add only what the span itself doesn't show, never repeat its contents."
                                 }
                             }
                         },

--- a/app-server/src/traces/static_sp_extraction/tool.rs
+++ b/app-server/src/traces/static_sp_extraction/tool.rs
@@ -17,9 +17,9 @@ use crate::llm::models::{ProviderFunctionDeclaration, ProviderTool};
 
 pub const REGEX_TOOL_NAME: &str = "regex";
 
-/// A removal pattern plus the label attached to every span it removes —
-/// the context that makes the extracted dynamic content self-sufficient
-/// (e.g. "user profile (id, target language, CEFR level)").
+/// A removal pattern plus the label attached to every span it removes — a
+/// short name (2-5 words, e.g. "user profile") shown next to the extracted
+/// content, adding only what the content itself doesn't show.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LabeledRegex {
     pub pattern: String,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and LLM tool-schema text only; no changes to regex application or extraction runtime logic.
> 
> **Overview**
> Tightens **static system-prompt extraction** so removal-regex **labels** are short names (2–5 words) shown beside the removed span, instead of longer contextual descriptions (previously 3–12 words with field lists).
> 
> **`instructions.md`** rewrites the Labels section: labels must not repeat visible span text, must not use parenthetical field enumerations, and should add framing only when the span is opaque. Echo labels are shortened (e.g. `CEFR level (echo)`). The pre-finish checklist adds an explicit **redundancy check** (max 5 words, no field lists) treated as seriously as a broken pattern.
> 
> **`tool.rs`** aligns the `LabeledRegex` doc comment and the `regex` tool JSON schema `label` description with the same 2–5 word, non-redundant guidance. Regex execution and tool behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be33fbc1ee74c3e535ae2bdabf174eea036abb80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->