### PR TITLE
openai responses

### DIFF
--- a/app-server/src/env/llm.rs
+++ b/app-server/src/env/llm.rs
@@ -27,10 +27,6 @@ pub const MODEL_LARGE: &str = "LLM_MODEL_LARGE";
 #[cfg_attr(not(feature = "signals"), allow(dead_code))]
 pub const ALWAYS_USE_REALTIME: BoolEnv = BoolEnv::new("SIGNALS_ALWAYS_USE_REALTIME", false);
 
-/// Route the OpenAI provider through the Responses API (`/responses`) instead
-/// of Chat Completions (`/chat/completions`). Default false (Chat Completions).
-pub const OPENAI_USE_RESPONSES: BoolEnv = BoolEnv::new("OPENAI_USE_RESPONSES", false);
-
 /// Per-request HTTP timeout (seconds) applied only to flex-tier Gemini requests.
 /// Flex responses can take minutes, so this is far higher than the shared client
 /// timeout. Lives here (not under signals) because the gemini client applies it

--- a/app-server/src/env/llm.rs
+++ b/app-server/src/env/llm.rs
@@ -27,6 +27,10 @@ pub const MODEL_LARGE: &str = "LLM_MODEL_LARGE";
 #[cfg_attr(not(feature = "signals"), allow(dead_code))]
 pub const ALWAYS_USE_REALTIME: BoolEnv = BoolEnv::new("SIGNALS_ALWAYS_USE_REALTIME", false);
 
+/// Route the OpenAI provider through the Responses API (`/responses`) instead
+/// of Chat Completions (`/chat/completions`). Default false (Chat Completions).
+pub const OPENAI_USE_RESPONSES: BoolEnv = BoolEnv::new("OPENAI_USE_RESPONSES", false);
+
 /// Per-request HTTP timeout (seconds) applied only to flex-tier Gemini requests.
 /// Flex responses can take minutes, so this is far higher than the shared client
 /// timeout. Lives here (not under signals) because the gemini client applies it

--- a/app-server/src/features/mod.rs
+++ b/app-server/src/features/mod.rs
@@ -100,7 +100,7 @@ fn has_llm_provider() -> bool {
         && std::env::var(env::secrets::AWS_SECRET_ACCESS_KEY).is_ok_and(|s| !s.is_empty())
         && std::env::var(env::secrets::AWS_REGION).is_ok_and(|s| !s.is_empty());
     match provider.as_str() {
-        "gemini" | "openai" => has_llm_api_key,
+        "gemini" | "openai" | "openai_responses" => has_llm_api_key,
         "bedrock" => has_aws,
         "mock" => true,
         _ => false,

--- a/app-server/src/llm/bedrock/mod.rs
+++ b/app-server/src/llm/bedrock/mod.rs
@@ -296,6 +296,7 @@ fn parse_usage(usage_obj: Option<&Value>) -> ProviderUsageMetadata {
         ),
         cache_read_input_tokens: cache_read,
         cache_creation_input_tokens: cache_write,
+        reasoning_token_count: None,
     }
 }
 

--- a/app-server/src/llm/gemini/accumulator.rs
+++ b/app-server/src/llm/gemini/accumulator.rs
@@ -2,7 +2,9 @@
 
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::{Candidate, Content, FinishReason, GenerateContentResponse, Part, UsageMetadata};
+use super::{
+    Candidate, Content, FinishReason, GeminiError, GenerateContentResponse, Part, UsageMetadata,
+};
 use crate::llm::models::{ProviderResponse, ProviderStreamChunk};
 use crate::llm::sse::StreamAccumulator;
 
