### PR TITLE
feat: fix circular barrel import

### DIFF
--- a/frontend/components/ui/infinite-datatable/model/table-config-store.tsx
+++ b/frontend/components/ui/infinite-datatable/model/table-config-store.tsx
@@ -6,7 +6,7 @@ import { createStore, type StoreApi } from "zustand";
 import { shallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 
-import { type CustomColumn } from "@/components/ui/columns-menu";
+import type { CustomColumn } from "@/components/ui/columns-menu/types";
 import { type Filter } from "@/lib/actions/common/filters";
 
 import { EMPTY_VIEW_PARAMS, type ViewParams } from "../views/params";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single import-path change for a type-only dependency; no runtime logic or API surface changes.
> 
> **Overview**
> **Breaks a circular barrel import** between the infinite datatable config store and the columns menu UI.
> 
> `table-config-store` now imports `CustomColumn` from `@/components/ui/columns-menu/types` instead of `@/components/ui/columns-menu`. The barrel re-exports `ColumnsMenu`, which already depends on `useTableConfigStore` from the store—so pulling types through the index created a cycle at module load time.
> 
> No behavior change to table config or column types; only the import path (and `import type` style) changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2742aca56dbee7ecbdaa9d92507ececb80fd1fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->