### PR TITLE
fix agent output extraction to same path as input, simplify the lock

### DIFF
--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -60,7 +60,10 @@ pub const SPAN_KEEP_DEFAULT_RULES_CACHE_KEY: &str = "signals_span_keep_default_r
 pub const TRACE_EVALUATION_ID_CACHE_KEY: &str = "trace_evaluation_id";
 pub const USER_TASK_REGEX_CACHE_KEY: &str = "user_task_regex";
 pub const USER_TASK_LOCK_CACHE_KEY: &str = "user_task_lock";
-pub const TRACE_OUTPUT_LOCK_CACHE_KEY: &str = "trace_output_lock";
+/// Stripped path (ancestor names, own segment removed) of the current
+/// user-task input winner span — every LLM span on this same stripped path
+/// is a trace-output candidate. See `input_extraction::lock::main_agent_path_cache_key`.
+pub const MAIN_AGENT_PATH_CACHE_KEY: &str = "main_agent_path";
 
 pub const INGESTION_RATE_LIMIT_PROJECT_ID_CACHE_KEY: &str = "ingestion_rate_limit_project_id";
 /// Per-project override N for the /v1/sql rate limit, set out-of-band via

--- a/app-server/src/ch/trace_agent_io.rs
+++ b/app-server/src/ch/trace_agent_io.rs
@@ -27,16 +27,19 @@ pub struct CHTraceAgentInput {
 /// A `trace_agent_output` row. Unlike [`CHTraceAgentInput`], `updated_at`
 /// (the RMT version) is set EXPLICITLY to the winning span's end time in
 /// nanoseconds — output strength is "latest end time", so versioning on it
-/// makes FINAL converge on the lock's winner regardless of arrival order.
-/// Field order MUST match the CREATE TABLE column order (positional
-/// RowBinary): `(project_id, trace_id, value, updated_at)`.
+/// makes FINAL converge on the latest-ending answer regardless of arrival
+/// order. `hashes` are per-message hashes into `deduped_content` (LAM-1953
+/// rework — was a rendered `value: String`; every output message is already
+/// content-hashed by the dedup pipeline, so storing hashes avoids
+/// duplicating bytes). Field order MUST match the CREATE TABLE column order
+/// (positional RowBinary): `(project_id, trace_id, hashes, updated_at)`.
 #[derive(Debug, Clone, Serialize, Deserialize, Row)]
 pub struct CHTraceAgentOutput {
     #[serde(with = "clickhouse::serde::uuid")]
     pub project_id: Uuid,
     #[serde(with = "clickhouse::serde::uuid")]
     pub trace_id: Uuid,
-    pub value: String,
+    pub hashes: Vec<[u8; 32]>,
     /// Winning span end time, nanoseconds since epoch (CH `DateTime64(9)`).
     pub updated_at: i64,
 }

--- a/app-server/src/ch/traces_agg.rs
+++ b/app-server/src/ch/traces_agg.rs
@@ -10,9 +10,7 @@ use super::{
     ClickhouseInsertable, DataPlaneBatch, SPANS_CH_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS, Table,
 };
 use crate::db::trace::Trace;
-use crate::traces::input_extraction::metadata::{
-    TRACE_OUTPUT_METADATA_KEY, USER_TASK_METADATA_KEY,
-};
+use crate::traces::input_extraction::metadata::USER_TASK_METADATA_KEY;
 
 /// `statuses` Enum8 values; must match the DDL enum
 /// `Enum8('success' = 1, 'error' = 2)` in the traces_agg migration.
@@ -74,14 +72,13 @@ fn encode_metadata(metadata: Option<&Value>) -> Vec<(String, String)> {
         return Vec::new();
     };
     map.iter()
-        // Extracted io lives in the `trace_agent_input`/`trace_agent_output`
-        // supplementary tables, not the traces_agg maxMap. The metadata
-        // patch that carries these keys is written to `traces_replacing`
-        // (the current read path) AND flows here via `from_patched_trace`,
-        // so strip them to keep the two stores from diverging.
-        .filter(|(k, _)| {
-            k.as_str() != USER_TASK_METADATA_KEY && k.as_str() != TRACE_OUTPUT_METADATA_KEY
-        })
+        // Extracted input lives in the `trace_agent_input` supplementary
+        // table, not the traces_agg maxMap. The metadata patch that carries
+        // this key is written to `traces_replacing` (the current read path)
+        // AND flows here via `from_patched_trace`, so strip it to keep the
+        // two stores from diverging. (Output has no metadata-key
+        // equivalent to strip — see `input_extraction::metadata`.)
+        .filter(|(k, _)| k.as_str() != USER_TASK_METADATA_KEY)
         .map(|(k, v)| (k.clone(), v.to_string()))
         .collect()
 }
@@ -320,19 +317,19 @@ mod tests {
     }
 
     #[test]
