### PR TITLE
fix: opt Radix Select out of browser translation (translate="no")

### DIFF
--- a/frontend/components/ui/select.tsx
+++ b/frontend/components/ui/select.tsx
@@ -18,6 +18,11 @@ const SelectTrigger = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
+    // Browser translation (e.g. Google Translate) rewrites the trigger/value
+    // text nodes out from under React, crashing reconciliation with a
+    // removeChild/insertBefore NotFoundError. `translate="no"` opts the whole
+    // subtree out of translation. See radix-ui/primitives #2578, #3795.
+    translate="no"
     className={cn(
       "flex h-7 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-2 py-2 text-xs ring-offset-background placeholder:text-muted-foreground focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
@@ -67,6 +72,9 @@ const SelectContent = React.forwardRef<
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
+      // Opt the portaled dropdown (and every item) out of browser translation
+      // so translated text nodes can't desync React's DOM. See SelectTrigger.
+      translate="no"
       className={cn(
         "relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&


### PR DESCRIPTION
## Problem

Browser translation (Google Translate, in-browser translate extensions) rewrites the text nodes inside a Radix `Select` out from under React. Because Radix Select **portals its content and swaps DOM nodes when the value changes**, React's reconciliation then tries to `removeChild`/`insertBefore` on nodes the translator has moved or replaced, throwing:

> Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.

…which takes down the whole app. Upstream: radix-ui/primitives [#2578](https://github.com/radix-ui/primitives/issues/2578), [#3795](https://github.com/radix-ui/primitives/issues/3795).

## Fix

Add `translate="no"` to the shadcn `SelectTrigger` (covers the displayed `SelectValue`) and `SelectContent` (covers every `SelectItem` in the portal). The translation engine skips those subtrees, so it never mutates the nodes React is reconciling. One change in `components/ui/select.tsx` fixes every `Select` in the app.

## Trade-off

The selected value and dropdown options are no longer machine-translated. That's the intended behavior here — stability over translating a handful of short, mostly-symbolic option labels — and matches the shadcn/Radix-recommended approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

