### PR TITLE
feat: add metric (single-number) widget type to dashboard

### DIFF
--- a/frontend/components/chart-builder/types.ts
+++ b/frontend/components/chart-builder/types.ts
@@ -3,6 +3,7 @@ export enum ChartType {
   "BarChart" = "bar",
   "HorizontalBarChart" = "horizontalBar",
   "Table" = "table",
+  "MetricCard" = "metric",
 }
 
 export type DisplayMode = "total" | "average" | "none";
@@ -31,9 +32,19 @@ export interface TableChartConfig extends BaseChartConfig {
   tableColumnConfig?: TableColumnConfig;
 }
 
-export type ChartConfig = AxisChartConfig | TableChartConfig;
+export interface MetricCardConfig extends BaseChartConfig {
+  type: ChartType.MetricCard;
+  /** The key in the result row to display. Defaults to first key if omitted. */
+  valueKey?: string;
+  /** Optional unit label shown below the number, e.g. "USD" or "tokens". */
+  unit?: string;
+}
+
+export type ChartConfig = AxisChartConfig | TableChartConfig | MetricCardConfig;
 
 export const isTableConfig = (config: ChartConfig): config is TableChartConfig => config.type === ChartType.Table;
+
+export const isMetricConfig = (config: ChartConfig): config is MetricCardConfig => config.type === ChartType.MetricCard;
 
 /** Resolve displayMode from config, with backward compatibility for `total: true`. */
 export const resolveDisplayMode = (config: ChartConfig): DisplayMode => {

--- a/frontend/components/dashboards/add-chart-dropdown.tsx
+++ b/frontend/components/dashboards/add-chart-dropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChartBar, ChartColumn, ChartLine, Pen, Table2 } from "lucide-react";
+import { ChartBar, ChartColumn, ChartLine, Hash, Pen, Table2 } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
@@ -17,6 +17,7 @@ const CHART_TYPE_ICONS: Record<string, typeof ChartLine> = {
   bar: ChartColumn,
   horizontalBar: ChartBar,
   table: Table2,
+  metric: Hash,
 };
 
 const TABLE_FILTERS: { label: string; value: PresetTable }[] = [

--- a/frontend/components/dashboards/chart-presets.ts
+++ b/frontend/components/dashboards/chart-presets.ts
@@ -15,12 +15,18 @@ interface TablePresetConfig {
   type: "table";
 }
 
+interface MetricPresetConfig {
+  type: "metric";
+  valueKey?: string;
+  unit?: string;
+}
+
 export interface ChartPreset {
   name: string;
   table: PresetTable;
   query: string;
   queryStructure: QueryStructure;
-  config: AxisPresetConfig | TablePresetConfig;
+  config: AxisPresetConfig | TablePresetConfig | MetricPresetConfig;
 }
 
 // The default timeRange Form.tsx generates at execute time for time-series
@@ -36,6 +42,63 @@ const TIME_SERIES_TIME_RANGE = (column: string): QueryStructure["timeRange"] => 
 });
 
 export const CHART_PRESETS: ChartPreset[] = [
+  // ── Metric (single-number) presets ──────────────────────────────────────
+  {
+    name: "Total cost (metric)",
+    table: "traces",
+    query: `SELECT
+    round(sum(total_cost), 6) AS total_cost
+FROM traces
+WHERE
+    start_time >= {start_time:DateTime64}
+    AND start_time <= {end_time:DateTime64}`,
+    queryStructure: {
+      table: "traces",
+      metrics: [{ fn: "sum", column: "total_cost", alias: "total_cost", args: [] }],
+      dimensions: [],
+      filters: [],
+      orderBy: [],
+    },
+    config: { type: "metric", valueKey: "total_cost", unit: "USD" },
+  },
+  {
+    name: "Total traces (metric)",
+    table: "traces",
+    query: `SELECT
+    count(*) AS total_traces
+FROM traces
+WHERE
+    start_time >= {start_time:DateTime64}
+    AND start_time <= {end_time:DateTime64}`,
+    queryStructure: {
+      table: "traces",
+      metrics: [{ fn: "count", column: "*", alias: "total_traces", args: [] }],
+      dimensions: [],
+      filters: [],
+      orderBy: [],
+    },
+    config: { type: "metric", valueKey: "total_traces" },
+  },
+  {
+    name: "Total tokens (metric)",
+    table: "spans",
+    query: `SELECT
+    sum(total_tokens) AS total_tokens
+FROM spans
+WHERE
+    span_type = 'LLM'
+    AND start_time >= {start_time:DateTime64}
+    AND start_time <= {end_time:DateTime64}`,
+    queryStructure: {
+      table: "spans",
+      metrics: [{ fn: "sum", column: "total_tokens", alias: "total_tokens", args: [] }],
+      dimensions: [],
+      filters: [{ field: "span_type", op: "eq", stringValue: "LLM" }],
+      orderBy: [],
+    },
+    config: { type: "metric", valueKey: "total_tokens", unit: "tokens" },
+  },
+  // ── Time-series & table presets (unchanged) ──────────────────────────────
   {
     name: "Trace p90 cost",
     table: "traces",

--- a/frontend/components/dashboards/chart.tsx
+++ b/frontend/components/dashboards/chart.tsx
@@ -6,11 +6,12 @@ import { useSWRConfig } from "swr";
 
 import { ChartRendererCore } from "@/components/chart-builder/charts";
 import { type ChartDragHandlers } from "@/components/chart-builder/charts/line-chart";
-import { ChartType, type TableColumnConfig } from "@/components/chart-builder/types";
+import { ChartType, isMetricConfig, type TableColumnConfig } from "@/components/chart-builder/types";
 import { transformDataToColumns } from "@/components/chart-builder/utils";
 import ChartHeader from "@/components/dashboards/chart-header";
 import { useDashboardSelectionStore } from "@/components/dashboards/dashboard-selection-store";
 import { useDashboardTraceStore } from "@/components/dashboards/dashboard-trace-context";
+import MetricWidget from "@/components/dashboards/metric-widget";
 import SelectionToolbar from "@/components/dashboards/selection-toolbar";
 import { type DashboardChart } from "@/components/dashboards/types";
 import { IconResizeHandle } from "@/components/ui/icons";
@@ -49,6 +50,7 @@ const Chart = ({ chart }: ChartProps) => {
   const { toast } = useToast();
   const { mutate: swrMutate } = useSWRConfig();
   const isTable = settings.config.type === ChartType.Table;
+  const isMetric = isMetricConfig(settings.config);
   const {
     chartId: selectionChartId,
     startLabel,
@@ -305,6 +307,8 @@ const Chart = ({ chart }: ChartProps) => {
           </div>
         ) : isLoading ? (
           <Skeleton className="h-full w-full" />
+        ) : isMetric ? (
+          <MetricWidget data={data} config={settings.config as import("@/components/chart-builder/types").MetricCardConfig} />
         ) : (
           <ChartRendererCore
             config={settings.config}

--- a/frontend/components/dashboards/metric-widget.tsx
+++ b/frontend/components/dashboards/metric-widget.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { type MetricCardConfig } from "@/components/chart-builder/types";
+
+interface MetricWidgetProps {
+  data: Record<string, any>[];
+  config: MetricCardConfig;
+}
+
+/**
+ * Formats a numeric value with K / M / B compact suffixes.
+ * Non-numeric values are returned as-is.
+ */
+function formatValue(raw: unknown): string {
+  const n = Number(raw);
+  if (isNaN(n)) return String(raw ?? "—");
+  if (Math.abs(n) >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`;
+  if (Math.abs(n) >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (Math.abs(n) >= 1_000) return `${(n / 1_000).toFixed(2)}K`;
+  // For small decimals keep up to 4 significant figures
+  if (n !== 0 && Math.abs(n) < 0.01) return n.toPrecision(4);
+  return n.toLocaleString(undefined, { maximumFractionDigits: 4 });
+}
+
+const MetricWidget = ({ data, config }: MetricWidgetProps) => {
+  const row = data[0];
+  let displayValue = "—";
+
+  if (row) {
+    const key = config.valueKey ?? Object.keys(row)[0];
+    displayValue = formatValue(row[key]);
+  }
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-1 min-h-0">
+      <span className="text-4xl font-semibold tabular-nums leading-none tracking-tight">
+        {displayValue}
+      </span>
+      {config.unit && (
+        <span className="text-sm text-muted-foreground">{config.unit}</span>
+      )}
+    </div>
+  );
+};
+
+export default MetricWidget;


### PR DESCRIPTION
## Summary

Closes #1499

Adds a new **Metric Card** widget type to the dashboard that displays a single aggregated number prominently — e.g. total cost, total token count, or trace count for a selected time period. This was previously only available as the summary header of a time-series chart, not as a standalone widget.

## Changes

### `frontend/components/chart-builder/types.ts`
- Added `MetricCard = "metric"` to the `ChartType` enum
- Added `MetricCardConfig` interface with optional `valueKey` (which result column to display) and `unit` (label shown below the number, e.g. `"USD"`)
- Extended `ChartConfig` union type to include `MetricCardConfig`
- Added `isMetricConfig` type-guard helper (mirrors existing `isTableConfig`)

### `frontend/components/dashboards/metric-widget.tsx` *(new file)*
- Renders the first row / configured `valueKey` column as a large centred number
- Compact suffix formatting: `1,234,567` → `1.23M`, `9,876` → `9.88K`
- Shows an em-dash (`—`) when the query returns no rows
- Optional `unit` label rendered below in muted text

### `frontend/components/dashboards/chart.tsx`
- Imports `isMetricConfig` and `MetricWidget`
- Adds an `isMetric` branch in the render tree — metric widgets skip `ChartRendererCore` entirely and render `<MetricWidget>` instead
- Loading skeleton and error state work identically to existing chart types

### `frontend/components/dashboards/add-chart-dropdown.tsx`
- Registers `metric` → `Hash` (lucide) in `CHART_TYPE_ICONS` so metric presets show a `#` icon in the preset picker

### `frontend/components/dashboards/chart-presets.ts`
- Adds `MetricPresetConfig` local interface
- Ships **3 ready-to-use metric presets**:
  - **Total cost (metric)** — `sum(total_cost)` from `traces`, unit `USD` (Traces tab)
  - **Total traces (metric)** — `count(*)` from `traces` (Traces tab)
  - **Total tokens (metric)** — `sum(total_tokens)` from LLM spans, unit `tokens` (Spans tab)

## How it works

A metric widget uses the exact same SQL execution path as every other chart. The query should return a single row with one numeric column. The `valueKey` config field selects which column to display; if omitted, the first column is used. This means any custom SQL query that aggregates to a scalar can also be used as a metric widget via the custom editor.

## Screenshots

> Metric widgets render as a large centred number inside the standard chart card, sharing the same header / resize handle / time-range filtering as other widget types.

## Testing

- Existing chart types are unaffected — the `isMetric` branch is only entered when `config.type === "metric"`
- The `formatValue` helper in `metric-widget.tsx` is a pure function and straightforward to unit-test
- All TypeScript types are fully discriminated; no `any` casts were introduced in the new code paths

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only dashboard feature on an isolated render branch; existing chart types are unchanged.
> 
> **Overview**
> Adds a **Metric Card** dashboard widget that shows a single aggregated value (with optional unit) instead of a chart or table, reusing the same SQL fetch path as other widgets.
> 
> **Types & rendering:** `ChartType.MetricCard` / `MetricCardConfig` (`valueKey`, `unit`) and `isMetricConfig` extend the chart config union. Dashboard `Chart` routes metric configs to a new `MetricWidget` (large centered number, K/M/B formatting, `—` when empty) instead of `ChartRendererCore`.
> 
> **Presets & picker:** Three metric presets (total cost, total traces, total tokens) are added to `CHART_PRESETS`, and the add-chart dropdown maps `metric` to a `Hash` icon for those entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d3254c382ced8ec667f26e03208d846eb793e53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->