### PR TITLE
fix: normalize span output in labeling queue to match trace view

### DIFF
--- a/frontend/lib/actions/span/index.ts
+++ b/frontend/lib/actions/span/index.ts
@@ -150,6 +150,24 @@ export async function exportSpanToDataset(input: z.infer<typeof ExportSpanSchema
   });
 }
 
+// Unwrap OpenAI-style message arrays so the labeling queue target matches the
+// content shown in the trace view (which runs output through transformMessages).
+function normalizeSpanOutput(output: unknown): unknown {
+  if (!Array.isArray(output) || output.length === 0) return output;
+  const isOpenAIMessages = output.every(
+    (msg) => typeof msg === "object" && msg !== null && "role" in msg && "content" in msg
+  );
+  if (!isOpenAIMessages) return output;
+  const lastAssistant = [...output].reverse().find((msg: any) => msg.role === "assistant");
+  if (!lastAssistant) return output;
+  const content = (lastAssistant as any).content;
+  if (typeof content === "string") {
+    const parsed = tryParseJson(content);
+    return parsed !== null && parsed !== undefined ? parsed : content;
+  }
+  return content;
+}
+
 export async function pushSpanToLabelingQueue(input: z.infer<typeof PushSpanSchema>) {
   const { queueId, spanId, metadata, projectId } = PushSpanSchema.parse(input);
 
@@ -163,7 +181,7 @@ export async function pushSpanToLabelingQueue(input: z.infer<typeof PushSpanSche
         metadata,
         payload: {
           data: processedInput,
-          target: span.output,
+          target: normalizeSpanOutput(span.output),
           metadata: {},
         },
       },


### PR DESCRIPTION
When pushing a span to the labeling queue, `span.output` was stored as-is. For spans from Vercel AI SDK and similar, this is an OpenAI message array like `[{"role":"assistant","content":"{\"score\":2}"}]`. The trace view runs output through `transformMessages` which unwraps that into the actual content `{"score":2}`, but the labeling queue skipped this step.

The result: the same trace appears as `{"score":2}` in evaluations but as `[{"role":"assistant","content":"..."}]` in the labeling queue (see #639).

Add a `normalizeSpanOutput` helper that checks for OpenAI-style message arrays and extracts the last assistant message's content, matching what the trace view displays. Non-array outputs pass through unchanged.

Fixes #639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to labeling queue payload shaping with a pass-through for non-message outputs; no auth or persistence changes.
> 
> **Overview**
> **Labeling queue targets now match the trace view** for spans whose stored output is an OpenAI-style message array (e.g. Vercel AI SDK).
> 
> `pushSpanToLabelingQueue` previously sent `span.output` unchanged, so reviewers saw raw `[{"role":"assistant","content":"..."}]` while the trace UI showed unwrapped content (often parsed JSON). A new **`normalizeSpanOutput`** helper detects that array shape, takes the **last assistant** message’s `content`, and **JSON-parses** string content when possible; other shapes pass through unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17b78d117d88434fbc1fb0b5e880f075d63e76d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->