### PR TITLE
allow reasoning effort with tools for openai if known

### DIFF
--- a/app-server/src/env/llm.rs
+++ b/app-server/src/env/llm.rs
@@ -40,3 +40,6 @@ pub const FLEX_LLM_TIMEOUT_SECS: NumEnv<u64> = NumEnv::new("SIGNALS_FLEX_LLM_TIM
 /// default, so it's raised and made configurable. Gemini flex-tier requests
 /// override this per-request with `FLEX_LLM_TIMEOUT_SECS`.
 pub const HTTP_TIMEOUT_SECS: NumEnv<u64> = NumEnv::new("LLM_HTTP_TIMEOUT_SECS", 300);
+
+pub const OPENAI_ALLOW_REASONING_WITH_TOOLS: BoolEnv =
+    BoolEnv::new("OPENAI_ALLOW_REASONING_WITH_TOOLS", false);

--- a/app-server/src/llm/openai/conversions.rs
+++ b/app-server/src/llm/openai/conversions.rs
@@ -77,8 +77,10 @@ pub fn provider_request_to_openai_body(model: &str, request: &ProviderRequest) -
         // gpt-5 reasoning models reject `reasoning_effort` + function tools on
         // /v1/chat/completions (400, "use /v1/responses instead") — true for both
         // OpenAI direct and some OpenAI-compatible gateways (LAM-1771: Signals),
-        // so only forward `reasoning_effort` when no tools are present.
-        if !has_tools {
+        // so only forward `reasoning_effort` when no tools are present, unless the
+        // endpoint is known to support the combination.
+        let allow_reasoning_with_tools = crate::env::llm::OPENAI_ALLOW_REASONING_WITH_TOOLS.get();
+        if !has_tools || allow_reasoning_with_tools {
             if let Some(tc) = gc.thinking_config.as_ref() {
                 if let Some(level) = tc.thinking_level.as_ref() {
                     if let Some(effort) = thinking_level_to_effort(level) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior is unchanged unless the new env var is set true; misconfiguration could cause 400s from incompatible OpenAI-compatible gateways.
> 
> **Overview**
> OpenAI Chat Completions conversion still **drops** `reasoning_effort` when function tools are on the request, because many gpt-5-style endpoints return HTTP 400 for that combo. Operators can now **opt in** when their gateway supports both.
> 
> A new boolean env **`OPENAI_ALLOW_REASONING_WITH_TOOLS`** (default **`false`**) is wired in `app-server/src/env/llm.rs`. In `provider_request_to_openai_body`, `reasoning_effort` is forwarded from thinking config when there are **no** tools **or** when that flag is **true**—preserving today’s safe default while enabling tool + reasoning on known-good endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35167aeb547b0141560d8c9b41ad78058dd5ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

