### PR TITLE
fix: leaf cluster pick

### DIFF
--- a/frontend/lib/actions/signals/trace.ts
+++ b/frontend/lib/actions/signals/trace.ts
@@ -34,7 +34,7 @@ export type TraceSignal = {
 
 type SignalEventRow = EventRow & { clusters: string[] | null };
 
-/** Pick the deepest (highest-level) named cluster for one event's cluster ids. */
+/** Pick the finest named cluster (min level > 0 = L1 leaf) for one event. */
 function pickLeafCluster(
   clusterIds: string[] | null,
   clusterMeta: Map<string, TraceSignalClusterNode>
@@ -43,13 +43,13 @@ function pickLeafCluster(
     (clusterIds ?? [])
       .map((id) => clusterMeta.get(id))
       .filter((n): n is TraceSignalClusterNode => !!n)
-      .sort((a, b) => b.level - a.level)[0] ?? null
+      .sort((a, b) => a.level - b.level)[0] ?? null
   );
 }
 
 /**
  * Signals (with their events) that fired on a trace, for the trace-view panel.
- * Each event carries its own deepest (leaf) cluster; the signal-level leaf
+ * Each event carries its own L1 (finest named) cluster; the signal-level leaf
  * cluster (its latest event's) drives the panel accent color.
  */
 export async function getTraceSignals(input: z.infer<typeof GetTraceSignalsSchema>): Promise<TraceSignal[]> {
@@ -85,9 +85,9 @@ export async function getTraceSignals(input: z.infer<typeof GetTraceSignalsSchem
     eventsBySignal.set(e.signalId, list);
   }
 
-  // The panel shows a leaf cluster per event (one finding may cluster
+  // The panel shows an L1 leaf cluster per event (one finding may cluster
   // differently from another), so gather cluster metadata for every event's
-  // clusters to pick each one's deepest node.
+  // clusters to pick each one's finest named node.
   const allClusterIds = new Set<string>();
   for (const events of eventsBySignal.values()) {
     for (const e of events) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single sort-direction fix in trace signal display logic with no auth, data, or API contract changes.
> 
> **Overview**
> **Fixes which cluster is shown** for each signal event on the trace-view panel when an event belongs to multiple named clusters in its ancestor chain.
> 
> `pickLeafCluster` now selects the **lowest `level`** (finest named / L1 leaf) instead of the highest level (coarsest parent). Comments in `getTraceSignals` are updated to match that semantics. Signal-level accent color still comes from the latest event’s chosen cluster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db4082aa4fbfcf054be7eae9327f69be8e2efc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->