-    fn extracted_io_keys_are_stripped_from_metadata() {
-        // The patch that carries these keys also lands in traces_replacing;
-        // here (traces_agg) they must NOT appear — io lives in the
-        // supplementary RMT tables.
+    fn extracted_input_key_is_stripped_from_metadata() {
+        // The patch that carries this key also lands in traces_replacing;
+        // here (traces_agg) it must NOT appear — input lives in the
+        // supplementary `trace_agent_input` table. Output has no metadata
+        // key at all (LAM-1953 rework: stored as hashes, never folded into
+        // `traces_replacing.metadata`), so there's nothing to strip for it.
         let metadata = json!({
             "user_key": "keep",
             "lmnr_user_task": "the task",
-            "lmnr_trace_output": "the answer",
         });
         let encoded = encode_metadata(Some(&metadata));
         assert!(encoded.iter().any(|(k, _)| k == "user_key"));
         assert!(!encoded.iter().any(|(k, _)| k == "lmnr_user_task"));
-        assert!(!encoded.iter().any(|(k, _)| k == "lmnr_trace_output"));
     }
 
     #[test]

--- a/app-server/src/traces/input_extraction/lock.rs
+++ b/app-server/src/traces/input_extraction/lock.rs
@@ -1,6 +1,5 @@
 //! Winner arbitration state: the per-trace record that arbitrates which
-//! LLM span's input owns the trace's user task, and which span's output
-//! owns the trace output.
+//! LLM span's input owns the trace's user task.
 //!
 //! Input arbitration is roster-based: the winner must be among the first
 //! [`ROSTER_CAP`] spans (by start time) at the shallowest observed depth,
@@ -14,13 +13,22 @@
 //! on `updated_at = now64()`, so a later qualifying write wins. This cache
 //! gate is the ONLY thing that decides which spans qualify — no manual
 //! version encoding, no clamping, no write mutex.
+//!
+//! Trace-output arbitration (LAM-1953 rework) does NOT have its own
+//! independent lock. Instead, whenever the input winner above is
+//! established, its stripped path (ancestor names, own segment removed) is
+//! cached under [`main_agent_path_cache_key`]. Every LLM span whose own
+//! stripped path equals that cached prefix is treated as being on the
+//! main-agent path and is eligible to update the trace output; the RMT
+//! version (`updated_at` = the span's end time) is what makes "latest wins"
+//! hold, so no separate depth/end-time gate is needed here.
 
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cache::keys::{TRACE_OUTPUT_LOCK_CACHE_KEY, USER_TASK_LOCK_CACHE_KEY};
+use crate::cache::keys::{MAIN_AGENT_PATH_CACHE_KEY, USER_TASK_LOCK_CACHE_KEY};
 use crate::cache::{Cache, CacheTrait};
 use crate::env::user_task::USER_TASK_LOCK_TTL_SECONDS;
 
@@ -32,8 +40,14 @@ pub fn lock_cache_key(project_id: Uuid, trace_id: Uuid) -> String {
     format!("{USER_TASK_LOCK_CACHE_KEY}:{project_id}:{trace_id}")
 }
 
-pub fn trace_output_lock_cache_key(project_id: Uuid, trace_id: Uuid) -> String {
-    format!("{TRACE_OUTPUT_LOCK_CACHE_KEY}:{project_id}:{trace_id}")
+/// Cache key for the current user-task input winner's stripped path
+/// (ancestor names, own segment removed). Every LLM span whose own stripped
+/// path equals this value is on the winning main-agent path and is a
+/// trace-output candidate (LAM-1953 rework: replaces the independent
+/// `OutputLockState` depth/end-time arbitration with reuse of the input
+/// winner).
+pub fn main_agent_path_cache_key(project_id: Uuid, trace_id: Uuid) -> String {
+    format!("{MAIN_AGENT_PATH_CACHE_KEY}:{project_id}:{trace_id}")
 }
 
 /// Roster span-id key: the last 16 hex chars of a span UUID's simple form.
@@ -225,49 +239,23 @@ pub async fn write_lock_merged(
     }
 }
 
-/// Winning-output state for the trace-output lock: the agent's final
-/// answer sits on the shallowest spine and is the LAST such message, so
-/// strictly shallower wins; at equal depth, strictly later end wins.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct OutputLockState {
-    /// Span path depth of the winning span.
-    #[serde(rename = "d")]
-    pub depth: usize,
-    /// End time (ns since epoch) of the winning span.
-    #[serde(rename = "t")]
-    pub end_time_ns: i64,
-}
-
-impl OutputLockState {
-    pub fn should_override(&self, candidate: &Self) -> bool {
-        if candidate.depth < self.depth {
-            return true;
-        }
-        candidate.depth == self.depth && candidate.end_time_ns > self.end_time_ns
-    }
-}
-
-/// Post-publish output-lock write: guarded (a stronger winner already in
-/// the lock is never rolled back). The output path has no queued consumer
-/// to re-assert a lock the producer failed to write, but the RMT row
-/// versions on `updated_at`, so a missed lock write only risks a
-/// redundant re-publish, not a wrong stored value. Best-effort (logged).
-pub(super) async fn write_output_lock_guarded(
+/// Write (or refresh the TTL of) the main-agent path cache for a trace.
+/// Called both when the input winner is (re-)established and, as a cheap
+/// keep-alive, whenever an output candidate matches the cached prefix — so
+/// a long-running trace's path cache doesn't expire mid-flight. Best-effort
+/// (logged).
+pub async fn write_main_agent_path(
     cache: &Arc<Cache>,
-    lock_key: &str,
-    state: &OutputLockState,
+    project_id: Uuid,
     trace_id: Uuid,
+    prefix: &[String],
 ) {
-    let current: Option<OutputLockState> = cache.get(lock_key).await.ok().flatten();
-    if current.is_some_and(|c| !c.should_override(state)) {
-        // A newer winner took the lock mid-flight: nothing to write.
-        return;
-    }
+    let key = main_agent_path_cache_key(project_id, trace_id);
     if let Err(e) = cache
-        .insert_with_ttl(lock_key, state, USER_TASK_LOCK_TTL_SECONDS.get())
+        .insert_with_ttl(&key, prefix, USER_TASK_LOCK_TTL_SECONDS.get())
         .await
     {
-        log::error!("trace-output: lock write failed for trace [{trace_id}]: {e:?}");
+        log::error!("trace-output: main-agent path write failed for trace [{trace_id}]: {e:?}");
     }
 }
 
@@ -298,8 +286,8 @@ mod tests {
         let t = Uuid::new_v4();
         assert_eq!(lock_cache_key(p, t), format!("user_task_lock:{p}:{t}"));
         assert_eq!(
-            trace_output_lock_cache_key(p, t),
-            format!("trace_output_lock:{p}:{t}")
+            main_agent_path_cache_key(p, t),
+            format!("main_agent_path:{p}:{t}")
         );
     }
 
@@ -498,29 +486,6 @@ mod tests {
         assert_eq!(stored.roster.len(), 2);
     }
 
-    #[tokio::test]
-    async fn write_output_lock_guarded_keeps_stronger_winner() {
-        use crate::cache::in_memory::InMemoryCache;
-        let cache: Arc<Cache> = Arc::new(Cache::InMemory(InMemoryCache::new(None)));
-        let trace_id = Uuid::new_v4();
-        let lock_key = format!("test_out_lock:{trace_id}");
-
-        // Stronger (later-ending) state lands first; a weaker write-back
-        // must not roll it back.
-        let strong = OutputLockState {
-            depth: 2,
-            end_time_ns: 200_000_000,
-        };
-        write_output_lock_guarded(&cache, &lock_key, &strong, trace_id).await;
-        let weak = OutputLockState {
-            depth: 2,
-            end_time_ns: 100_000_000,
-        };
-        write_output_lock_guarded(&cache, &lock_key, &weak, trace_id).await;
-        let stored: OutputLockState = cache.get(&lock_key).await.unwrap().unwrap();
-        assert_eq!(stored, strong);
-    }
-
     #[test]
     fn legacy_winner_snapshot_decodes_with_defaults() {
         // A queued pre-roster message's winner_state ({c,d,s,t}) decodes:
@@ -534,31 +499,18 @@ mod tests {
         assert_eq!(back.content_hash, "");
     }
 
-    #[test]
-    fn output_lock_shallower_wins_then_later_end() {
-        const MS: i64 = 1_000_000;
-        let prev = OutputLockState {
-            depth: 3,
-            end_time_ns: 100 * MS,
-        };
-        // Strictly shallower always overrides.
-        assert!(prev.should_override(&OutputLockState {
-            depth: 2,
-            end_time_ns: 50 * MS
-        }));
-        // Equal depth: only a strictly LATER end overrides.
-        assert!(prev.should_override(&OutputLockState {
-            depth: 3,
-            end_time_ns: 200 * MS
-        }));
-        assert!(!prev.should_override(&OutputLockState {
-            depth: 3,
-            end_time_ns: 100 * MS
-        }));
-        // Deeper never overrides.
-        assert!(!prev.should_override(&OutputLockState {
-            depth: 4,
-            end_time_ns: 200 * MS
-        }));
+    #[tokio::test]
+    async fn write_main_agent_path_roundtrips() {
+        use crate::cache::in_memory::InMemoryCache;
+        let cache: Arc<Cache> = Arc::new(Cache::InMemory(InMemoryCache::new(None)));
+        let project_id = Uuid::new_v4();
+        let trace_id = Uuid::new_v4();
+        let prefix = vec!["agent".to_string()];
+
+        write_main_agent_path(&cache, project_id, trace_id, &prefix).await;
+
+        let key = main_agent_path_cache_key(project_id, trace_id);
+        let stored: Vec<String> = cache.get(&key).await.unwrap().unwrap();
+        assert_eq!(stored, prefix);
     }
 }

--- a/app-server/src/traces/input_extraction/messages.rs
+++ b/app-server/src/traces/input_extraction/messages.rs
@@ -1,6 +1,9 @@
 //! Permissive parsing of LLM-span input messages: role normalization,
 //! message-array discovery across provider shapes, and text-part
-//! collection.
+//! collection. The output side no longer parses message shapes at all
+//! (LAM-1953 rework) — output extraction hashes the whole output array via
+//! the existing dedup pipeline instead of rendering text, so this module is
+//! input-only.
 
 use serde_json::Value;
 
@@ -117,59 +120,6 @@ pub(super) fn is_task_anchor_message(msg: &Value) -> bool {
             .any(|p| !p.trim().is_empty())
 }
 
-// ---------------------------------------------------------------------------
-// Output-side helpers
-// ---------------------------------------------------------------------------
-
-/// Does this message carry tool calls? Covers OpenAI (`tool_calls` array
-/// on the message), Anthropic (`tool_use` content parts), OTel GenAI
-/// semconv / LangChain (`tool_call` parts), OpenAI Responses
-/// (`function_call` parts), and AI SDK v7 verbatim payloads (dash-typed
-/// `tool-call` parts — stored unreshaped from `gen_ai.output.messages`
-/// per LAM-1922). Checks `content` AND `parts` — unlike text collection
-/// (`collect_message_parts`, which prefers `content` when both exist)
-/// this is a hand-off detector: a few payloads carry both fields, and a
-/// string/text-only `content` must not mask tool-call parts under
-/// `parts`, or an intermediate tool turn reads as the final answer.
-pub(super) fn has_tool_calls(message: &Value) -> bool {
-    if let Some(Value::Array(calls)) = message.get("tool_calls")
-        && !calls.is_empty()
-    {
-        return true;
-    }
-    ["content", "parts"].iter().any(|field| {
-        let Some(Value::Array(parts)) = message.get(field) else {
-            return false;
-        };
-        parts.iter().any(|p| {
-            matches!(
-                p.get("type").and_then(Value::as_str),
-                Some("tool_use" | "tool_call" | "tool-call" | "function_call")
-            )
-        })
-    })
-}
-
-/// The latest assistant/model message with non-empty rendered text and no
-/// tool calls — the agent's answer, as opposed to an intermediate turn
-/// that hands off to a tool.
-pub(super) fn last_assistant_text(output: &Value) -> Option<String> {
-    let single = std::slice::from_ref(output);
-    let messages: &[Value] = match find_messages_array(output) {
-        Some(arr) => arr,
-        // A bare `{role, content}` object is a single-message output.
-        None if output.is_object() => single,
-        None => return None,
-    };
-    messages.iter().rev().find_map(|msg| {
-        if normalize_role(msg) != Role::Assistant || has_tool_calls(msg) {
-            return None;
-        }
-        let text = collect_message_parts(msg).join("\n\n");
-        (!text.trim().is_empty()).then_some(text)
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -177,128 +127,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn has_tool_calls_detects_openai_tool_calls_array() {
-        let msg = json!({
-            "role": "assistant",
-            "content": null,
-            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "f"}}],
-        });
-        assert!(has_tool_calls(&msg));
-        // Empty array = no tool calls.
-        let msg = json!({"role": "assistant", "content": "hi", "tool_calls": []});
-        assert!(!has_tool_calls(&msg));
+    fn normalize_role_folds_provider_aliases() {
+        assert_eq!(normalize_role(&json!({"role": "human"})), Role::User);
+        assert_eq!(normalize_role(&json!({"role": "ai"})), Role::Assistant);
+        assert_eq!(normalize_role(&json!({"role": "model"})), Role::Assistant);
+        assert_eq!(normalize_role(&json!({"role": "developer"})), Role::System);
+        assert_eq!(normalize_role(&json!({})), Role::Other);
     }
 
     #[test]
-    fn has_tool_calls_detects_anthropic_tool_use_parts() {
-        let msg = json!({
-            "role": "assistant",
-            "content": [
-                {"type": "text", "text": "let me check"},
-                {"type": "tool_use", "id": "t1", "name": "search", "input": {}},
-            ],
-        });
-        assert!(has_tool_calls(&msg));
-        let msg = json!({
-            "role": "assistant",
-            "content": [{"type": "text", "text": "done"}],
-        });
-        assert!(!has_tool_calls(&msg));
-    }
-
-    #[test]
-    fn has_tool_calls_detects_genai_and_responses_part_types() {
-        // OTel GenAI semconv / LangChain: `tool_call` parts under `parts`.
-        let msg = json!({
-            "role": "assistant",
-            "parts": [
-                {"type": "text", "content": "let me check"},
-                {"type": "tool_call", "id": "c1", "name": "get_weather", "arguments": {}},
-            ],
-        });
-        assert!(has_tool_calls(&msg));
-        // OpenAI Responses: `function_call` part types.
-        let msg = json!({
-            "role": "assistant",
-            "content": [{"type": "function_call", "name": "f", "arguments": "{}"}],
-        });
-        assert!(has_tool_calls(&msg));
-        // AI SDK v7 verbatim: dash-typed `tool-call` parts (a mixed
-        // text + tool-call turn is a hand-off, not the final answer).
-        let msg = json!({
-            "role": "assistant",
-            "content": [
-                {"type": "text", "text": "let me check"},
-                {"type": "tool-call", "toolCallId": "c1", "toolName": "get_weather", "input": {}},
-            ],
-        });
-        assert!(has_tool_calls(&msg));
-    }
-
-    #[test]
-    fn has_tool_calls_checks_parts_even_when_content_is_present() {
-        // Some payloads carry BOTH fields; a string / text-only `content`
-        // must not mask tool calls under `parts` — this message is a
-        // hand-off, not a final answer.
-        let msg = json!({
-            "role": "assistant",
-            "content": "let me check",
-            "parts": [
-                {"type": "tool_call", "id": "c1", "name": "get_weather", "arguments": {}},
-            ],
-        });
-        assert!(has_tool_calls(&msg));
-        let msg = json!({
-            "role": "assistant",
-            "content": [{"type": "text", "text": "let me check"}],
-            "parts": [
-                {"type": "tool_call", "id": "c1", "name": "get_weather", "arguments": {}},
-            ],
-        });
-        assert!(has_tool_calls(&msg));
-        // Both present, neither carries tool parts: still toolless.
-        let msg = json!({
-            "role": "assistant",
-            "content": "done",
-            "parts": [{"type": "text", "content": "done"}],
-        });
-        assert!(!has_tool_calls(&msg));
-    }
-
-    #[test]
-    fn last_assistant_text_picks_latest_toolless_assistant_message() {
-        let output = json!([
-            {"role": "assistant", "content": "first answer"},
-            {"role": "assistant", "content": [
-                {"type": "text", "text": "calling"},
-                {"type": "tool_use", "id": "t1", "name": "f", "input": {}},
-            ]},
-            {"role": "assistant", "content": "final answer"},
-            {"role": "tool", "content": "tool result"},
-        ]);
-        assert_eq!(last_assistant_text(&output), Some("final answer".into()));
-    }
-
-    #[test]
-    fn last_assistant_text_skips_tool_call_and_empty_messages() {
-        let output = json!([
-            {"role": "assistant", "content": "real answer"},
-            {"role": "assistant", "content": "", },
-            {"role": "assistant", "content": null, "tool_calls": [{"id": "c"}]},
-        ]);
-        assert_eq!(last_assistant_text(&output), Some("real answer".into()));
-        // No qualifying message at all.
-        let output = json!([
-            {"role": "user", "content": "hi"},
-            {"role": "assistant", "content": null, "tool_calls": [{"id": "c"}]},
-        ]);
-        assert_eq!(last_assistant_text(&output), None);
-    }
-
-    #[test]
-    fn last_assistant_text_accepts_single_message_object_and_model_role() {
-        let output = json!({"role": "model", "parts": [{"type": "text", "text": "gemini says"}]});
-        assert_eq!(last_assistant_text(&output), Some("gemini says".into()));
-        assert_eq!(last_assistant_text(&json!("bare string")), None);
+    fn is_task_anchor_message_requires_user_role_and_nonempty_text() {
+        assert!(is_task_anchor_message(
+            &json!({"role": "user", "content": "hi"})
+        ));
+        assert!(!is_task_anchor_message(
+            &json!({"role": "user", "content": ""})
+        ));
+        assert!(!is_task_anchor_message(
+            &json!({"role": "assistant", "content": "hi"})
+        ));
     }
 }

--- a/app-server/src/traces/input_extraction/metadata.rs
+++ b/app-server/src/traces/input_extraction/metadata.rs
@@ -10,10 +10,11 @@ use super::regex::ApplyRegexResult;
 /// match) — "never ran" is the key being absent.
 pub const USER_TASK_METADATA_KEY: &str = "lmnr_user_task";
 
-/// The extracted trace output (the agent's final answer). Written by the
-/// inline output pass; no LLM/regex — the latest toolless assistant text
-/// from the shallowest LLM span.
-pub const TRACE_OUTPUT_METADATA_KEY: &str = "lmnr_trace_output";
+// There is no `TRACE_OUTPUT_METADATA_KEY` equivalent (LAM-1953 rework):
+// trace output is stored as per-message hashes into `deduped_content`
+// (`trace_agent_output` supplementary table), which aren't self-renderable
+// without a `deduped_content` lookup, so the output side is never folded
+// into `traces_replacing.metadata`.
 
 /// Map an extraction outcome onto the raw trace-input value (fed to
 /// `publish_trace_input_update`). Extracted text is signpost-split and

--- a/app-server/src/traces/input_extraction/output.rs
+++ b/app-server/src/traces/input_extraction/output.rs
@@ -1,143 +1,114 @@
-//! Trace-output capture and inline processing (LAM-1953): the latest
-//! toolless assistant message from the shallowest LLM span wins the
-//! `lmnr_trace_output` trace metadata key. No LLM, no regex, no queue —
-//! processing is fully inline on the producer hook.
+//! Trace-output capture and inline processing (LAM-1953 rework): every LLM
+//! span on the current user-task input winner's path (see
+//! `super::lock::main_agent_path_cache_key`) publishes its output message
+//! hashes as the trace's "output so far." No LLM, no regex, no queue, no
+//! independent lock — arbitration is inherited from the input winner, and
+//! "latest wins" is enforced by the `trace_agent_output` RMT version
+//! (`updated_at` = the span's end time), not by a separate depth/end-time
+//! gate.
 
 use std::sync::Arc;
 
 use uuid::Uuid;
 
-use super::lock::{OutputLockState, trace_output_lock_cache_key, write_output_lock_guarded};
-use super::messages::last_assistant_text;
-use crate::cache::{Cache, CacheTrait};
-use crate::db::{DB, spans::Span};
+use crate::cache::Cache;
+use crate::db::DB;
 use crate::mq::MessageQueue;
+use crate::traces::input_dedup::MessageDedup;
 use crate::traces::metadata::publish_trace_output_update;
 
-/// Per-span output candidate captured inside `preprocess_for_queue`,
-/// BEFORE the dedup strip removes `span.output`.
+/// Per-span output candidate captured inside `preprocess_for_queue`, AFTER
+/// the output dedup verdict is computed — the hashes are exactly
+/// `MessageDedup.hashes` for the span's output array, i.e. every message in
+/// the array, in order (no filtering to "the last toolless assistant
+/// message": tool-call-only turns are captured too, since it's cheaper to
+/// always write the latest than to predict a model-specific "I'm done" tool).
 #[derive(Debug, Clone)]
 pub struct OutputCandidate {
-    pub text: String,
+    pub hashes: Vec<[u8; 32]>,
     pub end_time_ns: i64,
 }
 
-pub fn capture_output_candidate(span: &Span) -> Option<OutputCandidate> {
-    if !span.is_llm_span() {
+/// Build an output candidate from the producer's output dedup verdict.
+/// `end_time_ns` is the span's own end time; out-of-range/unknown values
+/// degrade to `i64::MAX` ("unknown beats real" — outputs prefer the most
+/// recent final answer).
+pub fn capture_output_candidate(
+    output_dedup: Option<&MessageDedup>,
+    end_time_ns: i64,
+) -> Option<OutputCandidate> {
+    let dedup = output_dedup?;
+    if dedup.hashes.is_empty() {
         return None;
     }
-    let text = last_assistant_text(span.output.as_ref()?)?;
     Some(OutputCandidate {
-        // Out-of-range end times degrade to "latest possible": outputs
-        // prefer the most recent final answer, so unknown-time beats real.
-        end_time_ns: span.end_time.timestamp_nanos_opt().unwrap_or(i64::MAX),
-        text,
+        hashes: dedup.hashes.clone(),
+        end_time_ns,
     })
 }
 
-/// Inline trace-output processing: lock gate (shallower depth wins, then
-/// latest end time), metadata publish, guarded lock write. Fails open on
-/// cache errors; all failures are logged and swallowed.
-///
-/// Get-then-set race, ACCEPTED for the PG metadata path: two batches can
-/// both pass the gate and their patches — separate MQ messages — can be
-/// MERGED into PG in either order, so `lmnr_trace_output` may transiently
-/// keep the older answer while the lock records the newer winner. Any
-/// strictly-newer output repairs the value. The `trace_agent_output` RMT
-/// row versions on `updated_at`, so it converges on the newest write; a
-/// missed lock write only risks a redundant re-publish.
+/// Publish this candidate as the trace's output. Callers have already
+/// established that this span is on the main-agent path (or that no path is
+/// established yet, in which case every LLM span is treated as a
+/// candidate) — this function does no further gating; "latest wins" is
+/// enforced by the `trace_agent_output` RMT version.
 pub async fn process_trace_output_candidate(
     candidate: &OutputCandidate,
-    depth: usize,
     trace_id: Uuid,
     project_id: Uuid,
     queue: Arc<MessageQueue>,
     db: Arc<DB>,
     cache: Arc<Cache>,
 ) {
-    let state = OutputLockState {
-        depth,
-        end_time_ns: candidate.end_time_ns,
-    };
-    let lock_key = trace_output_lock_cache_key(project_id, trace_id);
-    let current: Option<OutputLockState> = match cache.get(&lock_key).await {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!("trace-output: lock read failed for trace [{trace_id}]: {e:?}");
-            None
-        }
-    };
-    if current.is_some_and(|c| !c.should_override(&state)) {
-        return;
-    }
-
     if let Err(e) = publish_trace_output_update(
         trace_id,
         project_id,
-        candidate.text.clone(),
+        candidate.hashes.clone(),
         candidate.end_time_ns,
         queue,
         db,
-        cache.clone(),
+        cache,
     )
     .await
     {
         log::error!("trace-output: failed to publish metadata patch for trace [{trace_id}]: {e:?}");
-        return;
     }
-
-    write_output_lock_guarded(&cache, &lock_key, &state, trace_id).await;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traces::span_attributes::SPAN_TYPE;
-    use crate::traces::spans::SpanAttributes;
-    use serde_json::{Value, json};
-    use std::collections::HashMap;
 
-    fn llm_span(output: Option<Value>) -> Span {
-        Span {
-            name: "llm_call".to_string(),
-            attributes: SpanAttributes::new(HashMap::from([(SPAN_TYPE.to_string(), json!("LLM"))])),
-            output,
-            ..Default::default()
+    fn dedup(hashes: Vec<[u8; 32]>) -> MessageDedup {
+        MessageDedup {
+            hashes,
+            trace_new_indices: vec![],
+            trace_new_contents: vec![],
+            storage_miss_offsets: vec![],
         }
     }
 
     #[test]
-    fn captures_last_toolless_assistant_text() {
-        let span = llm_span(Some(json!([
-            { "role": "user", "content": "hi" },
-            { "role": "assistant", "content": "final answer" }
-        ])));
-        let candidate = capture_output_candidate(&span).unwrap();
-        assert_eq!(candidate.text, "final answer");
+    fn captures_all_output_hashes_in_order() {
+        let h1 = [1u8; 32];
+        let h2 = [2u8; 32];
+        let d = dedup(vec![h1, h2]);
+        let candidate = capture_output_candidate(Some(&d), 100).unwrap();
+        assert_eq!(candidate.hashes, vec![h1, h2]);
+        assert_eq!(candidate.end_time_ns, 100);
     }
 
     #[test]
-    fn skips_non_llm_spans_and_missing_output() {
-        let mut span = llm_span(Some(json!([
-            { "role": "assistant", "content": "answer" }
-        ])));
-        span.attributes = SpanAttributes::new(HashMap::new());
-        span.span_type = crate::db::spans::SpanType::Default;
-        assert!(capture_output_candidate(&span).is_none());
-
-        let span = llm_span(None);
-        assert!(capture_output_candidate(&span).is_none());
+    fn captures_tool_call_only_output() {
+        // No special-casing for tool-call-only turns: the whole output
+        // array is hashed and captured regardless of message shape.
+        let d = dedup(vec![[9u8; 32]]);
+        assert!(capture_output_candidate(Some(&d), 5).is_some());
     }
 
     #[test]
-    fn skips_output_with_only_tool_call_messages() {
-        let span = llm_span(Some(json!([
-            {
-                "role": "assistant",
-                "content": null,
-                "tool_calls": [{ "id": "c1", "function": { "name": "f" } }]
-            }
-        ])));
-        assert!(capture_output_candidate(&span).is_none());
+    fn skips_none_dedup_and_empty_hashes() {
+        assert!(capture_output_candidate(None, 5).is_none());
+        assert!(capture_output_candidate(Some(&dedup(vec![])), 5).is_none());
     }
 }

--- a/app-server/src/traces/input_extraction/producer.rs
+++ b/app-server/src/traces/input_extraction/producer.rs
@@ -21,7 +21,8 @@ use uuid::Uuid;
 
 use super::input::prepare_user_task_input;
 use super::lock::{
-    RosterEntry, UserTaskLockState, WinnerState, lock_cache_key, roster_span_key, write_lock_merged,
+    RosterEntry, UserTaskLockState, WinnerState, lock_cache_key, main_agent_path_cache_key,
+    roster_span_key, write_lock_merged, write_main_agent_path,
 };
 use super::metadata::extraction_outcome_value;
 use super::output::{OutputCandidate, process_trace_output_candidate};
@@ -82,24 +83,15 @@ pub fn capture_user_task_candidate(span: &Span) -> Option<UserTaskCandidate> {
     })
 }
 
-/// Depth as the ingest pipeline will record it. This hook runs BEFORE the
-/// consumer's `prepare_span_for_recording` extends `lmnr.span.path` with
-/// the span's own name, and only auto-instrumented spans lack that final
-/// segment — so comparing raw lengths would let an auto-instrumented
-/// subagent span (true depth N+1, raw length N) tie with an SDK-created
-/// main-agent span (depth N) and hold the winner lock against it. Run the
-/// same extension here for exact parity; extending is idempotent and the
-/// consumer re-derives the path on its own copy.
-fn span_depth(attributes: &mut SpanAttributes, span_name: &str) -> usize {
-    attributes.extend_span_path(span_name);
-    attributes.path().map(|p| p.len()).unwrap_or(0)
-}
-
 /// One trace's input candidate after stats collection: owns the candidate
 /// (moved out of its context) plus the arbitration state derived from it.
+/// `path` is the candidate span's own full name-path — needed to derive the
+/// main-agent path prefix cached for trace-output matching once this
+/// candidate wins (see `super::lock::main_agent_path_cache_key`).
 struct InputContender {
     candidate: UserTaskCandidate,
     state: WinnerState,
+    path: Vec<String>,
 }
 
 /// Producer-side extraction pipeline, run after the batch is published.
@@ -133,34 +125,31 @@ pub async fn process_user_task_candidates(
         return;
     }
 
-    // Depth is computed once up front (`span_depth` mutates the span
-    // path); contexts are sorted by start time so roster registration
+    // Path is computed once up front. `extend_span_path` runs BEFORE the
+    // consumer's `prepare_span_for_recording` does the same, so depth here
+    // matches what ingest records (an auto-instrumented span otherwise
+    // lacks its own trailing segment and would tie one level shallower than
+    // it should). Contexts are sorted by start time so roster registration
     // order within the batch is deterministic.
-    let mut contexts: Vec<(UserTaskSpanContext, usize)> = contexts
+    let mut contexts: Vec<(UserTaskSpanContext, Vec<String>)> = contexts
         .into_iter()
         .map(|mut ctx| {
-            let depth = span_depth(&mut ctx.attributes, &ctx.span_name);
-            (ctx, depth)
+            ctx.attributes.extend_span_path(&ctx.span_name);
+            let path = ctx.attributes.path().unwrap_or_default();
+            (ctx, path)
         })
         .collect();
     contexts.sort_by_key(|(ctx, _)| ctx.start_time_ns);
 
-    // Pass 1: user-task inputs. Gated on `llm_client_available()` — this
-    // is the only pass that can enqueue LLM-backed regex generation, and
-    // without a client the extraction workers never spawn, so enqueueing
-    // would strand messages. Pass 2 (trace outputs) is fully inline with
-    // no LLM/queue and deliberately runs regardless.
-    // Collect per-trace contenders first (usage lookup needs &mut
-    // attributes), then arbitrate one trace at a time — registering EVERY
-    // batch candidate in the roster but attempting the effect only for
-    // the strongest, so a small trace arriving in one batch publishes
-    // once instead of once per ascending-token span.
-    let inputs_enabled = llm_client_available();
+    // Pass 1: user-task inputs. Winner/roster arbitration and main-agent
+    // path caching run UNCONDITIONALLY — depth + token comparison needs no
+    // LLM, and Pass 2 (trace outputs) depends on the path this pass
+    // establishes. Only the extraction EFFECT (publishing `lmnr_user_task`
+    // via a cached-regex apply, or enqueueing LLM-backed regex generation
+    // on a cache miss) is gated on `llm_client_available()` inside
+    // `process_trace_inputs`.
     let mut contenders: HashMap<Uuid, Vec<InputContender>> = HashMap::new();
-    for (ctx, depth) in contexts.iter_mut() {
-        if !inputs_enabled {
-            continue;
-        }
+    for (ctx, path) in contexts.iter_mut() {
         // Move the candidate out of the context — Pass 2 (outputs) only
         // reads `output_candidate`, so the input candidate can be owned
         // here, which drops the index-into-`contexts` indirection and the
@@ -186,7 +175,7 @@ pub async fn process_user_task_candidates(
         // helper above the main agent. (Tokens, not cost — cost is zero when
         // the model doesn't resolve in the pricing tables.)
         let state = WinnerState {
-            depth: *depth,
+            depth: path.len(),
             input_tokens: usage.input_tokens,
             start_time_ns: ctx.start_time_ns,
             span_id: roster_span_key(ctx.span_id),
@@ -195,7 +184,11 @@ pub async fn process_user_task_candidates(
         contenders
             .entry(ctx.trace_id)
             .or_default()
-            .push(InputContender { candidate, state });
+            .push(InputContender {
+                candidate,
+                state,
+                path: path.clone(),
+            });
     }
 
     for (trace_id, trace_contenders) in contenders {
@@ -203,6 +196,7 @@ pub async fn process_user_task_candidates(
             trace_id,
             trace_contenders,
             project_id,
+            llm_client_available(),
             queue.clone(),
             db.clone(),
             cache.clone(),
@@ -210,37 +204,61 @@ pub async fn process_user_task_candidates(
         .await;
     }
 
-    // Pass 2: trace outputs. Pre-arbitrate within the batch (shallowest
-    // depth, then latest end time) so one trace publishes at most one
-    // output per batch; the lock gate arbitrates across batches.
-    let mut best_outputs: HashMap<Uuid, (usize, i64, &OutputCandidate)> = HashMap::new();
-    for (ctx, depth) in &contexts {
+    // Pass 2: trace outputs. Every LLM span on the trace's main-agent path
+    // (the current input winner's stripped path, cached by Pass 1 above)
+    // is a candidate; among this batch's matches per trace, only the one
+    // with the latest `end_time_ns` publishes — "latest wins" beyond that
+    // is enforced by the `trace_agent_output` RMT version, not a lock.
+    // When no path is cached yet for a trace (no input winner established
+    // yet, or a cache miss/error), every LLM span in the batch is treated
+    // as matching so a trace's output is visible from its very first span.
+    let mut path_cache: HashMap<Uuid, Option<Vec<String>>> = HashMap::new();
+    let mut best_outputs: HashMap<Uuid, (i64, &OutputCandidate)> = HashMap::new();
+    for (ctx, path) in &contexts {
         let Some(output_candidate) = ctx.output_candidate.as_ref() else {
             continue;
         };
-        let entry = best_outputs.entry(ctx.trace_id).or_insert((
-            *depth,
-            output_candidate.end_time_ns,
-            output_candidate,
-        ));
-        if *depth < entry.0 || (*depth == entry.0 && output_candidate.end_time_ns > entry.1) {
-            *entry = (*depth, output_candidate.end_time_ns, output_candidate);
+        let cached_prefix = match path_cache.entry(ctx.trace_id) {
+            std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
+            std::collections::hash_map::Entry::Vacant(e) => {
+                let key = main_agent_path_cache_key(project_id, ctx.trace_id);
+                let prefix: Option<Vec<String>> = cache.get(&key).await.ok().flatten();
+                e.insert(prefix.clone());
+                prefix
+            }
+        };
+        let matches = match &cached_prefix {
+            // Must strip the last segment the same way the input side does.
+            Some(prefix) => &path[..path.len().saturating_sub(1)] == prefix.as_slice(),
+            // No winner established yet for this trace — every LLM span
+            // qualifies so output is visible before arbitration catches up.
+            None => true,
+        };
+        if !matches {
+            continue;
+        }
+        let entry = best_outputs
+            .entry(ctx.trace_id)
+            .or_insert((output_candidate.end_time_ns, output_candidate));
+        if output_candidate.end_time_ns > entry.0 {
+            *entry = (output_candidate.end_time_ns, output_candidate);
         }
     }
-    for (ctx, _) in &contexts {
-        let Some((depth, _, candidate)) = best_outputs.remove(&ctx.trace_id) else {
-            continue;
-        };
+    for (trace_id, (_, candidate)) in best_outputs {
         process_trace_output_candidate(
             candidate,
-            depth,
-            ctx.trace_id,
+            trace_id,
             project_id,
             queue.clone(),
             db.clone(),
             cache.clone(),
         )
         .await;
+        // Refresh the path cache TTL on every match so a long-running
+        // trace's cached prefix doesn't expire mid-flight.
+        if let Some(Some(prefix)) = path_cache.get(&trace_id) {
+            write_main_agent_path(&cache, project_id, trace_id, prefix).await;
+        }
     }
 }
 
@@ -276,14 +294,22 @@ fn should_run_effect(challenger: &WinnerState, winner: Option<&WinnerState>) -> 
 /// roster and winner were subagent-level); register every contender at
 /// the lock's depth (the roster keeps the [`super::lock::ROSTER_CAP`]
 /// earliest starters); the strongest eligible contender (see
-/// [`is_eligible`]) challenges the published winner and runs the effect
-/// only when [`should_run_effect`] holds. The lock is written back
-/// merge-guarded regardless of publish; the winner field moves only
-/// after the effect lands.
+/// [`is_eligible`]) challenges the published winner via
+/// [`should_run_effect`] (pure depth/token/content comparison — no LLM
+/// involved). Winning the challenge ALWAYS caches the winner's path (Pass 2
+/// needs this to find the main-agent spine even when no LLM client is
+/// configured). The LLM-backed extraction effect (cached-regex apply, or
+/// enqueue for regex generation) additionally runs only when
+/// `user_task_agent_enabled` — without a client the extraction workers never
+/// spawn, so enqueueing would strand messages. The lock is written back
+/// merge-guarded regardless; `lock.winner` moves as soon as the challenge is
+/// won (independent of whether the LLM effect itself lands, since there may
+/// be none to land).
 async fn process_trace_inputs(
     trace_id: Uuid,
     trace_contenders: Vec<InputContender>,
     project_id: Uuid,
+    user_task_agent_enabled: bool,
     queue: Arc<MessageQueue>,
     db: Arc<DB>,
     cache: Arc<Cache>,
@@ -345,6 +371,19 @@ async fn process_trace_inputs(
     {
         let state = challenger.state.clone();
         let candidate = &challenger.candidate;
+
+        // Cache the challenger's stripped path UNCONDITIONALLY — this is
+        // pure heuristic arbitration (depth/tokens/roster, no LLM involved),
+        // so Pass 2 (trace outputs) can find the main-agent spine even when
+        // no LLM client is configured. Must stay the same "drop own
+        // segment" heuristic as Pass 2's match check above.
+        let prefix = &challenger.path[..challenger.path.len().saturating_sub(1)];
+        write_main_agent_path(&cache, project_id, trace_id, prefix).await;
+
+        if !user_task_agent_enabled {
+            write_lock_merged(&cache, &lock_key, &lock, trace_id).await;
+            return;
+        }
 
         let regex_key = regex_cache_key(
             project_id,
@@ -449,24 +488,32 @@ mod tests {
         }
     }
 
+    fn extended_path(mut attrs: SpanAttributes, span_name: &str) -> Vec<String> {
+        attrs.extend_span_path(span_name);
+        attrs.path().unwrap_or_default()
+    }
+
     #[test]
-    fn span_depth_matches_ingest_extended_path() {
+    fn span_path_matches_ingest_extended_path() {
         // Auto-instrumented span: path lacks its own name — the extension
-        // appends it, so depth matches what ingest records.
-        let mut attrs = SpanAttributes::new(HashMap::from([(
+        // appends it, so the path matches what ingest records.
+        let attrs = SpanAttributes::new(HashMap::from([(
             SPAN_PATH.to_string(),
             json!(["agent", "subagent"]),
         )]));
-        assert_eq!(span_depth(&mut attrs, "llm_call"), 3);
+        assert_eq!(
+            extended_path(attrs, "llm_call"),
+            vec!["agent", "subagent", "llm_call"]
+        );
         // SDK span whose path already ends with its own name: idempotent.
-        let mut attrs = SpanAttributes::new(HashMap::from([(
+        let attrs = SpanAttributes::new(HashMap::from([(
             SPAN_PATH.to_string(),
             json!(["agent", "llm_call"]),
         )]));
-        assert_eq!(span_depth(&mut attrs, "llm_call"), 2);
+        assert_eq!(extended_path(attrs, "llm_call"), vec!["agent", "llm_call"]);
         // Missing path attribute: seeded as a 1-element array.
-        let mut attrs = SpanAttributes::new(HashMap::new());
-        assert_eq!(span_depth(&mut attrs, "llm_call"), 1);
+        let attrs = SpanAttributes::new(HashMap::new());
+        assert_eq!(extended_path(attrs, "llm_call"), vec!["llm_call"]);
     }
 
     #[test]

--- a/app-server/src/traces/input_extraction/producer.rs
+++ b/app-server/src/traces/input_extraction/producer.rs
@@ -293,18 +293,15 @@ fn should_run_effect(challenger: &WinnerState, winner: Option<&WinnerState>) -> 
 /// depth; a strictly shallower batch resets it — the previous depth's
 /// roster and winner were subagent-level); register every contender at
 /// the lock's depth (the roster keeps the [`super::lock::ROSTER_CAP`]
-/// earliest starters); the strongest eligible contender (see
-/// [`is_eligible`]) challenges the published winner via
-/// [`should_run_effect`] (pure depth/token/content comparison — no LLM
-/// involved). Winning the challenge ALWAYS caches the winner's path (Pass 2
-/// needs this to find the main-agent spine even when no LLM client is
-/// configured). The LLM-backed extraction effect (cached-regex apply, or
-/// enqueue for regex generation) additionally runs only when
-/// `user_task_agent_enabled` — without a client the extraction workers never
-/// spawn, so enqueueing would strand messages. The lock is written back
-/// merge-guarded regardless; `lock.winner` moves as soon as the challenge is
-/// won (independent of whether the LLM effect itself lands, since there may
-/// be none to land).
+/// earliest starters); pick the strongest eligible contender (see
+/// [`is_eligible`]) and cache its path unconditionally — that's pure
+/// depth/token arbitration, no LLM involved, and Pass 2 needs it regardless
+/// of whether the text extraction below runs. The LLM-backed extraction
+/// effect (cached-regex apply, or enqueue for regex generation) only runs
+/// when [`should_run_effect`] holds AND `user_task_agent_enabled` — without
+/// a client the extraction workers never spawn, so enqueueing would strand
+/// messages. The lock is written back merge-guarded regardless;
+/// `lock.winner` moves as soon as that effect lands.
 async fn process_trace_inputs(
     trace_id: Uuid,
     trace_contenders: Vec<InputContender>,
@@ -366,19 +363,23 @@ async fn process_trace_inputs(
 
     let challenger = eligible.reduce(|best, c| if c.state.beats(&best.state) { c } else { best });
 
+    if let Some(challenger) = challenger {
+        // Cache the strongest eligible span's path whenever it wins the
+        // depth/token comparison — independent of `should_run_effect` below,
+        // which only gates the LLM-backed text extraction. Otherwise a
+        // same-content shallower span (should_run_effect = false, since
+        // content didn't change) would leave Pass 2 matching against a
+        // stale, deeper path until the cache entry expires. Must stay the
+        // same "drop own segment" heuristic as Pass 2's match check above.
+        let prefix = &challenger.path[..challenger.path.len().saturating_sub(1)];
+        write_main_agent_path(&cache, project_id, trace_id, prefix).await;
+    }
+
     if let Some(challenger) = challenger
         && should_run_effect(&challenger.state, lock.winner.as_ref())
     {
         let state = challenger.state.clone();
         let candidate = &challenger.candidate;
-
-        // Cache the challenger's stripped path UNCONDITIONALLY — this is
-        // pure heuristic arbitration (depth/tokens/roster, no LLM involved),
-        // so Pass 2 (trace outputs) can find the main-agent spine even when
-        // no LLM client is configured. Must stay the same "drop own
-        // segment" heuristic as Pass 2's match check above.
-        let prefix = &challenger.path[..challenger.path.len().saturating_sub(1)];
-        write_main_agent_path(&cache, project_id, trace_id, prefix).await;
 
         if !user_task_agent_enabled {
             write_lock_merged(&cache, &lock_key, &lock, trace_id).await;

--- a/app-server/src/traces/metadata.rs
+++ b/app-server/src/traces/metadata.rs
@@ -19,8 +19,8 @@ use crate::{
     traces::{
         producer::publish_span_messages,
         span_attributes::{
-            ASSOCIATION_PROPERTIES_PREFIX, SPAN_METADATA_ONLY, SPAN_TRACE_INPUT, SPAN_TRACE_OUTPUT,
-            SPAN_TRACE_OUTPUT_END_TIME,
+            ASSOCIATION_PROPERTIES_PREFIX, SPAN_METADATA_ONLY, SPAN_TRACE_INPUT,
+            SPAN_TRACE_OUTPUT_END_TIME, SPAN_TRACE_OUTPUT_HASHES,
         },
         spans::SpanAttributes,
     },
@@ -122,22 +122,33 @@ pub async fn publish_trace_input_update(
     publish_metadata_only_span(trace_id, project_id, attributes, queue, db, cache).await
 }
 
-/// Set the extracted trace output. Same raw-transport contract as
-/// [`publish_trace_input_update`], on [`SPAN_TRACE_OUTPUT`], plus the
-/// winning span's `end_time_ns` on [`SPAN_TRACE_OUTPUT_END_TIME`] — the
-/// processor uses it as the `trace_agent_output` RMT version.
+/// Set the extracted trace output. Same virtual-span transport as
+/// [`publish_trace_input_update`], but carries per-message output HASHES
+/// (hex-encoded, into `deduped_content`) on [`SPAN_TRACE_OUTPUT_HASHES`]
+/// rather than a rendered string — every output message is already
+/// content-hashed by the dedup pipeline, so storing hashes avoids
+/// duplicating bytes that already live in `deduped_content`. The winning
+/// span's `end_time_ns` on [`SPAN_TRACE_OUTPUT_END_TIME`] is the
+/// `trace_agent_output` RMT version.
 pub async fn publish_trace_output_update(
     trace_id: Uuid,
     project_id: Uuid,
-    text: String,
+    hashes: Vec<[u8; 32]>,
     end_time_ns: i64,
     queue: Arc<MessageQueue>,
     db: Arc<DB>,
     cache: Arc<Cache>,
 ) -> Result<()> {
+    let hex_hashes: Vec<Value> = hashes
+        .iter()
+        .map(|h| Value::String(hex::encode(h)))
+        .collect();
     let attributes = HashMap::from([
         (SPAN_METADATA_ONLY.to_string(), Value::Bool(true)),
-        (SPAN_TRACE_OUTPUT.to_string(), Value::String(text)),
+        (
+            SPAN_TRACE_OUTPUT_HASHES.to_string(),
+            Value::Array(hex_hashes),
+        ),
         (
             SPAN_TRACE_OUTPUT_END_TIME.to_string(),
             Value::Number(end_time_ns.into()),

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -38,13 +38,13 @@ use crate::{
     },
     traces::{
         input_dedup::{DedupBatch, MessageDedup, build_dedup_batch, mark_seen},
-        input_extraction::metadata::{TRACE_OUTPUT_METADATA_KEY, USER_TASK_METADATA_KEY},
+        input_extraction::metadata::USER_TASK_METADATA_KEY,
         provider::convert_span_to_provider_format,
         realtime::{
             RealtimeDebuggerTrace, RealtimeTrace, TraceChannel, channels_for_trace,
             send_span_updates, send_trace_updates,
         },
-        span_attributes::{SPAN_TRACE_INPUT, SPAN_TRACE_OUTPUT, SPAN_TRACE_OUTPUT_END_TIME},
+        span_attributes::{SPAN_TRACE_INPUT, SPAN_TRACE_OUTPUT_END_TIME, SPAN_TRACE_OUTPUT_HASHES},
         spans::SpanUsage,
         tool_dedup::{ToolDedup, resolve_tool_dedup},
         utils::{get_llm_usage_for_span, prepare_span_for_recording},
@@ -111,30 +111,30 @@ fn tool_bytes(
 }
 
 /// Raw extracted trace io carried on a metadata-only virtual span, split
-/// out before the regular pipeline. The values are the verbatim JSON the
-/// façades put on `SPAN_TRACE_INPUT` / `SPAN_TRACE_OUTPUT` — no metadata
-/// key. The new `traces_agg` path stores them directly in the
-/// supplementary RMT tables; the deprecated path folds them into a
-/// metadata patch before this point.
+/// out before the regular pipeline. `input` is the verbatim JSON the
+/// façade put on `SPAN_TRACE_INPUT` — no metadata key. `output_hashes` are
+/// the per-message hashes into `deduped_content` (LAM-1953 rework — the
+/// output path no longer carries a rendered value). The new `traces_agg`
+/// path stores both directly in the supplementary RMT tables; the
+/// deprecated `traces_replacing.metadata` fold only covers input now (see
+/// the fold loop below).
 struct RawTraceIo {
     project_id: Uuid,
     trace_id: Uuid,
     input: Option<Value>,
-    output: Option<Value>,
+    output_hashes: Option<Vec<[u8; 32]>>,
     /// Winning span end time (ns) for the output — the RMT version. `None`
     /// only for legacy/malformed spans missing the attribute.
     output_end_time_ns: Option<i64>,
 }
 
-/// Build supplementary-table rows from the raw extracted io. `value` is the
-/// raw JSON string (matching the traces_agg metadata encoding). The input
-/// row leaves `updated_at` to the server default (`now64()`); the output
-/// row versions on the winning span's END TIME so FINAL converges on the
+/// Build supplementary-table rows from the raw extracted io. The input row
+/// leaves `updated_at` to the server default (`now64()`); the output row
+/// versions on the winning span's END TIME so FINAL converges on the
 /// latest-ending answer regardless of insert arrival order. The end time is
 /// clamped to `now_ns` — a missing/absurd (e.g. `i64::MAX` unknown-time
 /// sentinel) value would overflow `DateTime64(9)`; clamping to now still
-/// ranks it "latest" (real end times are ≤ now), preserving the lock's
-/// "unknown = latest" ordering.
+/// ranks it "latest" (real end times are ≤ now).
 fn collect_agent_io_rows(
     io: &[RawTraceIo],
     now_ns: i64,
@@ -149,12 +149,12 @@ fn collect_agent_io_rows(
                 value: value.to_string(),
             });
         }
-        if let Some(value) = &entry.output {
+        if let Some(hashes) = &entry.output_hashes {
             let updated_at = entry.output_end_time_ns.unwrap_or(now_ns).min(now_ns);
             outputs.push(CHTraceAgentOutput {
                 project_id: entry.project_id,
                 trace_id: entry.trace_id,
-                value: value.to_string(),
+                hashes: hashes.clone(),
                 updated_at,
             });
         }
@@ -203,9 +203,13 @@ pub async fn process_span_messages(
     // ClickHouse. Two flavours share the marker:
     //   - genuine metadata patches (POST /v1/traces/metadata): merged into the
     //     trace row (creating a virtual row when the span batch hasn't landed);
-    //   - extracted trace io (LAM-1953): the RAW value on `SPAN_TRACE_INPUT` /
-    //     `SPAN_TRACE_OUTPUT`, routed to the supplementary RMT tables (new path)
-    //     or folded into a metadata key for `traces_replacing` (deprecated path).
+    //   - extracted trace io (LAM-1953): the RAW value on `SPAN_TRACE_INPUT`
+    //     (input) / hex-encoded hashes on `SPAN_TRACE_OUTPUT_HASHES` (output),
+    //     routed to the supplementary RMT tables. Input is ALSO folded into a
+    //     `traces_replacing.metadata` key for the deprecated read path; output
+    //     is not — hashes alone aren't self-renderable without a
+    //     `deduped_content` lookup, and the old `lmnr_trace_output` metadata
+    //     key is not written anymore.
     let mut raw_trace_io: Vec<RawTraceIo> = Vec::new();
     let mut metadata_patches: Vec<TraceMetadataPatch> = Vec::new();
     for m in messages
@@ -214,13 +218,23 @@ pub async fn process_span_messages(
     {
         let attrs = &m.span.attributes.raw_attributes;
         let input = attrs.get(SPAN_TRACE_INPUT).cloned();
-        let output = attrs.get(SPAN_TRACE_OUTPUT).cloned();
-        if input.is_some() || output.is_some() {
+        let output_hashes = attrs.get(SPAN_TRACE_OUTPUT_HASHES).and_then(|v| {
+            v.as_array().map(|arr| {
+                arr.iter()
+                    .filter_map(Value::as_str)
+                    .filter_map(|s| {
+                        let bytes = hex::decode(s).ok()?;
+                        <[u8; 32]>::try_from(bytes).ok()
+                    })
+                    .collect::<Vec<[u8; 32]>>()
+            })
+        });
+        if input.is_some() || output_hashes.is_some() {
             raw_trace_io.push(RawTraceIo {
                 project_id: m.span.project_id,
                 trace_id: m.span.trace_id,
                 input,
-                output,
+                output_hashes,
                 output_end_time_ns: attrs
                     .get(SPAN_TRACE_OUTPUT_END_TIME)
                     .and_then(Value::as_i64),
@@ -251,29 +265,25 @@ pub async fn process_span_messages(
     }
     messages.retain(|m| !m.span.attributes.is_metadata_only());
 
-    // `traces_replacing` path: surface extracted io as trace metadata keys
-    // so it lands in `traces_replacing.metadata` (the current read path).
-    // Written on BOTH flag states for now — while `WRITE_TRACES_AGG` is a
-    // migration bridge, io lives in both `traces_replacing.metadata` AND the
-    // `trace_agent_input`/`_output` supplementary tables. Once the read path
+    // `traces_replacing` path: surface extracted INPUT as a trace metadata
+    // key so it lands in `traces_replacing.metadata` (the current read
+    // path). Written on BOTH flag states for now — while `WRITE_TRACES_AGG`
+    // is a migration bridge, input lives in both `traces_replacing.metadata`
+    // AND the `trace_agent_input` supplementary table. Once the read path
     // cuts over to `traces_agg_v0`, gate this fold on `!WRITE_TRACES_AGG` (or
-    // drop it) — all metadata-key knowledge of io lives here and dies with
-    // the old table.
+    // drop it) — all metadata-key knowledge of input lives here and dies
+    // with the old table. Output has no equivalent fold (see above).
     for io in &raw_trace_io {
+        let Some(value) = &io.input else {
+            continue;
+        };
         let mut map = serde_json::Map::new();
-        if let Some(value) = &io.input {
-            map.insert(USER_TASK_METADATA_KEY.to_string(), value.clone());
-        }
-        if let Some(value) = &io.output {
-            map.insert(TRACE_OUTPUT_METADATA_KEY.to_string(), value.clone());
-        }
-        if !map.is_empty() {
-            metadata_patches.push(TraceMetadataPatch {
-                trace_id: io.trace_id,
-                project_id: io.project_id,
-                metadata: Value::Object(map),
-            });
-        }
+        map.insert(USER_TASK_METADATA_KEY.to_string(), value.clone());
+        metadata_patches.push(TraceMetadataPatch {
+            trace_id: io.trace_id,
+            project_id: io.project_id,
+            metadata: Value::Object(map),
+        });
     }
 
     // Enrich spans with usage info

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -219,14 +219,24 @@ pub async fn process_span_messages(
         let attrs = &m.span.attributes.raw_attributes;
         let input = attrs.get(SPAN_TRACE_INPUT).cloned();
         let output_hashes = attrs.get(SPAN_TRACE_OUTPUT_HASHES).and_then(|v| {
-            v.as_array().map(|arr| {
-                arr.iter()
+            v.as_array().and_then(|arr| {
+                let decoded: Vec<[u8; 32]> = arr
+                    .iter()
                     .filter_map(Value::as_str)
                     .filter_map(|s| {
                         let bytes = hex::decode(s).ok()?;
                         <[u8; 32]>::try_from(bytes).ok()
                     })
-                    .collect::<Vec<[u8; 32]>>()
+                    .collect();
+                if decoded.len() < arr.len() {
+                    log::warn!(
+                        "trace-output: {} of {} hashes failed to decode on span {}",
+                        arr.len() - decoded.len(),
+                        arr.len(),
+                        m.span.span_id,
+                    );
+                }
+                (!decoded.is_empty()).then_some(decoded)
             })
         });
         if input.is_some() || output_hashes.is_some() {

--- a/app-server/src/traces/producer.rs
+++ b/app-server/src/traces/producer.rs
@@ -83,16 +83,24 @@ async fn preprocess_for_queue(span: &mut Span, cache: Arc<Cache>) -> DedupVerdic
         }
     }
 
-    // Capture the user-task + output candidates while `span.input` /
-    // `span.output` are still populated (the dedup strip below may null them).
+    // Capture the user-task candidate while `span.input` is still
+    // populated (the dedup strip below may null it).
     let user_task = crate::traces::input_extraction::capture_user_task_candidate(span);
-    let output_candidate = crate::traces::input_extraction::capture_output_candidate(span);
 
     // Tool dedup runs first so its source attributes are stripped before
     // anything else looks at `raw_attributes`.
     let tools = build_tool_dedup(span, cache.clone()).await;
     let input = build_message_dedup(span, span.input.as_ref(), cache.clone()).await;
     let output = build_message_dedup(span, span.output.as_ref(), cache).await;
+
+    // Output-candidate capture runs AFTER the output dedup verdict exists —
+    // it needs the per-message hashes (`output.hashes`), not the raw
+    // `span.output` value (LAM-1953 rework: output is stored as hashes into
+    // `deduped_content`, not a rendered string).
+    let output_candidate = crate::traces::input_extraction::capture_output_candidate(
+        output.as_ref(),
+        span.end_time.timestamp_nanos_opt().unwrap_or(i64::MAX),
+    );
 
     let keep_root_payload = span.parent_span_id.is_none() || is_top_span(span, &span.attributes);
 
@@ -224,7 +232,11 @@ pub async fn publish_span_messages(
                 trace_id: msg.span.trace_id,
                 span_id: msg.span.span_id,
                 span_name: msg.span.name.clone(),
-                start_time_ns: msg.span.start_time.timestamp_nanos_opt().unwrap_or(i64::MAX),
+                start_time_ns: msg
+                    .span
+                    .start_time
+                    .timestamp_nanos_opt()
+                    .unwrap_or(i64::MAX),
                 attributes: std::mem::take(&mut msg.span.attributes),
                 candidate,
                 output_candidate,

--- a/app-server/src/traces/span_attributes.rs
+++ b/app-server/src/traces/span_attributes.rs
@@ -34,16 +34,21 @@ pub const SPAN_PROMPT_HASH: &str = "lmnr.span.prompt_hash";
 /// the row is not written to `spans`, doesn't index in Quickwit, and
 /// contributes nothing to trace stats (start/end/tokens/num_spans/top_span/etc.).
 pub const SPAN_METADATA_ONLY: &str = "lmnr.internal.metadata_only";
-/// Raw extracted trace input / output carried verbatim on a metadata-only
-/// virtual span (LAM-1953). Unlike association-property metadata, these hold
-/// the raw JSON value with NO predefined key — the key is added only on the
-/// deprecated `traces_replacing` merge path; the supplementary RMT tables
-/// store the raw value directly.
+/// Raw extracted trace input carried verbatim on a metadata-only virtual
+/// span (LAM-1953). Unlike association-property metadata, this holds the
+/// raw JSON value with NO predefined key — the key is added only on the
+/// deprecated `traces_replacing` merge path; the supplementary RMT table
+/// stores the raw value directly.
 pub const SPAN_TRACE_INPUT: &str = "lmnr.internal.trace_input";
-pub const SPAN_TRACE_OUTPUT: &str = "lmnr.internal.trace_output";
-/// Winning span's end time (ns since epoch) accompanying `SPAN_TRACE_OUTPUT`:
-/// the RMT version for the `trace_agent_output` row, so FINAL converges on
-/// the latest-ending answer regardless of insert arrival order.
+/// Hex-encoded per-message output hashes (into `deduped_content`) carried
+/// verbatim on a metadata-only virtual span (LAM-1953 rework). The output
+/// path stores hashes, not a rendered string, because every output message
+/// is already content-hashed by the existing dedup pipeline.
+pub const SPAN_TRACE_OUTPUT_HASHES: &str = "lmnr.internal.trace_output_hashes";
+/// Winning span's end time (ns since epoch) accompanying
+/// `SPAN_TRACE_OUTPUT_HASHES`: the RMT version for the `trace_agent_output`
+/// row, so FINAL converges on the latest-ending answer regardless of
+/// insert arrival order.
 pub const SPAN_TRACE_OUTPUT_END_TIME: &str = "lmnr.internal.trace_output_end_time";
 /// Marker on the checkpoints pipeline's own tracing spans, skipped by its producer.
 pub const CHECKPOINT_INTERNAL_SPAN: &str = "lmnr.internal.checkpoint";

--- a/frontend/lib/clickhouse/migrations/54_traces_agg.sql
+++ b/frontend/lib/clickhouse/migrations/54_traces_agg.sql
@@ -13,7 +13,7 @@
 -- substring(_, 2).
 -- Extracted agent input/output (LAM-1953) live OUTSIDE traces_agg in the
 -- supplementary `trace_agent_input`/`trace_agent_output` RMT tables (mutable
--- latest-wins strings, which SimpleAggregateFunction(max) can't express) and
+-- latest-wins values, which SimpleAggregateFunction(max) can't express) and
 -- are surfaced via the view joins. `internal_metadata` is a reserved maxMap
 -- column (no writer yet), same encoding as `metadata`.
 CREATE TABLE IF NOT EXISTS default.traces_agg
@@ -59,22 +59,27 @@ PARTITION BY toYYYYMM(start_time)
 ORDER BY (project_id, id)
 SETTINGS index_granularity = 8192, deduplicate_merge_projection_mode = 'rebuild';
 
--- Extracted agent input/output (LAM-1953): one row per trace per table,
--- versioned on `updated_at`, ReplacingMergeTree converging on the largest.
--- The producer-side cache arbitration gate decides which spans qualify to
--- write here; the version then breaks ties between qualifying writes.
--- `value` is the raw JSON value (string or empty).
---   - OUTPUT: `updated_at` = the winning span's END TIME (clamped to insert
---     wall-clock). Output strength IS "latest end time at the shallowest
---     depth" (see `OutputLockState::should_override`), so versioning on end
---     time makes FINAL converge on exactly what the lock picks — arrival
---     order can't reverse it. Writers MUST set `updated_at` explicitly.
---   - INPUT: `updated_at` defaults to `now64(9)` (insert wall-clock). Input
---     strength is depth+tokens with no timestamp axis, so there's no content
---     order to version on; the cache gate is the selector and a get-then-set
---     race can (rarely) let a weaker last-arriving write win. Accepted:
---     encoding depth+tokens into a version was the manual machinery this
---     design deliberately dropped.
+-- Extracted agent input/output (LAM-1953, output storage reworked to
+-- hashes): one row per trace per table, versioned on `updated_at`,
+-- ReplacingMergeTree converging on the largest.
+--   - INPUT: `value` is the raw JSON value (string or empty). `updated_at`
+--     defaults to `now64(9)` (insert wall-clock). Input strength is
+--     depth+tokens with no timestamp axis, so there's no content order to
+--     version on; the producer-side cache arbitration gate is the selector
+--     and a get-then-set race can (rarely) let a weaker last-arriving write
+--     win. Accepted: encoding depth+tokens into a version was the manual
+--     machinery this design deliberately dropped.
+--   - OUTPUT: `hashes` are per-message hashes into `deduped_content` — every
+--     output message is already content-hashed by the dedup pipeline, so
+--     storing hashes (instead of a rendered string) avoids duplicating
+--     bytes that already live there and keeps merges small/predictable.
+--     `updated_at` = the winning span's END TIME (clamped to insert
+--     wall-clock). Every LLM span on the trace's main-agent path (the
+--     current user-task input winner's path, see
+--     `input_extraction::lock::main_agent_path_cache_key`) publishes a row;
+--     versioning on end time makes FINAL converge on the latest-ending
+--     answer regardless of arrival order. Writers MUST set `updated_at`
+--     explicitly.
 CREATE TABLE IF NOT EXISTS default.trace_agent_input
 (
     `project_id` UUID,
@@ -91,7 +96,7 @@ CREATE TABLE IF NOT EXISTS default.trace_agent_output
 (
     `project_id` UUID,
     `trace_id` UUID,
-    `value` String,
+    `hashes` Array(FixedString(32)),
     `updated_at` DateTime64(9, 'UTC') DEFAULT now64(9)
 )
 ENGINE = ReplacingMergeTree(updated_at)
@@ -164,7 +169,35 @@ SELECT
     t.span_names AS span_names,
     t.internal_metadata AS internal_metadata,
     ifNull(ai.value, '') AS agent_input,
-    ifNull(ao.value, '') AS agent_output
+    if(
+        empty(ao.hashes),
+        '',
+        arrayStringConcat(
+            arrayMap(
+                h -> multiIf(
+                    notEmpty(simpleJSONExtractRaw(
+                        dictGetOrDefault('deduped_content_dict', 'content', tuple(t.project_id, h), ''),
+                        'parts'
+                    )),
+                    simpleJSONExtractRaw(
+                        dictGetOrDefault('deduped_content_dict', 'content', tuple(t.project_id, h), ''),
+                        'parts'
+                    ),
+                    notEmpty(simpleJSONExtractRaw(
+                        dictGetOrDefault('deduped_content_dict', 'content', tuple(t.project_id, h), ''),
+                        'content'
+                    )),
+                    simpleJSONExtractRaw(
+                        dictGetOrDefault('deduped_content_dict', 'content', tuple(t.project_id, h), ''),
+                        'content'
+                    ),
+                    dictGetOrDefault('deduped_content_dict', 'content', tuple(t.project_id, h), '')
+                ),
+                ao.hashes
+            ),
+            '\n\n'
+        )
+    ) AS agent_output
 FROM (
     SELECT
         project_id,


### PR DESCRIPTION
- Write message hashes to extracted output, reconstruct on read
- prevent falling into summarizer / judge at end by capping agent path
- use the input lock and same path heuristic instead of separate output lock
- breaking migration is fine, it has never been applied anywhere

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core trace I/O extraction, cache arbitration, and ClickHouse supplementary-table shape; mis-path matching or hash decode failures could show wrong or empty agent output until RMT converges.
> 
> **Overview**
> Reworks **LAM-1953** trace output extraction so it stays on the same span path as the winning user-task input, instead of using a separate depth/end-time output lock.
> 
> **Output arbitration** replaces `trace_output_lock` with a **`main_agent_path`** cache entry: the stripped ancestor path of the strongest eligible input contender. Pass 2 only publishes output from LLM spans whose path matches that prefix (or from all LLM spans when no path is cached yet). “Latest wins” is left to `trace_agent_output` RMT versioning on span end time. User-task roster arbitration and path caching now run even when the LLM extraction client is unavailable; only the regex/queue **effect** stays gated on `llm_client_available()`.
> 
> **Storage and transport** stop rendering “last toolless assistant” text. Output is captured from **output dedup hashes** (full message array, in order) and written to ClickHouse as `hashes` on `trace_agent_output`, with virtual spans carrying `SPAN_TRACE_OUTPUT_HASHES` instead of `SPAN_TRACE_OUTPUT`. The **`lmnr_trace_output`** metadata fold is removed; the `traces_agg` view **reconstructs** `agent_output` via `deduped_content_dict` lookups. Input-side output parsing helpers in `messages.rs` are deleted accordingly.
> 
> **Breaking schema change** (migration 54): `trace_agent_output.value` → `hashes Array(FixedString(32))`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af4e35f6db658b8349ac21cb7fc866592e69a998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->