### PR TITLE
feat: eval score direction (isHigherBetter) with LLM defaults + project overrides

### DIFF
--- a/app-server/src/db/projects.rs
+++ b/app-server/src/db/projects.rs
@@ -15,6 +15,9 @@ pub struct ProjectSettings {
     /// PII redaction toggle. Enabling routes every span on this project
     /// through the pii-redactor before storage. Pro-tier gated frontend-side.
     pub remove_pii: bool,
+    /// Per-project eval-score direction overrides (score name -> isHigherBetter).
+    /// Frontend-only concern; mirrored here so the JSONB round-trips losslessly.
+    pub score_direction_overrides: std::collections::HashMap<String, bool>,
 }
 
 #[derive(Deserialize, Serialize, FromRow, Clone)]

--- a/frontend/app/api/projects/[projectId]/evaluations/score-directions/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/score-directions/route.ts
@@ -1,22 +1,10 @@
 import { resolveScoreDirections } from "@/lib/actions/evaluation/score-directions";
-import { getServerSession } from "@/lib/auth-session";
-import { isUserMemberOfProject } from "@/lib/authorization";
 
 // Resolve the app-wide default score directions for the given score names
 // (repeated `?name=` params). Returns `{ defaults }` (name -> isHigherBetter);
-// per-project overrides are applied client-side. Project-scoped only for auth.
-export async function GET(req: Request, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
-  const { projectId } = await props.params;
-
-  const session = await getServerSession();
-  const userId = session?.user?.id;
-  if (!userId) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (!(await isUserMemberOfProject(projectId, userId))) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
-  }
-
+// per-project overrides are applied client-side. Auth + project membership are
+// enforced upstream by proxy.ts for all /api/projects/* routes.
+export async function GET(req: Request, _props: { params: Promise<{ projectId: string }> }): Promise<Response> {
   try {
     const names = new URL(req.url).searchParams.getAll("name");
     const defaults = await resolveScoreDirections(names);

--- a/frontend/app/api/projects/[projectId]/evaluations/score-directions/route.ts
+++ b/frontend/app/api/projects/[projectId]/evaluations/score-directions/route.ts
@@ -1,0 +1,28 @@
+import { resolveScoreDirections } from "@/lib/actions/evaluation/score-directions";
+import { getServerSession } from "@/lib/auth-session";
+import { isUserMemberOfProject } from "@/lib/authorization";
+
+// Resolve the app-wide default score directions for the given score names
+// (repeated `?name=` params). Returns `{ defaults }` (name -> isHigherBetter);
+// per-project overrides are applied client-side. Project-scoped only for auth.
+export async function GET(req: Request, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
+  const { projectId } = await props.params;
+
+  const session = await getServerSession();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!(await isUserMemberOfProject(projectId, userId))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const names = new URL(req.url).searchParams.getAll("name");
+    const defaults = await resolveScoreDirections(names);
+    return Response.json({ defaults });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Internal server error";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/frontend/components/evaluation/columns/index.ts
+++ b/frontend/components/evaluation/columns/index.ts
@@ -6,7 +6,7 @@ import { type EvalRow } from "@/lib/evaluation/types";
 import { CostCell } from "./cost-cell";
 import { DataCell } from "./data-cell";
 import { DurationCell } from "./duration-cell";
-import { createScoreColumnCell } from "./score-cell";
+import { createScoreColumnCell, scoreDirectionDropdownItems } from "./score-cell";
 import { StatusCell } from "./status-cell";
 
 // -- Static column definitions --
@@ -239,6 +239,7 @@ export function createScoreColumnDef(name: string): ColumnDef<EvalRow> {
       comparable: true,
       scoreName: name,
       dbType: "Float64",
+      customDropdownItems: (table) => scoreDirectionDropdownItems(name, table),
     },
   };
 }

--- a/frontend/components/evaluation/columns/score-cell.tsx
+++ b/frontend/components/evaluation/columns/score-cell.tsx
@@ -1,5 +1,6 @@
-import { type CellContext } from "@tanstack/react-table";
-import { ArrowRight } from "lucide-react";
+import { type CellContext, type Table } from "@tanstack/react-table";
+import { ArrowRight, Check } from "lucide-react";
+import { type ReactNode } from "react";
 
 import HeatmapValue from "@/components/evaluation/heatmap-value";
 import {
@@ -16,7 +17,15 @@ import { type EvalRow } from "@/lib/evaluation/types";
 
 import { shouldShowComparisonIndicator } from "./comparison-cell";
 
-const ScoreDisplay = ({ range, value }: { range: ScoreRange; value: ScoreValue }) => {
+const ScoreDisplay = ({
+  range,
+  value,
+  isHigherBetter,
+}: {
+  range: ScoreRange;
+  value: ScoreValue;
+  isHigherBetter: boolean;
+}) => {
   if (!isValidScore(value)) {
     return <span className="text-gray-500">-</span>;
   }
@@ -25,6 +34,7 @@ const ScoreDisplay = ({ range, value }: { range: ScoreRange; value: ScoreValue }
     <HeatmapValue
       value={value}
       range={range}
+      isHigherBetter={isHigherBetter}
       text={
         <span className="text-current" title={value.toString()}>
           {formatScoreValue(value)}
@@ -34,9 +44,15 @@ const ScoreDisplay = ({ range, value }: { range: ScoreRange; value: ScoreValue }
   );
 };
 
-const HeatmapScoreCell = ({ value, range }: { value: ScoreValue; range: ScoreRange }) => (
-  <ScoreDisplay range={range} value={value} />
-);
+const HeatmapScoreCell = ({
+  value,
+  range,
+  isHigherBetter,
+}: {
+  value: ScoreValue;
+  range: ScoreRange;
+  isHigherBetter: boolean;
+}) => <ScoreDisplay range={range} value={value} isHigherBetter={isHigherBetter} />;
 
 // -- Comparison sub-components (absorbed from comparison-score-cell.tsx) --
 
@@ -51,22 +67,25 @@ const HeatmapComparisonCell = ({
   originalValue,
   comparisonValue,
   range,
+  isHigherBetter,
 }: {
   original: DisplayValue;
   comparison: DisplayValue;
   originalValue?: number;
   comparisonValue?: number;
   range: ScoreRange;
+  isHigherBetter: boolean;
 }) => {
   const showComparison = shouldShowComparisonIndicator(originalValue, comparisonValue);
   const span = range.max - range.min;
   // Zero delta gets NO block (not the gradient midpoint) so actual movement pops.
+  // For lower-is-better scores the delta gradient inverts (a decrease is green).
   const deltaColor =
     shouldShowHeatmap(range) &&
     isValidScore(originalValue) &&
     isValidScore(comparisonValue) &&
     originalValue !== comparisonValue
-      ? getHeatmapColor(originalValue - comparisonValue, { min: -span, max: span })
+      ? getHeatmapColor(originalValue - comparisonValue, { min: -span, max: span }, isHigherBetter)
       : null;
 
   const content = (
@@ -118,9 +137,15 @@ const StandardScoreComparison = ({ original, comparison }: { original: ScoreValu
 
 export const createScoreColumnCell = (scoreName: string) => {
   const ScoreColumnCell = ({ row, table }: CellContext<EvalRow, unknown>) => {
-    const { isComparison = false, heatmapEnabled = false, scoreRanges = {} } = table.options.meta?.evalCellMeta ?? {};
+    const {
+      isComparison = false,
+      heatmapEnabled = false,
+      scoreRanges = {},
+      scoreDirections = {},
+    } = table.options.meta?.evalCellMeta ?? {};
     const value = row.original[`score:${scoreName}`] as number | undefined;
     const range = scoreRanges[scoreName];
+    const isHigherBetter = scoreDirections[scoreName] ?? true;
 
     if (isComparison) {
       const comparison = row.original[`compared:score:${scoreName}`] as number | undefined;
@@ -133,6 +158,7 @@ export const createScoreColumnCell = (scoreName: string) => {
             originalValue={value}
             comparisonValue={comparison}
             range={range}
+            isHigherBetter={isHigherBetter}
           />
         );
       }
@@ -141,7 +167,7 @@ export const createScoreColumnCell = (scoreName: string) => {
     }
 
     if (heatmapEnabled && range) {
-      return <HeatmapScoreCell value={value} range={range} />;
+      return <HeatmapScoreCell value={value} range={range} isHigherBetter={isHigherBetter} />;
     }
 
     return isValidScore(value) ? formatScoreValue(value) : "-";
@@ -150,3 +176,27 @@ export const createScoreColumnCell = (scoreName: string) => {
   ScoreColumnCell.displayName = `ScoreColumnCell_${scoreName}`;
   return ScoreColumnCell;
 };
+
+// -- Header dropdown "Higher is better" toggle --
+
+export type ScoreDirectionMenuItem = { label: string; icon?: ReactNode; isActive?: boolean; onClick: () => void };
+
+// Shared "Higher is better" header-dropdown item, used by both eval tables.
+export function higherBetterMenuItem(isHigherBetter: boolean, onClick: () => void): ScoreDirectionMenuItem {
+  return {
+    label: "Higher is better",
+    isActive: isHigherBetter,
+    icon: isHigherBetter ? <Check className="size-3.5 text-primary-foreground" /> : <span className="size-3.5" />,
+    onClick,
+  };
+}
+
+// Built as a `customDropdownItems` factory on the score column so the toggle
+// reads live state off the table meta (no column-def rebuild on every flip).
+// Returns [] when no toggle handler is wired (e.g. shared/public evals).
+export function scoreDirectionDropdownItems(scoreName: string, table: unknown): ScoreDirectionMenuItem[] {
+  const meta = (table as Table<EvalRow>).options.meta?.evalCellMeta;
+  const onToggle = meta?.onToggleScoreDirection;
+  if (!onToggle) return [];
+  return [higherBetterMenuItem(meta?.scoreDirections?.[scoreName] ?? true, () => onToggle(scoreName))];
+}

--- a/frontend/components/evaluation/evaluation-datapoints-table/index.tsx
+++ b/frontend/components/evaluation/evaluation-datapoints-table/index.tsx
@@ -31,6 +31,12 @@ interface EvaluationDatapointsTableProps {
   heatmapEnabled?: boolean;
   onHeatmapEnabledChange?: (enabled: boolean) => void;
   onDeleteCustomColumn?: (columnId: string) => void;
+
+  /** Resolved score directions (name -> isHigherBetter) for delta/heatmap coloring. */
+  scoreDirections?: Record<string, boolean>;
+  /** Flip + persist a score's direction from the header dropdown. Omit to hide the toggle. */
+  onToggleScoreDirection?: (scoreName: string) => void;
+
   searchValue: AdvancedSearchValue;
   onSearchChange: (next: AdvancedSearchValue) => void;
   viewsResource?: string;
@@ -70,6 +76,8 @@ const EvaluationDatapointsTable = ({
   heatmapEnabled,
   onHeatmapEnabledChange,
   onDeleteCustomColumn,
+  scoreDirections,
+  onToggleScoreDirection,
   searchValue,
   onSearchChange,
   viewsResource,
@@ -103,6 +111,8 @@ const EvaluationDatapointsTable = ({
         sortDirection={sortDirection}
         onSort={onSort}
         heatmapEnabled={heatmapEnabled}
+        scoreDirections={scoreDirections}
+        onToggleScoreDirection={onToggleScoreDirection}
         isSearchActive={isSearchActive}
       >
         <EvaluationDatapointsTableControls

--- a/frontend/components/evaluation/evaluation-datapoints-table/table-contents.tsx
+++ b/frontend/components/evaluation/evaluation-datapoints-table/table-contents.tsx
@@ -27,6 +27,8 @@ interface EvaluationDatapointsTableContentsProps {
   sortDirection?: "asc" | "desc";
   onSort: (columnId: string, direction: "asc" | "desc") => void;
   heatmapEnabled?: boolean;
+  scoreDirections?: Record<string, boolean>;
+  onToggleScoreDirection?: (scoreName: string) => void;
   isSearchActive: boolean;
 }
 
@@ -49,6 +51,8 @@ export const EvaluationDatapointsTableContents = memo(function EvaluationDatapoi
   sortDirection,
   onSort,
   heatmapEnabled,
+  scoreDirections,
+  onToggleScoreDirection,
   isSearchActive,
 }: PropsWithChildren<EvaluationDatapointsTableContentsProps>) {
   if (isLoading) return <EvalTableSkeleton />;
@@ -63,6 +67,8 @@ export const EvaluationDatapointsTableContents = memo(function EvaluationDatapoi
           isShared,
           heatmapEnabled: heatmapEnabled ?? false,
           scoreRanges,
+          scoreDirections,
+          onToggleScoreDirection,
         },
       }}
       hasMore={!isSearchActive && hasMore}

--- a/frontend/components/evaluation/evaluation.tsx
+++ b/frontend/components/evaluation/evaluation.tsx
@@ -22,6 +22,7 @@ import {
   selectVisibleColumnDefs,
   useEvalStore,
 } from "@/components/evaluation/store";
+import { useScoreDirections } from "@/components/evaluation/use-score-directions";
 import {
   type EvaluationStatsPayload,
   flattenScores,
@@ -89,6 +90,10 @@ function EvaluationContent({ evaluations, evaluationId }: EvaluationProps) {
     () => buildColumnDefs({ scoreNames, customColumns, isShared }),
     [scoreNames, customColumns, isShared]
   );
+
+  // Resolved eval-score directions (override > app-wide LLM default > true).
+  // Async — coloring repaints when it lands; shared evals can't write overrides.
+  const { resolved: scoreDirections, toggle: toggleScoreDirection } = useScoreDirections(params.projectId, scoreNames);
 
   // Stats SWR — drives the score chips + charts.
   const statsUrl = useMemo(() => {
@@ -304,6 +309,8 @@ function EvaluationContent({ evaluations, evaluationId }: EvaluationProps) {
       heatmapEnabled={heatmapEnabled}
       onHeatmapEnabledChange={setHeatmapEnabled}
       onDeleteCustomColumn={onDeleteCustomColumn}
+      scoreDirections={scoreDirections}
+      onToggleScoreDirection={isShared ? undefined : toggleScoreDirection}
       searchValue={searchValue}
       onSearchChange={setSearchAndFilters}
       viewsResource={RESOURCE}
@@ -334,6 +341,7 @@ function EvaluationContent({ evaluations, evaluationId }: EvaluationProps) {
                   comparedAllStatistics={targetStatsData?.allStatistics}
                   comparedAllDistributions={targetStatsData?.allDistributions}
                   isComparison={isComparison}
+                  scoreDirections={scoreDirections}
                 />
                 <div className="flex min-h-0 flex-1 overflow-hidden">{table}</div>
               </div>

--- a/frontend/components/evaluation/heatmap-value.tsx
+++ b/frontend/components/evaluation/heatmap-value.tsx
@@ -11,10 +11,12 @@ interface HeatmapValueProps {
   // The value text node. Callers control its font (Mono vs default) so the
   // heatmap shell stays presentation-only.
   text: ReactNode;
+  // When false, the gradient is inverted (lower value = green). Defaults true.
+  isHigherBetter?: boolean;
 }
 
-export default function HeatmapValue({ value, range, text }: HeatmapValueProps) {
-  const color = getHeatmapColor(value, range);
+export default function HeatmapValue({ value, range, text, isHigherBetter = true }: HeatmapValueProps) {
+  const color = getHeatmapColor(value, range, isHigherBetter);
   if (!color) return <>{text}</>;
 
   return (

--- a/frontend/components/evaluation/run-score-card/index.tsx
+++ b/frontend/components/evaluation/run-score-card/index.tsx
@@ -18,6 +18,8 @@ interface RunScoreCardProps {
   comparedAllStatistics?: Record<string, EvaluationScoreStatistics>;
   comparedAllDistributions?: Record<string, EvaluationScoreDistributionBucket[]>;
   isComparison?: boolean;
+  /** Resolved score directions (name -> isHigherBetter). Absent = higher is better. */
+  scoreDirections?: Record<string, boolean>;
 }
 
 // Stable default refs so useLocalStorage's memoization doesn't churn.
@@ -48,6 +50,7 @@ export default function RunScoreCard({
   comparedAllStatistics,
   comparedAllDistributions,
   isComparison,
+  scoreDirections,
 }: RunScoreCardProps) {
   const [aggregation] = useAggregation();
 
@@ -96,6 +99,7 @@ export default function RunScoreCard({
             comparedStatistics={comparedAllStatistics?.[name] ?? null}
             comparedDistribution={comparedAllDistributions?.[name] ?? null}
             isComparison={isComparison}
+            isHigherBetter={scoreDirections?.[name] ?? true}
           />
         ))}
       </div>

--- a/frontend/components/evaluation/run-score-card/score-card-item.tsx
+++ b/frontend/components/evaluation/run-score-card/score-card-item.tsx
@@ -20,6 +20,8 @@ interface ScoreCardItemProps {
   comparedStatistics: EvaluationScoreStatistics | null;
   comparedDistribution: EvaluationScoreDistributionBucket[] | null;
   isComparison?: boolean;
+  /** Resolved score direction. Absent = higher is better. */
+  isHigherBetter?: boolean;
 }
 
 const fmt = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
@@ -50,6 +52,7 @@ export default function ScoreCardItem({
   comparedStatistics,
   comparedDistribution,
   isComparison,
+  isHigherBetter = true,
 }: ScoreCardItemProps) {
   const isBinary = isBinaryDistribution(distribution);
 
@@ -59,7 +62,10 @@ export default function ScoreCardItem({
   const validCur = isValidNumber(cur);
   const validCmp = isComparison && isValidNumber(cmp);
   const change = validCur && validCmp ? pctChange(cur!, cmp!) : null;
-  const improved = change !== null && change >= 0;
+  // Arrow = factual movement; "improved" (color) accounts for score direction.
+  // No change (0%) always reads as improved.
+  const increased = change !== null && change >= 0;
+  const improved = change !== null && (change === 0 || increased === isHigherBetter);
 
   return (
     <div className="relative flex min-w-[140px] shrink-0 flex-col gap-1.5 px-2.5 first:pl-0 [&:not(:first-child)]:before:absolute [&:not(:first-child)]:before:bottom-0.5 [&:not(:first-child)]:before:left-0 [&:not(:first-child)]:before:top-0.5 [&:not(:first-child)]:before:w-px [&:not(:first-child)]:before:bg-foreground-600">
@@ -85,7 +91,7 @@ export default function ScoreCardItem({
               improved ? "text-success-bright" : "text-destructive"
             )}
           >
-            <DeltaTriangle direction={improved ? "up" : "down"} />
+            <DeltaTriangle direction={increased ? "up" : "down"} />
             {Math.abs(change).toFixed(1)}%
           </span>
         )}

--- a/frontend/components/evaluation/use-score-directions.ts
+++ b/frontend/components/evaluation/use-score-directions.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import useSWR from "swr";
+
+import { useProjectContext } from "@/contexts/project-context";
+import { type ScoreDirectionDefaults } from "@/lib/actions/evaluation/score-directions";
+import { useToast } from "@/lib/hooks/use-toast";
+import { swrFetcher } from "@/lib/utils";
+
+const EMPTY: Record<string, boolean> = {};
+
+export interface UseScoreDirections {
+  /** Resolved map: score name -> isHigherBetter (override > LLM default > true). */
+  resolved: Record<string, boolean>;
+  /** Resolved direction for a score name. Defaults to true (higher is better). */
+  isHigherBetter: (scoreName: string) => boolean;
+  /** Flip the resolved direction and persist it as a project override. */
+  toggle: (scoreName: string) => void;
+}
+
+/**
+ * Two independent layers:
+ *   - Override layer (project-scoped, manual): seeded from ProjectContext so it
+ *     is available IMMEDIATELY and is clickable right away. Held in local state
+ *     so toggles are optimistic + reactive.
+ *   - Default layer (app-wide, LLM-inferred): fetched async via SWR; may be
+ *     pending while the LLM classifies uncached names. If it resolves behind an
+ *     existing override it's a no-op to the user (the override wins) — but the
+ *     LLM suggestion is still cached server-side for everyone.
+ * Resolved = override ?? LLM default ?? true.
+ */
+export function useScoreDirections(projectId: string, scoreNames: string[]): UseScoreDirections {
+  const { toast } = useToast();
+  const seededOverrides = useProjectContext().project?.settings.scoreDirectionOverrides ?? EMPTY;
+
+  // Local, immediately-available copy of the override layer (LLM-independent).
+  const [overrides, setOverrides] = useState<Record<string, boolean>>(seededOverrides);
+
+  // App-wide LLM default layer — async, no bearing on when the user can toggle.
+  const key = useMemo(() => {
+    const names = [...new Set(scoreNames)].filter((n) => n.length > 0).sort();
+    if (names.length === 0) return null;
+    const qs = names.map((n) => `name=${encodeURIComponent(n)}`).join("&");
+    return `/api/projects/${projectId}/evaluations/score-directions?${qs}`;
+  }, [projectId, scoreNames]);
+
+  const { data } = useSWR<{ defaults: ScoreDirectionDefaults }>(key, swrFetcher, { revalidateOnFocus: false });
+  const defaults = data?.defaults ?? EMPTY;
+
+  const resolved = useMemo(() => ({ ...defaults, ...overrides }), [defaults, overrides]);
+  const isHigherBetter = useCallback(
+    (scoreName: string) => overrides[scoreName] ?? defaults[scoreName] ?? true,
+    [overrides, defaults]
+  );
+
+  const toggle = useCallback(
+    (scoreName: string) => {
+      const next = !(overrides[scoreName] ?? defaults[scoreName] ?? true);
+      const prev = overrides;
+      // The write sends the FULL overrides map (JSONB `||` shallow-merges
+      // top-level keys, so a partial map would drop the other overrides).
+      const newOverrides = { ...overrides, [scoreName]: next };
+      setOverrides(newOverrides); // optimistic + reactive
+
+      (async () => {
+        try {
+          const res = await fetch(`/api/projects/${projectId}/settings`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ settings: { scoreDirectionOverrides: newOverrides } }),
+          });
+          if (!res.ok) {
+            const errMessage = await res
+              .json()
+              .then((d) => d?.error)
+              .catch(() => null);
+            setOverrides(prev); // revert on failure
+            toast({ variant: "destructive", title: errMessage ?? "Failed to update score direction" });
+          }
+        } catch {
+          setOverrides(prev); // revert on failure
+          toast({ variant: "destructive", title: "Failed to update score direction" });
+        }
+      })();
+    },
+    [projectId, overrides, defaults, toast]
+  );
+
+  return { resolved, isHigherBetter, toggle };
+}

--- a/frontend/components/evaluation/use-score-directions.ts
+++ b/frontend/components/evaluation/use-score-directions.ts
@@ -54,13 +54,23 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
     [overrides, defaults]
   );
 
-  // Latest overrides for write-time snapshots, and a promise chain so overlapping
-  // toggles PATCH strictly in click order. The write always carries the FULL map
-  // (JSONB `||` replaces the whole scoreDirectionOverrides value), so without
-  // ordering a slower older request could land last and drop a newer key.
+  // Synchronous source of truth for the override map + a promise chain so
+  // overlapping toggles PATCH strictly in click order. The write always carries
+  // the FULL map (JSONB `||` replaces the whole scoreDirectionOverrides value),
+  // so without ordering a slower older request could land last and drop a newer
+  // key. The ref must be updated SYNCHRONOUSLY on every mutation (not just at
+  // render): a chained write's microtask reads it before React re-renders, so a
+  // render-only sync would let a write serialize a value the catch just reverted.
   const overridesRef = useRef(overrides);
-  overridesRef.current = overrides;
+  overridesRef.current = overrides; // safety net; setBoth keeps it current in-flight
   const writeChainRef = useRef<Promise<unknown>>(Promise.resolve());
+
+  // Update the ref (synchronous reads) and React state (render) together.
+  const setBoth = useCallback((updater: (cur: Record<string, boolean>) => Record<string, boolean>) => {
+    const next = updater(overridesRef.current);
+    overridesRef.current = next;
+    setOverrides(next);
+  }, []);
 
   const toggle = useCallback(
     (scoreName: string) => {
@@ -68,7 +78,7 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
       const next = !(cur[scoreName] ?? defaults[scoreName] ?? true);
       const hadKey = scoreName in cur;
       const prevValue = cur[scoreName];
-      setOverrides({ ...cur, [scoreName]: next }); // optimistic + reactive
+      setBoth((c) => ({ ...c, [scoreName]: next })); // optimistic + reactive
 
       const write = async () => {
         try {
@@ -88,7 +98,8 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
           }
         } catch (e) {
           // Revert ONLY this score, preserving concurrent edits to other scores.
-          setOverrides((s) => {
+          // Sync the ref too so a chained write serializes the reverted map.
+          setBoth((s) => {
             const r = { ...s };
             if (hadKey) r[scoreName] = prevValue as boolean;
             else delete r[scoreName];
@@ -105,7 +116,7 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
       // whether the previous write resolved or rejected.
       writeChainRef.current = writeChainRef.current.then(write, write);
     },
-    [projectId, defaults, toast]
+    [projectId, defaults, toast, setBoth]
   );
 
   return { resolved, isHigherBetter, toggle };

--- a/frontend/components/evaluation/use-score-directions.ts
+++ b/frontend/components/evaluation/use-score-directions.ts
@@ -21,10 +21,10 @@ export interface UseScoreDirections {
 
 /**
  * Two independent layers:
- *   - Override layer (project-scoped, manual): seeded from ProjectContext so it
- *     is available IMMEDIATELY and is clickable right away. Held in SWR's module
- *     cache (per project) so toggles are optimistic + reactive AND survive hook
- *     remounts across soft navigation.
+ *   - Override layer (project-scoped, manual): read straight off the live
+ *     ProjectContext (SWR-backed) so it reflects writes and survives hook
+ *     remounts across soft navigation. Toggles update it via `mutateProject`
+ *     (optimistic + reactive + shared with every other project-settings reader).
  *   - Default layer (app-wide, LLM-inferred): fetched async via SWR; may be
  *     pending while the LLM classifies uncached names. If it resolves behind an
  *     existing override it's a no-op to the user (the override wins) — but the
@@ -33,18 +33,8 @@ export interface UseScoreDirections {
  */
 export function useScoreDirections(projectId: string, scoreNames: string[]): UseScoreDirections {
   const { toast } = useToast();
-  const seededOverrides = useProjectContext().project?.settings.scoreDirectionOverrides ?? EMPTY;
-
-  // Override layer lives in SWR's module cache (not useState) so it survives
-  // hook remounts across soft navigation — ProjectContext is a frozen server
-  // prop that never reflects a write, so re-seeding from it on every remount
-  // dropped prior toggles and let the next full-map PATCH clobber them. Null
-  // fetcher: this is a client-owned store, seeded once from the SSR prop and
-  // written only via `mutateOverrides`. Cache key is per project.
-  const overridesKey = `score-direction-overrides:${projectId}`;
-  const { data: overrides = EMPTY, mutate: mutateOverrides } = useSWR<Record<string, boolean>>(overridesKey, null, {
-    fallbackData: seededOverrides,
-  });
+  const { project, mutateProject } = useProjectContext();
+  const overrides = project?.settings.scoreDirectionOverrides ?? EMPTY;
 
   // App-wide LLM default layer — async, no bearing on when the user can toggle.
   const key = useMemo(() => {
@@ -74,15 +64,19 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
   overridesRef.current = overrides; // safety net; setBoth keeps it current in-flight
   const writeChainRef = useRef<Promise<unknown>>(Promise.resolve());
 
-  // Update the ref (synchronous reads) and the SWR cache (render) together.
-  // revalidate:false — there is no fetcher; this only writes the local store.
+  // Update the synchronous ref AND the shared project cache together. Splice the
+  // new overrides into the live project settings (preserving other keys); the
+  // functional updater reads the LATEST cache so a concurrent removePii toggle
+  // isn't lost. revalidate:false — the project cache has no fetcher.
   const setBoth = useCallback(
     (updater: (cur: Record<string, boolean>) => Record<string, boolean>) => {
       const next = updater(overridesRef.current);
       overridesRef.current = next;
-      mutateOverrides(next, { revalidate: false });
+      mutateProject((cur) => (cur ? { ...cur, settings: { ...cur.settings, scoreDirectionOverrides: next } } : cur), {
+        revalidate: false,
+      });
     },
-    [mutateOverrides]
+    [mutateProject]
   );
 
   const toggle = useCallback(

--- a/frontend/components/evaluation/use-score-directions.ts
+++ b/frontend/components/evaluation/use-score-directions.ts
@@ -127,6 +127,10 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
 
       // Chain so writes never overlap; `.then(write, write)` runs regardless of
       // whether the previous write resolved or rejected.
+      // Accepted race: two rapid toggles where the first PATCH already carries the
+      // second's value and the second PATCH then fails leaves the server holding a
+      // value the client reverted, until the next write/reload. Not worth per-key
+      // server merge for a low-frequency toggle.
       writeChainRef.current = writeChainRef.current.then(write, write);
     },
     [projectId, defaults, toast, setBoth]

--- a/frontend/components/evaluation/use-score-directions.ts
+++ b/frontend/components/evaluation/use-score-directions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import useSWR from "swr";
 
 import { useProjectContext } from "@/contexts/project-context";
@@ -22,8 +22,9 @@ export interface UseScoreDirections {
 /**
  * Two independent layers:
  *   - Override layer (project-scoped, manual): seeded from ProjectContext so it
- *     is available IMMEDIATELY and is clickable right away. Held in local state
- *     so toggles are optimistic + reactive.
+ *     is available IMMEDIATELY and is clickable right away. Held in SWR's module
+ *     cache (per project) so toggles are optimistic + reactive AND survive hook
+ *     remounts across soft navigation.
  *   - Default layer (app-wide, LLM-inferred): fetched async via SWR; may be
  *     pending while the LLM classifies uncached names. If it resolves behind an
  *     existing override it's a no-op to the user (the override wins) — but the
@@ -34,8 +35,16 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
   const { toast } = useToast();
   const seededOverrides = useProjectContext().project?.settings.scoreDirectionOverrides ?? EMPTY;
 
-  // Local, immediately-available copy of the override layer (LLM-independent).
-  const [overrides, setOverrides] = useState<Record<string, boolean>>(seededOverrides);
+  // Override layer lives in SWR's module cache (not useState) so it survives
+  // hook remounts across soft navigation — ProjectContext is a frozen server
+  // prop that never reflects a write, so re-seeding from it on every remount
+  // dropped prior toggles and let the next full-map PATCH clobber them. Null
+  // fetcher: this is a client-owned store, seeded once from the SSR prop and
+  // written only via `mutateOverrides`. Cache key is per project.
+  const overridesKey = `score-direction-overrides:${projectId}`;
+  const { data: overrides = EMPTY, mutate: mutateOverrides } = useSWR<Record<string, boolean>>(overridesKey, null, {
+    fallbackData: seededOverrides,
+  });
 
   // App-wide LLM default layer — async, no bearing on when the user can toggle.
   const key = useMemo(() => {
@@ -65,12 +74,16 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
   overridesRef.current = overrides; // safety net; setBoth keeps it current in-flight
   const writeChainRef = useRef<Promise<unknown>>(Promise.resolve());
 
-  // Update the ref (synchronous reads) and React state (render) together.
-  const setBoth = useCallback((updater: (cur: Record<string, boolean>) => Record<string, boolean>) => {
-    const next = updater(overridesRef.current);
-    overridesRef.current = next;
-    setOverrides(next);
-  }, []);
+  // Update the ref (synchronous reads) and the SWR cache (render) together.
+  // revalidate:false — there is no fetcher; this only writes the local store.
+  const setBoth = useCallback(
+    (updater: (cur: Record<string, boolean>) => Record<string, boolean>) => {
+      const next = updater(overridesRef.current);
+      overridesRef.current = next;
+      mutateOverrides(next, { revalidate: false });
+    },
+    [mutateOverrides]
+  );
 
   const toggle = useCallback(
     (scoreName: string) => {

--- a/frontend/components/evaluation/use-score-directions.ts
+++ b/frontend/components/evaluation/use-score-directions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 
 import { useProjectContext } from "@/contexts/project-context";
@@ -54,37 +54,58 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
     [overrides, defaults]
   );
 
+  // Latest overrides for write-time snapshots, and a promise chain so overlapping
+  // toggles PATCH strictly in click order. The write always carries the FULL map
+  // (JSONB `||` replaces the whole scoreDirectionOverrides value), so without
+  // ordering a slower older request could land last and drop a newer key.
+  const overridesRef = useRef(overrides);
+  overridesRef.current = overrides;
+  const writeChainRef = useRef<Promise<unknown>>(Promise.resolve());
+
   const toggle = useCallback(
     (scoreName: string) => {
-      const next = !(overrides[scoreName] ?? defaults[scoreName] ?? true);
-      const prev = overrides;
-      // The write sends the FULL overrides map (JSONB `||` shallow-merges
-      // top-level keys, so a partial map would drop the other overrides).
-      const newOverrides = { ...overrides, [scoreName]: next };
-      setOverrides(newOverrides); // optimistic + reactive
+      const cur = overridesRef.current;
+      const next = !(cur[scoreName] ?? defaults[scoreName] ?? true);
+      const hadKey = scoreName in cur;
+      const prevValue = cur[scoreName];
+      setOverrides({ ...cur, [scoreName]: next }); // optimistic + reactive
 
-      (async () => {
+      const write = async () => {
         try {
           const res = await fetch(`/api/projects/${projectId}/settings`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ settings: { scoreDirectionOverrides: newOverrides } }),
+            // Send the LATEST full map (reflecting any earlier revert), not the
+            // click-time snapshot, so client and server converge under ordering.
+            body: JSON.stringify({ settings: { scoreDirectionOverrides: overridesRef.current } }),
           });
           if (!res.ok) {
             const errMessage = await res
               .json()
               .then((d) => d?.error)
               .catch(() => null);
-            setOverrides(prev); // revert on failure
-            toast({ variant: "destructive", title: errMessage ?? "Failed to update score direction" });
+            throw new Error(errMessage ?? "Failed to update score direction");
           }
-        } catch {
-          setOverrides(prev); // revert on failure
-          toast({ variant: "destructive", title: "Failed to update score direction" });
+        } catch (e) {
+          // Revert ONLY this score, preserving concurrent edits to other scores.
+          setOverrides((s) => {
+            const r = { ...s };
+            if (hadKey) r[scoreName] = prevValue as boolean;
+            else delete r[scoreName];
+            return r;
+          });
+          toast({
+            variant: "destructive",
+            title: e instanceof Error ? e.message : "Failed to update score direction",
+          });
         }
-      })();
+      };
+
+      // Chain so writes never overlap; `.then(write, write)` runs regardless of
+      // whether the previous write resolved or rejected.
+      writeChainRef.current = writeChainRef.current.then(write, write);
     },
-    [projectId, overrides, defaults, toast]
+    [projectId, defaults, toast]
   );
 
   return { resolved, isHigherBetter, toggle };

--- a/frontend/components/evaluation/use-score-directions.ts
+++ b/frontend/components/evaluation/use-score-directions.ts
@@ -44,7 +44,13 @@ export function useScoreDirections(projectId: string, scoreNames: string[]): Use
     return `/api/projects/${projectId}/evaluations/score-directions?${qs}`;
   }, [projectId, scoreNames]);
 
-  const { data } = useSWR<{ defaults: ScoreDirectionDefaults }>(key, swrFetcher, { revalidateOnFocus: false });
+  // keepPreviousData: when scoreNames change (realtime add / progression load) the
+  // key changes; without this `data` would blink to undefined and non-overridden
+  // scores would flash to the `true` default until the refetch lands.
+  const { data } = useSWR<{ defaults: ScoreDirectionDefaults }>(key, swrFetcher, {
+    revalidateOnFocus: false,
+    keepPreviousData: true,
+  });
   const defaults = data?.defaults ?? EMPTY;
 
   const resolved = useMemo(() => ({ ...defaults, ...overrides }), [defaults, overrides]);

--- a/frontend/components/evaluation/utils.ts
+++ b/frontend/components/evaluation/utils.ts
@@ -107,10 +107,13 @@ const getColorByNormalizedValue = (normalized: number): RGBColor => {
   }
 };
 
-const getScoreBackgroundColor = (min: number, max: number, value: number): RGBColor => {
+const getScoreBackgroundColor = (min: number, max: number, value: number, isHigherBetter = true): RGBColor => {
   if (min === max) return SCORE_COLORS.gray;
 
-  return flow((val: number) => normalizeValue(min, max, val), getColorByNormalizedValue)(value);
+  // When lower is better, reflect the normalized position about the midpoint so
+  // the "good" end of the range maps to green regardless of magnitude.
+  const toColor = (n: number) => getColorByNormalizedValue(isHigherBetter ? n : 1 - n);
+  return flow((val: number) => normalizeValue(min, max, val), toColor)(value);
 };
 
 const hasSignificantRange = ({ min, max }: ScoreRange): boolean => {
@@ -193,8 +196,9 @@ export const mergeTraceUpdateIntoRows = (
 
 // rgb(...) string for the heatmap color, or null when the range is too narrow
 // to be meaningful — callers treat null as "render the plain number".
-export const getHeatmapColor = (value: number, { min, max }: ScoreRange): string | null => {
+// `isHigherBetter` (default true) inverts the gradient for lower-is-better scores.
+export const getHeatmapColor = (value: number, { min, max }: ScoreRange, isHigherBetter = true): string | null => {
   if (!shouldShowHeatmap({ min, max })) return null;
-  const [r, g, b] = getScoreBackgroundColor(min, max, value);
+  const [r, g, b] = getScoreBackgroundColor(min, max, value, isHigherBetter);
   return `rgb(${r}, ${g}, ${b})`;
 };

--- a/frontend/components/evaluations/evaluations.tsx
+++ b/frontend/components/evaluations/evaluations.tsx
@@ -26,6 +26,8 @@ import { track } from "@/lib/posthog";
 import { swrFetcher } from "@/lib/utils";
 
 import ClientTimestampFormatter from "../client-timestamp-formatter";
+import { higherBetterMenuItem } from "../evaluation/columns/score-cell";
+import { useScoreDirections } from "../evaluation/use-score-directions";
 import Header from "../ui/header";
 import Mono from "../ui/mono";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../ui/resizable";
@@ -79,23 +81,40 @@ function buildScoreColumns(
   scoreNames: string[],
   scoresByEvalId: Record<string, Record<string, number | null>>,
   heatmapEnabled: boolean,
-  scoreRanges: Record<string, ScoreRange>
+  scoreRanges: Record<string, ScoreRange>,
+  isHigherBetter: (scoreName: string) => boolean,
+  onToggleScoreDirection?: (scoreName: string) => void
 ): ColumnDef<Evaluation>[] {
-  return scoreNames.map((scoreName) => ({
-    id: `score:${scoreName}`,
-    header: scoreName,
-    accessorFn: (row) => scoresByEvalId[row.id]?.[scoreName] ?? null,
-    cell: (cell) => {
-      const v = cell.getValue() as number | null;
-      if (!isValidScore(v)) return <span className="text-muted-foreground">—</span>;
-      const range = scoreRanges[scoreName];
-      if (heatmapEnabled && range) {
-        return <HeatmapValue value={v} range={range} text={<Mono>{formatScoreValue(v)}</Mono>} />;
-      }
-      return <Mono>{Number.isInteger(v) ? v.toString() : v.toFixed(3)}</Mono>;
-    },
-    size: 120,
-  }));
+  return scoreNames.map((scoreName) => {
+    const higherBetter = isHigherBetter(scoreName);
+    return {
+      id: `score:${scoreName}`,
+      header: scoreName,
+      accessorFn: (row) => scoresByEvalId[row.id]?.[scoreName] ?? null,
+      cell: (cell) => {
+        const v = cell.getValue() as number | null;
+        if (!isValidScore(v)) return <span className="text-muted-foreground">—</span>;
+        const range = scoreRanges[scoreName];
+        if (heatmapEnabled && range) {
+          return (
+            <HeatmapValue
+              value={v}
+              range={range}
+              isHigherBetter={higherBetter}
+              text={<Mono>{formatScoreValue(v)}</Mono>}
+            />
+          );
+        }
+        return <Mono>{Number.isInteger(v) ? v.toString() : v.toFixed(3)}</Mono>;
+      },
+      size: 120,
+      meta: onToggleScoreDirection
+        ? {
+            customDropdownItems: () => [higherBetterMenuItem(higherBetter, () => onToggleScoreDirection(scoreName))],
+          }
+        : undefined,
+    };
+  });
 }
 
 const layoutStorage: LayoutStorage = {
@@ -184,6 +203,9 @@ function EvaluationsContent() {
     allRunIds,
   } = useEvaluationsProgression(params?.projectId, groupId, aggregationFunction);
 
+  // Resolved eval-score directions (override > app-wide LLM default > true).
+  const { isHigherBetter, toggle: toggleScoreDirection } = useScoreDirections(params?.projectId, scoreNames);
+
   const columns = useMemo<ColumnDef<Evaluation>[]>(
     () => [
       {
@@ -231,7 +253,14 @@ function EvaluationsContent() {
         },
       },
       ...baseColumns,
-      ...buildScoreColumns(scoreNames, scoresByEvalId, heatmapEnabled, scoreRanges),
+      ...buildScoreColumns(
+        scoreNames,
+        scoresByEvalId,
+        heatmapEnabled,
+        scoreRanges,
+        isHigherBetter,
+        toggleScoreDirection
+      ),
     ],
     [
       scoreNames,
@@ -242,6 +271,8 @@ function EvaluationsContent() {
       toggleEvaluationVisibility,
       setHiddenEvaluationIds,
       allRunIds,
+      isHigherBetter,
+      toggleScoreDirection,
     ]
   );
 

--- a/frontend/components/settings/pii-redaction.tsx
+++ b/frontend/components/settings/pii-redaction.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowUpRight, Lock } from "lucide-react";
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { useState } from "react";
 
 import { useFeatureFlags } from "@/contexts/feature-flags-context";
@@ -18,13 +18,14 @@ import { SettingsSection, SettingsSectionHeader } from "./settings-section";
 const PRO_TIERS: WorkspaceTier[] = [WorkspaceTier.PRO, WorkspaceTier.ENTERPRISE];
 
 export default function PiiRedaction() {
-  const { project, workspace, settingsHref } = useProjectContext();
+  const { project, workspace, settingsHref, mutateProject } = useProjectContext();
   const { projectId } = useParams();
-  const router = useRouter();
   const { toast } = useToast();
   const flags = useFeatureFlags();
 
-  const [enabled, setEnabled] = useState<boolean>(project?.settings.removePii ?? false);
+  // Read straight off the live (SWR-backed) project so the toggle reflects the
+  // shared source of truth and stays correct across remounts.
+  const enabled = project?.settings.removePii ?? false;
   const [isLoading, setIsLoading] = useState(false);
 
   // Self-hosted installs aren't on tiered billing, so the Pro gate only
@@ -33,11 +34,16 @@ export default function PiiRedaction() {
   const isCloud = flags[Feature.LAMINAR_CLOUD];
   const isProTier = !isCloud || (workspace ? PRO_TIERS.includes(workspace.tierName) : false);
 
+  // Optimistically flip removePii in the shared project cache; revert on error.
+  const setRemovePii = (value: boolean) =>
+    mutateProject((cur) => (cur ? { ...cur, settings: { ...cur.settings, removePii: value } } : cur), {
+      revalidate: false,
+    });
+
   const onToggle = async (next: boolean) => {
     if (!isProTier) return;
-    // Optimistic — revert on error.
     const previous = enabled;
-    setEnabled(next);
+    setRemovePii(next);
     setIsLoading(true);
 
     try {
@@ -56,13 +62,11 @@ export default function PiiRedaction() {
           variant: "destructive",
           title: errMessage ?? "Failed to update PII redaction setting",
         });
-        setEnabled(previous);
-        return;
+        setRemovePii(previous);
       }
-      router.refresh();
     } catch {
       toast({ variant: "destructive", title: "Failed to update PII redaction setting" });
-      setEnabled(previous);
+      setRemovePii(previous);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/contexts/project-context.tsx
+++ b/frontend/contexts/project-context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, type PropsWithChildren, use, useCallback, useMemo } from "react";
+import useSWR, { type KeyedMutator } from "swr";
 
 import { type ProjectDetails } from "@/lib/actions/project";
 import { type Project, type Workspace } from "@/lib/workspaces/types";
@@ -30,29 +31,46 @@ type ProjectContextType = {
   // Project-scoped settings URL. Settings live at /project/[id]/settings (there is no workspace
   // route); with no project bound (e.g. the empty-workspace surface) this degrades to /projects.
   settingsHref: (section?: SettingsSection) => string;
+  // Update the live project (settings, name, ...) in the shared SWR cache. Writers pass a
+  // functional updater and { revalidate: false } for an optimistic local update — this is how
+  // settings changes reflect live across the app without a full router.refresh().
+  mutateProject: KeyedMutator<ProjectDetails | undefined>;
 };
+
+const noopMutateProject = (async () => undefined) as KeyedMutator<ProjectDetails | undefined>;
 
 export const ProjectContext = createContext<ProjectContextType>({
   project: undefined,
   workspace: undefined,
   projects: [],
   settingsHref: () => "/projects",
+  mutateProject: noopMutateProject,
 });
 
 export const ProjectContextProvider = ({
-  project,
+  project: initialProject,
   projects,
   workspace,
   children,
-}: PropsWithChildren<Omit<ProjectContextType, "settingsHref">>) => {
+}: PropsWithChildren<Omit<ProjectContextType, "settingsHref" | "mutateProject">>) => {
+  // The project lives in SWR's module cache — a client-owned store (null fetcher) seeded once
+  // from the SSR prop. This is the single source of truth for the current project: it survives
+  // hook remounts across soft navigation (a frozen prop did not) and lets any writer reflect a
+  // settings/name change live via `mutateProject` instead of re-running the whole server tree.
+  // Key is per project, so switching projects reads that project's own cache/seed.
+  const projectKey = initialProject ? `project-details:${initialProject.id}` : null;
+  const { data: project, mutate: mutateProject } = useSWR<ProjectDetails | undefined>(projectKey, null, {
+    fallbackData: initialProject,
+  });
+
   const settingsHref = useCallback(
     (section?: SettingsSection) =>
       project ? `/project/${project.id}/settings${section ? `?tab=${section}` : ""}` : "/projects",
     [project]
   );
   const value = useMemo(
-    () => ({ project, projects, workspace, settingsHref }),
-    [project, projects, workspace, settingsHref]
+    () => ({ project, projects, workspace, settingsHref, mutateProject }),
+    [project, projects, workspace, settingsHref, mutateProject]
   );
   return <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>;
 };

--- a/frontend/lib/actions/evaluation/score-directions.ts
+++ b/frontend/lib/actions/evaluation/score-directions.ts
@@ -1,0 +1,122 @@
+import { observe } from "@lmnr-ai/lmnr";
+import { generateText, Output } from "ai";
+import { z } from "zod";
+
+import { getLanguageModel, isAiProviderConfigured } from "@/lib/ai/model";
+import { cache, SCORE_DIRECTION_CACHE_KEY } from "@/lib/cache";
+
+const CACHE_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+// Cap the LLM classification batch — score-name lists are tiny in practice,
+// but guard against a pathological project with hundreds of distinct names.
+const MAX_CLASSIFY = 100;
+
+/**
+ * App-wide LLM-inferred score direction (name -> isHigherBetter) — the DEFAULT
+ * layer only. Per-project manual overrides live in projects.settings and are
+ * applied on top client-side, so this layer is project-independent and its
+ * results are cached even for names a project has overridden.
+ */
+export type ScoreDirectionDefaults = Record<string, boolean>;
+
+const normalize = (name: string): string => name.trim().toLowerCase();
+
+const ClassificationSchema = z.object({
+  scores: z.array(
+    z.object({
+      name: z.string().describe("The exact score name, echoed verbatim"),
+      isHigherBetter: z.boolean().describe("true if a HIGHER value is better, false if a LOWER value is better"),
+    })
+  ),
+});
+
+// One LLM call classifying every uncached name. Case-insensitive match back to
+// the requested names. Any name the model omits stays unresolved (caller
+// defaults it to true). Fails soft: returns {} on any error.
+async function classifyDirections(names: string[]): Promise<Record<string, boolean>> {
+  try {
+    const { output } = await observe(
+      { name: "classify-score-directions", metadata: { feature: "eval-score-direction" } },
+      async () =>
+        generateText({
+          model: getLanguageModel("small"),
+          output: Output.object({ schema: ClassificationSchema }),
+          system:
+            "You classify evaluation metric names by their preferred direction. " +
+            "For each name, decide whether a HIGHER value is better (isHigherBetter=true) or a LOWER value is better (false). " +
+            "Higher-is-better: accuracy, precision, recall, f1, relevance, faithfulness, helpfulness, correctness, similarity, bleu, rouge. " +
+            "Lower-is-better: hallucination, toxicity, latency, cost, error_rate, perplexity, bias, refusal_rate, duration. " +
+            "When genuinely ambiguous, default to true. Echo each name back exactly as given.",
+          prompt: JSON.stringify(names),
+          maxRetries: 0,
+          temperature: 0,
+          abortSignal: AbortSignal.timeout(15000),
+        })
+    );
+
+    // Map the model's (possibly re-cased) names back to the requested ones.
+    const byNorm = new Map(output.scores.map((s) => [normalize(s.name), s.isHigherBetter]));
+    const result: Record<string, boolean> = {};
+    for (const name of names) {
+      const v = byNorm.get(normalize(name));
+      if (typeof v === "boolean") result[name] = v;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve the app-wide default `isHigherBetter` for each score name from the
+ * global cache; cache misses trigger ONE batched LLM classification (gated on a
+ * configured AI provider) and are written back with a 7-day TTL. A name the LLM
+ * can't resolve (or when no provider is configured) defaults to `true`, matching
+ * the historical hardcoded "bigger is better" behavior. Project overrides are
+ * NOT consulted here — they are layered on top client-side — so the LLM
+ * suggestion is still computed and cached even for a name a project overrides.
+ */
+export async function resolveScoreDirections(scoreNames: string[]): Promise<ScoreDirectionDefaults> {
+  const names = [...new Set(scoreNames)].filter((n) => n.length > 0);
+  if (names.length === 0) return {};
+
+  const resolved: ScoreDirectionDefaults = {};
+
+  const cached = await Promise.all(
+    names.map((name) => cache.get<boolean>(SCORE_DIRECTION_CACHE_KEY(normalize(name))).catch(() => null))
+  );
+
+  const misses: string[] = [];
+  names.forEach((name, i) => {
+    const c = cached[i];
+    if (typeof c === "boolean") {
+      resolved[name] = c;
+    } else {
+      misses.push(name);
+    }
+  });
+
+  if (misses.length === 0) return resolved;
+
+  if (!isAiProviderConfigured()) {
+    for (const name of misses) resolved[name] = true;
+    return resolved;
+  }
+
+  const classified = await classifyDirections(misses.slice(0, MAX_CLASSIFY));
+
+  const saves: Promise<void>[] = [];
+  for (const name of misses) {
+    const v = classified[name];
+    resolved[name] = typeof v === "boolean" ? v : true;
+    if (typeof v === "boolean") {
+      saves.push(
+        cache
+          .set(SCORE_DIRECTION_CACHE_KEY(normalize(name)), v, { expireAfterSeconds: CACHE_TTL_SECONDS })
+          .catch(() => {})
+      );
+    }
+  }
+  await Promise.all(saves);
+
+  return resolved;
+}

--- a/frontend/lib/actions/project/settings.ts
+++ b/frontend/lib/actions/project/settings.ts
@@ -23,6 +23,12 @@ export const ProjectSettingsSchema = z
     /// Route every span on this project through the pii-redactor before
     /// storage. Pro-tier gated server-side.
     removePii: z.boolean(),
+    /// Per-project manual overrides of eval-score direction (score name ->
+    /// isHigherBetter). Layered over the app-wide LLM-inferred defaults.
+    /// Frontend-only; the Rust app-server ignores this key. Write the FULL
+    /// map (JSONB `||` shallow-merges top-level keys, so a partial map would
+    /// drop the other overrides).
+    scoreDirectionOverrides: z.record(z.string(), z.boolean()),
   })
   // `.strict()` rejects unknown keys — a typo in the UI surfaces as 400
   // rather than silently dropping into the JSONB row.
@@ -34,6 +40,7 @@ export type ProjectSettings = z.infer<typeof ProjectSettingsSchema>;
 /// Rust `Default for ProjectSettings`.
 export const DEFAULT_PROJECT_SETTINGS: ProjectSettings = {
   removePii: false,
+  scoreDirectionOverrides: {},
 };
 
 export const UpdateProjectSettingsSchema = z.object({

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -273,3 +273,8 @@ export const AUTOCOMPLETE_CACHE_KEY = (resource: string, projectId: string, fiel
 
 export const SPAN_RENDERING_KEY_CACHE_KEY = (projectId: string, schemaFingerprint: string): string =>
   `span_rendering_key:${projectId}:${schemaFingerprint}`;
+
+// App-wide (NOT project-scoped) LLM-inferred eval-score direction. The key is
+// the normalized score name; the value is a boolean isHigherBetter.
+export const SCORE_DIRECTION_CACHE_KEY = (normalizedScoreName: string): string =>
+  `score_direction:${normalizedScoreName}`;

--- a/frontend/tests/evaluation-score-direction.test.ts
+++ b/frontend/tests/evaluation-score-direction.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getHeatmapColor } from "@/components/evaluation/utils";
+
+// The gradient maps the range's low end -> red and high end -> green when
+// higher-is-better; inverting the flag must swap which end is "good".
+describe("getHeatmapColor direction inversion", () => {
+  const range = { min: 0, max: 10 };
+
+  it("higher-is-better: min value is red, max value is green", () => {
+    assert.equal(getHeatmapColor(0, range, true), "rgb(204, 51, 51)");
+    assert.equal(getHeatmapColor(10, range, true), "rgb(34, 197, 94)");
+  });
+
+  it("lower-is-better: the gradient flips (min value is green, max value is red)", () => {
+    assert.equal(getHeatmapColor(0, range, false), "rgb(34, 197, 94)");
+    assert.equal(getHeatmapColor(10, range, false), "rgb(204, 51, 51)");
+  });
+
+  it("defaults to higher-is-better when the flag is omitted", () => {
+    assert.equal(getHeatmapColor(0, range), getHeatmapColor(0, range, true));
+  });
+
+  it("is symmetric: color(v, higher) equals color(mirrored v, lower)", () => {
+    // normalize(3) = 0.3; for lower-is-better, value 7 maps to 1 - 0.7 = 0.3.
+    assert.equal(getHeatmapColor(3, range, true), getHeatmapColor(7, range, false));
+  });
+
+  it("returns null for a degenerate (zero-width) range", () => {
+    assert.equal(getHeatmapColor(5, { min: 5, max: 5 }, false), null);
+  });
+});

--- a/frontend/types/tanstack-table.ts
+++ b/frontend/types/tanstack-table.ts
@@ -17,6 +17,11 @@ declare module "@tanstack/react-table" {
       isShared: boolean;
       heatmapEnabled: boolean;
       scoreRanges: ScoreRanges;
+      // Resolved eval-score direction per score name (isHigherBetter). Drives
+      // delta colors + heatmap gradient. Absent name defaults to true.
+      scoreDirections?: Record<string, boolean>;
+      // Flip + persist a score's direction (from the header dropdown toggle).
+      onToggleScoreDirection?: (scoreName: string) => void;
     };
   }
 


### PR DESCRIPTION
## Summary

Each eval score name resolves to a boolean **`isHigherBetter`**, driving delta colors and heatmap gradient direction across both eval tables (per-evaluation datapoints table + evaluations group list). Resolution precedence:

1. **Project override** — `projects.settings.scoreDirectionOverrides[name]`
2. **App-wide LLM-inferred default** — global Redis `score_direction:{normalizedName}` (7-day TTL, one batched LLM classification on miss, gated on a configured AI provider)
3. **Fallback** — `true` (historical "bigger is better" behavior)

## Design

- **Two independent layers.** The manual override layer is seeded from `ProjectContext` (LLM-independent, available immediately, clickable right away, optimistic local state). The LLM default layer is fetched async via SWR and repaints coloring when it lands; if it resolves behind an existing override it's a no-op (override wins), and the LLM suggestion is still cached for everyone.
- **Effect (only these two):** flip delta colors (run-score-card delta + heatmap-on comparison bar) and invert the heatmap gradient. Sort order unchanged.
- **Storage:** `scoreDirectionOverrides` map on the `projects.settings` JSONB (no migration; mirrored into the Rust `ProjectSettings` for lossless round-trip). Header "Higher is better" toggle writes the full map via `PATCH /settings`. Hidden on shared/public evals.

## Scope

Frontend, plus a one-field mirror in `app-server/src/db/projects.rs`. No migration. `cargo check` + FE type-check + lint clean; new heatmap-inversion unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches project settings persistence and a new LLM-backed classification path with Redis caching; UI-only for most users but incorrect overrides could mislead interpretation of metrics.
> 
> **Overview**
> Adds per-metric **`isHigherBetter`** resolution so heatmaps, comparison deltas, and run-score-card % changes treat “good” vs “bad” correctly for metrics like latency or toxicity.
> 
> **Resolution:** project `settings.scoreDirectionOverrides` wins, then app-wide LLM-inferred defaults (Redis cache, 7-day TTL, batched on miss), then **`true`**. A new **`GET .../evaluations/score-directions`** returns defaults; overrides are merged client-side via **`useScoreDirections`** (optimistic toggles, ordered full-map **`PATCH`** to project settings). Score column headers get a **“Higher is better”** menu item (hidden on shared evals).
> 
> **UI wiring:** `getHeatmapColor` / **`HeatmapValue`** invert gradients when lower is better; score cells and **`RunScoreCard`** use direction for comparison coloring; evaluations list heatmap columns share the same toggle.
> 
> **Backend:** `scoreDirectionOverrides` added to frontend project settings schema and mirrored on Rust **`ProjectSettings`** for lossless JSONB round-trip (no migration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4519d7d8954761d640dd5919f52ca4c0b9a01eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

