### PR TITLE
fix metadata patch and max end_time

### DIFF
--- a/app-server/src/ch/traces_agg.rs
+++ b/app-server/src/ch/traces_agg.rs
@@ -165,15 +165,30 @@ impl CHTraceAgg {
     /// standpoint, so this is best-effort, not LWW) and `num_spans` (+1,
     /// matching the PG counter bump that pays for the virtual metadata-only
     /// span). `now_ns` is the fallback timestamp.
+    ///
+    /// A patch that beats the trace's real span batch creates a stub row with
+    /// `now()` placeholder start/end times (`Trace::is_stub`). In
+    /// `traces_replacing`, the later aggregation upsert explicitly discards a
+    /// stub's placeholder times before applying `LEAST`/`GREATEST`, so the
+    /// placeholder is harmless there. `traces_agg`'s `end_time` is a
+    /// `SimpleAggregateFunction(max, ...)` with no such correction — once a
+    /// too-late placeholder is merged in, no later, earlier, correct partial
+    /// can ever lower it back down. So for a stub row this emits the `min`/
+    /// `max` identities (epoch / `i64::MAX` ns) instead of the placeholder,
+    /// making this partial a no-op on both aggregates until a real span
+    /// batch's own partial supplies the true times.
     pub fn from_patched_trace(trace: &Trace, now_ns: i64) -> Self {
-        let start_time = trace
-            .start_time()
-            .map(chrono_to_nanoseconds)
-            .unwrap_or(now_ns);
-        let end_time = trace
-            .end_time()
-            .map(chrono_to_nanoseconds)
-            .unwrap_or(now_ns);
+        let (start_time, end_time) = if trace.is_stub() {
+            (i64::MAX, 0)
+        } else {
+            (
+                trace
+                    .start_time()
+                    .map(chrono_to_nanoseconds)
+                    .unwrap_or(now_ns),
+                trace.end_time().map(chrono_to_nanoseconds).unwrap_or(now_ns),
+            )
+        };
 
         CHTraceAgg {
             id: trace.id(),
@@ -222,9 +237,54 @@ impl ClickhouseInsertable for CHTraceAgg {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn from_patched_trace_stub_row_emits_identity_times() {
+        // A patch that beats the real span batch creates a stub row
+        // (span_names still NULL) with `now()` placeholder start/end times.
+        // Those placeholders must never ride into traces_agg's min/max
+        // aggregates — otherwise a too-late placeholder `end_time` would
+        // permanently inflate the aggregate via `max`, since no later,
+        // correct, earlier partial can ever lower it back down.
+        let now_ns = 1_000_000_000;
+        let trace = Trace::test_new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Some(Utc::now()),
+            Some(Utc::now()),
+            None, // span_names: None => stub
+        );
+        assert!(trace.is_stub());
+
+        let row = CHTraceAgg::from_patched_trace(&trace, now_ns);
+        assert_eq!(row.start_time, i64::MAX, "min identity for start_time");
+        assert_eq!(row.end_time, 0, "max identity for end_time");
+    }
+
+    #[test]
+    fn from_patched_trace_real_row_keeps_its_times() {
+        // A patch against an already-real row (span_names populated by a
+        // prior aggregation upsert) must propagate the real times verbatim —
+        // only the stub case is special-cased.
+        let start = Utc::now();
+        let end = Utc::now();
+        let trace = Trace::test_new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Some(start),
+            Some(end),
+            Some(json!({"some_span": true})),
+        );
+        assert!(!trace.is_stub());
+
+        let row = CHTraceAgg::from_patched_trace(&trace, 0);
+        assert_eq!(row.start_time, chrono_to_nanoseconds(start));
+        assert_eq!(row.end_time, chrono_to_nanoseconds(end));
+    }
 
     #[test]
     fn metadata_values_are_raw_json() {

--- a/app-server/src/ch/traces_agg.rs
+++ b/app-server/src/ch/traces_agg.rs
@@ -173,13 +173,24 @@ impl CHTraceAgg {
     /// placeholder is harmless there. `traces_agg`'s `end_time` is a
     /// `SimpleAggregateFunction(max, ...)` with no such correction — once a
     /// too-late placeholder is merged in, no later, earlier, correct partial
-    /// can ever lower it back down. So for a stub row this emits the `min`/
-    /// `max` identities (epoch / `i64::MAX` ns) instead of the placeholder,
-    /// making this partial a no-op on both aggregates until a real span
-    /// batch's own partial supplies the true times.
+    /// can ever lower it back down. So for a stub row this emits `end_time =
+    /// 0` (the `max` identity) instead of the placeholder, making this
+    /// partial a no-op on `end_time` until a real span batch's own partial
+    /// supplies the true value.
+    ///
+    /// `start_time` can't use the `min` identity (epoch 0 / `i64::MAX`) the
+    /// same way: `traces_agg` is `PARTITION BY toYYYYMM(start_time)`, so an
+    /// epoch or far-future value would land this partial in a different
+    /// partition than the real span batch's — and the two partials would
+    /// never merge together. Instead use `now_ns + 1h`: any real trace's
+    /// `start_time` is at or before ingest time, so `min` still always picks
+    /// the real value once it arrives, while staying in the same (or an
+    /// adjacent) monthly partition as `now_ns` so the merge is local.
     pub fn from_patched_trace(trace: &Trace, now_ns: i64) -> Self {
+        const STUB_START_TIME_OFFSET_NS: i64 = 60 * 60 * 1_000_000_000;
+
         let (start_time, end_time) = if trace.is_stub() {
-            (i64::MAX, 0)
+            (now_ns + STUB_START_TIME_OFFSET_NS, 0)
         } else {
             (
                 trace
@@ -243,12 +254,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_patched_trace_stub_row_emits_identity_times() {
+    fn from_patched_trace_stub_row_avoids_placeholder_times() {
         // A patch that beats the real span batch creates a stub row
         // (span_names still NULL) with `now()` placeholder start/end times.
         // Those placeholders must never ride into traces_agg's min/max
-        // aggregates — otherwise a too-late placeholder `end_time` would
-        // permanently inflate the aggregate via `max`, since no later,
+        // aggregates as-is — otherwise a too-late placeholder `end_time`
+        // would permanently inflate the aggregate via `max`, since no later,
         // correct, earlier partial can ever lower it back down.
         let now_ns = 1_000_000_000;
         let trace = Trace::test_new(
@@ -261,8 +272,17 @@ mod tests {
         assert!(trace.is_stub());
 
         let row = CHTraceAgg::from_patched_trace(&trace, now_ns);
-        assert_eq!(row.start_time, i64::MAX, "min identity for start_time");
+        // end_time uses the true `max` identity: harmless no-op until a real
+        // span batch supplies the actual value.
         assert_eq!(row.end_time, 0, "max identity for end_time");
+        // start_time can't use the `min` identity (epoch/i64::MAX) because
+        // traces_agg partitions on toYYYYMM(start_time) — an epoch or
+        // far-future value would land this partial in a different partition
+        // than the real span batch's, and the two would never merge. Instead
+        // it's nudged 1h into the future of ingest time: still a `min`
+        // no-op against any real (past-or-present) start_time, while staying
+        // in the same/adjacent monthly partition.
+        assert_eq!(row.start_time, now_ns + 60 * 60 * 1_000_000_000);
     }
 
     #[test]

--- a/app-server/src/db/trace.rs
+++ b/app-server/src/db/trace.rs
@@ -147,6 +147,57 @@ impl Trace {
             .unwrap_or_default()
     }
 
+    /// True when this row has never been touched by a real span batch —
+    /// `span_names` is set by every aggregation upsert and never by a
+    /// metadata-only patch, so `NULL` means the row is either a freshly
+    /// created stub (patch beat the trace's span batch) or, on the RETURNING
+    /// path, still is one after this very patch. Placeholder `now()`
+    /// start/end times on such a row must never be treated as real.
+    pub fn is_stub(&self) -> bool {
+        self.span_names.is_none()
+    }
+
+    /// Test-only constructor so other modules' tests (e.g. `ch::traces_agg`)
+    /// can build a `Trace` without reaching into its private fields.
+    #[cfg(test)]
+    pub fn test_new(
+        id: Uuid,
+        project_id: Uuid,
+        start_time: Option<DateTime<Utc>>,
+        end_time: Option<DateTime<Utc>>,
+        span_names: Option<Value>,
+    ) -> Self {
+        Trace {
+            id,
+            start_time,
+            end_time,
+            trace_type: 0,
+            top_span_id: None,
+            top_span_name: None,
+            top_span_type: None,
+            session_id: None,
+            metadata: None,
+            user_id: None,
+            input_token_count: 0,
+            output_token_count: 0,
+            total_token_count: 0,
+            cache_read_input_tokens: Some(0),
+            cache_creation_input_tokens: Some(0),
+            reasoning_tokens: Some(0),
+            input_cost: 0.0,
+            output_cost: 0.0,
+            cost: 0.0,
+            project_id,
+            status: None,
+            tags: vec![],
+            num_spans: 1,
+            has_browser_session: None,
+            span_names,
+            root_span_input: None,
+            root_span_output: None,
+        }
+    }
+
     #[cfg_attr(not(feature = "signals"), allow(dead_code))]
     pub fn matches_filters(&self, spans: &[Span], filters: &[Filter]) -> bool {
         if filters.is_empty() {

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -251,32 +251,28 @@ pub async fn process_span_messages(
     }
     messages.retain(|m| !m.span.attributes.is_metadata_only());
 
-    // `traces_replacing` path: surface extracted io as trace metadata keys so
-    // it lands in `traces_replacing.metadata` (the current read path). Only
-    // needed while that table is the read path — once `WRITE_TRACES_AGG` is
-    // on, io is already fully served by the `trace_agent_input`/`_output`
-    // supplementary tables (written unconditionally below), so this fold is
-    // skipped entirely. It MUST be skipped, not just redundant: folding it in
-    // also feeds `CHTraceAgg::from_patched_trace` (below), whose stub-row
-    // placeholder `now()` times can otherwise permanently inflate
-    // `traces_agg.end_time` via its `max` aggregate — a real bug independent
-    // of the metadata-key duplication.
-    if !env::clickhouse::WRITE_TRACES_AGG.get() {
-        for io in &raw_trace_io {
-            let mut map = serde_json::Map::new();
-            if let Some(value) = &io.input {
-                map.insert(USER_TASK_METADATA_KEY.to_string(), value.clone());
-            }
-            if let Some(value) = &io.output {
-                map.insert(TRACE_OUTPUT_METADATA_KEY.to_string(), value.clone());
-            }
-            if !map.is_empty() {
-                metadata_patches.push(TraceMetadataPatch {
-                    trace_id: io.trace_id,
-                    project_id: io.project_id,
-                    metadata: Value::Object(map),
-                });
-            }
+    // `traces_replacing` path: surface extracted io as trace metadata keys
+    // so it lands in `traces_replacing.metadata` (the current read path).
+    // Written on BOTH flag states for now — while `WRITE_TRACES_AGG` is a
+    // migration bridge, io lives in both `traces_replacing.metadata` AND the
+    // `trace_agent_input`/`_output` supplementary tables. Once the read path
+    // cuts over to `traces_agg_v0`, gate this fold on `!WRITE_TRACES_AGG` (or
+    // drop it) — all metadata-key knowledge of io lives here and dies with
+    // the old table.
+    for io in &raw_trace_io {
+        let mut map = serde_json::Map::new();
+        if let Some(value) = &io.input {
+            map.insert(USER_TASK_METADATA_KEY.to_string(), value.clone());
+        }
+        if let Some(value) = &io.output {
+            map.insert(TRACE_OUTPUT_METADATA_KEY.to_string(), value.clone());
+        }
+        if !map.is_empty() {
+            metadata_patches.push(TraceMetadataPatch {
+                trace_id: io.trace_id,
+                project_id: io.project_id,
+                metadata: Value::Object(map),
+            });
         }
     }
 

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -251,28 +251,32 @@ pub async fn process_span_messages(
     }
     messages.retain(|m| !m.span.attributes.is_metadata_only());
 
-    // `traces_replacing` path: surface extracted io as trace metadata keys
-    // so it lands in `traces_replacing.metadata` (the current read path).
-    // Written on BOTH flag states for now — while `WRITE_TRACES_AGG` is a
-    // migration bridge, io lives in both `traces_replacing.metadata` AND the
-    // `trace_agent_input`/`_output` supplementary tables. Once the read path
-    // cuts over to `traces_agg_v0`, gate this fold on `!WRITE_TRACES_AGG` (or
-    // drop it) — all metadata-key knowledge of io lives here and dies with
-    // the old table.
-    for io in &raw_trace_io {
-        let mut map = serde_json::Map::new();
-        if let Some(value) = &io.input {
-            map.insert(USER_TASK_METADATA_KEY.to_string(), value.clone());
-        }
-        if let Some(value) = &io.output {
-            map.insert(TRACE_OUTPUT_METADATA_KEY.to_string(), value.clone());
-        }
-        if !map.is_empty() {
-            metadata_patches.push(TraceMetadataPatch {
-                trace_id: io.trace_id,
-                project_id: io.project_id,
-                metadata: Value::Object(map),
-            });
+    // `traces_replacing` path: surface extracted io as trace metadata keys so
+    // it lands in `traces_replacing.metadata` (the current read path). Only
+    // needed while that table is the read path — once `WRITE_TRACES_AGG` is
+    // on, io is already fully served by the `trace_agent_input`/`_output`
+    // supplementary tables (written unconditionally below), so this fold is
+    // skipped entirely. It MUST be skipped, not just redundant: folding it in
+    // also feeds `CHTraceAgg::from_patched_trace` (below), whose stub-row
+    // placeholder `now()` times can otherwise permanently inflate
+    // `traces_agg.end_time` via its `max` aggregate — a real bug independent
+    // of the metadata-key duplication.
+    if !env::clickhouse::WRITE_TRACES_AGG.get() {
+        for io in &raw_trace_io {
+            let mut map = serde_json::Map::new();
+            if let Some(value) = &io.input {
+                map.insert(USER_TASK_METADATA_KEY.to_string(), value.clone());
+            }
+            if let Some(value) = &io.output {
+                map.insert(TRACE_OUTPUT_METADATA_KEY.to_string(), value.clone());
+            }
+            if !map.is_empty() {
+                metadata_patches.push(TraceMetadataPatch {
+                    trace_id: io.trace_id,
+                    project_id: io.project_id,
+                    metadata: Value::Object(map),
+                });
+            }
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes trace aggregation ingest timing logic for a race between metadata patches and span batches; wrong stub handling could still mis-partition or skew min/max until real spans arrive.
> 
> **Overview**
> Fixes **ClickHouse `traces_agg`** when a metadata patch lands before the trace’s span batch and Postgres still has a **stub** row (`span_names` NULL) with `now()` placeholder start/end times.
> 
> **`Trace::is_stub()`** identifies those rows (metadata-only patches never set `span_names`). **`CHTraceAgg::from_patched_trace`** no longer forwards placeholder times for stubs: **`end_time = 0`** so `max` is a no-op until a real span partial sets the true end, and **`start_time = now_ns + 1h`** so `min` still picks the real start when it arrives without putting the partial in a different monthly partition than the span batch. Non-stub patches keep propagating real times unchanged.
> 
> Adds **`Trace::test_new`** for cross-module tests and unit tests for stub vs real patched traces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7173346cf71442d6472812fd1dc54aa0b8d7b833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->