### PR TITLE
expose metadata map, add partitioning

### DIFF
--- a/frontend/lib/clickhouse/migrations/54_traces_agg.sql
+++ b/frontend/lib/clickhouse/migrations/54_traces_agg.sql
@@ -84,6 +84,7 @@ CREATE TABLE IF NOT EXISTS default.trace_agent_input
 )
 ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY (project_id, trace_id)
+PARTITION BY toYYYYMM(start_time)
 SETTINGS index_granularity = 8192;
 
 CREATE TABLE IF NOT EXISTS default.trace_agent_output
@@ -94,6 +95,7 @@ CREATE TABLE IF NOT EXISTS default.trace_agent_output
     `updated_at` DateTime64(9, 'UTC') DEFAULT now64(9)
 )
 ENGINE = ReplacingMergeTree(updated_at)
+PARTITION BY toYYYYMM(start_time)
 ORDER BY (project_id, trace_id)
 SETTINGS index_granularity = 8192;
 
@@ -132,6 +134,7 @@ SELECT
             '}'
         )
     ) AS metadata,
+    t.metadata as metadata_map,
     t.session_id AS session_id,
     t.user_id AS user_id,
     -- no status-bearing spans resolves to 'success', matching traces_v0's two-value contract
@@ -159,21 +162,7 @@ SELECT
     toBool(t.has_browser_session) AS has_browser_session,
     t.id AS id,
     t.span_names AS span_names,
-    if(
-        length(mapKeys(t.internal_metadata)) = 0,
-        '',
-        concat(
-            '{',
-            arrayStringConcat(
-                arrayMap(
-                    (k, v) -> concat(toJSONString(k), ':', v),
-                    mapKeys(t.internal_metadata), mapValues(t.internal_metadata)
-                ),
-                ','
-            ),
-            '}'
-        )
-    ) AS internal_metadata,
+    t.internal_metadata AS internal_metadata,
     ifNull(ai.value, '') AS agent_input,
     ifNull(ao.value, '') AS agent_output
 FROM (

--- a/frontend/lib/clickhouse/migrations/54_traces_agg.sql
+++ b/frontend/lib/clickhouse/migrations/54_traces_agg.sql
@@ -84,7 +84,7 @@ CREATE TABLE IF NOT EXISTS default.trace_agent_input
 )
 ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY (project_id, trace_id)
-PARTITION BY toYYYYMM(start_time)
+PARTITION BY toYYYYMM(updated_at)
 SETTINGS index_granularity = 8192;
 
 CREATE TABLE IF NOT EXISTS default.trace_agent_output
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS default.trace_agent_output
     `updated_at` DateTime64(9, 'UTC') DEFAULT now64(9)
 )
 ENGINE = ReplacingMergeTree(updated_at)
-PARTITION BY toYYYYMM(start_time)
+PARTITION BY toYYYYMM(updated_at)
 ORDER BY (project_id, trace_id)
 SETTINGS index_granularity = 8192;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changing internal_metadata from a string to a Map is a breaking contract for any consumer expecting JSON text; partitioning new DDL affects deploy/migration behavior on existing ReplacingMergeTree data.
> 
> **Overview**
> Updates the **`traces_agg_v0`** view and related ClickHouse DDL so trace metadata is available as native maps and agent I/O tables are monthly partitioned.
> 
> **`trace_agent_input`** and **`trace_agent_output`** now use **`PARTITION BY toYYYYMM(updated_at)`**, aligning pruning with how **`traces_agg`** partitions on **`start_time`**.
> 
> The view adds **`metadata_map`** (`t.metadata`) alongside the existing string **`metadata`** column, so callers can query key/value metadata without parsing the concatenated JSON string.
> 
> **`internal_metadata`** is no longer built with the same `concat`/`arrayMap` JSON string logic; it is exposed as **`t.internal_metadata`** (the aggregated **`Map(String, String)`**), matching how metadata is stored in **`traces_agg`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff35a04558cb3094ab52f07958b69c3b85e2a393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

