### PR TITLE
feat: carry agent_input live on realtime trace-update payload

### DIFF
--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -384,6 +384,21 @@ pub async fn process_span_messages(
         });
     }
 
+    // Extracted input threaded to the realtime dispatch as a first-class field
+    // (Option B in the handoff) so the debugger / traces table show it live —
+    // NOT sourced from the deprecated `lmnr_user_task` metadata fold above, which
+    // is on a demolition schedule. `value.to_string()` matches
+    // `CHTraceAgentInput.value` (and thus `traces_v0.agent_input`), so the live
+    // value renders identically to the fresh-fetch path.
+    let agent_input_by_trace: HashMap<(Uuid, Uuid), String> = raw_trace_io
+        .iter()
+        .filter_map(|io| {
+            io.input
+                .as_ref()
+                .map(|v| ((io.project_id, io.trace_id), v.to_string()))
+        })
+        .collect();
+
     // Enrich spans with usage info
     let mut span_usage_vec = Vec::with_capacity(messages.len());
 
@@ -736,7 +751,13 @@ pub async fn process_span_messages(
 
             debugger_session_blocks::upsert_blocks_for_traces(&db.pool, &updated_traces).await;
 
-            dispatch_trace_realtime_updates(&updated_traces, cache.clone(), &pubsub).await;
+            dispatch_trace_realtime_updates(
+                &updated_traces,
+                &agent_input_by_trace,
+                cache.clone(),
+                &pubsub,
+            )
+            .await;
         }
 
         // Dual-write partial rows to `traces_agg` (AggregatingMergeTree,
@@ -1119,7 +1140,12 @@ pub async fn process_span_messages(
     Ok(())
 }
 
