### PR TITLE
fix: guard template picker fetch

### DIFF
--- a/frontend/components/ui/template-renderer/template-picker.tsx
+++ b/frontend/components/ui/template-renderer/template-picker.tsx
@@ -84,12 +84,15 @@ export const TemplatePickerProvider = ({
   traceId,
   children,
 }: PropsWithChildren<TemplatePickerProviderProps>) => {
-  const { projectId } = useParams();
+  const { projectId } = useParams<{ projectId?: string }>();
   const { toast } = useToast();
 
-  const templatesBaseUrl = `/api/projects/${projectId}/render-templates`;
-
-  const { data: templates } = useSWR<TemplateInfo[]>(`${templatesBaseUrl}?type=${scope}`, swrFetcher);
+  // Shared pages have no projectId; fetching would 401 → sign-in via swrFetcher.
+  const templatesBaseUrl = projectId ? `/api/projects/${projectId}/render-templates` : null;
+  const { data: templates } = useSWR<TemplateInfo[]>(
+    templatesBaseUrl ? `${templatesBaseUrl}?type=${scope}` : null,
+    swrFetcher
+  );
 
   const { setPresetTemplate, getPresetTemplate } = useTemplateRenderer();
 
@@ -115,6 +118,7 @@ export const TemplatePickerProvider = ({
 
   const fetchTemplate = useCallback(
     async (templateId: string): Promise<Template | null> => {
+      if (!templatesBaseUrl) return null;
       try {
         const res = await fetch(`${templatesBaseUrl}/${templateId}`);
         if (!res.ok) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small guard around template API usage on non-project routes; normal project-scoped behavior is unchanged when `projectId` is present.
> 
> **Overview**
> **`TemplatePickerProvider`** now treats **`projectId`** from the route as optional and **does not fetch** `/api/projects/.../render-templates` when it is missing (e.g. shared trace views).
> 
> SWR is keyed with **`null`** instead of a malformed project URL, and **`fetchTemplate`** returns early in the same case so individual template loads are skipped too.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3baa2b6b4f5ae22ce1177de6edbb5a3450cc472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

