### PR TITLE
feat: posthog inject head, move providers to body

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -68,27 +68,23 @@ export default async function RootLayout({ children }: PropsWithChildren) {
   const session = posthogEnabled ? await getServerSession().catch(() => null) : null;
   const email = session?.user?.email ?? undefined;
 
-  const body = (
-    <body className="flex flex-col h-full">
-      <BasePathFetchShim />
-      <NuqsAdapter>
-        <div className="flex">
-          <div className="flex flex-col grow max-w-full min-h-screen">
-            <main className="z-10 flex flex-col grow">{children}</main>
-            <Toaster />
-          </div>
-        </div>
-      </NuqsAdapter>
-    </body>
-  );
-
   return (
     <html lang="en" className={cn("h-full antialiased", sans.variable, manrope.variable, sansLanding.variable)}>
-      <FeatureFlagsProvider flags={featureFlags}>
-        <PostHogProvider telemetryEnabled={posthogEnabled} email={email}>
-          {body}
-        </PostHogProvider>
-      </FeatureFlagsProvider>
+      <body className="flex flex-col h-full">
+        <BasePathFetchShim />
+        <FeatureFlagsProvider flags={featureFlags}>
+          <PostHogProvider telemetryEnabled={posthogEnabled} email={email}>
+            <NuqsAdapter>
+              <div className="flex">
+                <div className="flex flex-col grow max-w-full min-h-screen">
+                  <main className="z-10 flex flex-col grow">{children}</main>
+                  <Toaster />
+                </div>
+              </div>
+            </NuqsAdapter>
+          </PostHogProvider>
+        </FeatureFlagsProvider>
+      </body>
     </html>
   );
 }

--- a/frontend/lib/posthog/client.ts
+++ b/frontend/lib/posthog/client.ts
@@ -41,6 +41,7 @@ export const init = (telemetryEnabled: boolean) => {
   if (posthog.__loaded) return;
   posthog.init(POSTHOG_KEY, {
     api_host: POSTHOG_HOST,
+    external_scripts_inject_target: "head",
     person_profiles: "identified_only",
     capture_pageview: "history_change",
     session_recording: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small layout and PostHog client config changes with no auth, data, or business-logic impact.
> 
> **Overview**
> **Root layout** now places `FeatureFlagsProvider` and `PostHogProvider` inside `<body>` instead of wrapping the body from under `<html>`, so the React tree matches valid document structure while keeping the same app shell (`NuqsAdapter`, main, `Toaster`).
> 
> **PostHog init** sets `external_scripts_inject_target: "head"` so PostHog’s externally loaded scripts are injected into the document head rather than the default target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dbb98092ce142be935902821ba307af5ee64e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->