### PR TITLE
fix: raw sanitize rendering

### DIFF
--- a/frontend/components/ui/content-renderer/markdown.tsx
+++ b/frontend/components/ui/content-renderer/markdown.tsx
@@ -28,7 +28,8 @@ const PureMarkdownRenderer = ({ value, className, containerRef }: MarkdownRender
         "[&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:overflow-x-hidden [&_pre_code]:whitespace-pre-wrap text-xs"
       )}
       controls={{ mermaid: { download: false, fullscreen: false } }}
-      rehypePlugins={[defaultRehypePlugins.harden]}
+      // raw renders embedded HTML (else its text is dropped); sanitize strips XSS from untrusted content.
+      rehypePlugins={[defaultRehypePlugins.raw, defaultRehypePlugins.sanitize, defaultRehypePlugins.harden]}
       components={{
         h1: ({ node: _node, children, className, ...props }) => (
           <h1 {...props} className={cn(className, "mt-3 mb-1 text-base font-semibold")}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches untrusted markdown rendering and XSS defenses; plugin order (sanitize before harden) is important, but the change explicitly adds sanitization rather than removing it.
> 
> **Overview**
> Fixes markdown preview in the content renderer so **embedded HTML is actually rendered** instead of being dropped, by adding Streamdown’s **`raw`** rehype plugin ahead of the existing hardening step.
> 
> The plugin chain is now **`raw` → `sanitize` → `harden`**, so untrusted markdown (e.g. span/trace content) can include HTML while **`sanitize`** strips XSS before output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 743c745dd727e4eaec90c0200311b6f659c6668b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->