-async fn dispatch_trace_realtime_updates(traces: &[Trace], cache: Arc<Cache>, pubsub: &PubSub) {
+async fn dispatch_trace_realtime_updates(
+    traces: &[Trace],
+    agent_input_by_trace: &HashMap<(Uuid, Uuid), String>,
+    cache: Arc<Cache>,
+    pubsub: &PubSub,
+) {
     if traces.is_empty() {
         return;
     }
@@ -1129,25 +1155,30 @@ async fn dispatch_trace_realtime_updates(traces: &[Trace], cache: Arc<Cache>, pu
     let mut debugger_buckets: HashMap<(Uuid, String), Vec<RealtimeDebuggerTrace>> = HashMap::new();
 
     for trace in traces {
+        // Only present on the flush where extraction landed; None otherwise. The
+        // frontend guards against an empty value clobbering a populated one.
+        let agent_input = agent_input_by_trace
+            .get(&(trace.project_id(), trace.id()))
+            .cloned();
         for channel in channels_for_trace(trace, cache.as_ref()).await {
             match channel {
                 TraceChannel::Project => {
                     project_buckets
                         .entry(trace.project_id())
                         .or_default()
-                        .push(RealtimeTrace::from_trace(trace));
+                        .push(RealtimeTrace::from_trace(trace, agent_input.clone()));
                 }
                 TraceChannel::Evaluation(evaluation_id) => {
                     evaluation_buckets
                         .entry((trace.project_id(), evaluation_id))
                         .or_default()
-                        .push(RealtimeTrace::from_trace(trace));
+                        .push(RealtimeTrace::from_trace(trace, agent_input.clone()));
                 }
                 TraceChannel::RolloutDebugger(rollout_session_id) => {
                     debugger_buckets
                         .entry((trace.project_id(), rollout_session_id))
                         .or_default()
-                        .push(RealtimeDebuggerTrace::from_trace(trace));
+                        .push(RealtimeDebuggerTrace::from_trace(trace, agent_input.clone()));
                 }
             }
         }

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -384,12 +384,8 @@ pub async fn process_span_messages(
         });
     }
 
-    // Extracted input threaded to the realtime dispatch as a first-class field
-    // (Option B in the handoff) so the debugger / traces table show it live —
-    // NOT sourced from the deprecated `lmnr_user_task` metadata fold above, which
-    // is on a demolition schedule. `value.to_string()` matches
-    // `CHTraceAgentInput.value` (and thus `traces_v0.agent_input`), so the live
-    // value renders identically to the fresh-fetch path.
+    // Extracted input threaded to the realtime dispatch so it shows live, NOT via
+    // the deprecated `lmnr_user_task` fold. `to_string()` matches `traces_v0.agent_input`.
     let agent_input_by_trace: HashMap<(Uuid, Uuid), String> = raw_trace_io
         .iter()
         .filter_map(|io| {

--- a/app-server/src/traces/realtime.rs
+++ b/app-server/src/traces/realtime.rs
@@ -46,10 +46,8 @@ pub struct RealtimeTrace {
     tags: Vec<String>, // Span tags
     root_span_input: Option<String>,
     root_span_output: Option<String>,
-    // LLM-extracted "user task" (Feature::InputExtraction). Lands seconds after
-    // the trace via an async metadata-only span, so it's threaded in here
-    // separately from the PG `Trace` fields — see `dispatch_trace_realtime_updates`.
-    // JSON-stringified to match `traces_v0.agent_input` (the fresh-fetch value).
+    // Extracted "user task" (Feature::InputExtraction), threaded in separately —
+    // it lands async, seconds after the trace. JSON-stringified per traces_v0.
     agent_input: Option<String>,
 }
 
@@ -232,9 +230,8 @@ fn rollout_session_id_from_metadata(trace: &Trace) -> Option<String> {
 }
 
 impl RealtimeTrace {
-    /// Convert database trace to realtime format. `agent_input` is the extracted
-    /// user task (JSON-stringified, matching `traces_v0.agent_input`), threaded
-    /// from ingestion; `None` for span-batch updates where extraction hasn't run.
+    /// `agent_input`: extracted user task threaded from ingestion; `None` on
+    /// span-batch updates where extraction hasn't run yet.
     pub fn from_trace(trace: &Trace, agent_input: Option<String>) -> Self {
         Self {
             id: trace.id(),

--- a/app-server/src/traces/realtime.rs
+++ b/app-server/src/traces/realtime.rs
@@ -46,6 +46,11 @@ pub struct RealtimeTrace {
     tags: Vec<String>, // Span tags
     root_span_input: Option<String>,
     root_span_output: Option<String>,
+    // LLM-extracted "user task" (Feature::InputExtraction). Lands seconds after
+    // the trace via an async metadata-only span, so it's threaded in here
+    // separately from the PG `Trace` fields — see `dispatch_trace_realtime_updates`.
+    // JSON-stringified to match `traces_v0.agent_input` (the fresh-fetch value).
+    agent_input: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -54,6 +59,8 @@ pub struct RealtimeDebuggerTrace {
     trace_id: Uuid,
     metadata: Option<Value>,
     has_browser_session: Option<bool>,
+    // See `RealtimeTrace::agent_input`.
+    agent_input: Option<String>,
 }
 
 /// Realtime span data for frontend consumption (lightweight, no input/output)
@@ -225,8 +232,10 @@ fn rollout_session_id_from_metadata(trace: &Trace) -> Option<String> {
 }
 
 impl RealtimeTrace {
-    /// Convert database trace to realtime format
-    pub fn from_trace(trace: &Trace) -> Self {
+    /// Convert database trace to realtime format. `agent_input` is the extracted
+    /// user task (JSON-stringified, matching `traces_v0.agent_input`), threaded
+    /// from ingestion; `None` for span-batch updates where extraction hasn't run.
+    pub fn from_trace(trace: &Trace, agent_input: Option<String>) -> Self {
         Self {
             id: trace.id(),
             start_time: trace.start_time(),
@@ -253,16 +262,18 @@ impl RealtimeTrace {
             tags: trace.tags().clone(),
             root_span_input: trace.root_span_input(),
             root_span_output: trace.root_span_output(),
+            agent_input,
         }
     }
 }
 
 impl RealtimeDebuggerTrace {
-    pub fn from_trace(trace: &Trace) -> Self {
+    pub fn from_trace(trace: &Trace, agent_input: Option<String>) -> Self {
         Self {
             trace_id: trace.id(),
             metadata: trace.metadata().cloned(),
             has_browser_session: trace.has_browser_session(),
+            agent_input,
         }
     }
 }

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-session-view-content.tsx
@@ -109,9 +109,14 @@ export default function DebuggerSessionViewContent({ sessionId }: { sessionId: s
       trace_update: (event: MessageEvent) => {
         const payload = JSON.parse(event.data);
         if (!Array.isArray(payload.traces)) return;
-        storeApi
-          .getState()
-          .applyTraceUpdates(payload.traces as { traceId: string; metadata?: unknown; hasBrowserSession?: boolean }[]);
+        storeApi.getState().applyTraceUpdates(
+          payload.traces as {
+            traceId: string;
+            metadata?: unknown;
+            hasBrowserSession?: boolean;
+            agentInput?: string | null;
+          }[]
+        );
         backfillPendingEvalScores();
       },
       // Note / eval block pushed → upsert it into the timeline.

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -631,11 +631,8 @@ export const createDebuggerSessionViewStore = (options: {
               return;
             }
 
-            // Known run → live-patch the row. Both fields land after the initial
-            // load: hasBrowserSession once the browser span arrives, agentInput
-            // seconds later when async input extraction finishes. The empty guard
-            // is essential — a span-batch trace_update carries an empty agentInput
-            // and must not blank a value a prior extraction flush already set.
+            // Known run → live-patch fields that land after the initial load. The
+            // empty guard stops a span-batch update blanking an already-set agentInput.
             const patch: Record<string, unknown> = {};
             if (typeof t.hasBrowserSession === "boolean") patch.hasBrowserSession = t.hasBrowserSession;
             if (t.agentInput) patch.agentInput = t.agentInput;

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -155,6 +155,9 @@ const mergeTraceRow = (prev: TraceRow, next: TraceRow): TraceRow => {
     if (value !== undefined) (merged as Record<string, unknown>)[key] = value;
   }
   merged.endTime = new Date(prev.endTime).getTime() > new Date(next.endTime).getTime() ? prev.endTime : next.endTime;
+  // agentInput is sticky: extraction lands async, so a row hydrated (or updated)
+  // before it's written carries an empty value that must not blank a populated one.
+  if (!next.agentInput && prev.agentInput) merged.agentInput = prev.agentInput;
   return merged;
 };
 
@@ -173,7 +176,8 @@ const upsertTraceRows = (existing: TraceRow[], incoming: TraceRow[]): TraceRow[]
 };
 
 // Minimal TraceRow for a trace we only know the id of (live trace_update).
-const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {}): TraceRow => ({
+// agentInput is seeded when a cache-hit extraction update beats the span batch.
+const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {}, agentInput?: string): TraceRow => ({
   id: traceId,
   startTime: new Date().toISOString(),
   endTime: new Date().toISOString(),
@@ -188,6 +192,7 @@ const minimalTraceRow = (traceId: string, metadata: Record<string, string> = {})
   status: "success",
   spanTags: [],
   traceTags: [],
+  ...(agentInput ? { agentInput } : {}),
 });
 
 // Lifecycle of a trace block's row: absent → not requested yet (virtualizer
@@ -594,7 +599,8 @@ export const createDebuggerSessionViewStore = (options: {
               // ahead are already in `traceSpans`. Mark the row loaded — the
               // hydrate below refines it, and ensureTraceRows must not refetch.
               if (!hasRow) {
-                get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata)]);
+                const seedInput = typeof t.agentInput === "string" && t.agentInput ? t.agentInput : undefined;
+                get().setTraces((traces) => [...traces, minimalTraceRow(t.traceId, metadata, seedInput)]);
                 set(
                   (s) =>
                     ({

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -290,10 +290,17 @@ interface DebuggerSessionViewActions {
   applyRealtimeSpans: (spans: RealtimeSpan[]) => void;
 
   // Realtime: merge a trace_update into the block list (add + auto-expand if new).
-  applyTraceUpdate: (t: { traceId: string; metadata?: unknown; hasBrowserSession?: boolean }) => void;
+  applyTraceUpdate: (t: {
+    traceId: string;
+    metadata?: unknown;
+    hasBrowserSession?: boolean;
+    agentInput?: string | null;
+  }) => void;
 
   // Batch entry point for a trace_update payload.
-  applyTraceUpdates: (traces: { traceId: string; metadata?: unknown; hasBrowserSession?: boolean }[]) => void;
+  applyTraceUpdates: (
+    traces: { traceId: string; metadata?: unknown; hasBrowserSession?: boolean; agentInput?: string | null }[]
+  ) => void;
 
   // Realtime: upsert a pushed note / eval block (by id). Traces are ignored here
   // (they arrive via trace_update).
@@ -624,11 +631,16 @@ export const createDebuggerSessionViewStore = (options: {
               return;
             }
 
-            // Known run → update the row's hasBrowserSession.
-            if (typeof t.hasBrowserSession === "boolean") {
-              get().setTraces((traces) =>
-                traces.map((row) => (row.id === t.traceId ? { ...row, hasBrowserSession: t.hasBrowserSession } : row))
-              );
+            // Known run → live-patch the row. Both fields land after the initial
+            // load: hasBrowserSession once the browser span arrives, agentInput
+            // seconds later when async input extraction finishes. The empty guard
+            // is essential — a span-batch trace_update carries an empty agentInput
+            // and must not blank a value a prior extraction flush already set.
+            const patch: Record<string, unknown> = {};
+            if (typeof t.hasBrowserSession === "boolean") patch.hasBrowserSession = t.hasBrowserSession;
+            if (t.agentInput) patch.agentInput = t.agentInput;
+            if (Object.keys(patch).length > 0) {
+              get().setTraces((traces) => traces.map((row) => (row.id === t.traceId ? { ...row, ...patch } : row)));
             }
           },
 

--- a/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
+++ b/frontend/components/debugger-sessions/debugger-session-view/store/index.tsx
@@ -155,9 +155,9 @@ const mergeTraceRow = (prev: TraceRow, next: TraceRow): TraceRow => {
     if (value !== undefined) (merged as Record<string, unknown>)[key] = value;
   }
   merged.endTime = new Date(prev.endTime).getTime() > new Date(next.endTime).getTime() ? prev.endTime : next.endTime;
-  // agentInput is sticky: extraction lands async, so a row hydrated (or updated)
-  // before it's written carries an empty value that must not blank a populated one.
-  if (!next.agentInput && prev.agentInput) merged.agentInput = prev.agentInput;
+  // agentInput is sticky: extraction lands async, so an empty value (span batch,
+  // or a row hydrated before the write) must never blank a populated one.
+  merged.agentInput = next.agentInput || prev.agentInput;
   return merged;
 };
 

--- a/frontend/components/traces/traces-table/realtime.ts
+++ b/frontend/components/traces/traces-table/realtime.ts
@@ -28,5 +28,5 @@ export const realtimeTraceToRow = (trace: RealtimeTracePayload): TraceRow => ({
   traceTags: [],
   // Real extracted input arrives seconds late; until then fall back to the
   // root-span input as a transient stand-in (full refetch has the true value).
-  agentInput: trace.agentInput ?? trace.rootSpanInput ?? undefined,
+  agentInput: trace.agentInput || trace.rootSpanInput || undefined,
 });

--- a/frontend/components/traces/traces-table/realtime.ts
+++ b/frontend/components/traces/traces-table/realtime.ts
@@ -26,9 +26,7 @@ export const realtimeTraceToRow = (trace: RealtimeTracePayload): TraceRow => ({
   userId: trace.userId ?? undefined,
   spanTags: trace.tags ?? [],
   traceTags: [],
-  // Agent input is extracted asynchronously (Feature::InputExtraction), seconds
-  // after the trace. The extraction flush carries the real value; earlier
-  // span-batch updates don't, so fall back to the root-span input as a transient
-  // stand-in. Either way the next full fetch of the row has the true value.
+  // Real extracted input arrives seconds late; until then fall back to the
+  // root-span input as a transient stand-in (full refetch has the true value).
   agentInput: trace.agentInput ?? trace.rootSpanInput ?? undefined,
 });

--- a/frontend/components/traces/traces-table/realtime.ts
+++ b/frontend/components/traces/traces-table/realtime.ts
@@ -26,9 +26,9 @@ export const realtimeTraceToRow = (trace: RealtimeTracePayload): TraceRow => ({
   userId: trace.userId ?? undefined,
   spanTags: trace.tags ?? [],
   traceTags: [],
-  // Agent input is extracted asynchronously and lives in traces_agg, which the
-  // realtime SSE payload doesn't carry. Use the payload's root-span input as a
-  // transient live stand-in; the true agent_input replaces it on the next full
-  // fetch of the row.
-  agentInput: trace.rootSpanInput ?? undefined,
+  // Agent input is extracted asynchronously (Feature::InputExtraction), seconds
+  // after the trace. The extraction flush carries the real value; earlier
+  // span-batch updates don't, so fall back to the root-span input as a transient
+  // stand-in. Either way the next full fetch of the row has the true value.
+  agentInput: trace.agentInput ?? trace.rootSpanInput ?? undefined,
 });

--- a/frontend/components/traces/traces-table/table-contents.tsx
+++ b/frontend/components/traces/traces-table/table-contents.tsx
@@ -197,9 +197,10 @@ export const TracesTableContents = memo(function TracesTableContents({
           const newTraces = [...currentTraces];
           newTraces[existingTraceIndex] = {
             ...traceData,
-            // Only a real extracted value overwrites agent input; a later span-batch
-            // update (null) keeps what a prior extraction flush already set.
-            agentInput: trace.agentInput ?? prev.agentInput ?? traceData.agentInput,
+            // Prefer a real extracted value, else keep a populated prior one, else the
+            // rootSpanInput stand-in. Truthiness (not ??) so an empty "" from the initial
+            // traces_v0 fetch (ifNull → '') yields to the stand-in instead of sticking.
+            agentInput: trace.agentInput || prev.agentInput || traceData.agentInput,
           };
           return newTraces;
         }

--- a/frontend/components/traces/traces-table/table-contents.tsx
+++ b/frontend/components/traces/traces-table/table-contents.tsx
@@ -181,7 +181,8 @@ export const TracesTableContents = memo(function TracesTableContents({
   }, [setNavigationRefList, traces]);
 
   const updateRealtimeTrace = useCallback(
-    (traceData: TraceRow) => {
+    (trace: RealtimeTracePayload) => {
+      const traceData = realtimeTraceToRow(trace);
       if (!traceData.startTime || !isTraceInTimeRange(traceData.startTime)) {
         return;
       }
@@ -189,11 +190,17 @@ export const TracesTableContents = memo(function TracesTableContents({
       updateData((currentTraces) => {
         if (!currentTraces || currentTraces.length === 0) return currentTraces;
 
-        const existingTraceIndex = currentTraces.findIndex((trace) => trace.id === traceData.id);
+        const existingTraceIndex = currentTraces.findIndex((t) => t.id === traceData.id);
 
         if (existingTraceIndex !== -1) {
+          const prev = currentTraces[existingTraceIndex];
           const newTraces = [...currentTraces];
-          newTraces[existingTraceIndex] = traceData;
+          newTraces[existingTraceIndex] = {
+            ...traceData,
+            // Only a real extracted value overwrites agent input; a later span-batch
+            // update (null) keeps what a prior extraction flush already set.
+            agentInput: trace.agentInput ?? prev.agentInput ?? traceData.agentInput,
+          };
           return newTraces;
         }
 
@@ -220,7 +227,7 @@ export const TracesTableContents = memo(function TracesTableContents({
           const payload = JSON.parse(event.data) as { traces?: RealtimeTracePayload[] };
           if (payload.traces && Array.isArray(payload.traces)) {
             for (const trace of payload.traces) {
-              updateRealtimeTrace(realtimeTraceToRow(trace));
+              updateRealtimeTrace(trace);
             }
           }
         } catch (e) {

--- a/frontend/lib/traces/types.ts
+++ b/frontend/lib/traces/types.ts
@@ -182,6 +182,11 @@ export type RealtimeTracePayload = {
   tags: string[];
   rootSpanInput: string | null;
   rootSpanOutput: string | null;
+  // Extracted "user task" (Feature::InputExtraction). Lands seconds after the
+  // trace via an async metadata-only span, so it's null on span-batch updates
+  // and populated only on the extraction flush. JSON-stringified, matching the
+  // fresh-fetch `agent_input as agentInput` value.
+  agentInput: string | null;
 };
 
 export type TracePreview = {

--- a/frontend/lib/traces/types.ts
+++ b/frontend/lib/traces/types.ts
@@ -182,10 +182,8 @@ export type RealtimeTracePayload = {
   tags: string[];
   rootSpanInput: string | null;
   rootSpanOutput: string | null;
-  // Extracted "user task" (Feature::InputExtraction). Lands seconds after the
-  // trace via an async metadata-only span, so it's null on span-batch updates
-  // and populated only on the extraction flush. JSON-stringified, matching the
-  // fresh-fetch `agent_input as agentInput` value.
+  // Extracted "user task"; null on span-batch updates, set on the extraction
+  // flush. JSON-stringified, matching fresh-fetch `agent_input`.
   agentInput: string | null;
 };
 


### PR DESCRIPTION
## What

Makes the extracted trace **input** (`agent_input`, `Feature::InputExtraction`) a first-class field on the realtime `trace_update` SSE payload, so the debugger session view (and the traces table) show the input **live** without a manual reload.

## Why

`agent_input` is written **asynchronously** — an LLM regex round-trip that finishes seconds after the trace lands (output is an instant inline heuristic, so it already appears immediately). The debugger loads each trace row **once** and never refetches; its `trace_update` handler only patched `hasBrowserSession`, so the input pill stayed empty until reload.

The regular trace view looks instant only because opening it is a fresh fetch by which time extraction has finished — it doesn't live-update `agent_input` either.

Regression origin: PR #2120 / LAM-2006 switched the debugger's collapsed-body input source from a span-derived read-time preview to the stored `agent_input` column. The DB value is correct; it just never reaches the already-rendered row live.

## Approach — Option B (thread the value)

Rather than reading `agent_input` off the deprecated `lmnr_user_task` metadata fold (Option A, on a demolition schedule), the extracted value is threaded straight from the ingestion path (`raw_trace_io`) to the realtime dispatch as a first-class field on **both** `RealtimeTrace` (traces table) and `RealtimeDebuggerTrace` (debugger). It's JSON-stringified (`value.to_string()`) to match `CHTraceAgentInput.value` / `traces_v0.agent_input`, so the live value renders identically to the fresh-fetch path.

## Empty-value guard

A span-batch `trace_update` (before extraction runs) carries no `agent_input`. The frontend only overwrites `agentInput` when the payload value is non-empty, so an earlier batch can't blank a value a later extraction flush already set. The traces-table path keeps `rootSpanInput` as a transient fallback (unchanged behavior when the real value isn't present yet).

## Touch-points

**Backend**
- `app-server/src/traces/realtime.rs` — `agent_input: Option<String>` on both realtime structs; `from_trace` takes the value.
- `app-server/src/traces/processor.rs` — build `agent_input_by_trace` from `raw_trace_io`, thread it into `dispatch_trace_realtime_updates`.

**Frontend**
- `lib/traces/types.ts` — `agentInput` on `RealtimeTracePayload`.
- debugger store + content dispatcher — set `row.agentInput` in the known-run branch with the empty guard.
- `traces-table/realtime.ts` — prefer the real `agentInput`, fall back to `rootSpanInput`.

## Testing
- `cargo check` (default features) ✅
- `pnpm type-check` ✅ / `pnpm lint` (0 errors) ✅
- Manual: start a fresh debugger run, confirm the input pill appears live a few seconds after the trace (output appears immediately) with no reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SSE field and guarded client merges; no auth or persistence semantics change beyond richer realtime payloads.
> 
> **Overview**
> **Extracted user-task input (`agent_input`) now rides on live `trace_update` SSE payloads**, so debugger sessions and the traces table can show the input pill without a reload.
> 
> On ingest, the server builds `agent_input_by_trace` from `raw_trace_io` (JSON-stringified to match stored `agent_input`) and passes it into `dispatch_trace_realtime_updates`. **`RealtimeTrace` and `RealtimeDebuggerTrace` gain an `agentInput` field** populated only on the flush where input extraction landed; earlier span-batch updates omit it.
> 
> The frontend treats **`agentInput` as sticky**: merges prefer non-empty extracted values and ignore empty payloads so a late extraction update cannot be wiped by an earlier batch. The traces table still uses **`rootSpanInput` as a transient fallback** until the real value arrives; row updates layer extracted → prior → stand-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f82e3018728ba46e23bb60405da1d89ba1b0aa91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

