### PR TITLE
anthropic enable thinking summaries, gpt5.6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 .agent-team/
 .lmnr/
 .cursor/
+.agents/

--- a/app-server/src/llm/bedrock/mod.rs
+++ b/app-server/src/llm/bedrock/mod.rs
@@ -243,6 +243,7 @@ fn build_request_body(model: &str, request: &ProviderRequest) -> ProviderResult<
             // the caller's level is forwarded only as a soft `effort` hint.
             body["thinking"] = serde_json::json!({
                 "type": "adaptive",
+                "display": "summarized"
             });
             // `effort` MUST be a sibling of `thinking` under `output_config` —
             // nesting it inside `thinking` triggers a Bedrock ValidationException.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small Bedrock request-shape tweak for adaptive-thinking models plus a gitignore entry; no auth or broad logic changes in the diff.
> 
> **Overview**
> For Claude models that use **adaptive thinking** on AWS Bedrock, the invoke payload now includes `"display": "summarized"` on the `thinking` object (alongside `type: "adaptive"`), so the API returns summarized thinking rather than the default display mode.
> 
> Also adds **`.agents/`** to `.gitignore` so local agent tooling directories are not committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4247298336ec3ab5a3667ba7433c4fab5af05b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