@@ -41,6 +43,7 @@ impl GeminiStreamAccumulator {
 
 impl StreamAccumulator for GeminiStreamAccumulator {
     type Chunk = GenerateContentResponse;
+    type Error = GeminiError;
 
     fn ingest(
         &mut self,
@@ -85,7 +88,7 @@ impl StreamAccumulator for GeminiStreamAccumulator {
         }
     }
 
-    fn into_response(self, _model: &str) -> ProviderResponse {
+    fn into_response(self, _model: &str) -> Result<ProviderResponse, GeminiError> {
         let candidate = Candidate {
             content: Some(Content {
                 role: self.role.or_else(|| Some("model".to_string())),
@@ -96,13 +99,13 @@ impl StreamAccumulator for GeminiStreamAccumulator {
             safety_ratings: None,
             index: None,
         };
-        GenerateContentResponse {
+        Ok(GenerateContentResponse {
             candidates: Some(vec![candidate]),
             usage_metadata: self.usage_metadata,
             model_version: self.model_version,
             response_id: self.response_id,
         }
-        .into()
+        .into())
     }
 }
 

--- a/app-server/src/llm/gemini/accumulator.rs
+++ b/app-server/src/llm/gemini/accumulator.rs
@@ -88,7 +88,7 @@ impl StreamAccumulator for GeminiStreamAccumulator {
         }
     }
 
-    fn into_response(self, _model: &str) -> Result<ProviderResponse, GeminiError> {
+    fn try_into_response(self, _model: &str) -> Result<ProviderResponse, GeminiError> {
         let candidate = Candidate {
             content: Some(Content {
                 role: self.role.or_else(|| Some("model".to_string())),

--- a/app-server/src/llm/gemini/conversions.rs
+++ b/app-server/src/llm/gemini/conversions.rs
@@ -61,6 +61,7 @@ impl From<GenerateContentResponse> for ProviderResponse {
                         .sum()
                 }),
                 cache_creation_input_tokens: None,
+                reasoning_token_count: u.thoughts_token_count,
             }),
             model_version: resp.model_version,
         }

--- a/app-server/src/llm/mod.rs
+++ b/app-server/src/llm/mod.rs
@@ -3,6 +3,7 @@ pub mod gemini;
 pub mod mock;
 pub mod models;
 pub mod openai;
+pub mod openai_responses;
 pub(crate) mod sse;
 
 pub use bedrock::BedrockClient;
@@ -10,6 +11,7 @@ pub use gemini::GeminiClient;
 pub use mock::MockProviderClient;
 pub use models::*;
 pub use openai::OpenAIClient;
+pub use openai_responses::OpenAIResponsesClient;
 
 use enum_dispatch::enum_dispatch;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
@@ -154,6 +156,7 @@ pub(crate) enum ProviderClient {
     Gemini(GeminiClient),
     Bedrock(BedrockClient),
     OpenAI(OpenAIClient),
+    OpenAIResponses(OpenAIResponsesClient),
     Mock(MockProviderClient),
 }
 
@@ -435,11 +438,30 @@ impl LlmClient {
         }
 
         if has_openai_credentials() {
-            let client = OpenAIClient::new().map_err(|e| {
-                ProviderError::ConfigError(format!("Failed to create OpenAI client: {e}"))
-            })?;
-            log::info!("Initialized OpenAI provider at {}", client.api_base_url());
-            providers.insert("openai".to_string(), ProviderClient::OpenAI(client));
+            // The Responses API and Chat Completions are separate client impls;
+            // OPENAI_USE_RESPONSES selects which one backs the `openai` provider.
+            let provider = if env::llm::OPENAI_USE_RESPONSES.get() {
+                let client = OpenAIResponsesClient::new().map_err(|e| {
+                    ProviderError::ConfigError(format!(
+                        "Failed to create OpenAI Responses client: {e}"
+                    ))
+                })?;
+                log::info!(
+                    "Initialized OpenAI provider (Responses API) at {}",
+                    client.api_base_url()
+                );
+                ProviderClient::OpenAIResponses(client)
+            } else {
+                let client = OpenAIClient::new().map_err(|e| {
+                    ProviderError::ConfigError(format!("Failed to create OpenAI client: {e}"))
+                })?;
+                log::info!(
+                    "Initialized OpenAI provider (Chat Completions) at {}",
+                    client.api_base_url()
+                );
+                ProviderClient::OpenAI(client)
+            };
+            providers.insert("openai".to_string(), provider);
         }
 
         if default_provider == "mock" {

--- a/app-server/src/llm/mod.rs
+++ b/app-server/src/llm/mod.rs
@@ -220,9 +220,10 @@ fn has_gemini_credentials() -> bool {
     llm_provider_env() == "gemini" && has_llm_api_key()
 }
 
-/// True when `LLM_PROVIDER=openai` and `LLM_API_KEY` is set.
+/// True when `LLM_PROVIDER` selects OpenAI — Chat Completions (`openai`) or the
+/// Responses API (`openai_responses`) — and `LLM_API_KEY` is set.
 fn has_openai_credentials() -> bool {
-    llm_provider_env() == "openai" && has_llm_api_key()
+    matches!(llm_provider_env().as_str(), "openai" | "openai_responses") && has_llm_api_key()
 }
 
 /// Bedrock initializes whenever AWS creds are present, independent of
@@ -389,9 +390,9 @@ pub fn model_for_size(provider: &str, size: ModelSize) -> String {
         ("bedrock", ModelSize::Small) => "us.anthropic.claude-haiku-4-5-20251001-v1:0".to_string(),
         ("bedrock", ModelSize::Medium) => "us.anthropic.claude-sonnet-5".to_string(),
         ("bedrock", ModelSize::Large) => "us.anthropic.claude-opus-4-8".to_string(),
-        ("openai", ModelSize::Small) => "gpt-5.4-mini".to_string(),
-        ("openai", ModelSize::Medium) => "gpt-5.4".to_string(),
-        ("openai", ModelSize::Large) => "gpt-5.5".to_string(),
+        ("openai" | "openai_responses", ModelSize::Small) => "gpt-5.4-mini".to_string(),
+        ("openai" | "openai_responses", ModelSize::Medium) => "gpt-5.4".to_string(),
+        ("openai" | "openai_responses", ModelSize::Large) => "gpt-5.5".to_string(),
         _ => "".to_string(),
     }
 }
@@ -438,9 +439,11 @@ impl LlmClient {
         }
 
         if has_openai_credentials() {
-            // The Responses API and Chat Completions are separate client impls;
-            // OPENAI_USE_RESPONSES selects which one backs the `openai` provider.
-            let provider = if env::llm::OPENAI_USE_RESPONSES.get() {
+            // Chat Completions (`openai`) and the Responses API (`openai_responses`)
+            // are separate client impls, selected by LLM_PROVIDER and registered
+            // under that same provider name.
+            let provider_name = llm_provider_env();
+            let provider = if provider_name == "openai_responses" {
                 let client = OpenAIResponsesClient::new().map_err(|e| {
                     ProviderError::ConfigError(format!(
                         "Failed to create OpenAI Responses client: {e}"
@@ -461,7 +464,7 @@ impl LlmClient {
                 );
                 ProviderClient::OpenAI(client)
             };
-            providers.insert("openai".to_string(), provider);
+            providers.insert(provider_name, provider);
         }
 
         if default_provider == "mock" {
@@ -560,7 +563,13 @@ impl LlmClient {
         };
         let size = request.model_size.unwrap_or(ModelSize::Medium);
         let model = model_for_size(resolved_provider, size);
-        (model, resolved_provider.to_string())
+        // Report the Responses client under the canonical `openai` name so
+        // cost/observability keying matches Chat Completions.
+        let reported_provider = match resolved_provider {
+            "openai_responses" => "openai",
+            other => other,
+        };
+        (model, reported_provider.to_string())
     }
 
     #[cfg_attr(not(feature = "signals"), allow(dead_code))]

--- a/app-server/src/llm/mod.rs
+++ b/app-server/src/llm/mod.rs
@@ -220,10 +220,16 @@ fn has_gemini_credentials() -> bool {
     llm_provider_env() == "gemini" && has_llm_api_key()
 }
 
-/// True when `LLM_PROVIDER` selects OpenAI — Chat Completions (`openai`) or the
-/// Responses API (`openai_responses`) — and `LLM_API_KEY` is set.
+/// True when `LLM_PROVIDER=openai` (Chat Completions) and `LLM_API_KEY` is set.
 fn has_openai_credentials() -> bool {
-    matches!(llm_provider_env().as_str(), "openai" | "openai_responses") && has_llm_api_key()
+    llm_provider_env() == "openai" && has_llm_api_key()
+}
+
+/// True when `LLM_PROVIDER=openai_responses` (Responses API) and `LLM_API_KEY`
+/// is set. Separate from `has_openai_credentials` since the two are distinct
+/// client impls registered under their own provider names.
+fn has_openai_responses_credentials() -> bool {
+    llm_provider_env() == "openai_responses" && has_llm_api_key()
 }
 
 /// Bedrock initializes whenever AWS creds are present, independent of
@@ -392,7 +398,8 @@ pub fn model_for_size(provider: &str, size: ModelSize) -> String {
         ("bedrock", ModelSize::Large) => "us.anthropic.claude-opus-4-8".to_string(),
         ("openai" | "openai_responses", ModelSize::Small) => "gpt-5.4-mini".to_string(),
         ("openai" | "openai_responses", ModelSize::Medium) => "gpt-5.4".to_string(),
-        ("openai" | "openai_responses", ModelSize::Large) => "gpt-5.5".to_string(),
+        ("openai", ModelSize::Large) => "gpt-5.5".to_string(),
+        ("openai_responses", ModelSize::Large) => "gpt-5.6".to_string(),
         _ => "".to_string(),
     }
 }
@@ -439,32 +446,28 @@ impl LlmClient {
         }
 
         if has_openai_credentials() {
-            // Chat Completions (`openai`) and the Responses API (`openai_responses`)
-            // are separate client impls, selected by LLM_PROVIDER and registered
-            // under that same provider name.
-            let provider_name = llm_provider_env();
-            let provider = if provider_name == "openai_responses" {
-                let client = OpenAIResponsesClient::new().map_err(|e| {
-                    ProviderError::ConfigError(format!(
-                        "Failed to create OpenAI Responses client: {e}"
-                    ))
-                })?;
-                log::info!(
-                    "Initialized OpenAI provider (Responses API) at {}",
-                    client.api_base_url()
-                );
-                ProviderClient::OpenAIResponses(client)
-            } else {
-                let client = OpenAIClient::new().map_err(|e| {
-                    ProviderError::ConfigError(format!("Failed to create OpenAI client: {e}"))
-                })?;
-                log::info!(
-                    "Initialized OpenAI provider (Chat Completions) at {}",
-                    client.api_base_url()
-                );
-                ProviderClient::OpenAI(client)
-            };
-            providers.insert(provider_name, provider);
+            let client = OpenAIClient::new().map_err(|e| {
+                ProviderError::ConfigError(format!("Failed to create OpenAI client: {e}"))
+            })?;
+            log::info!(
+                "Initialized OpenAI provider (Chat Completions) at {}",
+                client.api_base_url()
+            );
+            providers.insert("openai".to_string(), ProviderClient::OpenAI(client));
+        }
+
+        if has_openai_responses_credentials() {
+            let client = OpenAIResponsesClient::new().map_err(|e| {
+                ProviderError::ConfigError(format!("Failed to create OpenAI Responses client: {e}"))
+            })?;
+            log::info!(
+                "Initialized OpenAI provider (Responses API) at {}",
+                client.api_base_url()
+            );
+            providers.insert(
+                "openai_responses".to_string(),
+                ProviderClient::OpenAIResponses(client),
+            );
         }
 
         if default_provider == "mock" {

--- a/app-server/src/llm/models.rs
+++ b/app-server/src/llm/models.rs
@@ -227,6 +227,10 @@ pub struct ProviderUsageMetadata {
     pub cache_read_input_tokens: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_creation_input_tokens: Option<i32>,
+    /// Reasoning/thinking tokens, when the provider reports them separately.
+    /// Already counted within `candidates_token_count`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_token_count: Option<i32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/app-server/src/llm/openai/accumulator.rs
+++ b/app-server/src/llm/openai/accumulator.rs
@@ -7,6 +7,7 @@ use crate::llm::models::{
     ProviderCandidate, ProviderContent, ProviderFinishReason, ProviderFunctionCall, ProviderPart,
     ProviderResponse, ProviderStreamChunk, ProviderUsageMetadata,
 };
+use crate::llm::openai::OpenAIError;
 use crate::llm::sse::StreamAccumulator;
 
 #[derive(Default)]
@@ -20,6 +21,7 @@ pub(super) struct OpenAIStreamAccumulator {
 
 impl StreamAccumulator for OpenAIStreamAccumulator {
     type Chunk = Value;
+    type Error = OpenAIError;
 
     fn ingest(&mut self, chunk: Value, tx: &UnboundedSender<ProviderStreamChunk>) {
         if let Some(usage) = chunk.get("usage").filter(|u| !u.is_null()) {
@@ -88,7 +90,7 @@ impl StreamAccumulator for OpenAIStreamAccumulator {
         }
     }
 
-    fn into_response(self, model: &str) -> ProviderResponse {
+    fn into_response(self, model: &str) -> Result<ProviderResponse, OpenAIError> {
         let mut parts: Vec<ProviderPart> = Vec::new();
         if !self.reasoning.is_empty() {
             parts.push(ProviderPart {
@@ -119,7 +121,7 @@ impl StreamAccumulator for OpenAIStreamAccumulator {
             });
         }
 
-        ProviderResponse {
+        Ok(ProviderResponse {
             candidates: Some(vec![ProviderCandidate {
                 content: Some(ProviderContent {
                     role: Some("model".to_string()),
@@ -129,7 +131,7 @@ impl StreamAccumulator for OpenAIStreamAccumulator {
             }]),
             usage_metadata: self.usage,
             model_version: Some(model.to_string()),
-        }
+        })
     }
 }
 

--- a/app-server/src/llm/openai/accumulator.rs
+++ b/app-server/src/llm/openai/accumulator.rs
@@ -90,7 +90,7 @@ impl StreamAccumulator for OpenAIStreamAccumulator {
         }
     }
 
-    fn into_response(self, model: &str) -> Result<ProviderResponse, OpenAIError> {
+    fn try_into_response(self, model: &str) -> Result<ProviderResponse, OpenAIError> {
         let mut parts: Vec<ProviderPart> = Vec::new();
         if !self.reasoning.is_empty() {
             parts.push(ProviderPart {

--- a/app-server/src/llm/openai/conversions.rs
+++ b/app-server/src/llm/openai/conversions.rs
@@ -101,7 +101,7 @@ pub fn provider_request_to_openai_stream_body(model: &str, request: &ProviderReq
     body
 }
 
-fn thinking_level_to_effort(level: &ProviderThinkingLevel) -> Option<&'static str> {
+pub(crate) fn thinking_level_to_effort(level: &ProviderThinkingLevel) -> Option<&'static str> {
     match level {
         ProviderThinkingLevel::ThinkingLevelUnspecified => None,
         ProviderThinkingLevel::Minimal => Some("minimal"),
@@ -346,6 +346,7 @@ pub(super) fn parse_usage(usage: &Value) -> ProviderUsageMetadata {
         total_token_count: total_tokens,
         cache_read_input_tokens: cached_tokens,
         cache_creation_input_tokens: None,
+        reasoning_token_count: None,
     }
 }
 

--- a/app-server/src/llm/openai/conversions.rs
+++ b/app-server/src/llm/openai/conversions.rs
@@ -229,6 +229,22 @@ pub fn parse_openai_response(value: Value) -> Result<ProviderResponse, OpenAIErr
 
         let mut parts: Vec<ProviderPart> = Vec::new();
 
+        // OpenAI-compatible proxies return reasoning under `reasoning_content`
+        // (DeepSeek/vLLM/Fireworks) or `reasoning` (OpenRouter); official OpenAI
+        // exposes none here. Mirror the streaming accumulator's field names.
+        if let Some(reasoning) = message
+            .and_then(|m| m.get("reasoning_content").or_else(|| m.get("reasoning")))
+            .and_then(|r| r.as_str())
+        {
+            if !reasoning.is_empty() {
+                parts.push(ProviderPart {
+                    text: Some(reasoning.to_string()),
+                    thought: Some(true),
+                    ..Default::default()
+                });
+            }
+        }
+
         if let Some(content_val) = message.and_then(|m| m.get("content")) {
             if let Some(text) = content_val.as_str() {
                 if !text.is_empty() {
@@ -575,6 +591,32 @@ mod tests {
         assert_eq!(usage.cache_read_input_tokens, Some(4));
         assert_eq!(usage.cache_creation_input_tokens, None);
         assert_eq!(resp.model_version.as_deref(), Some("gpt-5-mini"));
+    }
+
+    #[test]
+    fn parses_reasoning_content_as_thought() {
+        // OpenAI-compatible gateways (Fireworks GLM, DeepSeek) return reasoning
+        // under `message.reasoning_content` on non-streaming responses.
+        let value = json!({
+            "model": "glm-4.6",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "reasoning_content": "let me think",
+                    "content": "answer"
+                },
+                "finish_reason": "stop"
+            }]
+        });
+        let resp = parse_openai_response(value).unwrap();
+        let cand = &resp.candidates.as_ref().unwrap()[0];
+        let parts = cand.content.as_ref().unwrap().parts.as_ref().unwrap();
+        assert!(
+            parts
+                .iter()
+                .any(|p| p.thought == Some(true) && p.text.as_deref() == Some("let me think"))
+        );
+        assert!(parts.iter().any(|p| p.text.as_deref() == Some("answer")));
     }
 
     #[test]

--- a/app-server/src/llm/openai/mod.rs
+++ b/app-server/src/llm/openai/mod.rs
@@ -6,6 +6,10 @@ pub mod conversions;
 
 pub use client::OpenAIClient;
 
+use crate::env;
+use crate::llm::default_headers_from_env;
+use serde_json::Value;
+use std::time::Duration;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -52,4 +56,79 @@ impl From<OpenAIError> for super::ProviderError {
             }
         }
     }
+}
+
+pub type OpenAIResult<T> = Result<T, OpenAIError>;
+
+/// Shared HTTP setup for the OpenAI-compatible clients (Chat Completions and
+/// Responses). Both read the same `LLM_API_KEY` / `LLM_BASE_URL` and build an
+/// identically-configured `reqwest::Client`.
+pub(super) struct OpenAIHttpConfig {
+    pub client: reqwest::Client,
+    pub api_key: String,
+    pub api_base_url: String,
+}
+
+pub(super) fn build_http_config() -> OpenAIResult<OpenAIHttpConfig> {
+    let api_key = std::env::var(env::llm::API_KEY)
+        .map_err(|_| OpenAIError::config("LLM_API_KEY environment variable not set"))?;
+
+    let raw_base_url = std::env::var(env::llm::BASE_URL)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+    let api_base_url = raw_base_url.trim_end_matches('/').to_string();
+    let default_headers = default_headers_from_env().map_err(OpenAIError::config)?;
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(env::llm::HTTP_TIMEOUT_SECS.get()))
+        .default_headers(default_headers)
+        .build()
+        .map_err(|e| OpenAIError::config(format!("Failed to build HTTP client: {}", e)))?;
+
+    Ok(OpenAIHttpConfig {
+        client,
+        api_key,
+        api_base_url,
+    })
+}
+
+/// POST a JSON body to an OpenAI-compatible endpoint. On a non-success status,
+/// extracts the provider's `error.message` and returns an `ApiError`; otherwise
+/// hands back the raw response for the caller to read as text or a byte stream.
+pub(super) async fn send_openai_request(
+    client: &reqwest::Client,
+    api_key: &str,
+    url: &str,
+    body: &Value,
+) -> OpenAIResult<reqwest::Response> {
+    let response = client
+        .post(url)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("Content-Type", "application/json")
+        .json(body)
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let error_text = response.text().await.unwrap_or_default();
+        log::error!("OpenAI API error ({}): {}", status, error_text);
+        let message = serde_json::from_str::<Value>(&error_text)
+            .ok()
+            .and_then(|v| {
+                v.get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                    .map(|s| s.to_string())
+            })
+            .unwrap_or(error_text);
+        return Err(OpenAIError::ApiError {
+            status_code: status.as_u16(),
+            message,
+        });
+    }
+
+    Ok(response)
 }

--- a/app-server/src/llm/openai_responses/accumulator.rs
+++ b/app-server/src/llm/openai_responses/accumulator.rs
@@ -7,6 +7,7 @@ use super::conversions::parse_openai_responses_response;
 use crate::llm::models::{
     ProviderCandidate, ProviderContent, ProviderPart, ProviderResponse, ProviderStreamChunk,
 };
+use crate::llm::openai::OpenAIError;
 use crate::llm::sse::StreamAccumulator;
 
 /// Accumulator for the Responses API SSE stream. Deltas are forwarded live for
@@ -22,6 +23,7 @@ pub(super) struct OpenAIResponsesStreamAccumulator {
 
 impl StreamAccumulator for OpenAIResponsesStreamAccumulator {
     type Chunk = Value;
+    type Error = OpenAIError;
 
     fn ingest(&mut self, chunk: Value, tx: &UnboundedSender<ProviderStreamChunk>) {
         let Some(event_type) = chunk.get("type").and_then(|t| t.as_str()) else {
@@ -53,15 +55,14 @@ impl StreamAccumulator for OpenAIResponsesStreamAccumulator {
         }
     }
 
-    fn into_response(self, model: &str) -> ProviderResponse {
-        // Prefer the authoritative full response object from the terminal event.
+    fn into_response(self, model: &str) -> Result<ProviderResponse, OpenAIError> {
+        // The terminal event carries the authoritative result. Parsing also
+        // surfaces a `response.failed` event as an error rather than empty content.
         if let Some(response) = self.final_response {
-            if let Ok(parsed) = parse_openai_responses_response(response) {
-                return parsed;
-            }
+            return parse_openai_responses_response(response);
         }
 
-        // Fallback: assemble from accumulated deltas (no tool calls / usage).
+        // No terminal event (stream cut short): assemble from accumulated deltas.
         let mut parts: Vec<ProviderPart> = Vec::new();
         if !self.reasoning.is_empty() {
             parts.push(ProviderPart {
@@ -76,7 +77,7 @@ impl StreamAccumulator for OpenAIResponsesStreamAccumulator {
                 ..Default::default()
             });
         }
-        ProviderResponse {
+        Ok(ProviderResponse {
             candidates: Some(vec![ProviderCandidate {
                 content: Some(ProviderContent {
                     role: Some("model".to_string()),
@@ -86,7 +87,7 @@ impl StreamAccumulator for OpenAIResponsesStreamAccumulator {
             }]),
             usage_metadata: None,
             model_version: Some(model.to_string()),
-        }
+        })
     }
 }
 
@@ -112,10 +113,13 @@ mod tests {
         ))]);
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ProviderStreamChunk>();
-        let response =
-            accumulate_sse::<OpenAIResponsesStreamAccumulator, OpenAIError>(byte_stream, "gpt-5", &tx)
-                .await
-                .unwrap();
+        let response = accumulate_sse::<OpenAIResponsesStreamAccumulator, OpenAIError>(
+            byte_stream,
+            "gpt-5",
+            &tx,
+        )
+        .await
+        .unwrap();
         drop(tx);
 
         let mut texts = Vec::new();
@@ -141,5 +145,32 @@ mod tests {
         let usage = response.usage_metadata.unwrap();
         assert_eq!(usage.candidates_token_count, Some(7));
         assert_eq!(usage.reasoning_token_count, Some(4));
+    }
+
+    #[tokio::test]
+    async fn responses_stream_failed_event_propagates_error() {
+        let body = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n",
+            "data: {\"type\":\"response.failed\",\"response\":{\"model\":\"gpt-5\",\"status\":\"failed\",\"error\":{\"code\":\"server_error\",\"message\":\"boom\"}}}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let byte_stream = stream::iter(vec![Ok::<_, reqwest::Error>(Bytes::copy_from_slice(
+            body.as_bytes(),
+        ))]);
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<ProviderStreamChunk>();
+        let result = accumulate_sse::<OpenAIResponsesStreamAccumulator, OpenAIError>(
+            byte_stream,
+            "gpt-5",
+            &tx,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(OpenAIError::ApiError {
+                status_code: 500,
+                ..
+            })
+        ));
     }
 }

--- a/app-server/src/llm/openai_responses/accumulator.rs
+++ b/app-server/src/llm/openai_responses/accumulator.rs
@@ -1,0 +1,145 @@
+#![cfg_attr(not(feature = "signals"), allow(dead_code))]
+
+use serde_json::Value;
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::conversions::parse_openai_responses_response;
+use crate::llm::models::{
+    ProviderCandidate, ProviderContent, ProviderPart, ProviderResponse, ProviderStreamChunk,
+};
+use crate::llm::sse::StreamAccumulator;
+
+/// Accumulator for the Responses API SSE stream. Deltas are forwarded live for
+/// UX; the terminal `response.completed`/`incomplete`/`failed` event carries the
+/// full `response` object which is parsed for the authoritative final result
+/// (output items + usage, including reasoning tokens).
+#[derive(Default)]
+pub(super) struct OpenAIResponsesStreamAccumulator {
+    reasoning: String,
+    text: String,
+    final_response: Option<Value>,
+}
+
+impl StreamAccumulator for OpenAIResponsesStreamAccumulator {
+    type Chunk = Value;
+
+    fn ingest(&mut self, chunk: Value, tx: &UnboundedSender<ProviderStreamChunk>) {
+        let Some(event_type) = chunk.get("type").and_then(|t| t.as_str()) else {
+            return;
+        };
+        match event_type {
+            "response.output_text.delta" => {
+                if let Some(delta) = chunk.get("delta").and_then(|d| d.as_str()) {
+                    if !delta.is_empty() {
+                        self.text.push_str(delta);
+                        let _ = tx.send(ProviderStreamChunk::Text(delta.to_string()));
+                    }
+                }
+            }
+            "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
+                if let Some(delta) = chunk.get("delta").and_then(|d| d.as_str()) {
+                    if !delta.is_empty() {
+                        self.reasoning.push_str(delta);
+                        let _ = tx.send(ProviderStreamChunk::Thought(delta.to_string()));
+                    }
+                }
+            }
+            "response.completed" | "response.incomplete" | "response.failed" => {
+                if let Some(response) = chunk.get("response") {
+                    self.final_response = Some(response.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn into_response(self, model: &str) -> ProviderResponse {
+        // Prefer the authoritative full response object from the terminal event.
+        if let Some(response) = self.final_response {
+            if let Ok(parsed) = parse_openai_responses_response(response) {
+                return parsed;
+            }
+        }
+
+        // Fallback: assemble from accumulated deltas (no tool calls / usage).
+        let mut parts: Vec<ProviderPart> = Vec::new();
+        if !self.reasoning.is_empty() {
+            parts.push(ProviderPart {
+                text: Some(self.reasoning),
+                thought: Some(true),
+                ..Default::default()
+            });
+        }
+        if !self.text.is_empty() {
+            parts.push(ProviderPart {
+                text: Some(self.text),
+                ..Default::default()
+            });
+        }
+        ProviderResponse {
+            candidates: Some(vec![ProviderCandidate {
+                content: Some(ProviderContent {
+                    role: Some("model".to_string()),
+                    parts: Some(parts),
+                }),
+                finish_reason: None,
+            }]),
+            usage_metadata: None,
+            model_version: Some(model.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::openai::OpenAIError;
+    use crate::llm::sse::accumulate_sse;
+    use bytes::Bytes;
+    use futures_util::stream;
+
+    #[tokio::test]
+    async fn responses_stream_forwards_deltas_and_parses_terminal_event() {
+        let body = concat!(
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"think\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hel\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"lo\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"model\":\"gpt-5\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":7,\"output_tokens_details\":{\"reasoning_tokens\":4},\"total_tokens\":10}}}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let byte_stream = stream::iter(vec![Ok::<_, reqwest::Error>(Bytes::copy_from_slice(
+            body.as_bytes(),
+        ))]);
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ProviderStreamChunk>();
+        let response =
+            accumulate_sse::<OpenAIResponsesStreamAccumulator, OpenAIError>(byte_stream, "gpt-5", &tx)
+                .await
+                .unwrap();
+        drop(tx);
+
+        let mut texts = Vec::new();
+        let mut thoughts = Vec::new();
+        while let Ok(chunk) = rx.try_recv() {
+            match chunk {
+                ProviderStreamChunk::Text(t) => texts.push(t),
+                ProviderStreamChunk::Thought(t) => thoughts.push(t),
+            }
+        }
+        assert_eq!(texts, vec!["Hel".to_string(), "lo".to_string()]);
+        assert_eq!(thoughts, vec!["think".to_string()]);
+
+        // Final result comes from the authoritative terminal event.
+        let parts = response.candidates.unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()
+            .parts
+            .clone()
+            .unwrap();
+        assert!(parts.iter().any(|p| p.text.as_deref() == Some("Hello")));
+        let usage = response.usage_metadata.unwrap();
+        assert_eq!(usage.candidates_token_count, Some(7));
+        assert_eq!(usage.reasoning_token_count, Some(4));
+    }
+}

--- a/app-server/src/llm/openai_responses/accumulator.rs
+++ b/app-server/src/llm/openai_responses/accumulator.rs
@@ -55,7 +55,7 @@ impl StreamAccumulator for OpenAIResponsesStreamAccumulator {
         }
     }
 
-    fn into_response(self, model: &str) -> Result<ProviderResponse, OpenAIError> {
+    fn try_into_response(self, model: &str) -> Result<ProviderResponse, OpenAIError> {
         // The terminal event carries the authoritative result. Parsing also
         // surfaces a `response.failed` event as an error rather than empty content.
         if let Some(response) = self.final_response {

--- a/app-server/src/llm/openai_responses/client.rs
+++ b/app-server/src/llm/openai_responses/client.rs
@@ -15,9 +15,9 @@ use crate::llm::{
 };
 use tokio::sync::mpsc::UnboundedSender;
 
-/// OpenAI provider using the Responses API (`/responses`). Selected over
-/// [`OpenAIClient`](crate::llm::openai::OpenAIClient) when
-/// `OPENAI_USE_RESPONSES` is enabled.
+/// OpenAI provider using the Responses API (`/responses`). Registered under the
+/// `openai_responses` provider name (via `LLM_PROVIDER`), separate from the
+/// Chat Completions [`OpenAIClient`](crate::llm::openai::OpenAIClient).
 #[derive(Clone)]
 pub struct OpenAIResponsesClient {
     client: reqwest::Client,

--- a/app-server/src/llm/openai_responses/client.rs
+++ b/app-server/src/llm/openai_responses/client.rs
@@ -1,10 +1,13 @@
 #![cfg_attr(not(feature = "signals"), allow(dead_code))]
 
-use super::accumulator::OpenAIStreamAccumulator;
+use super::accumulator::OpenAIResponsesStreamAccumulator;
 use super::conversions::{
-    parse_openai_response, provider_request_to_openai_body, provider_request_to_openai_stream_body,
+    parse_openai_responses_response, provider_request_to_responses_body,
+    provider_request_to_responses_stream_body,
 };
-use super::{OpenAIHttpConfig, OpenAIResult, build_http_config, send_openai_request};
+use crate::llm::openai::{
+    OpenAIError, OpenAIHttpConfig, OpenAIResult, build_http_config, send_openai_request,
+};
 use crate::llm::{
     LanguageModelClient, ProviderResult,
     models::{ProviderRequest, ProviderResponse, ProviderStreamChunk},
@@ -12,15 +15,17 @@ use crate::llm::{
 };
 use tokio::sync::mpsc::UnboundedSender;
 
-/// OpenAI provider using the Chat Completions API (`/chat/completions`).
+/// OpenAI provider using the Responses API (`/responses`). Selected over
+/// [`OpenAIClient`](crate::llm::openai::OpenAIClient) when
+/// `OPENAI_USE_RESPONSES` is enabled.
 #[derive(Clone)]
-pub struct OpenAIClient {
+pub struct OpenAIResponsesClient {
     client: reqwest::Client,
     api_key: String,
     api_base_url: String,
 }
 
-impl OpenAIClient {
+impl OpenAIResponsesClient {
     pub fn new() -> OpenAIResult<Self> {
         let OpenAIHttpConfig {
             client,
@@ -39,21 +44,21 @@ impl OpenAIClient {
     }
 }
 
-impl LanguageModelClient for OpenAIClient {
+impl LanguageModelClient for OpenAIResponsesClient {
     async fn generate_content(
         &self,
         model: &str,
         request: &ProviderRequest,
     ) -> ProviderResult<ProviderResponse> {
-        let body = provider_request_to_openai_body(model, request);
-        let url = format!("{}/chat/completions", self.api_base_url);
+        let body = provider_request_to_responses_body(model, request);
+        let url = format!("{}/responses", self.api_base_url);
 
         let response = send_openai_request(&self.client, &self.api_key, &url, &body).await?;
-        let response_text = response.text().await.map_err(super::OpenAIError::from)?;
+        let response_text = response.text().await.map_err(OpenAIError::from)?;
         let response_json: serde_json::Value =
-            serde_json::from_str(&response_text).map_err(super::OpenAIError::from)?;
+            serde_json::from_str(&response_text).map_err(OpenAIError::from)?;
 
-        parse_openai_response(response_json).map_err(Into::into)
+        parse_openai_responses_response(response_json).map_err(Into::into)
     }
 
     async fn generate_content_stream(
@@ -62,12 +67,12 @@ impl LanguageModelClient for OpenAIClient {
         request: &ProviderRequest,
         chunk_tx: &UnboundedSender<ProviderStreamChunk>,
     ) -> ProviderResult<ProviderResponse> {
-        let body = provider_request_to_openai_stream_body(model, request);
-        let url = format!("{}/chat/completions", self.api_base_url);
+        let body = provider_request_to_responses_stream_body(model, request);
+        let url = format!("{}/responses", self.api_base_url);
 
         let response = send_openai_request(&self.client, &self.api_key, &url, &body).await?;
 
-        accumulate_sse::<OpenAIStreamAccumulator, super::OpenAIError>(
+        accumulate_sse::<OpenAIResponsesStreamAccumulator, OpenAIError>(
             response.bytes_stream(),
             model,
             chunk_tx,

--- a/app-server/src/llm/openai_responses/client.rs
+++ b/app-server/src/llm/openai_responses/client.rs
@@ -50,7 +50,7 @@ impl LanguageModelClient for OpenAIResponsesClient {
         model: &str,
         request: &ProviderRequest,
     ) -> ProviderResult<ProviderResponse> {
-        let body = provider_request_to_responses_body(model, request);
+        let body = provider_request_to_responses_body(model, request)?;
         let url = format!("{}/responses", self.api_base_url);
 
         let response = send_openai_request(&self.client, &self.api_key, &url, &body).await?;
@@ -67,7 +67,7 @@ impl LanguageModelClient for OpenAIResponsesClient {
         request: &ProviderRequest,
         chunk_tx: &UnboundedSender<ProviderStreamChunk>,
     ) -> ProviderResult<ProviderResponse> {
-        let body = provider_request_to_responses_stream_body(model, request);
+        let body = provider_request_to_responses_stream_body(model, request)?;
         let url = format!("{}/responses", self.api_base_url);
 
         let response = send_openai_request(&self.client, &self.api_key, &url, &body).await?;

--- a/app-server/src/llm/openai_responses/conversions.rs
+++ b/app-server/src/llm/openai_responses/conversions.rs
@@ -15,15 +15,18 @@ use crate::llm::models::{
     ProviderCandidate, ProviderContent, ProviderFinishReason, ProviderFunctionCall, ProviderPart,
     ProviderRequest, ProviderResponse, ProviderUsageMetadata,
 };
-use crate::llm::openai::OpenAIError;
 use crate::llm::openai::conversions::thinking_level_to_effort;
+use crate::llm::openai::{OpenAIError, OpenAIResult};
 use serde_json::{Value, json};
 
 /// Build the OpenAI Responses request body from a `ProviderRequest`.
-pub fn provider_request_to_responses_body(model: &str, request: &ProviderRequest) -> Value {
+pub fn provider_request_to_responses_body(
+    model: &str,
+    request: &ProviderRequest,
+) -> OpenAIResult<Value> {
     let mut input: Vec<Value> = Vec::new();
     for content in &request.contents {
-        append_content_as_items(content, &mut input);
+        append_content_as_items(content, &mut input)?;
     }
 
     let mut body = json!({
@@ -75,16 +78,19 @@ pub fn provider_request_to_responses_body(model: &str, request: &ProviderRequest
         }
     }
 
-    body
+    Ok(body)
 }
 
 /// Same as [`provider_request_to_responses_body`] but flags the request for SSE
 /// streaming. Usage rides the terminal `response.completed` event, so no
 /// `stream_options` toggle is needed.
-pub fn provider_request_to_responses_stream_body(model: &str, request: &ProviderRequest) -> Value {
-    let mut body = provider_request_to_responses_body(model, request);
+pub fn provider_request_to_responses_stream_body(
+    model: &str,
+    request: &ProviderRequest,
+) -> OpenAIResult<Value> {
+    let mut body = provider_request_to_responses_body(model, request)?;
     body["stream"] = json!(true);
-    body
+    Ok(body)
 }
 
 fn concat_text_parts(content: &ProviderContent) -> String {
@@ -106,7 +112,7 @@ fn concat_text_parts(content: &ProviderContent) -> String {
 /// Expand one internal `ProviderContent` into one (or more) Responses input items:
 /// a `{role, content}` message for text, `function_call` items for tool calls,
 /// and `function_call_output` items for tool results.
-fn append_content_as_items(content: &ProviderContent, out: &mut Vec<Value>) {
+fn append_content_as_items(content: &ProviderContent, out: &mut Vec<Value>) -> OpenAIResult<()> {
     let raw_role = content.role.as_deref().unwrap_or("user");
     let role = match raw_role {
         "assistant" | "model" => "assistant",
@@ -125,7 +131,10 @@ fn append_content_as_items(content: &ProviderContent, out: &mut Vec<Value>) {
             continue;
         }
         if let Some(fr) = part.function_response {
-            let call_id = fr.id.unwrap_or_default();
+            // The Responses API 400s on an empty `call_id`, and a synthetic one
+            // couldn't be paired to its `function_call`. Fail fast on malformed
+            // history rather than emit an item the API rejects.
+            let call_id = require_call_id(fr.id, "function_call_output")?;
             let output_str = serde_json::to_string(&fr.response).unwrap_or_default();
             tool_results.push(json!({
                 "type": "function_call_output",
@@ -135,7 +144,7 @@ fn append_content_as_items(content: &ProviderContent, out: &mut Vec<Value>) {
             continue;
         }
         if let Some(fc) = part.function_call {
-            let call_id = fc.id.unwrap_or_default();
+            let call_id = require_call_id(fc.id, "function_call")?;
             let args = fc.args.unwrap_or(Value::Object(Default::default()));
             let arguments_str = serde_json::to_string(&args).unwrap_or("{}".to_string());
             tool_calls.push(json!({
@@ -159,6 +168,14 @@ fn append_content_as_items(content: &ProviderContent, out: &mut Vec<Value>) {
     }
     out.extend(tool_calls);
     out.extend(tool_results);
+    Ok(())
+}
+
+/// A tool-call/result item requires a non-empty `call_id` to link the two
+/// halves; the Responses API rejects an empty one with a 400.
+fn require_call_id(id: Option<String>, item: &str) -> OpenAIResult<String> {
+    id.filter(|s| !s.is_empty())
+        .ok_or_else(|| OpenAIError::config(format!("{item} is missing a non-empty call_id")))
 }
 
 /// Parse an OpenAI Responses API response JSON into a `ProviderResponse`.
@@ -443,7 +460,7 @@ mod tests {
             role: None,
             parts: Some(vec![text_part("Be terse")]),
         });
-        let body = provider_request_to_responses_body("gpt-5", &req);
+        let body = provider_request_to_responses_body("gpt-5", &req).unwrap();
         assert_eq!(body["instructions"], "Be terse");
         let input = body["input"].as_array().unwrap();
         assert_eq!(input.len(), 1);
@@ -460,7 +477,7 @@ mod tests {
             tool_response(Some("call_1"), "get_weather", json!({"temp": 60})),
             user("Thanks"),
         ]);
-        let body = provider_request_to_responses_body("gpt-5", &req);
+        let body = provider_request_to_responses_body("gpt-5", &req).unwrap();
         let input = body["input"].as_array().unwrap();
         assert_eq!(input.len(), 4);
         assert_eq!(input[0]["content"], "Find weather");
@@ -472,6 +489,17 @@ mod tests {
         assert_eq!(input[2]["call_id"], "call_1");
         assert_eq!(input[2]["output"], "{\"temp\":60}");
         assert_eq!(input[3]["content"], "Thanks");
+    }
+
+    #[test]
+    fn missing_tool_call_id_is_rejected() {
+        let req = request(vec![assistant_with_tool_call(
+            None,
+            "get_weather",
+            json!({"city": "SF"}),
+        )]);
+        let err = provider_request_to_responses_body("gpt-5", &req).unwrap_err();
+        assert!(matches!(err, OpenAIError::ConfigError(_)));
     }
 
     #[test]
@@ -492,7 +520,7 @@ mod tests {
             }),
             ..Default::default()
         });
-        let body = provider_request_to_responses_body("gpt-5", &req);
+        let body = provider_request_to_responses_body("gpt-5", &req).unwrap();
         let tools = body["tools"].as_array().unwrap();
         assert_eq!(tools[0]["type"], "function");
         assert_eq!(tools[0]["name"], "lookup");

--- a/app-server/src/llm/openai_responses/conversions.rs
+++ b/app-server/src/llm/openai_responses/conversions.rs
@@ -163,6 +163,12 @@ fn append_content_as_items(content: &ProviderContent, out: &mut Vec<Value>) {
 
 /// Parse an OpenAI Responses API response JSON into a `ProviderResponse`.
 pub fn parse_openai_responses_response(value: Value) -> Result<ProviderResponse, OpenAIError> {
+    // A `failed` status is a provider-side failure, not a valid empty response —
+    // surface the `error` payload instead of returning empty content.
+    if value.get("status").and_then(|s| s.as_str()) == Some("failed") {
+        return Err(responses_failed_error(&value));
+    }
+
     let output = value
         .get("output")
         .and_then(|o| o.as_array())
@@ -281,6 +287,30 @@ fn extract_reasoning_summary(item: &Value) -> String {
         }
     }
     out
+}
+
+/// Build an error from a `status: "failed"` Responses payload. The status code
+/// is chosen so the shared `OpenAIError::ApiError` → `ProviderError` mapping
+/// derives sensible retry semantics: `rate_limit_exceeded` → 429 (retryable,
+/// resource-exhausted), `server_error` → 500 (retryable), anything else → 400
+/// (non-retryable — retrying a model/content failure won't help).
+fn responses_failed_error(value: &Value) -> OpenAIError {
+    let error = value.get("error");
+    let message = error
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+        .or_else(|| error.and_then(|e| e.as_str()))
+        .unwrap_or("Responses API returned status \"failed\"")
+        .to_string();
+    let status_code = match error.and_then(|e| e.get("code")).and_then(|c| c.as_str()) {
+        Some("rate_limit_exceeded") => 429,
+        Some("server_error") => 500,
+        _ => 400,
+    };
+    OpenAIError::ApiError {
+        status_code,
+        message,
+    }
 }
 
 fn map_responses_status(value: &Value) -> Option<ProviderFinishReason> {
@@ -535,6 +565,27 @@ mod tests {
         assert_eq!(fc.id.as_deref(), Some("call_abc"));
         assert_eq!(fc.name, "get_weather");
         assert_eq!(fc.args.as_ref().unwrap()["city"], "SF");
+    }
+
+    #[test]
+    fn failed_status_returns_error_with_message() {
+        let value = json!({
+            "model": "gpt-5",
+            "status": "failed",
+            "error": {"code": "server_error", "message": "the model failed"},
+            "output": []
+        });
+        let err = parse_openai_responses_response(value).unwrap_err();
+        match err {
+            OpenAIError::ApiError {
+                status_code,
+                message,
+            } => {
+                assert_eq!(status_code, 500);
+                assert_eq!(message, "the model failed");
+            }
+            other => panic!("expected ApiError, got {other:?}"),
+        }
     }
 
     #[test]

--- a/app-server/src/llm/openai_responses/conversions.rs
+++ b/app-server/src/llm/openai_responses/conversions.rs
@@ -69,7 +69,9 @@ pub fn provider_request_to_responses_body(model: &str, request: &ProviderRequest
             .and_then(|tc| tc.thinking_level.as_ref())
             .and_then(thinking_level_to_effort)
         {
-            body["reasoning"] = json!({ "effort": effort });
+            // `summary: "auto"` requests a reasoning summary (richest available)
+            // so summary text is returned alongside the answer.
+            body["reasoning"] = json!({ "effort": effort, "summary": "auto" });
         }
     }
 
@@ -462,6 +464,7 @@ mod tests {
         assert_eq!(tools[0]["parameters"]["type"], "object");
         // Responses allows reasoning + tools together.
         assert_eq!(body["reasoning"]["effort"], "high");
+        assert_eq!(body["reasoning"]["summary"], "auto");
         assert_eq!(body["max_output_tokens"], 100);
         assert!(body.get("temperature").is_none());
     }
@@ -494,7 +497,11 @@ mod tests {
                 .iter()
                 .any(|p| p.thought == Some(true) && p.text.as_deref() == Some("thinking"))
         );
-        assert!(parts.iter().any(|p| p.text.as_deref() == Some("hello there")));
+        assert!(
+            parts
+                .iter()
+                .any(|p| p.text.as_deref() == Some("hello there"))
+        );
         let usage = resp.usage_metadata.unwrap();
         assert_eq!(usage.prompt_token_count, Some(10));
         assert_eq!(usage.candidates_token_count, Some(20));

--- a/app-server/src/llm/openai_responses/conversions.rs
+++ b/app-server/src/llm/openai_responses/conversions.rs
@@ -275,15 +275,20 @@ fn extract_message_text(item: &Value) -> Option<String> {
     Some(out)
 }
 
-/// Concatenate `summary_text` pieces from a Responses `reasoning` item.
+/// Extract reasoning text from a Responses `reasoning` item. OpenAI o-series
+/// return a human summary under `summary[].summary_text`; some providers return
+/// the raw reasoning under `content[].reasoning_text`.
+/// Read both so thinking surfaces regardless of provider.
 fn extract_reasoning_summary(item: &Value) -> String {
-    let Some(summary) = item.get("summary").and_then(|s| s.as_array()) else {
-        return String::new();
-    };
     let mut out = String::new();
-    for piece in summary {
-        if let Some(t) = piece.get("text").and_then(|x| x.as_str()) {
-            out.push_str(t);
+    for field in ["summary", "content"] {
+        let Some(arr) = item.get(field).and_then(|s| s.as_array()) else {
+            continue;
+        };
+        for piece in arr {
+            if let Some(t) = piece.get("text").and_then(|x| x.as_str()) {
+                out.push_str(t);
+            }
         }
     }
     out
@@ -539,6 +544,33 @@ mod tests {
         assert_eq!(usage.cache_read_input_tokens, Some(4));
         assert_eq!(usage.reasoning_token_count, Some(12));
         assert_eq!(resp.model_version.as_deref(), Some("gpt-5-2026"));
+    }
+
+    #[test]
+    fn parses_reasoning_from_content_reasoning_text() {
+        // Providers like GLM on Fireworks return raw reasoning under
+        // `content[].reasoning_text`, not the OpenAI-style `summary`.
+        let value = json!({
+            "model": "glm-4.6",
+            "status": "completed",
+            "output": [
+                {"type": "reasoning", "summary": [], "content": [
+                    {"type": "reasoning_text", "text": "let me think"}
+                ]},
+                {"type": "message", "role": "assistant", "content": [
+                    {"type": "output_text", "text": "answer"}
+                ]}
+            ]
+        });
+        let resp = parse_openai_responses_response(value).unwrap();
+        let cand = &resp.candidates.as_ref().unwrap()[0];
+        let parts = cand.content.as_ref().unwrap().parts.as_ref().unwrap();
+        assert!(
+            parts
+                .iter()
+                .any(|p| p.thought == Some(true) && p.text.as_deref() == Some("let me think"))
+        );
+        assert!(parts.iter().any(|p| p.text.as_deref() == Some("answer")));
     }
 
     #[test]

--- a/app-server/src/llm/openai_responses/conversions.rs
+++ b/app-server/src/llm/openai_responses/conversions.rs
@@ -1,0 +1,545 @@
+#![cfg_attr(not(feature = "signals"), allow(dead_code))]
+
+//! Conversions between the internal Gemini-shaped `ProviderRequest`/`ProviderResponse`
+//! types and the OpenAI Responses API (`/v1/responses`) wire format.
+//!
+//! The Responses API models a conversation as a flat `input` array of typed
+//! items: `{role, content}` message items, `function_call` items (assistant tool
+//! calls), and `function_call_output` items (tool results) keyed by `call_id`.
+//! The system prompt rides the top-level `instructions` field. Reasoning models
+//! accept `reasoning.effort` alongside function tools here (unlike Chat
+//! Completions), and report thinking tokens under
+//! `usage.output_tokens_details.reasoning_tokens`.
+
+use crate::llm::models::{
+    ProviderCandidate, ProviderContent, ProviderFinishReason, ProviderFunctionCall, ProviderPart,
+    ProviderRequest, ProviderResponse, ProviderUsageMetadata,
+};
+use crate::llm::openai::OpenAIError;
+use crate::llm::openai::conversions::thinking_level_to_effort;
+use serde_json::{Value, json};
+
+/// Build the OpenAI Responses request body from a `ProviderRequest`.
+pub fn provider_request_to_responses_body(model: &str, request: &ProviderRequest) -> Value {
+    let mut input: Vec<Value> = Vec::new();
+    for content in &request.contents {
+        append_content_as_items(content, &mut input);
+    }
+
+    let mut body = json!({
+        "model": model,
+        "input": input,
+    });
+
+    if let Some(sys) = request.system_instruction.as_ref() {
+        let text = concat_text_parts(sys);
+        if !text.is_empty() {
+            body["instructions"] = Value::String(text);
+        }
+    }
+
+    if let Some(tools) = request.tools.as_ref() {
+        let tool_array: Vec<Value> = tools
+            .iter()
+            .flat_map(|t| &t.function_declarations)
+            .map(|f| {
+                json!({
+                    "type": "function",
+                    "name": f.name,
+                    "description": f.description,
+                    "parameters": f.parameters,
+                })
+            })
+            .collect();
+        if !tool_array.is_empty() {
+            body["tools"] = Value::Array(tool_array);
+        }
+    }
+
+    if let Some(gc) = request.generation_config.as_ref() {
+        // Same rationale as Chat Completions: don't forward sampling params.
+        if let Some(m) = gc.max_output_tokens {
+            body["max_output_tokens"] = json!(m);
+        }
+        // Responses accepts reasoning + function tools together, so forward the
+        // effort unconditionally (the Chat Completions no-tools guard doesn't apply).
+        if let Some(effort) = gc
+            .thinking_config
+            .as_ref()
+            .and_then(|tc| tc.thinking_level.as_ref())
+            .and_then(thinking_level_to_effort)
+        {
+            body["reasoning"] = json!({ "effort": effort });
+        }
+    }
+
+    body
+}
+
+/// Same as [`provider_request_to_responses_body`] but flags the request for SSE
+/// streaming. Usage rides the terminal `response.completed` event, so no
+/// `stream_options` toggle is needed.
+pub fn provider_request_to_responses_stream_body(model: &str, request: &ProviderRequest) -> Value {
+    let mut body = provider_request_to_responses_body(model, request);
+    body["stream"] = json!(true);
+    body
+}
+
+fn concat_text_parts(content: &ProviderContent) -> String {
+    let Some(parts) = content.parts.as_ref() else {
+        return String::new();
+    };
+    let mut out = String::new();
+    for part in parts {
+        if part.thought == Some(true) {
+            continue;
+        }
+        if let Some(t) = &part.text {
+            out.push_str(t);
+        }
+    }
+    out
+}
+
+/// Expand one internal `ProviderContent` into one (or more) Responses input items:
+/// a `{role, content}` message for text, `function_call` items for tool calls,
+/// and `function_call_output` items for tool results.
+fn append_content_as_items(content: &ProviderContent, out: &mut Vec<Value>) {
+    let raw_role = content.role.as_deref().unwrap_or("user");
+    let role = match raw_role {
+        "assistant" | "model" => "assistant",
+        "system" => "system",
+        _ => "user",
+    };
+
+    let parts = content.parts.as_ref().cloned().unwrap_or_default();
+
+    let mut text_buf = String::new();
+    let mut tool_calls: Vec<Value> = Vec::new();
+    let mut tool_results: Vec<Value> = Vec::new();
+
+    for part in parts {
+        if part.thought == Some(true) {
+            continue;
+        }
+        if let Some(fr) = part.function_response {
+            let call_id = fr.id.unwrap_or_default();
+            let output_str = serde_json::to_string(&fr.response).unwrap_or_default();
+            tool_results.push(json!({
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": output_str,
+            }));
+            continue;
+        }
+        if let Some(fc) = part.function_call {
+            let call_id = fc.id.unwrap_or_default();
+            let args = fc.args.unwrap_or(Value::Object(Default::default()));
+            let arguments_str = serde_json::to_string(&args).unwrap_or("{}".to_string());
+            tool_calls.push(json!({
+                "type": "function_call",
+                "call_id": call_id,
+                "name": fc.name,
+                "arguments": arguments_str,
+            }));
+            continue;
+        }
+        if let Some(t) = part.text {
+            text_buf.push_str(&t);
+        }
+    }
+
+    if !text_buf.is_empty() {
+        out.push(json!({
+            "role": role,
+            "content": text_buf,
+        }));
+    }
+    out.extend(tool_calls);
+    out.extend(tool_results);
+}
+
+/// Parse an OpenAI Responses API response JSON into a `ProviderResponse`.
+pub fn parse_openai_responses_response(value: Value) -> Result<ProviderResponse, OpenAIError> {
+    let output = value
+        .get("output")
+        .and_then(|o| o.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut parts: Vec<ProviderPart> = Vec::new();
+
+    for item in output {
+        let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        match item_type {
+            "message" => {
+                if let Some(text) = extract_message_text(&item) {
+                    if !text.is_empty() {
+                        parts.push(ProviderPart {
+                            text: Some(text),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            "reasoning" => {
+                let summary = extract_reasoning_summary(&item);
+                if !summary.is_empty() {
+                    parts.push(ProviderPart {
+                        text: Some(summary),
+                        thought: Some(true),
+                        ..Default::default()
+                    });
+                }
+            }
+            "function_call" => {
+                let id = item
+                    .get("call_id")
+                    .or_else(|| item.get("id"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let name = item
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args = item
+                    .get("arguments")
+                    .and_then(|a| a.as_str())
+                    .and_then(|s| serde_json::from_str::<Value>(s).ok())
+                    .or_else(|| item.get("arguments").cloned());
+                parts.push(ProviderPart {
+                    function_call: Some(ProviderFunctionCall { id, name, args }),
+                    ..Default::default()
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let finish_reason = map_responses_status(&value);
+
+    let candidate = ProviderCandidate {
+        content: Some(ProviderContent {
+            role: Some("model".to_string()),
+            parts: Some(parts),
+        }),
+        finish_reason,
+    };
+
+    let usage = value
+        .get("usage")
+        .filter(|u| !u.is_null())
+        .map(parse_responses_usage);
+    let model_version = value
+        .get("model")
+        .and_then(|m| m.as_str())
+        .map(|s| s.to_string());
+
+    Ok(ProviderResponse {
+        candidates: Some(vec![candidate]),
+        usage_metadata: usage,
+        model_version,
+    })
+}
+
+/// Concatenate `output_text` pieces from a Responses `message` item's content array.
+fn extract_message_text(item: &Value) -> Option<String> {
+    let content = item.get("content")?;
+    if let Some(text) = content.as_str() {
+        return Some(text.to_string());
+    }
+    let arr = content.as_array()?;
+    let mut out = String::new();
+    for piece in arr {
+        let piece_type = piece.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        // `output_text` is the assistant's text; `refusal` carries a decline message.
+        if piece_type == "output_text" || piece_type == "refusal" {
+            if let Some(t) = piece
+                .get("text")
+                .or_else(|| piece.get("refusal"))
+                .and_then(|x| x.as_str())
+            {
+                out.push_str(t);
+            }
+        }
+    }
+    Some(out)
+}
+
+/// Concatenate `summary_text` pieces from a Responses `reasoning` item.
+fn extract_reasoning_summary(item: &Value) -> String {
+    let Some(summary) = item.get("summary").and_then(|s| s.as_array()) else {
+        return String::new();
+    };
+    let mut out = String::new();
+    for piece in summary {
+        if let Some(t) = piece.get("text").and_then(|x| x.as_str()) {
+            out.push_str(t);
+        }
+    }
+    out
+}
+
+fn map_responses_status(value: &Value) -> Option<ProviderFinishReason> {
+    let status = value.get("status").and_then(|s| s.as_str())?;
+    Some(match status {
+        "completed" => ProviderFinishReason::Stop,
+        "incomplete" => {
+            let reason = value
+                .get("incomplete_details")
+                .and_then(|d| d.get("reason"))
+                .and_then(|r| r.as_str())
+                .unwrap_or("");
+            match reason {
+                "max_output_tokens" => ProviderFinishReason::MaxTokens,
+                "content_filter" => ProviderFinishReason::Safety,
+                other => ProviderFinishReason::Other(other.to_string()),
+            }
+        }
+        other => ProviderFinishReason::Other(other.to_string()),
+    })
+}
+
+fn parse_responses_usage(usage: &Value) -> ProviderUsageMetadata {
+    let input_tokens = usage
+        .get("input_tokens")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+    // `output_tokens` already includes reasoning tokens per the API convention.
+    let output_tokens = usage
+        .get("output_tokens")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+    let total_tokens = usage
+        .get("total_tokens")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+    let cached_tokens = usage
+        .get("input_tokens_details")
+        .and_then(|d| d.get("cached_tokens"))
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+    let reasoning_tokens = usage
+        .get("output_tokens_details")
+        .and_then(|d| d.get("reasoning_tokens"))
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+
+    ProviderUsageMetadata {
+        prompt_token_count: input_tokens,
+        candidates_token_count: output_tokens,
+        total_token_count: total_tokens,
+        cache_read_input_tokens: cached_tokens,
+        cache_creation_input_tokens: None,
+        reasoning_token_count: reasoning_tokens,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::models::{
+        ProviderContent, ProviderFunctionCall, ProviderFunctionDeclaration,
+        ProviderFunctionResponse, ProviderGenerationConfig, ProviderPart, ProviderRequest,
+        ProviderThinkingConfig, ProviderThinkingLevel, ProviderTool,
+    };
+
+    fn text_part(s: &str) -> ProviderPart {
+        ProviderPart {
+            text: Some(s.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn user(text: &str) -> ProviderContent {
+        ProviderContent {
+            role: Some("user".to_string()),
+            parts: Some(vec![text_part(text)]),
+        }
+    }
+
+    fn assistant_with_tool_call(id: Option<&str>, name: &str, args: Value) -> ProviderContent {
+        ProviderContent {
+            role: Some("model".to_string()),
+            parts: Some(vec![ProviderPart {
+                function_call: Some(ProviderFunctionCall {
+                    id: id.map(|s| s.to_string()),
+                    name: name.to_string(),
+                    args: Some(args),
+                }),
+                ..Default::default()
+            }]),
+        }
+    }
+
+    fn tool_response(id: Option<&str>, name: &str, response: Value) -> ProviderContent {
+        ProviderContent {
+            role: Some("user".to_string()),
+            parts: Some(vec![ProviderPart {
+                function_response: Some(ProviderFunctionResponse {
+                    id: id.map(|s| s.to_string()),
+                    name: name.to_string(),
+                    response,
+                }),
+                ..Default::default()
+            }]),
+        }
+    }
+
+    fn request(contents: Vec<ProviderContent>) -> ProviderRequest {
+        ProviderRequest {
+            contents,
+            system_instruction: None,
+            tools: None,
+            generation_config: None,
+            service_tier: None,
+            provider: None,
+            model_size: None,
+        }
+    }
+
+    #[test]
+    fn system_goes_to_instructions_and_user_to_input() {
+        let mut req = request(vec![user("Hello")]);
+        req.system_instruction = Some(ProviderContent {
+            role: None,
+            parts: Some(vec![text_part("Be terse")]),
+        });
+        let body = provider_request_to_responses_body("gpt-5", &req);
+        assert_eq!(body["instructions"], "Be terse");
+        let input = body["input"].as_array().unwrap();
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+        assert_eq!(input[0]["content"], "Hello");
+        assert_eq!(body["model"], "gpt-5");
+    }
+
+    #[test]
+    fn tool_call_and_result_become_flat_items() {
+        let req = request(vec![
+            user("Find weather"),
+            assistant_with_tool_call(Some("call_1"), "get_weather", json!({"city": "SF"})),
+            tool_response(Some("call_1"), "get_weather", json!({"temp": 60})),
+            user("Thanks"),
+        ]);
+        let body = provider_request_to_responses_body("gpt-5", &req);
+        let input = body["input"].as_array().unwrap();
+        assert_eq!(input.len(), 4);
+        assert_eq!(input[0]["content"], "Find weather");
+        assert_eq!(input[1]["type"], "function_call");
+        assert_eq!(input[1]["call_id"], "call_1");
+        assert_eq!(input[1]["name"], "get_weather");
+        assert_eq!(input[1]["arguments"], "{\"city\":\"SF\"}");
+        assert_eq!(input[2]["type"], "function_call_output");
+        assert_eq!(input[2]["call_id"], "call_1");
+        assert_eq!(input[2]["output"], "{\"temp\":60}");
+        assert_eq!(input[3]["content"], "Thanks");
+    }
+
+    #[test]
+    fn tools_are_flat_and_reasoning_forwarded_with_tools() {
+        let mut req = request(vec![user("hi")]);
+        req.tools = Some(vec![ProviderTool {
+            function_declarations: vec![ProviderFunctionDeclaration {
+                name: "lookup".to_string(),
+                description: "find a thing".to_string(),
+                parameters: json!({"type": "object", "properties": {}}),
+            }],
+        }]);
+        req.generation_config = Some(ProviderGenerationConfig {
+            max_output_tokens: Some(100),
+            thinking_config: Some(ProviderThinkingConfig {
+                include_thoughts: Some(true),
+                thinking_level: Some(ProviderThinkingLevel::High),
+            }),
+            ..Default::default()
+        });
+        let body = provider_request_to_responses_body("gpt-5", &req);
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["type"], "function");
+        assert_eq!(tools[0]["name"], "lookup");
+        assert_eq!(tools[0]["parameters"]["type"], "object");
+        // Responses allows reasoning + tools together.
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert_eq!(body["max_output_tokens"], 100);
+        assert!(body.get("temperature").is_none());
+    }
+
+    #[test]
+    fn parses_text_response_with_reasoning_usage() {
+        let value = json!({
+            "model": "gpt-5-2026",
+            "status": "completed",
+            "output": [
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "thinking"}]},
+                {"type": "message", "role": "assistant", "content": [
+                    {"type": "output_text", "text": "hello there"}
+                ]}
+            ],
+            "usage": {
+                "input_tokens": 10,
+                "input_tokens_details": {"cached_tokens": 4},
+                "output_tokens": 20,
+                "output_tokens_details": {"reasoning_tokens": 12},
+                "total_tokens": 30
+            }
+        });
+        let resp = parse_openai_responses_response(value).unwrap();
+        let cand = &resp.candidates.as_ref().unwrap()[0];
+        assert_eq!(cand.finish_reason, Some(ProviderFinishReason::Stop));
+        let parts = cand.content.as_ref().unwrap().parts.as_ref().unwrap();
+        assert!(
+            parts
+                .iter()
+                .any(|p| p.thought == Some(true) && p.text.as_deref() == Some("thinking"))
+        );
+        assert!(parts.iter().any(|p| p.text.as_deref() == Some("hello there")));
+        let usage = resp.usage_metadata.unwrap();
+        assert_eq!(usage.prompt_token_count, Some(10));
+        assert_eq!(usage.candidates_token_count, Some(20));
+        assert_eq!(usage.total_token_count, Some(30));
+        assert_eq!(usage.cache_read_input_tokens, Some(4));
+        assert_eq!(usage.reasoning_token_count, Some(12));
+        assert_eq!(resp.model_version.as_deref(), Some("gpt-5-2026"));
+    }
+
+    #[test]
+    fn parses_function_call_response() {
+        let value = json!({
+            "model": "gpt-5",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_abc",
+                    "name": "get_weather",
+                    "arguments": "{\"city\": \"SF\"}"
+                }
+            ],
+            "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        });
+        let resp = parse_openai_responses_response(value).unwrap();
+        let cand = &resp.candidates.as_ref().unwrap()[0];
+        assert_eq!(cand.finish_reason, Some(ProviderFinishReason::Stop));
+        let parts = cand.content.as_ref().unwrap().parts.as_ref().unwrap();
+        let fc = parts[0].function_call.as_ref().unwrap();
+        assert_eq!(fc.id.as_deref(), Some("call_abc"));
+        assert_eq!(fc.name, "get_weather");
+        assert_eq!(fc.args.as_ref().unwrap()["city"], "SF");
+    }
+
+    #[test]
+    fn incomplete_max_output_tokens_maps_to_max_tokens() {
+        let value = json!({
+            "model": "gpt-5",
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output": []
+        });
+        let resp = parse_openai_responses_response(value).unwrap();
+        let cand = &resp.candidates.as_ref().unwrap()[0];
+        assert_eq!(cand.finish_reason, Some(ProviderFinishReason::MaxTokens));
+    }
+}

--- a/app-server/src/llm/openai_responses/mod.rs
+++ b/app-server/src/llm/openai_responses/mod.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(not(feature = "signals"), allow(dead_code))]
+
+mod accumulator;
+pub mod client;
+pub mod conversions;
+
+pub use client::OpenAIResponsesClient;

--- a/app-server/src/llm/sse.rs
+++ b/app-server/src/llm/sse.rs
@@ -10,8 +10,11 @@ use crate::llm::models::{ProviderResponse, ProviderStreamChunk};
 
 pub(crate) trait StreamAccumulator: Default {
     type Chunk: DeserializeOwned;
+    /// Error surfaced when the terminal event indicates the provider failed the
+    /// request (e.g. a Responses `response.failed` event).
+    type Error;
     fn ingest(&mut self, chunk: Self::Chunk, tx: &UnboundedSender<ProviderStreamChunk>);
-    fn into_response(self, model: &str) -> ProviderResponse;
+    fn into_response(self, model: &str) -> Result<ProviderResponse, Self::Error>;
 }
 
 pub(crate) async fn accumulate_sse<A, E>(
@@ -21,7 +24,7 @@ pub(crate) async fn accumulate_sse<A, E>(
 ) -> Result<ProviderResponse, E>
 where
     A: StreamAccumulator,
-    E: From<reqwest::Error> + From<serde_json::Error>,
+    E: From<reqwest::Error> + From<serde_json::Error> + From<A::Error>,
 {
     let mut accumulator = A::default();
     let mut payloads = Box::pin(sse_data_stream(byte_stream));
@@ -29,7 +32,7 @@ where
         let chunk: A::Chunk = serde_json::from_str(&payload?)?;
         accumulator.ingest(chunk, tx);
     }
-    Ok(accumulator.into_response(model))
+    accumulator.into_response(model).map_err(E::from)
 }
 
 fn sse_data_stream(

--- a/app-server/src/llm/sse.rs
+++ b/app-server/src/llm/sse.rs
@@ -14,7 +14,7 @@ pub(crate) trait StreamAccumulator: Default {
     /// request (e.g. a Responses `response.failed` event).
     type Error;
     fn ingest(&mut self, chunk: Self::Chunk, tx: &UnboundedSender<ProviderStreamChunk>);
-    fn into_response(self, model: &str) -> Result<ProviderResponse, Self::Error>;
+    fn try_into_response(self, model: &str) -> Result<ProviderResponse, Self::Error>;
 }
 
 pub(crate) async fn accumulate_sse<A, E>(
@@ -32,7 +32,7 @@ where
         let chunk: A::Chunk = serde_json::from_str(&payload?)?;
         accumulator.ingest(chunk, tx);
     }
-    accumulator.into_response(model).map_err(E::from)
+    accumulator.try_into_response(model).map_err(E::from)
 }
 
 fn sse_data_stream(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core LLM routing and streaming for all OpenAI-family providers; misconfiguration or conversion bugs could break Signals/tool flows, though changes are largely additive with broad unit tests.
> 
> **Overview**
> Adds a new **`openai_responses`** LLM provider (`LLM_PROVIDER=openai_responses`) that talks to OpenAI’s **`/responses`** API alongside the existing Chat Completions client. It maps internal requests to the Responses wire format (flat `input` items, `instructions`, tools, **`reasoning.effort` + `summary: auto`** even when function tools are present), streams via Responses SSE events, and **reports usage under the canonical `openai` name** for cost/observability.
> 
> **Shared plumbing:** Chat Completions HTTP setup is factored into **`build_http_config`** / **`send_openai_request`** in `openai/mod.rs`. SSE **`StreamAccumulator`** now uses **`try_into_response`** so terminal failures (e.g. `response.failed`) surface as errors instead of empty responses.
> 
> **Usage & reasoning:** **`ProviderUsageMetadata`** gains **`reasoning_token_count`** (Gemini thoughts tokens; Responses `output_tokens_details.reasoning_tokens`). Chat Completions non-streaming parsing now maps proxy **`reasoning_content` / `reasoning`** fields to thought parts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c928407fc93c189f333c7c88ad9076e7f3296710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

