### PR TITLE
fix: column resize, swr cache seed

### DIFF
--- a/frontend/components/ui/infinite-datatable/ui/cell.tsx
+++ b/frontend/components/ui/infinite-datatable/ui/cell.tsx
@@ -8,17 +8,20 @@ interface InfiniteTableCellProps<TData extends RowData> {
   cell: Cell<TData, unknown>;
   // Primitive so the memo comparator sees selection changes; TanStack reuses the same Cell across renders.
   isSelected: boolean;
+  // Layout primitives resolved by the parent: getSize()/getStart() read live state off a reused
+  // Column, so the comparator can't see resize changes unless they arrive as primitives.
+  size: number;
+  start: number;
+  isPinned: boolean;
   // Changes when columns or table `meta` change, forcing re-render of cells with out-of-row content.
   cellRenderToken: object;
 }
 
-function InfiniteTableCellInner<TData extends RowData>({ cell }: InfiniteTableCellProps<TData>) {
-  const isPinned = cell.column.getIsPinned() === "left";
-
+function InfiniteTableCellInner<TData extends RowData>({ cell, size, start, isPinned }: InfiniteTableCellProps<TData>) {
   const style: CSSProperties = {
     position: isPinned ? "sticky" : "relative",
-    left: isPinned ? cell.column.getStart("left") : undefined,
-    width: cell.column.getSize(),
+    left: isPinned ? start : undefined,
+    width: size,
     zIndex: isPinned ? 10 : 0,
     display: "flex",
   };
@@ -44,8 +47,9 @@ function areCellPropsEqual<TData extends RowData>(
   return (
     prev.cell.id === next.cell.id &&
     prev.cell.row.original === next.cell.row.original &&
-    prev.cell.column.getSize() === next.cell.column.getSize() &&
-    prev.cell.column.getIsPinned() === next.cell.column.getIsPinned() &&
+    prev.size === next.size &&
+    prev.start === next.start &&
+    prev.isPinned === next.isPinned &&
     prev.isSelected === next.isSelected &&
     prev.cellRenderToken === next.cellRenderToken
   );

--- a/frontend/components/ui/infinite-datatable/ui/row.tsx
+++ b/frontend/components/ui/infinite-datatable/ui/row.tsx
@@ -77,7 +77,15 @@ function InfiniteDatatableRowInner<TData extends RowData>({
     >
       {isSelected && <td className="border-l-2 border-l-primary absolute h-full left-0 top-0 z-10" />}
       {row.getVisibleCells().map((cell) => (
-        <InfiniteTableCell key={cell.id} cell={cell} isSelected={isSelected} cellRenderToken={cellRenderToken} />
+        <InfiniteTableCell
+          key={cell.id}
+          cell={cell}
+          isSelected={isSelected}
+          size={cell.column.getSize()}
+          start={cell.column.getStart("left")}
+          isPinned={cell.column.getIsPinned() === "left"}
+          cellRenderToken={cellRenderToken}
+        />
       ))}
     </TableRow>
   );

--- a/frontend/contexts/project-context.tsx
+++ b/frontend/contexts/project-context.tsx
@@ -63,14 +63,15 @@ export const ProjectContextProvider = ({
     fallbackData: initialProject,
   });
 
-  // `fallbackData` sets returned `data` but not the writable cache, so `mutateProject((cur)=>...)`
-  // gets `cur === undefined` and no-ops. Seed the cache once per key so optimistic writers work.
+  // `fallbackData` doesn't write the cache, so `mutateProject((cur)=>...)` gets undefined and no-ops.
+  // Seed the cache; re-seed on SSR prop change (same-project refresh keeps the key) to avoid staleness.
+  const projectSignature = initialProject ? JSON.stringify(initialProject) : null;
   useEffect(() => {
     if (projectKey && initialProject) {
       mutateProject(initialProject, { revalidate: false });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectKey]);
+  }, [projectKey, projectSignature]);
 
   const settingsHref = useCallback(
     (section?: SettingsSection) =>

--- a/frontend/contexts/project-context.tsx
+++ b/frontend/contexts/project-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, type PropsWithChildren, use, useCallback, useMemo } from "react";
+import { createContext, type PropsWithChildren, use, useCallback, useEffect, useMemo } from "react";
 import useSWR, { type KeyedMutator } from "swr";
 
 import { type ProjectDetails } from "@/lib/actions/project";
@@ -62,6 +62,15 @@ export const ProjectContextProvider = ({
   const { data: project, mutate: mutateProject } = useSWR<ProjectDetails | undefined>(projectKey, null, {
     fallbackData: initialProject,
   });
+
+  // `fallbackData` sets returned `data` but not the writable cache, so `mutateProject((cur)=>...)`
+  // gets `cur === undefined` and no-ops. Seed the cache once per key so optimistic writers work.
+  useEffect(() => {
+    if (projectKey && initialProject) {
+      mutateProject(initialProject, { revalidate: false });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectKey]);
 
   const settingsHref = useCallback(
     (section?: SettingsSection) =>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UI memoization and client cache seeding with no auth, security, or server data-path changes.
> 
> **Overview**
> Fixes **infinite datatable** cells not updating width/position after column resize by passing **`size`**, **`start`**, and **`isPinned`** from the row (where TanStack column state is read) into the memoized cell, and comparing those primitives in `areCellPropsEqual` instead of calling `getSize()` / `getStart()` on a reused column object inside the comparator.
> 
> Seeds the **project context** SWR cache on mount and when the SSR `initialProject` payload changes, because `fallbackData` alone leaves `mutateProject((cur) => …)` with `undefined` and makes optimistic updates no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a93ed451d2e9074e16488ed3ed486e1acea44f58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->