### PR TITLE
feat: add duplicate widget action to dashboard chart header

### DIFF
--- a/frontend/components/dashboards/chart-header.tsx
+++ b/frontend/components/dashboards/chart-header.tsx
@@ -1,4 +1,4 @@
-import { Edit, Ellipsis, GripVertical, Pen, Trash2 } from "lucide-react";
+import { Copy, Edit, Ellipsis, GripVertical, Pen, Trash2 } from "lucide-react";
 import Link from "next/link";
 import React, { type FocusEvent, type KeyboardEventHandler, useCallback, useEffect, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
@@ -9,6 +9,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
@@ -42,6 +43,7 @@ const ChartHeader = ({ name, id, projectId }: ChartHeaderProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isEditing, setIsEditing] = useState(false);
   const { mutate } = useSWRConfig();
+
   const handleDeleteChart = useCallback(async () => {
     try {
       await mutate<DashboardChart[]>(
@@ -61,6 +63,49 @@ const ChartHeader = ({ name, id, projectId }: ChartHeaderProps) => {
     } catch (e) {
       toast({
         title: "Failed to delete chart. Please try again.",
+        variant: "destructive",
+      });
+    }
+  }, [id, mutate, projectId, toast]);
+
+  const handleDuplicateChart = useCallback(async () => {
+    const key = `/api/projects/${projectId}/dashboard-charts`;
+    try {
+      await mutate<DashboardChart[]>(
+        key,
+        async (currentData) => {
+          // Find the source chart to copy its full settings
+          const source = (currentData || []).find((item) => item.id === id);
+          if (!source) return currentData;
+
+          const res = await fetch(key, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              name: `${source.name} (copy)`,
+              query: source.query,
+              config: source.settings.config,
+              queryStructure: source.settings.queryStructure ?? null,
+            }),
+          });
+
+          if (!res.ok) {
+            throw new Error("Failed to duplicate chart");
+          }
+
+          const newChart: DashboardChart = await res.json();
+          return [...(currentData || []), newChart];
+        },
+        {
+          revalidate: true,
+          populateCache: true,
+          rollbackOnError: true,
+        }
+      );
+      track("dashboards", "chart_duplicated");
+    } catch (e) {
+      toast({
+        title: "Failed to duplicate chart. Please try again.",
         variant: "destructive",
       });
     }
@@ -144,7 +189,7 @@ const ChartHeader = ({ name, id, projectId }: ChartHeaderProps) => {
               <Ellipsis className="size-4" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-32">
+          <DropdownMenuContent align="end" className="w-36">
             <DropdownMenuItem
               onClick={(e) => {
                 e.stopPropagation();
@@ -161,6 +206,17 @@ const ChartHeader = ({ name, id, projectId }: ChartHeaderProps) => {
                 Edit
               </DropdownMenuItem>
             </Link>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDuplicateChart();
+              }}
+              className="cursor-pointer"
+            >
+              <Copy className="h-3.5 w-3.5 mr-1 text-inherit" />
+              Duplicate
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={(e) => {
                 e.stopPropagation();


### PR DESCRIPTION
## Summary

Closes #1498

Adds a **Duplicate** option to the `⋯` dropdown on every dashboard widget, sitting between _Edit_ and _Delete_ (with a separator before Delete to reduce accidental mis-clicks).

## Changes

**Only `frontend/components/dashboards/chart-header.tsx` is modified** — no new files, no API changes.

### What was added

- `handleDuplicateChart` — a `useCallback` that:
  1. Finds the source `DashboardChart` in the existing SWR cache
  2. POSTs to `/api/projects/:projectId/dashboard-charts` with `name: "<original> (copy)"`, plus the source's `query`, `config`, and `queryStructure`
  3. Appends the newly created chart object to the SWR cache (`populateCache: true`, `rollbackOnError: true`)
  4. Calls `track("dashboards", "chart_duplicated")` consistent with the existing `chart_deleted` tracking call
  5. Shows a destructive toast on any error
- `Copy` icon imported from `lucide-react` (already a dependency)
- `DropdownMenuSeparator` imported (already exported by the existing `dropdown-menu` component) to visually separate the destructive Delete action
- Dropdown width bumped from `w-32` → `w-36` to accommodate the slightly wider "Duplicate" label

## Why this approach

The existing `handleDeleteChart` and `handleUpdateChart` both use the same `mutate<DashboardChart[]>(key, async updater, options)` SWR pattern. `handleDuplicateChart` follows that pattern exactly, keeping the code consistent and making it easy to review.

The POST body mirrors what `AddChartDropdown` sends when creating a chart from a preset, so no backend changes are needed — the existing endpoint already handles it.

## Testing

- Open any dashboard with at least one widget
- Click `⋯` → **Duplicate**
- A copy of the widget appears immediately with the name `"<original> (copy)"`
- Renaming, editing, and deleting the copy works independently of the source
- Network error path: block the POST in DevTools — a toast appears and no phantom chart is added

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI file reuses the existing chart-creation API and SWR patterns; no auth, data-model, or backend changes.
> 
> **Overview**
> Adds a **Duplicate** action to each dashboard widget’s `⋯` menu so users can clone a chart without reconfiguring it.
> 
> `handleDuplicateChart` reads the source chart from the SWR cache, **POSTs** to the existing `/api/projects/:projectId/dashboard-charts` endpoint with `"<name> (copy)"` plus the source `query`, `config`, and `queryStructure`, then appends the returned chart to the cache (with rollback on error). It fires `track("dashboards", "chart_duplicated")` and shows a destructive toast on failure, matching the rename/delete handlers.
> 
> The menu gains a **Duplicate** item (with `Copy` icon) between Edit and Delete, a **separator** before Delete, and the dropdown is slightly wider (`w-36`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3769a9a520116f55a4aecf50190f037b9cf1ef0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->