### PR TITLE
feat: perf sessions

### DIFF
--- a/frontend/app/api/projects/[projectId]/sessions/[sessionId]/traces/route.ts
+++ b/frontend/app/api/projects/[projectId]/sessions/[sessionId]/traces/route.ts
@@ -1,0 +1,25 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { prettifyError, ZodError } from "zod/v4";
+
+import { getSessionTraces } from "@/lib/actions/sessions";
+
+export async function GET(
+  req: NextRequest,
+  props: { params: Promise<{ projectId: string; sessionId: string }> }
+): Promise<Response> {
+  const params = await props.params;
+  const { projectId, sessionId } = params;
+
+  try {
+    const result = await getSessionTraces({ projectId, sessionId });
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json({ error: prettifyError(error) }, { status: 400 });
+    }
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch session traces." },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/components/traces/session-view/session-view-content.tsx
+++ b/frontend/components/traces/session-view/session-view-content.tsx
@@ -17,8 +17,6 @@ interface SessionViewContentProps {
   sessionId: string;
 }
 
-const PAGE_SIZE = 200;
-
 export default function SessionViewContent({ sessionId }: SessionViewContentProps) {
   const { projectId } = useParams<{ projectId: string }>();
 
@@ -50,13 +48,8 @@ export default function SessionViewContent({ sessionId }: SessionViewContentProp
         setIsTracesLoading(true);
         setTracesError(undefined);
 
-        const params = new URLSearchParams();
-        params.set("pageNumber", "0");
-        params.set("pageSize", String(PAGE_SIZE));
-        params.set("filter", JSON.stringify({ column: "session_id", value: sessionId, operator: "eq" }));
-        params.set("sortDirection", "ASC");
-
-        const res = await fetch(`/api/projects/${projectId}/traces?${params.toString()}`, {
+        const encodedSessionId = sessionId.split("/").map(encodeURIComponent).join("/");
+        const res = await fetch(`/api/projects/${projectId}/sessions/${encodedSessionId}/traces`, {
           signal: controller.signal,
         });
         if (!res.ok) {

--- a/frontend/components/traces/session-view/session-view-content.tsx
+++ b/frontend/components/traces/session-view/session-view-content.tsx
@@ -48,7 +48,7 @@ export default function SessionViewContent({ sessionId }: SessionViewContentProp
         setIsTracesLoading(true);
         setTracesError(undefined);
 
-        const encodedSessionId = sessionId.split("/").map(encodeURIComponent).join("/");
+        const encodedSessionId = encodeURIComponent(sessionId);
         const res = await fetch(`/api/projects/${projectId}/sessions/${encodedSessionId}/traces`, {
           signal: controller.signal,
         });

--- a/frontend/components/traces/session-view/store/index.tsx
+++ b/frontend/components/traces/session-view/store/index.tsx
@@ -76,7 +76,8 @@ const createSessionViewStore = (options?: { initialSession?: SessionSummary; sto
             params.append("searchIn", "output");
             for (const f of filters) params.append("filter", JSON.stringify(f));
 
-            const url = `/api/projects/${projectId}/sessions/${session.sessionId}/spans?${params.toString()}`;
+            const encodedSessionId = encodeURIComponent(session.sessionId);
+            const url = `/api/projects/${projectId}/sessions/${encodedSessionId}/spans?${params.toString()}`;
             const res = await fetch(url);
             if (!res.ok) {
               const err = (await res.json().catch(() => ({ error: "Unknown error" }))) as { error?: string };

--- a/frontend/lib/actions/sessions/index.ts
+++ b/frontend/lib/actions/sessions/index.ts
@@ -9,7 +9,7 @@ import { searchSpans, type SpanSearchHit } from "@/lib/actions/traces/search";
 import { clickhouseClient } from "@/lib/clickhouse/client";
 import { type SpanSearchType } from "@/lib/clickhouse/types";
 import { getTimeRange } from "@/lib/clickhouse/utils";
-import { type SessionRow } from "@/lib/traces/types";
+import { type SessionRow, type TraceRow } from "@/lib/traces/types";
 
 export const GetSessionsSchema = PaginationFiltersSchema.extend({
   ...TimeRangeSchema.shape,
@@ -83,6 +83,81 @@ export async function getSessions(input: z.infer<typeof GetSessionsSchema>): Pro
   const sessionItems = items.map((item) => ({ ...item, subRows: [] }));
 
   return { items: sessionItems };
+}
+
+export const GetSessionTracesSchema = z.object({
+  projectId: z.guid(),
+  sessionId: z.string().min(1),
+});
+
+// Pad the derived start_time bounds so the validator's traces_v0 window covers rows a newer version could shift (LAM-1876).
+const SESSION_TRACES_PAD_BEFORE_MS = 60 * 60 * 1000;
+const SESSION_TRACES_PAD_AFTER_MS = 3 * 60 * 60 * 1000;
+// No pagination in the session panel; cap the payload.
+const SESSION_TRACES_LIMIT = 500;
+
+// Only the columns the session view renders.
+const sessionTracesSelectColumns = [
+  "id",
+  "formatDateTime(start_time, '%Y-%m-%dT%H:%i:%S.%fZ') as startTime",
+  "formatDateTime(end_time, '%Y-%m-%dT%H:%i:%S.%fZ') as endTime",
+  "input_tokens as inputTokens",
+  "output_tokens as outputTokens",
+  "total_tokens as totalTokens",
+  "input_cost as inputCost",
+  "output_cost as outputCost",
+  "total_cost as totalCost",
+  "cache_read_input_tokens as cacheReadInputTokens",
+  "metadata",
+  "agent_input as agentInput",
+];
+
+// Two queries: a `session_id`-only filter has no time bound (whole-project scan), so first resolve the
+// session's start_time range cheaply, then fetch the UI columns bounded by it so the validator prunes traces_v0.
+export async function getSessionTraces(input: z.infer<typeof GetSessionTracesSchema>): Promise<{ items: TraceRow[] }> {
+  const { projectId, sessionId } = GetSessionTracesSchema.parse(input);
+
+  const bounds = await executeQuery<{ minStart: string; maxStart: string }>({
+    query: `
+      SELECT
+        formatDateTime(min(start_time), '%Y-%m-%dT%H:%i:%S.%fZ') as minStart,
+        formatDateTime(max(start_time), '%Y-%m-%dT%H:%i:%S.%fZ') as maxStart
+      FROM traces
+      WHERE session_id = {sessionId: String}
+    `,
+    parameters: { sessionId },
+    projectId,
+  });
+
+  const { minStart, maxStart } = bounds[0] ?? { minStart: "", maxStart: "" };
+  // Empty session: min/max over no rows yields the epoch-zero sentinel.
+  if (!minStart || !maxStart || minStart.startsWith("1970-01-01")) {
+    return { items: [] };
+  }
+
+  const startTime = new Date(new Date(minStart).getTime() - SESSION_TRACES_PAD_BEFORE_MS).toISOString();
+  const endTime = new Date(new Date(maxStart).getTime() + SESSION_TRACES_PAD_AFTER_MS).toISOString();
+
+  const items = await executeQuery<TraceRow>({
+    query: `
+      SELECT ${sessionTracesSelectColumns.join(", ")}
+      FROM traces
+      WHERE session_id = {sessionId: String}
+        AND start_time >= {startTime: String}
+        AND start_time <= {endTime: String}
+      ORDER BY start_time ASC
+      LIMIT {limit: UInt32}
+    `,
+    parameters: {
+      sessionId,
+      startTime: startTime.replace("Z", ""),
+      endTime: endTime.replace("Z", ""),
+      limit: SESSION_TRACES_LIMIT,
+    },
+    projectId,
+  });
+
+  return { items };
 }
 
 export async function deleteSessions(input: z.infer<typeof DeleteSessionsSchema>) {

--- a/frontend/lib/actions/sessions/index.ts
+++ b/frontend/lib/actions/sessions/index.ts
@@ -124,6 +124,7 @@ export async function getSessionTraces(input: z.infer<typeof GetSessionTracesSch
         formatDateTime(max(start_time), '%Y-%m-%dT%H:%i:%S.%fZ') as maxStart
       FROM traces
       WHERE session_id = {sessionId: String}
+        AND trace_type = 'DEFAULT'
     `,
     parameters: { sessionId },
     projectId,
@@ -143,6 +144,7 @@ export async function getSessionTraces(input: z.infer<typeof GetSessionTracesSch
       SELECT ${sessionTracesSelectColumns.join(", ")}
       FROM traces
       WHERE session_id = {sessionId: String}
+        AND trace_type = 'DEFAULT'
         AND start_time >= {startTime: String}
         AND start_time <= {endTime: String}
       ORDER BY start_time ASC


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how session traces are queried in ClickHouse (two queries, time padding, 500 cap vs prior page size 200), which could affect correctness or completeness for very large sessions; scope is read-path only with no auth changes.
> 
> **Overview**
> **Session trace loading** no longer goes through the generic paginated `/api/projects/.../traces` endpoint with a `session_id` filter. The session view now calls **`GET /api/projects/:projectId/sessions/:sessionId/traces`**, backed by new **`getSessionTraces`** server logic.
> 
> That action uses a **two-step ClickHouse strategy**: first compute min/max `start_time` for the session’s default traces, then fetch only the columns the session UI needs within a padded time window (so partition/validator pruning applies and whole-project scans are avoided). Results are capped at **500** traces, ascending by start time.
> 
> **URL safety:** `sessionId` is **`encodeURIComponent`**’d when building session traces and session span search URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7cf63aa3248c94b4bc24e03617310a9a36cd1f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

