### PR TITLE
fix(a11y): add accessible labels to search, chart, cli-auth, and email controls

### DIFF
--- a/frontend/components/auth/email-sign-in.tsx
+++ b/frontend/components/auth/email-sign-in.tsx
@@ -42,9 +42,13 @@ export function EmailSignInButton({ callbackUrl, action = "sign_in_attempted", c
   return (
     <div className={cn("h-full flex flex-col gap-4", className)}>
       <div className="flex flex-col gap-2">
-        <Label className="text-sm text-muted-foreground text-left">Sign in with email (local only)</Label>
+        <Label htmlFor="email-sign-in" className="text-sm text-muted-foreground text-left">
+          Sign in with email (local only)
+        </Label>
         <Input
+          id="email-sign-in"
           type="email"
+          autoComplete="email"
           placeholder="Email"
           size="md"
           value={email}

--- a/frontend/components/chart-builder/export-chart-dialog.tsx
+++ b/frontend/components/chart-builder/export-chart-dialog.tsx
@@ -89,6 +89,7 @@ const ExportChartDialog = ({ children }: PropsWithChildren) => {
         <Separator />
         <Input
           id="chart-name"
+          aria-label="Chart name"
           value={name || ""}
           onChange={(e) => setChartName(e.target.value || undefined)}
           placeholder="Enter chart name"

--- a/frontend/components/chart-builder/index.tsx
+++ b/frontend/components/chart-builder/index.tsx
@@ -69,7 +69,7 @@ const ChartBuilderCore = () => {
           <div>
             <label className="text-sm font-medium mb-1 block">Chart type</label>
             <Select value={chartConfig.type || ""} onValueChange={setChartType}>
-              <SelectTrigger className="focus:ring-0">
+              <SelectTrigger className="focus:ring-0" aria-label="Chart type">
                 <SelectValue placeholder="Select Chart Type" />
               </SelectTrigger>
               <SelectContent>

--- a/frontend/components/cli-auth/create-first-project.tsx
+++ b/frontend/components/cli-auth/create-first-project.tsx
@@ -131,9 +131,9 @@ export function CreateFirstProject({ userCode, workspaces, onApproved, onDenied 
                 />
               </Field>
             ) : workspaces.length > 1 ? (
-              <Field label="Workspace">
+              <Field label="Workspace" as="div">
                 <Select value={workspaceId} onValueChange={setWorkspaceId} disabled={busy}>
-                  <SelectTrigger className="h-9">
+                  <SelectTrigger className="h-9" aria-label="Workspace">
                     <SelectValue placeholder="Select a workspace" />
                   </SelectTrigger>
                   <SelectContent>

--- a/frontend/components/cli-auth/create-project-dialog.tsx
+++ b/frontend/components/cli-auth/create-project-dialog.tsx
@@ -90,9 +90,9 @@ export function CreateProjectDialog({ open, onOpenChange, workspaces, onCreated 
               />
             </Field>
           ) : workspaces.length > 1 ? (
-            <Field label="Workspace">
+            <Field label="Workspace" as="div">
               <Select value={workspaceId} onValueChange={setWorkspaceId}>
-                <SelectTrigger className="h-9">
+                <SelectTrigger className="h-9" aria-label="Workspace">
                   <SelectValue placeholder="Select a workspace" />
                 </SelectTrigger>
                 <SelectContent>

--- a/frontend/components/cli-auth/shared.tsx
+++ b/frontend/components/cli-auth/shared.tsx
@@ -9,11 +9,13 @@ export function Centered({ children }: { children: ReactNode }) {
 }
 
 export function Field({ label, children }: { label: string; children: ReactNode }) {
+  // A wrapping <label> implicitly associates the text with the control inside it,
+  // giving inputs an accessible name without threading an id through every call site.
   return (
-    <div className="flex flex-col gap-1">
+    <label className="flex flex-col gap-1">
       <span className="text-xs text-muted-foreground">{label}</span>
       {children}
-    </div>
+    </label>
   );
 }
 

--- a/frontend/components/cli-auth/shared.tsx
+++ b/frontend/components/cli-auth/shared.tsx
@@ -8,14 +8,17 @@ export function Centered({ children }: { children: ReactNode }) {
   return <div className="flex min-h-screen w-full items-center justify-center bg-background p-6">{children}</div>;
 }
 
-export function Field({ label, children }: { label: string; children: ReactNode }) {
+export function Field({ label, children, as = "label" }: { label: string; children: ReactNode; as?: "label" | "div" }) {
   // A wrapping <label> implicitly associates the text with the control inside it,
   // giving inputs an accessible name without threading an id through every call site.
+  // Radix Select misbehaves when nested in a <label> (the menu won't close on
+  // mobile), so pass as="div" for Select and give the trigger its own aria-label.
+  const Tag = as;
   return (
-    <label className="flex flex-col gap-1">
+    <Tag className="flex flex-col gap-1">
       <span className="text-xs text-muted-foreground">{label}</span>
       {children}
-    </label>
+    </Tag>
   );
 }
 

--- a/frontend/components/common/advanced-search/components/tag.tsx
+++ b/frontend/components/common/advanced-search/components/tag.tsx
@@ -256,7 +256,14 @@ const FilterTag = ({ tag, resource = "traces", isSelected = false, ref }: Filter
         mode={focusState.type === "idle" ? "nav" : focusState.mode}
       />
 
-      <Button variant="ghost" ref={removeRef} onClick={handleRemove} className={removeButtonClassName} type="button">
+      <Button
+        variant="ghost"
+        ref={removeRef}
+        onClick={handleRemove}
+        className={removeButtonClassName}
+        type="button"
+        aria-label="Remove filter"
+      >
         <X className="w-3 h-3 text-secondary-foreground" />
       </Button>
     </div>

--- a/frontend/components/common/advanced-search/components/tag.tsx
+++ b/frontend/components/common/advanced-search/components/tag.tsx
@@ -262,7 +262,7 @@ const FilterTag = ({ tag, resource = "traces", isSelected = false, ref }: Filter
         onClick={handleRemove}
         className={removeButtonClassName}
         type="button"
-        aria-label="Remove filter"
+        aria-label={`Remove ${columnFilter.name} filter`}
       >
         <X className="w-3 h-3 text-secondary-foreground" />
       </Button>

--- a/frontend/components/common/advanced-search/components/tag.tsx
+++ b/frontend/components/common/advanced-search/components/tag.tsx
@@ -15,6 +15,7 @@ import {
 } from "react";
 
 import { Button } from "@/components/ui/button";
+import { OperatorLabelMap } from "@/components/ui/infinite-datatable/ui/datatable-filter/utils";
 import { AUTOCOMPLETE_FIELDS } from "@/lib/actions/autocomplete/fields";
 import { cn } from "@/lib/utils";
 
@@ -70,6 +71,14 @@ const FilterTag = ({ tag, resource = "traces", isSelected = false, ref }: Filter
     dataType: tag.dataType ?? "string",
   };
   const dataType = columnFilter.dataType;
+
+  // Include operator + value so several filters on the SAME column get distinct
+  // remove-button names (e.g. "Remove metadata = foo filter"); fall back to the
+  // bare name while the tag is still being built and has no value yet.
+  const valueText = Array.isArray(tag.value) ? tag.value.join(", ") : tag.value;
+  const removeLabel = valueText
+    ? `Remove ${columnFilter.name} ${OperatorLabelMap[tag.operator]} ${valueText} filter`
+    : `Remove ${columnFilter.name} filter`;
 
   const focusMainInput = useCallback(() => {
     mainInputRef.current?.focus();
@@ -262,7 +271,7 @@ const FilterTag = ({ tag, resource = "traces", isSelected = false, ref }: Filter
         onClick={handleRemove}
         className={removeButtonClassName}
         type="button"
-        aria-label={`Remove ${columnFilter.name} filter`}
+        aria-label={removeLabel}
       >
         <X className="w-3 h-3 text-secondary-foreground" />
       </Button>

--- a/frontend/components/common/search-input.tsx
+++ b/frontend/components/common/search-input.tsx
@@ -71,7 +71,7 @@ const SearchInput = ({ onSearch, placeholder, className }: SearchInputProps) => 
           onChange={(e) => setInputValue(e.target.value)}
         />
         {inputValue && (
-          <Button onClick={handleClearInput} variant="ghost" className="h-4 w-4" size="icon">
+          <Button aria-label="Close" onClick={handleClearInput} variant="ghost" className="h-4 w-4" size="icon">
             <X size={16} className="text-secondary-foreground cursor-pointer" />
           </Button>
         )}

--- a/frontend/components/common/search-input.tsx
+++ b/frontend/components/common/search-input.tsx
@@ -71,7 +71,7 @@ const SearchInput = ({ onSearch, placeholder, className }: SearchInputProps) => 
           onChange={(e) => setInputValue(e.target.value)}
         />
         {inputValue && (
-          <Button aria-label="Close" onClick={handleClearInput} variant="ghost" className="h-4 w-4" size="icon">
+          <Button aria-label="Clear search" onClick={handleClearInput} variant="ghost" className="h-4 w-4" size="icon">
             <X size={16} className="text-secondary-foreground cursor-pointer" />
           </Button>
         )}

--- a/frontend/components/dashboards/chart-header.tsx
+++ b/frontend/components/dashboards/chart-header.tsx
@@ -136,6 +136,7 @@ const ChartHeader = ({ name, id, projectId }: ChartHeaderProps) => {
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
+              aria-label="More options"
               variant="ghost"
               size="sm"
               className="h-6 w-6 text-muted-foreground p-0 ml-auto focus-visible:ring-0"

--- a/frontend/components/dashboards/selection-toolbar.tsx
+++ b/frontend/components/dashboards/selection-toolbar.tsx
@@ -113,6 +113,7 @@ export default function SelectionToolbar() {
               Open in traces
             </Button>
             <button
+              aria-label="Close"
               onClick={clearSelection}
               className="text-muted-foreground hover:text-primary-foreground transition-colors"
             >

--- a/frontend/components/dashboards/selection-toolbar.tsx
+++ b/frontend/components/dashboards/selection-toolbar.tsx
@@ -113,7 +113,7 @@ export default function SelectionToolbar() {
               Open in traces
             </Button>
             <button
-              aria-label="Close"
+              aria-label="Clear selection"
               onClick={clearSelection}
               className="text-muted-foreground hover:text-primary-foreground transition-colors"
             >

--- a/frontend/components/dataset/dataset-panel.tsx
+++ b/frontend/components/dataset/dataset-panel.tsx
@@ -338,7 +338,7 @@ export default function DatasetPanel({
       <>
         <div className="flex flex-col h-full w-full">
           <div className="h-12 flex flex-none space-x-2 px-3 items-center border-b">
-            <Button variant="ghost" className="px-1" onClick={handleClose}>
+            <Button aria-label="Collapse panel" variant="ghost" className="px-1" onClick={handleClose}>
               <ChevronsRight />
             </Button>
             <div>Row</div>

--- a/frontend/components/datasets/create-dataset-dialog.tsx
+++ b/frontend/components/datasets/create-dataset-dialog.tsx
@@ -88,7 +88,7 @@ export default function CreateDatasetDialog({
           </div>
           <DialogFooter>
             <Button className="w-fit" onClick={createNewDataset} disabled={!newDatasetName || isLoading} handleEnter>
-              <Loader2 className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
+              <Loader2 data-icon="inline-start" className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
               Create
             </Button>
           </DialogFooter>

--- a/frontend/components/datasets/rename-dataset-dialog.tsx
+++ b/frontend/components/datasets/rename-dataset-dialog.tsx
@@ -104,7 +104,7 @@ export default function RenameDatasetDialog({ dataset, children }: PropsWithChil
           </div>
           <DialogFooter>
             <Button disabled={!newName.trim() || isLoading} onClick={handleRename}>
-              <Loader2 className={cn("mr-2 h-4 w-4", isLoading ? "animate-spin" : "hidden")} />
+              <Loader2 data-icon="inline-start" className={cn("mr-2 h-4 w-4", isLoading ? "animate-spin" : "hidden")} />
               Rename
             </Button>
           </DialogFooter>

--- a/frontend/components/error/error-page.tsx
+++ b/frontend/components/error/error-page.tsx
@@ -48,11 +48,11 @@ export default function ErrorPage({ error, backAction, backLabel }: ErrorPagePro
             size="lg"
             variant="outline"
           >
-            <ArrowLeft className="size-4 transition-transform group-active:-translate-x-0.5" />
+            <ArrowLeft data-icon="inline-start" className="size-4 transition-transform group-active:-translate-x-0.5" />
             {backLabel}
           </Button>
           <Button onClick={handleRetry} className="gap-2 pl-3 pr-5 transition-transform" size="lg" variant="default">
-            <RefreshCw ref={refreshIconRef} className="size-4" />
+            <RefreshCw data-icon="inline-start" ref={refreshIconRef} className="size-4" />
             Try again
           </Button>
         </div>

--- a/frontend/components/evaluation/evaluation-datapoints-table/eval-table-skeleton.tsx
+++ b/frontend/components/evaluation/evaluation-datapoints-table/eval-table-skeleton.tsx
@@ -25,7 +25,7 @@ export default function EvalTableSkeleton() {
               <ChevronDown className="size-3.5 shrink-0 opacity-60" />
             </Button>
 
-            <Button className="h-7 w-7" variant="outline" size="icon" disabled>
+            <Button aria-label="Settings" className="h-7 w-7" variant="outline" size="icon" disabled>
               <Settings className="h-4 w-4 text-secondary-foreground" />
             </Button>
           </div>

--- a/frontend/components/evaluation/evaluation-datapoints-table/eval-table-skeleton.tsx
+++ b/frontend/components/evaluation/evaluation-datapoints-table/eval-table-skeleton.tsx
@@ -20,9 +20,9 @@ export default function EvalTableSkeleton() {
               Columns
             </Button>
             <Button className="gap-1 text-secondary-foreground" variant="outline" disabled>
-              <Layers2 className="h-3.5 w-3.5" />
+              <Layers2 data-icon="inline-start" className="h-3.5 w-3.5" />
               Default view
-              <ChevronDown className="size-3.5 shrink-0 opacity-60" />
+              <ChevronDown data-icon="inline-end" className="size-3.5 shrink-0 opacity-60" />
             </Button>
 
             <Button aria-label="Settings" className="h-7 w-7" variant="outline" size="icon" disabled>

--- a/frontend/components/evaluation/evaluation-datapoints-table/table-controls.tsx
+++ b/frontend/components/evaluation/evaluation-datapoints-table/table-controls.tsx
@@ -69,7 +69,7 @@ export function EvaluationDatapointsTableControls({
         {onHeatmapEnabledChange && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button className="h-7 w-7" variant="outline" size="icon">
+              <Button aria-label="Settings" className="h-7 w-7" variant="outline" size="icon">
                 <SettingsIcon className="h-4 w-4 text-secondary-foreground" />
               </Button>
             </DropdownMenuTrigger>

--- a/frontend/components/evaluation/evaluation-header/index.tsx
+++ b/frontend/components/evaluation/evaluation-header/index.tsx
@@ -126,7 +126,7 @@ const EvaluationHeader = ({ evaluations, name, urlKey, datasets }: EvaluationHea
       <div className="flex items-center gap-2 shrink-0">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="secondary" className="h-7 w-7 p-0">
+            <Button aria-label="More options" variant="secondary" className="h-7 w-7 p-0">
               <Ellipsis className="w-3" />
             </Button>
           </DropdownMenuTrigger>

--- a/frontend/components/evaluations/table-controls.tsx
+++ b/frontend/components/evaluations/table-controls.tsx
@@ -60,7 +60,7 @@ export function EvaluationsTableControls({
         {scoreNames.length > 0 && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button className="h-7 w-7" variant="outline" size="icon">
+              <Button aria-label="Settings" className="h-7 w-7" variant="outline" size="icon">
                 <SettingsIcon className="h-4 w-4 text-secondary-foreground" />
               </Button>
             </DropdownMenuTrigger>

--- a/frontend/components/landing/sections/understand-why-trace-view/ask-ai.tsx
+++ b/frontend/components/landing/sections/understand-why-trace-view/ask-ai.tsx
@@ -225,6 +225,7 @@ export default function AskAi() {
                 maxRows={6}
               />
               <Button
+                aria-label="Up"
                 type="submit"
                 size="icon"
                 className="h-7 w-7 rounded-full border bg-primary flex-shrink-0 mr-1 mb-1"

--- a/frontend/components/landing/sections/understand-why-trace-view/ask-ai.tsx
+++ b/frontend/components/landing/sections/understand-why-trace-view/ask-ai.tsx
@@ -225,7 +225,7 @@ export default function AskAi() {
                 maxRows={6}
               />
               <Button
-                aria-label="Up"
+                aria-label="Send message"
                 type="submit"
                 size="icon"
                 className="h-7 w-7 rounded-full border bg-primary flex-shrink-0 mr-1 mb-1"

--- a/frontend/components/landing/sections/understand-why-trace-view/trace-bento.tsx
+++ b/frontend/components/landing/sections/understand-why-trace-view/trace-bento.tsx
@@ -88,17 +88,17 @@ const TraceViewHeaderRow1 = ({
 }) => (
   <div className="flex items-center gap-1">
     <span className={cn(HEADER_ITEM_CLS, "gap-0.5")}>
-      <Button variant="ghost" disabled className="h-7 px-0.5 disabled:opacity-100">
+      <Button aria-label="Collapse panel" variant="ghost" disabled className="h-7 px-0.5 disabled:opacity-100">
         <ChevronsRight className="w-5 h-5" />
       </Button>
-      <Button variant="ghost" disabled className="h-7 px-0.5 disabled:opacity-100">
+      <Button aria-label="Expand" variant="ghost" disabled className="h-7 px-0.5 disabled:opacity-100">
         <Maximize className="w-4 h-4" />
       </Button>
     </span>
 
     <span className={HEADER_ITEM_CLS}>
       <span className="text-base font-medium pl-2 flex-shrink-0">Trace</span>
-      <Button variant="ghost" disabled className="h-7 px-1 disabled:opacity-100">
+      <Button aria-label="Expand" variant="ghost" disabled className="h-7 px-1 disabled:opacity-100">
         <ChevronDown className="w-3 h-3" />
       </Button>
     </span>

--- a/frontend/components/landing/sections/understand-why-trace-view/trace-bento.tsx
+++ b/frontend/components/landing/sections/understand-why-trace-view/trace-bento.tsx
@@ -109,7 +109,7 @@ const TraceViewHeaderRow1 = ({
         disabled
         className={cn("h-6 text-xs px-1.5 disabled:opacity-100", chatActive && "border-primary text-primary")}
       >
-        <Sparkles size={14} className="mr-1" />
+        <Sparkles data-icon="inline-start" size={14} className="mr-1" />
         Chat
       </Button>
     </span>
@@ -120,7 +120,7 @@ const TraceViewHeaderRow1 = ({
         onClick={onSignalsToggle}
         className={cn("h-6 text-xs px-1.5", signalsActive && "border-primary text-primary")}
       >
-        <Radio size={14} className="mr-1" />
+        <Radio data-icon="inline-start" size={14} className="mr-1" />
         Signals (1)
       </Button>
     </span>

--- a/frontend/components/notifications/notification-panel/index.tsx
+++ b/frontend/components/notifications/notification-panel/index.tsx
@@ -175,6 +175,7 @@ const NotificationPanel = () => {
                     </Link>
                   )}
                   <button
+                    aria-label="Close"
                     onClick={close}
                     className="flex items-center justify-center rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
                   >

--- a/frontend/components/onboarding/steps/slack-step.tsx
+++ b/frontend/components/onboarding/steps/slack-step.tsx
@@ -80,7 +80,7 @@ export default function SlackStep({ stepIndex, totalSteps, onAdvance, onBack }: 
         <div className="my-auto shrink-0">
           {slackConnected ? (
             <Button className="border-success bg-success/80 gap-1 hover:bg-success/80 2xl:h-9">
-              <CheckCircle2 className="h-4 w-4 2xl:h-5 2xl:w-5" />
+              <CheckCircle2 data-icon="inline-start" className="h-4 w-4 2xl:h-5 2xl:w-5" />
               <span className="text-xs 2xl:text-sm">Connected</span>
             </Button>
           ) : (

--- a/frontend/components/playground/image-with-preview.tsx
+++ b/frontend/components/playground/image-with-preview.tsx
@@ -33,7 +33,7 @@ const ImageWithPreview = ({ src, className, alt }: ImageWithPreviewProps) => {
         <DialogTitle className="flex justify-between items-center">
           <span>Image Preview</span>
           <DialogClose asChild>
-            <Button className="size-4" variant="ghost" size="icon">
+            <Button aria-label="Close" className="size-4" variant="ghost" size="icon">
               <X size={12} />
             </Button>
           </DialogClose>

--- a/frontend/components/playground/messages/index.tsx
+++ b/frontend/components/playground/messages/index.tsx
@@ -86,7 +86,7 @@ const Messages = () => {
       </ScrollArea>
       <div className="px-4">
         <Button onClick={() => append(defaultMessage)} variant="outline" className="self-start h-8">
-          <Plus className="mr-2" size={12} />
+          <Plus data-icon="inline-start" className="mr-2" size={12} />
           Add message
         </Button>
       </div>

--- a/frontend/components/playground/messages/message-parts.tsx
+++ b/frontend/components/playground/messages/message-parts.tsx
@@ -70,7 +70,13 @@ const MessageParts = ({ parentIndex, fields, remove }: MessagePartsProps) => {
                   className="border-none bg-transparent p-0 focus-visible:ring-0 flex-1 h-fit rounded-none max-h-96"
                 />
                 {fields.length > 1 && (
-                  <Button onClick={() => remove(index)} className={buttonClassName} variant="outline" size="icon">
+                  <Button
+                    aria-label="Close"
+                    onClick={() => remove(index)}
+                    className={buttonClassName}
+                    variant="outline"
+                    size="icon"
+                  >
                     <X className="text-gray-400" size={12} />
                   </Button>
                 )}
@@ -123,7 +129,13 @@ const MessageParts = ({ parentIndex, fields, remove }: MessagePartsProps) => {
                   />
                 </div>
                 {fields.length > 1 && (
-                  <Button onClick={() => remove(index)} className={buttonClassName} variant="outline" size="icon">
+                  <Button
+                    aria-label="Close"
+                    onClick={() => remove(index)}
+                    className={buttonClassName}
+                    variant="outline"
+                    size="icon"
+                  >
                     <X className="text-gray-400" size={12} />
                   </Button>
                 )}
@@ -156,7 +168,13 @@ const MessageParts = ({ parentIndex, fields, remove }: MessagePartsProps) => {
                   <ToolResultOutput parentIndex={parentIndex} index={index} output={part.output} />
                 </div>
                 {fields.length > 1 && (
-                  <Button onClick={() => remove(index)} className={buttonClassName} variant="outline" size="icon">
+                  <Button
+                    aria-label="Close"
+                    onClick={() => remove(index)}
+                    className={buttonClassName}
+                    variant="outline"
+                    size="icon"
+                  >
                     <X className="text-gray-400" size={12} />
                   </Button>
                 )}
@@ -181,6 +199,7 @@ const MessageParts = ({ parentIndex, fields, remove }: MessagePartsProps) => {
                         onChange={handleFileSelect(onChange)}
                       />
                       <Button
+                        aria-label="Attach file"
                         onClick={() => fileInputRef.current?.click()}
                         size="icon"
                         variant="outline"
@@ -190,6 +209,7 @@ const MessageParts = ({ parentIndex, fields, remove }: MessagePartsProps) => {
                       </Button>
                       {fields.length > 1 && (
                         <Button
+                          aria-label="Close"
                           onClick={() => remove(index)}
                           className={cn(buttonClassName, "ml-auto")}
                           variant="outline"

--- a/frontend/components/playground/messages/message-parts.tsx
+++ b/frontend/components/playground/messages/message-parts.tsx
@@ -71,7 +71,7 @@ const MessageParts = ({ parentIndex, fields, remove }: MessagePartsProps) => {
                 />
                 {fields.length > 1 && (
                   <Button
-                    aria-label="Close"
+                    aria-label="Remove message part"
                     onClick={() => remove(index)}
                     className={buttonClassName}
                     variant="outline"
@@ -130,7 +130,7 @@ const MessageParts = ({ parentIndex, fields, remove }: MessagePartsProps) => {
                 </div>
                 {fields.length > 1 && (
                   <Button
-                    aria-label="Close"
+                    aria-label="Remove message part"
                     onClick={() => remove(index)}
                     className={buttonClassName}
                     variant="outline"
@@ -169,7 +169,7 @@ const MessageParts = ({ parentIndex, fields, remove }: MessagePartsProps) => {
                 </div>
                 {fields.length > 1 && (
                   <Button
-                    aria-label="Close"
+                    aria-label="Remove message part"
                     onClick={() => remove(index)}
                     className={buttonClassName}
                     variant="outline"
@@ -209,7 +209,7 @@ const MessageParts = ({ parentIndex, fields, remove }: MessagePartsProps) => {
                       </Button>
                       {fields.length > 1 && (
                         <Button
-                          aria-label="Close"
+                          aria-label="Remove message part"
                           onClick={() => remove(index)}
                           className={cn(buttonClassName, "ml-auto")}
                           variant="outline"

--- a/frontend/components/playground/messages/message.tsx
+++ b/frontend/components/playground/messages/message.tsx
@@ -113,7 +113,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
               </TooltipPortal>
               <TooltipTrigger asChild>
                 <Button
-                  aria-label="New chat"
+                  aria-label="Add text message part"
                   onClick={() => append(defaultTextPart)}
                   className={buttonClassName}
                   variant="outline"
@@ -148,7 +148,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
             </TooltipPortal>
             <TooltipTrigger asChild>
               <Button
-                aria-label="Settings"
+                aria-label="Add tool result part"
                 onClick={() => append(defaultToolResultPart)}
                 className={buttonClassName}
                 variant="outline"
@@ -166,7 +166,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
             </TooltipPortal>
             <TooltipTrigger asChild>
               <Button
-                aria-label="Settings"
+                aria-label="Add tool call part"
                 onClick={() => append(defaultToolCallPart)}
                 className={buttonClassName}
                 variant="outline"
@@ -183,7 +183,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
           </TooltipPortal>
           <TooltipTrigger asChild>
             <Button
-              aria-label="Add"
+              aria-label="Add message"
               onClick={() => insert(index + 1, defaultMessage)}
               className={buttonClassName}
               variant="outline"
@@ -200,7 +200,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
             </TooltipPortal>
             <TooltipTrigger asChild>
               <Button
-                aria-label="Remove"
+                aria-label="Remove message"
                 onClick={() => remove(index)}
                 className={buttonClassName}
                 variant="outline"
@@ -212,7 +212,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
           </Tooltip>
         )}
         <CollapsibleTrigger asChild>
-          <Button aria-label="Next" variant="ghost" size="icon" className="w-6 h-6 ml-auto">
+          <Button aria-label="Toggle message parts" variant="ghost" size="icon" className="w-6 h-6 ml-auto">
             <ChevronRight className="w-4 h-4 text-muted-foreground mr-2 group-data-[state=open]:rotate-90 transition-transform duration-200" />
           </Button>
         </CollapsibleTrigger>

--- a/frontend/components/playground/messages/message.tsx
+++ b/frontend/components/playground/messages/message.tsx
@@ -113,6 +113,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
               </TooltipPortal>
               <TooltipTrigger asChild>
                 <Button
+                  aria-label="New chat"
                   onClick={() => append(defaultTextPart)}
                   className={buttonClassName}
                   variant="outline"
@@ -128,6 +129,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
               </TooltipPortal>
               <TooltipTrigger asChild>
                 <Button
+                  aria-label="Add image"
                   onClick={() => append(defaultImagePart)}
                   className={buttonClassName}
                   variant="outline"
@@ -146,6 +148,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
             </TooltipPortal>
             <TooltipTrigger asChild>
               <Button
+                aria-label="Settings"
                 onClick={() => append(defaultToolResultPart)}
                 className={buttonClassName}
                 variant="outline"
@@ -163,6 +166,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
             </TooltipPortal>
             <TooltipTrigger asChild>
               <Button
+                aria-label="Settings"
                 onClick={() => append(defaultToolCallPart)}
                 className={buttonClassName}
                 variant="outline"
@@ -179,6 +183,7 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
           </TooltipPortal>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Add"
               onClick={() => insert(index + 1, defaultMessage)}
               className={buttonClassName}
               variant="outline"
@@ -194,14 +199,20 @@ const Message = ({ insert, remove, update, index, deletable = true }: MessagePro
               <TooltipContent>Remove message</TooltipContent>
             </TooltipPortal>
             <TooltipTrigger asChild>
-              <Button onClick={() => remove(index)} className={buttonClassName} variant="outline" size="icon">
+              <Button
+                aria-label="Remove"
+                onClick={() => remove(index)}
+                className={buttonClassName}
+                variant="outline"
+                size="icon"
+              >
                 <CircleMinus className="text-muted-foreground" size={12} />
               </Button>
             </TooltipTrigger>
           </Tooltip>
         )}
         <CollapsibleTrigger asChild>
-          <Button variant="ghost" size="icon" className="w-6 h-6 ml-auto">
+          <Button aria-label="Next" variant="ghost" size="icon" className="w-6 h-6 ml-auto">
             <ChevronRight className="w-4 h-4 text-muted-foreground mr-2 group-data-[state=open]:rotate-90 transition-transform duration-200" />
           </Button>
         </CollapsibleTrigger>

--- a/frontend/components/playground/messages/params-popover.tsx
+++ b/frontend/components/playground/messages/params-popover.tsx
@@ -25,6 +25,7 @@ const ParamsPopover = ({ className }: ParamsPopoverProps) => {
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>
             <Button
+              aria-label="Settings"
               size="icon"
               disabled={!watch("model")}
               variant="outline"

--- a/frontend/components/playground/messages/structured-output-sheet.tsx
+++ b/frontend/components/playground/messages/structured-output-sheet.tsx
@@ -47,6 +47,7 @@ export default function StructuredOutputSheet({
       return (
         <SheetTrigger asChild>
           <Button
+            aria-label="Edit JSON"
             disabled={!model}
             variant="outline"
             size="icon"
@@ -62,6 +63,7 @@ export default function StructuredOutputSheet({
       <div className="flex flex-row [&>*:first-child]:border-r-0 [&>*:first-child]:rounded-l [&>*:first-child]:rounded-r-none [&>*:last-child]:rounded-r [&>*:last-child]:rounded-l-none">
         <SheetTrigger asChild>
           <Button
+            aria-label="Edit JSON"
             disabled={!model}
             variant="outlinePrimary"
             size="icon"
@@ -71,6 +73,7 @@ export default function StructuredOutputSheet({
           </Button>
         </SheetTrigger>
         <Button
+          aria-label="Close"
           onClick={() => setValue("structuredOutput", undefined)}
           className="size-7"
           variant="outlinePrimary"

--- a/frontend/components/playground/messages/structured-output-sheet.tsx
+++ b/frontend/components/playground/messages/structured-output-sheet.tsx
@@ -73,7 +73,7 @@ export default function StructuredOutputSheet({
           </Button>
         </SheetTrigger>
         <Button
-          aria-label="Close"
+          aria-label="Clear structured output"
           onClick={() => setValue("structuredOutput", undefined)}
           className="size-7"
           variant="outlinePrimary"

--- a/frontend/components/playground/messages/tools-sheet.tsx
+++ b/frontend/components/playground/messages/tools-sheet.tsx
@@ -79,7 +79,7 @@ export default function ToolsSheet({
       return (
         <SheetTrigger asChild>
           <Button
-            aria-label="Settings"
+            aria-label="Tools"
             disabled={!model}
             variant="outline"
             size="icon"
@@ -100,7 +100,7 @@ export default function ToolsSheet({
           </Button>
         </SheetTrigger>
         <Button
-          aria-label="Close"
+          aria-label="Clear tools"
           onClick={() => setValue("tools", "")}
           className="size-7"
           variant="outlinePrimary"

--- a/frontend/components/playground/messages/tools-sheet.tsx
+++ b/frontend/components/playground/messages/tools-sheet.tsx
@@ -78,7 +78,13 @@ export default function ToolsSheet({
     if (toolsCount === 0) {
       return (
         <SheetTrigger asChild>
-          <Button disabled={!model} variant="outline" size="icon" className={cn("focus-visible:ring-0", className)}>
+          <Button
+            aria-label="Settings"
+            disabled={!model}
+            variant="outline"
+            size="icon"
+            className={cn("focus-visible:ring-0", className)}
+          >
             <Bolt className="size-4" />
           </Button>
         </SheetTrigger>
@@ -93,7 +99,13 @@ export default function ToolsSheet({
             <span className="ml-1 text-xs ">{pluralize(toolsCount, "tool", "tools")}</span>
           </Button>
         </SheetTrigger>
-        <Button onClick={() => setValue("tools", "")} className="size-7" variant="outlinePrimary" size="icon">
+        <Button
+          aria-label="Close"
+          onClick={() => setValue("tools", "")}
+          className="size-7"
+          variant="outlinePrimary"
+          size="icon"
+        >
           <X className="size-4" />
         </Button>
       </div>

--- a/frontend/components/playground/playground-panel.tsx
+++ b/frontend/components/playground/playground-panel.tsx
@@ -174,9 +174,9 @@ export default function PlaygroundPanel({
         </Button>
         {isLoading ? (
           <Button variant="outlinePrimary" onClick={abortRequest} className="ml-auto h-7 w-fit px-2">
-            <Square className="w-4 h-4 mr-1" />
+            <Square data-icon="inline-start" className="w-4 h-4 mr-1" />
             <span className="mr-2 text-xs">Stop</span>
-            <Loader className="animate-spin w-4 h-4" />
+            <Loader data-icon="inline-end" className="animate-spin w-4 h-4" />
           </Button>
         ) : (
           <Button icon="playIcon" onClick={handleSubmit(submit)} className="ml-auto w-fit">

--- a/frontend/components/playgrounds/create-playground-dialog.tsx
+++ b/frontend/components/playgrounds/create-playground-dialog.tsx
@@ -68,7 +68,7 @@ export default function CreatePlaygroundDialog() {
           </div>
           <DialogFooter>
             <Button onClick={createNewPlayground} disabled={!newPlaygroundName || isLoading} handleEnter>
-              <Loader2 className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
+              <Loader2 data-icon="inline-start" className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
               Create
             </Button>
           </DialogFooter>

--- a/frontend/components/playgrounds/table-contents.tsx
+++ b/frontend/components/playgrounds/table-contents.tsx
@@ -192,7 +192,7 @@ export const PlaygroundsTableContents = memo(function PlaygroundsTableContents({
         <div className="flex flex-col space-y-2">
           <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
             <DialogTrigger asChild>
-              <Button variant="ghost">
+              <Button aria-label="Delete" variant="ghost">
                 <Trash2 size={12} />
               </Button>
             </DialogTrigger>

--- a/frontend/components/projects/project-create-dialog.tsx
+++ b/frontend/components/projects/project-create-dialog.tsx
@@ -132,7 +132,7 @@ export default function ProjectCreateDialog({
         </div>
         <DialogFooter>
           <Button onClick={createNewProject} handleEnter={true} disabled={!newProjectName || isCreatingProject}>
-            <Loader2
+            <Loader2 data-icon="inline-start"
               className={cn("mr-2 hidden", {
                 "animate-spin block": isCreatingProject,
               })}

--- a/frontend/components/projects/sidebar-footer.tsx
+++ b/frontend/components/projects/sidebar-footer.tsx
@@ -35,7 +35,11 @@ const SidebarFooterComponent = () => {
             <div className={cn("flex flex-col rounded-lg border bg-muted relative p-2")}>
               <div className="flex justify-between items-start">
                 <p className="text-xs text-muted-foreground mb-2">Laminar is fully open source</p>
-                <button onClick={() => setShowStarCard(false)} className="text-muted-foreground hover:text-foreground">
+                <button
+                  aria-label="Close"
+                  onClick={() => setShowStarCard(false)}
+                  className="text-muted-foreground hover:text-foreground"
+                >
                   <X size={16} />
                 </button>
               </div>

--- a/frontend/components/queue/target-panel/schema-drift-banner.tsx
+++ b/frontend/components/queue/target-panel/schema-drift-banner.tsx
@@ -40,7 +40,7 @@ export default function SchemaDriftBanner({ targetIsObject, targetType, extras, 
         </div>
         <Button variant="ghost" size="sm" className="h-7 text-xs shrink-0" onClick={onViewJson}>
           View JSON
-          <ArrowRight className="size-3 ml-1" />
+          <ArrowRight data-icon="inline-end" className="size-3 ml-1" />
         </Button>
       </div>
     );
@@ -66,7 +66,7 @@ export default function SchemaDriftBanner({ targetIsObject, targetType, extras, 
       </div>
       <Button variant="ghost" size="sm" className="h-7 text-xs shrink-0" onClick={onViewJson}>
         View JSON
-        <ArrowRight className="size-3 ml-1" />
+        <ArrowRight data-icon="inline-end" className="size-3 ml-1" />
       </Button>
     </div>
   );

--- a/frontend/components/queue/toolbar.tsx
+++ b/frontend/components/queue/toolbar.tsx
@@ -26,7 +26,7 @@ export default function Toolbar() {
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant="secondary" onClick={() => setPushOpen(true)} disabled={triggerDisabled}>
-                <Database className="size-3.5 mr-1" />
+                <Database data-icon="inline-start" className="size-3.5 mr-1" />
                 Push to dataset
               </Button>
             </TooltipTrigger>

--- a/frontend/components/queues/create-queue-dialog.tsx
+++ b/frontend/components/queues/create-queue-dialog.tsx
@@ -91,7 +91,7 @@ export default function CreateQueueDialog({
         </div>
         <DialogFooter>
           <Button onClick={createNewQueue} disabled={!newQueueName || isLoading} handleEnter>
-            <Loader2 className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
+            <Loader2 data-icon="inline-start" className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
             Create
           </Button>
         </DialogFooter>

--- a/frontend/components/queues/table-contents.tsx
+++ b/frontend/components/queues/table-contents.tsx
@@ -221,7 +221,7 @@ export const QueuesTableContents = memo(function QueuesTableContents({
         <div className="flex flex-col space-y-2">
           <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
             <DialogTrigger asChild>
-              <Button variant="ghost">
+              <Button aria-label="Delete" variant="ghost">
                 <Trash2 size={12} />
               </Button>
             </DialogTrigger>

--- a/frontend/components/settings/agent-versions/agent-versions-list.tsx
+++ b/frontend/components/settings/agent-versions/agent-versions-list.tsx
@@ -29,7 +29,7 @@ export default function AgentVersionsList({ projectId, agentId, onBack }: AgentV
   return (
     <SettingsSection>
       <Button variant="ghost" className="w-fit -ml-2 h-7 text-muted-foreground" onClick={onBack}>
-        <ArrowLeft className="size-4 mr-1" />
+        <ArrowLeft data-icon="inline-start" className="size-4 mr-1" />
         All agents
       </Button>
       <SettingsSectionHeader

--- a/frontend/components/settings/alerts/alert-filters-section.tsx
+++ b/frontend/components/settings/alerts/alert-filters-section.tsx
@@ -201,7 +201,7 @@ function FilterCard({
         disabled={columns.length === 0}
         onClick={() => append(getDefaultFilter(columns))}
       >
-        <Plus className="w-3.5 h-3.5 mr-1" />
+        <Plus data-icon="inline-start" className="w-3.5 h-3.5 mr-1" />
         Add condition
       </Button>
     </div>
@@ -236,7 +236,7 @@ export default function AlertFiltersSection({ schema }: { schema: unknown }) {
           disabled={columns.length === 0}
           onClick={() => append({ filters: [getDefaultFilter(columns)] })}
         >
-          <Plus className="w-3.5 h-3.5 mr-1" />
+          <Plus data-icon="inline-start" className="w-3.5 h-3.5 mr-1" />
           Add filter
         </Button>
       </div>

--- a/frontend/components/settings/alerts/alert-filters-section.tsx
+++ b/frontend/components/settings/alerts/alert-filters-section.tsx
@@ -153,7 +153,7 @@ function FilterConditionRow({
           )
         }
       />
-      <Button type="button" variant="ghost" size="icon" onClick={onRemove}>
+      <Button aria-label="Close" type="button" variant="ghost" size="icon" onClick={onRemove}>
         <X className="w-3.5 h-3.5" />
       </Button>
     </div>
@@ -179,7 +179,7 @@ function FilterCard({
     <div className="rounded-md border p-3 space-y-2">
       <div className="flex items-center justify-between">
         <span className="text-xs text-muted-foreground">All conditions must match</span>
-        <Button type="button" variant="ghost" size="icon" onClick={onRemove}>
+        <Button aria-label="Delete" type="button" variant="ghost" size="icon" onClick={onRemove}>
           <Trash2 className="w-3.5 h-3.5" />
         </Button>
       </div>

--- a/frontend/components/settings/alerts/alert-filters-section.tsx
+++ b/frontend/components/settings/alerts/alert-filters-section.tsx
@@ -153,7 +153,7 @@ function FilterConditionRow({
           )
         }
       />
-      <Button aria-label="Close" type="button" variant="ghost" size="icon" onClick={onRemove}>
+      <Button aria-label="Remove filter" type="button" variant="ghost" size="icon" onClick={onRemove}>
         <X className="w-3.5 h-3.5" />
       </Button>
     </div>

--- a/frontend/components/settings/alerts/alert-filters-section.tsx
+++ b/frontend/components/settings/alerts/alert-filters-section.tsx
@@ -153,7 +153,7 @@ function FilterConditionRow({
           )
         }
       />
-      <Button aria-label="Remove filter" type="button" variant="ghost" size="icon" onClick={onRemove}>
+      <Button aria-label="Remove condition" type="button" variant="ghost" size="icon" onClick={onRemove}>
         <X className="w-3.5 h-3.5" />
       </Button>
     </div>
@@ -179,7 +179,7 @@ function FilterCard({
     <div className="rounded-md border p-3 space-y-2">
       <div className="flex items-center justify-between">
         <span className="text-xs text-muted-foreground">All conditions must match</span>
-        <Button aria-label="Delete" type="button" variant="ghost" size="icon" onClick={onRemove}>
+        <Button aria-label="Remove filter" type="button" variant="ghost" size="icon" onClick={onRemove}>
           <Trash2 className="w-3.5 h-3.5" />
         </Button>
       </div>

--- a/frontend/components/settings/alerts/alerts-manager.tsx
+++ b/frontend/components/settings/alerts/alerts-manager.tsx
@@ -195,6 +195,7 @@ export default function AlertsManager({ projectId, workspaceId, userEmail, fixed
                     </div>
                     <div className="flex shrink-0 items-center">
                       <Button
+                        aria-label="Delete"
                         variant="ghost"
                         size="icon"
                         className={cn(

--- a/frontend/components/settings/custom-model-costs.tsx
+++ b/frontend/components/settings/custom-model-costs.tsx
@@ -266,7 +266,7 @@ function CopyModelCostsDialog({ onCopy }: { onCopy: (targetProjectId: string) =>
     >
       <DialogTrigger asChild>
         <Button variant="outline" className="w-fit">
-          <Copy size={14} className="mr-1" />
+          <Copy data-icon="inline-start" size={14} className="mr-1" />
           Copy to project
         </Button>
       </DialogTrigger>

--- a/frontend/components/settings/custom-model-costs.tsx
+++ b/frontend/components/settings/custom-model-costs.tsx
@@ -496,12 +496,13 @@ export default function CustomModelCosts() {
                     initialCosts={costObj}
                     onSave={upsertCost}
                     trigger={
-                      <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                      <Button aria-label="Edit" variant="ghost" size="sm" className="h-8 w-8 p-0">
                         <Pencil size={14} />
                       </Button>
                     }
                   />
                   <Button
+                    aria-label="Delete"
                     variant="ghost"
                     size="sm"
                     className="h-8 w-8 p-0"

--- a/frontend/components/settings/delete-project.tsx
+++ b/frontend/components/settings/delete-project.tsx
@@ -160,7 +160,7 @@ export default function DeleteProject() {
               Cancel
             </Button>
             <Button variant="destructive" disabled={!isDeleteEnabled} onClick={deleteProject}>
-              <Loader2 className={cn("mr-2 h-4 w-4", isLoading ? "animate-spin" : "hidden")} />
+              <Loader2 data-icon="inline-start" className={cn("mr-2 h-4 w-4", isLoading ? "animate-spin" : "hidden")} />
               Delete
             </Button>
           </DialogFooter>

--- a/frontend/components/settings/pii-redaction.tsx
+++ b/frontend/components/settings/pii-redaction.tsx
@@ -92,7 +92,7 @@ export default function PiiRedaction() {
               <Button asChild size="sm" variant="outline" className="h-7">
                 <Link href={settingsHref("billing")}>
                   Upgrade plan
-                  <ArrowUpRight className="ml-1 size-3" />
+                  <ArrowUpRight data-icon="inline-end" className="ml-1 size-3" />
                 </Link>
               </Button>
             )}

--- a/frontend/components/settings/project-api-keys/generate-key-dialog-content.tsx
+++ b/frontend/components/settings/project-api-keys/generate-key-dialog-content.tsx
@@ -82,7 +82,7 @@ export function GenerateKeyDialogContent({
       </div>
       <DialogFooter>
         <Button onClick={onClick} handleEnter disabled={isLoading}>
-          <Loader2 className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
+          <Loader2 data-icon="inline-start" className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
           Create
         </Button>
       </DialogFooter>

--- a/frontend/components/settings/provider-api-keys.tsx
+++ b/frontend/components/settings/provider-api-keys.tsx
@@ -80,6 +80,7 @@ export default function ProviderApiKeys() {
             <td className="px-4">
               <div className="flex justify-end">
                 <Button
+                  aria-label="Delete"
                   variant="ghost"
                   size="sm"
                   className="h-8 w-8 p-0"

--- a/frontend/components/settings/rename-project.tsx
+++ b/frontend/components/settings/rename-project.tsx
@@ -97,7 +97,7 @@ export default function RenameProject() {
           </div>
           <DialogFooter>
             <Button disabled={!newProjectName.trim() || isLoading} onClick={renameProject} handleEnter={true}>
-              <Loader2 className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
+              <Loader2 data-icon="inline-start" className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
               Rename
             </Button>
           </DialogFooter>

--- a/frontend/components/settings/revoke-dialog.tsx
+++ b/frontend/components/settings/revoke-dialog.tsx
@@ -20,7 +20,7 @@ export default function RevokeDialog({ apiKey, onRevoke, entity }: RevokeApiKeyD
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button variant="ghost">
+        <Button aria-label="Delete" variant="ghost">
           {" "}
           <Trash2 size={14} />
         </Button>

--- a/frontend/components/settings/revoke-dialog.tsx
+++ b/frontend/components/settings/revoke-dialog.tsx
@@ -41,7 +41,7 @@ export default function RevokeDialog({ apiKey, onRevoke, entity }: RevokeApiKeyD
               setIsOpen(false);
             }}
           >
-            <Loader2 className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
+            <Loader2 data-icon="inline-start" className={cn("mr-2 hidden", isLoading ? "animate-spin block" : "")} size={16} />
             Revoke
           </Button>
         </DialogFooter>

--- a/frontend/components/shared/evaluation/shared-eval-trace-view.tsx
+++ b/frontend/components/shared/evaluation/shared-eval-trace-view.tsx
@@ -58,7 +58,7 @@ function SharedEvalTraceViewContent({ traceId, onClose }: SharedEvalTraceViewPro
     return (
       <div className="flex flex-col h-full">
         <div className="flex items-center border-b px-2 py-1.5">
-          <Button variant="ghost" className="px-0.5" onClick={onClose}>
+          <Button aria-label="Collapse panel" variant="ghost" className="px-0.5" onClick={onClose}>
             <ChevronsRight className="w-5 h-5" />
           </Button>
         </div>
@@ -71,7 +71,7 @@ function SharedEvalTraceViewContent({ traceId, onClose }: SharedEvalTraceViewPro
     return (
       <div className="flex flex-col h-full">
         <div className="flex items-center border-b px-2 py-1.5">
-          <Button variant="ghost" className="px-0.5" onClick={onClose}>
+          <Button aria-label="Collapse panel" variant="ghost" className="px-0.5" onClick={onClose}>
             <ChevronsRight className="w-5 h-5" />
           </Button>
         </div>

--- a/frontend/components/shared/traces/header.tsx
+++ b/frontend/components/shared/traces/header.tsx
@@ -55,12 +55,12 @@ const Header = ({ onClose, isHideTimelineControls = false }: HeaderProps) => {
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center min-w-0 gap-2">
           <div className="flex items-center flex-shrink-0 gap-0.5">
-            <Button variant="ghost" className="px-0.5" onClick={onClose}>
+            <Button aria-label="Collapse panel" variant="ghost" className="px-0.5" onClick={onClose}>
               <ChevronsRight className="w-5 h-5" />
             </Button>
             {trace && (
               <Link passHref href={`/shared/traces/${trace.id}`}>
-                <Button variant="ghost" className="px-0.5">
+                <Button aria-label="Expand" variant="ghost" className="px-0.5">
                   <Maximize className="w-4 h-4" />
                 </Button>
               </Link>
@@ -71,7 +71,7 @@ const Header = ({ onClose, isHideTimelineControls = false }: HeaderProps) => {
               <span className="text-base font-medium ml-2 flex-shrink-0">Trace</span>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" className="h-6 px-1 hover:bg-secondary">
+                  <Button aria-label="Expand" variant="ghost" className="h-6 px-1 hover:bg-secondary">
                     <ChevronDown className="size-3.5" />
                   </Button>
                 </DropdownMenuTrigger>

--- a/frontend/components/shared/traces/header.tsx
+++ b/frontend/components/shared/traces/header.tsx
@@ -71,7 +71,7 @@ const Header = ({ onClose, isHideTimelineControls = false }: HeaderProps) => {
               <span className="text-base font-medium ml-2 flex-shrink-0">Trace</span>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button aria-label="Expand" variant="ghost" className="h-6 px-1 hover:bg-secondary">
+                  <Button aria-label="Trace actions" variant="ghost" className="h-6 px-1 hover:bg-secondary">
                     <ChevronDown className="size-3.5" />
                   </Button>
                 </DropdownMenuTrigger>

--- a/frontend/components/shared/traces/session-player.tsx
+++ b/frontend/components/shared/traces/session-player.tsx
@@ -229,7 +229,7 @@ const SessionPlayer = ({ traceId, onClose }: SessionPlayerProps) => {
     <div className="relative w-full h-full flex flex-col">
       <div className="h-8 border-b pl-4 flex items-center gap-0 shrink-0">
         <span className="text-sm font-medium">Session</span>
-        <Button onClick={onClose} className="ml-auto" variant="ghost">
+        <Button aria-label="Close" onClick={onClose} className="ml-auto" variant="ghost">
           <X className="w-4 h-4" />
         </Button>
       </div>

--- a/frontend/components/shared/traces/trace-view.tsx
+++ b/frontend/components/shared/traces/trace-view.tsx
@@ -176,7 +176,7 @@ export const PureTraceView = ({ trace, spans, onClose }: TraceViewProps) => {
                         variant="outline"
                         onClick={() => setBrowserSession(!browserSession)}
                       >
-                        <CirclePlay size={14} className="mr-1" />
+                        <CirclePlay data-icon="inline-start" size={14} className="mr-1" />
                         Media
                       </Button>
                     )}

--- a/frontend/components/signal/create-signal-job/selection-banner.tsx
+++ b/frontend/components/signal/create-signal-job/selection-banner.tsx
@@ -40,7 +40,7 @@ const SelectionBanner = ({
         <div className="flex-1 text-sm text-secondary-foreground">
           All <span className="font-medium">{traceCount.toLocaleString()}</span> matching traces selected
         </div>
-        <Button variant="ghost" size="icon" onClick={onClearSelection}>
+        <Button aria-label="Close" variant="ghost" size="icon" onClick={onClearSelection}>
           <X className="size-3.5" />
         </Button>
       </div>
@@ -60,7 +60,7 @@ const SelectionBanner = ({
           </Button>
         )}
       </div>
-      <Button variant="ghost" size="icon" onClick={onClearSelection}>
+      <Button aria-label="Close" variant="ghost" size="icon" onClick={onClearSelection}>
         <X className="size-3.5" />
       </Button>
     </div>

--- a/frontend/components/signal/create-signal-job/selection-banner.tsx
+++ b/frontend/components/signal/create-signal-job/selection-banner.tsx
@@ -40,7 +40,7 @@ const SelectionBanner = ({
         <div className="flex-1 text-sm text-secondary-foreground">
           All <span className="font-medium">{traceCount.toLocaleString()}</span> matching traces selected
         </div>
-        <Button aria-label="Close" variant="ghost" size="icon" onClick={onClearSelection}>
+        <Button aria-label="Clear selection" variant="ghost" size="icon" onClick={onClearSelection}>
           <X className="size-3.5" />
         </Button>
       </div>
@@ -60,7 +60,7 @@ const SelectionBanner = ({
           </Button>
         )}
       </div>
-      <Button aria-label="Close" variant="ghost" size="icon" onClick={onClearSelection}>
+      <Button aria-label="Clear selection" variant="ghost" size="icon" onClick={onClearSelection}>
         <X className="size-3.5" />
       </Button>
     </div>

--- a/frontend/components/signals/create-signal-drawer/enum-values-input.tsx
+++ b/frontend/components/signals/create-signal-drawer/enum-values-input.tsx
@@ -63,6 +63,7 @@ export default function EnumValuesInput({
         >
           {value}
           <button
+            aria-label="Close"
             type="button"
             onClick={() => removeValue(value)}
             className="hover:text-destructive text-muted-foreground transition-colors"

--- a/frontend/components/signals/create-signal-drawer/enum-values-input.tsx
+++ b/frontend/components/signals/create-signal-drawer/enum-values-input.tsx
@@ -63,7 +63,7 @@ export default function EnumValuesInput({
         >
           {value}
           <button
-            aria-label="Close"
+            aria-label="Remove value"
             type="button"
             onClick={() => removeValue(value)}
             className="hover:text-destructive text-muted-foreground transition-colors"

--- a/frontend/components/signals/create-signal-drawer/schema-field-row.tsx
+++ b/frontend/components/signals/create-signal-drawer/schema-field-row.tsx
@@ -120,7 +120,7 @@ export default function SchemaFieldRow({
           )}
         />
         <Button
-          aria-label="Close"
+          aria-label="Remove field"
           type="button"
           variant="ghost"
           onClick={onRemove}

--- a/frontend/components/signals/create-signal-drawer/schema-field-row.tsx
+++ b/frontend/components/signals/create-signal-drawer/schema-field-row.tsx
@@ -119,7 +119,14 @@ export default function SchemaFieldRow({
             />
           )}
         />
-        <Button type="button" variant="ghost" onClick={onRemove} disabled={!canRemove} className="py-[7px] shrink-0">
+        <Button
+          aria-label="Close"
+          type="button"
+          variant="ghost"
+          onClick={onRemove}
+          disabled={!canRemove}
+          className="py-[7px] shrink-0"
+        >
           <X className="w-3.5 h-3.5" />
         </Button>
       </div>

--- a/frontend/components/signals/create-signal-drawer/triggers-section.tsx
+++ b/frontend/components/signals/create-signal-drawer/triggers-section.tsx
@@ -225,7 +225,7 @@ function FilterRow({ index, onRemove }: { index: number; onRemove: () => void })
           )
         }
       />
-      <Button aria-label="Close" type="button" variant="ghost" size="icon" onClick={onRemove}>
+      <Button aria-label="Remove trigger" type="button" variant="ghost" size="icon" onClick={onRemove}>
         <X className="w-3.5 h-3.5" />
       </Button>
     </div>

--- a/frontend/components/signals/create-signal-drawer/triggers-section.tsx
+++ b/frontend/components/signals/create-signal-drawer/triggers-section.tsx
@@ -225,7 +225,7 @@ function FilterRow({ index, onRemove }: { index: number; onRemove: () => void })
           )
         }
       />
-      <Button type="button" variant="ghost" size="icon" onClick={onRemove}>
+      <Button aria-label="Close" type="button" variant="ghost" size="icon" onClick={onRemove}>
         <X className="w-3.5 h-3.5" />
       </Button>
     </div>

--- a/frontend/components/signals/create-signal-drawer/triggers-section.tsx
+++ b/frontend/components/signals/create-signal-drawer/triggers-section.tsx
@@ -84,7 +84,7 @@ function SpanNamesInput() {
         </div>
       ))}
       <Button type="button" variant="outline" size="sm" className="w-fit" onClick={() => write([...rows, ""])}>
-        <Plus className="w-3.5 h-3.5 mr-1" />
+        <Plus data-icon="inline-start" className="w-3.5 h-3.5 mr-1" />
         Add span name
       </Button>
       {hasName ? (
@@ -247,7 +247,7 @@ function FiltersSection() {
           hint="Once triggered, the signal only runs on traces matching all of these conditions."
         />
         <Button type="button" variant="outline" className="w-fit" onClick={() => append(getDefaultFilter())}>
-          <Plus className="w-3.5 h-3.5 mr-1" />
+          <Plus data-icon="inline-start" className="w-3.5 h-3.5 mr-1" />
           Add filter
         </Button>
       </div>

--- a/frontend/components/slack/slack-channel-projects.tsx
+++ b/frontend/components/slack/slack-channel-projects.tsx
@@ -179,6 +179,7 @@ export default function SlackChannelProjects({ workspaceId, className }: SlackCh
                 <TableCell className="px-2 py-1 truncate text-xs">{b.projectName ?? b.projectId}</TableCell>
                 <TableCell className="px-2 py-1">
                   <Button
+                    aria-label="Delete"
                     variant="ghost"
                     size="icon"
                     className="h-6 w-6 text-muted-foreground hover:text-destructive"

--- a/frontend/components/slack/slack-connection-card.tsx
+++ b/frontend/components/slack/slack-connection-card.tsx
@@ -163,7 +163,7 @@ export default function SlackConnectionCard({
             )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground">
+                <Button aria-label="More options" variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground">
                   <EllipsisVertical size={14} />
                 </Button>
               </DropdownMenuTrigger>

--- a/frontend/components/sql/dnd-components.tsx
+++ b/frontend/components/sql/dnd-components.tsx
@@ -24,8 +24,8 @@ const PureDraggableColumn = ({ column, category, onRemove }: DraggableColumnProp
 
   const style = transform
     ? {
-      transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
-    }
+        transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+      }
     : undefined;
 
   return (
@@ -36,11 +36,17 @@ const PureDraggableColumn = ({ column, category, onRemove }: DraggableColumnProp
       className={cn("mb-2", isDragging ? "opacity-30" : "opacity-100")}
     >
       <div className="flex items-center p-1 border rounded bg-card shadow-md">
-        <Button ref={setActivatorNodeRef} {...listeners} className="p-1 h-fit" variant="ghost">
+        <Button
+          aria-label="Drag to reorder"
+          ref={setActivatorNodeRef}
+          {...listeners}
+          className="p-1 h-fit"
+          variant="ghost"
+        >
           <GripVertical className="h-4 w-4 mr-2 shrink-0 text-muted-foreground" />
         </Button>
         <span className="truncate font-mono text-sm">{column}</span>
-        <Button onClick={onRemove} variant="ghost" className="ml-auto p-1 h-fit">
+        <Button aria-label="Close" onClick={onRemove} variant="ghost" className="ml-auto p-1 h-fit">
           <X className="w-4 h-4" />
         </Button>
       </div>

--- a/frontend/components/sql/dnd-components.tsx
+++ b/frontend/components/sql/dnd-components.tsx
@@ -46,7 +46,7 @@ const PureDraggableColumn = ({ column, category, onRemove }: DraggableColumnProp
           <GripVertical className="h-4 w-4 mr-2 shrink-0 text-muted-foreground" />
         </Button>
         <span className="truncate font-mono text-sm">{column}</span>
-        <Button aria-label="Close" onClick={onRemove} variant="ghost" className="ml-auto p-1 h-fit">
+        <Button aria-label="Remove column" onClick={onRemove} variant="ghost" className="ml-auto p-1 h-fit">
           <X className="w-4 h-4" />
         </Button>
       </div>

--- a/frontend/components/sql/editor-panel.tsx
+++ b/frontend/components/sql/editor-panel.tsx
@@ -224,7 +224,7 @@ export default function EditorPanel() {
             <div className="ml-auto">
               {isLoading ? (
                 <Button onClick={cancelQuery} className="rounded-tr-none rounded-br-none border-r-0">
-                  <Square size={14} className="mr-1" fill="currentColor" />
+                  <Square data-icon="inline-start" size={14} className="mr-1" fill="currentColor" />
                   <span className="mr-2">Cancel</span>
                 </Button>
               ) : (
@@ -233,16 +233,16 @@ export default function EditorPanel() {
                   onClick={executeQuery}
                   className="rounded-tr-none rounded-br-none border-r-0"
                 >
-                  <PlayIcon size={14} className="mr-1" />
+                  <PlayIcon data-icon="inline-start" size={14} className="mr-1" />
                   <span className="mr-2">Run</span>
                   <div className="text-center text-xs opacity-75">⌘ + ⏎</div>
                 </Button>
               )}
               <ExportSqlDialog results={results} sqlQuery={template?.query || ""} sqlTemplateId={template?.id}>
                 <Button disabled={!hasQuery} variant="secondary" className="rounded-tl-none rounded-bl-none">
-                  <Database className="size-3.5 mr-2" />
+                  <Database data-icon="inline-start" className="size-3.5 mr-2" />
                   Export
-                  <ChevronDown className="size-3.5 ml-2" />
+                  <ChevronDown data-icon="inline-end" className="size-3.5 ml-2" />
                 </Button>
               </ExportSqlDialog>
             </div>

--- a/frontend/components/sql/export-sql-dialog.tsx
+++ b/frontend/components/sql/export-sql-dialog.tsx
@@ -263,9 +263,9 @@ export default function ExportSqlDialog({
       <DropdownMenuTrigger asChild>
         {children || (
           <Button disabled={!sqlQuery?.trim()} variant="secondary" className="w-fit px-2">
-            <Database className="size-3.5 mr-2" />
+            <Database data-icon="inline-start" className="size-3.5 mr-2" />
             Export
-            <ChevronDown className="size-3.5 ml-2" />
+            <ChevronDown data-icon="inline-end" className="size-3.5 ml-2" />
           </Button>
         )}
       </DropdownMenuTrigger>

--- a/frontend/components/sql/sidebar.tsx
+++ b/frontend/components/sql/sidebar.tsx
@@ -145,6 +145,7 @@ const QueryItem = ({ handleDelete, template }: { template: SQLTemplate; handleDe
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
+              aria-label="More options"
               variant="ghost"
               size="sm"
               className="opacity-0 group-hover:opacity-100 h-6 w-6 min-w-6 p-0 ml-auto focus-visible:ring-0 hover:bg-muted"
@@ -268,7 +269,7 @@ const Sidebar = ({ templates, isLoading }: { templates: SQLTemplate[]; isLoading
       <div className="flex items-center p-2 px-4 border-b shrink-0">
         <span className="font-medium">Queries</span>
         <Link className="ml-auto" href={`/project/${projectId}/sql`}>
-          <Button onClick={handleCreate} variant="outline" className="size-6 p-0 lg:flex">
+          <Button aria-label="Add" onClick={handleCreate} variant="outline" className="size-6 p-0 lg:flex">
             <Plus className="w-4 h-4" />
           </Button>
         </Link>

--- a/frontend/components/sql/template-editor.tsx
+++ b/frontend/components/sql/template-editor.tsx
@@ -141,7 +141,7 @@ export default function TemplateEditor({ className }: TemplateEditorProps) {
               <p className="text-sm text-muted-foreground">Create a new query or select one from the sidebar</p>
             </div>
             <Button onClick={handleCreate} variant="secondaryLight" size="sm" className="gap-2">
-              <Plus className="w-4 h-4" />
+              <Plus data-icon="inline-start" className="w-4 h-4" />
               New Query
             </Button>
           </div>

--- a/frontend/components/tags/span-tags-list.tsx
+++ b/frontend/components/tags/span-tags-list.tsx
@@ -157,7 +157,7 @@ const SpanTagsList = ({ spanId, className }: SpanTagsListProps) => {
       >
         <DropdownMenuTrigger asChild>
           <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
-            <Tag className="size-3.5" />
+            <Tag data-icon="inline-start" className="size-3.5" />
             Tags
           </Button>
         </DropdownMenuTrigger>

--- a/frontend/components/tags/trace-tags-list.tsx
+++ b/frontend/components/tags/trace-tags-list.tsx
@@ -156,7 +156,7 @@ export const TraceTagsButton = ({ traceId, className }: TraceTagsProps) => {
     >
       <DropdownMenuTrigger asChild>
         <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
-          <Tag className="size-3.5" />
+          <Tag data-icon="inline-start" className="size-3.5" />
           Tags
         </Button>
       </DropdownMenuTrigger>

--- a/frontend/components/traces/error-card.tsx
+++ b/frontend/components/traces/error-card.tsx
@@ -44,7 +44,7 @@ const ErrorCard = ({ attributes }: ErrorCardProps) => {
                 variant="ghost"
                 text={`${errorType || "Exception"}: ${errorMessage || "No message"}\n\n${errorTrace || "No stacktrace"}`}
               />
-              <Button className="w-8 h-8" size="icon" variant="ghost">
+              <Button aria-label="Next" className="w-8 h-8" size="icon" variant="ghost">
                 <ChevronRight className="w-3 h-3 text-muted-foreground group-data-[state=open]:rotate-90 transition-transform duration-200" />
               </Button>
             </div>

--- a/frontend/components/traces/error-card.tsx
+++ b/frontend/components/traces/error-card.tsx
@@ -44,7 +44,7 @@ const ErrorCard = ({ attributes }: ErrorCardProps) => {
                 variant="ghost"
                 text={`${errorType || "Exception"}: ${errorMessage || "No message"}\n\n${errorTrace || "No stacktrace"}`}
               />
-              <Button aria-label="Next" className="w-8 h-8" size="icon" variant="ghost">
+              <Button aria-label="Toggle stack trace" className="w-8 h-8" size="icon" variant="ghost">
                 <ChevronRight className="w-3 h-3 text-muted-foreground group-data-[state=open]:rotate-90 transition-transform duration-200" />
               </Button>
             </div>

--- a/frontend/components/traces/session-player.tsx
+++ b/frontend/components/traces/session-player.tsx
@@ -235,7 +235,7 @@ const SessionPlayer = ({ traceId, onClose }: SessionPlayerProps) => {
     <div className="relative w-full h-full flex flex-col">
       <div className="h-8 border-b pl-4 flex items-center gap-0 shrink-0">
         <span className="text-sm font-medium">Session</span>
-        <Button onClick={onClose} className="ml-auto" variant="ghost">
+        <Button aria-label="Close" onClick={onClose} className="ml-auto" variant="ghost">
           <X className="w-4 h-4" />
         </Button>
       </div>

--- a/frontend/components/traces/session-view/session-condensed-timeline/close-button.tsx
+++ b/frontend/components/traces/session-view/session-condensed-timeline/close-button.tsx
@@ -12,7 +12,7 @@ interface CloseButtonProps {
 export default function CloseButton({ onClose }: CloseButtonProps) {
   return (
     <div className="absolute z-40 top-0 right-0 flex items-end overflow-hidden h-6 w-7 bg-muted border-b border-l rounded-none rounded-bl">
-      <Button onClick={onClose} variant="ghost" size="icon" className="size-5 min-w-5">
+      <Button aria-label="Close" onClick={onClose} variant="ghost" size="icon" className="size-5 min-w-5">
         <X className="size-3.5" />
       </Button>
     </div>

--- a/frontend/components/traces/session-view/session-panel/regular-timeline-toggle.tsx
+++ b/frontend/components/traces/session-view/session-panel/regular-timeline-toggle.tsx
@@ -25,7 +25,7 @@ export default function RegularTimelineToggle() {
         sessionTimelineEnabled ? "border-primary text-primary hover:bg-primary/10" : "hover:bg-secondary"
       )}
     >
-      <GanttChart size={14} className="mr-1" />
+      <GanttChart data-icon="inline-start" size={14} className="mr-1" />
       Timeline
     </Button>
   );

--- a/frontend/components/traces/session-view/session-panel/trace-control-bar.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-control-bar.tsx
@@ -84,7 +84,7 @@ export default function TraceControlBar({ trace, analyticsFeature = "sessions" }
             isTimelineOpen ? "border-primary text-primary hover:bg-primary/10" : "hover:bg-secondary"
           )}
         >
-          <GanttChart size={14} className="mr-1" />
+          <GanttChart data-icon="inline-start" size={14} className="mr-1" />
           Timeline
         </Button>
       )}

--- a/frontend/components/traces/session-view/session-timeline/controls.tsx
+++ b/frontend/components/traces/session-view/session-timeline/controls.tsx
@@ -19,7 +19,7 @@ export default function SessionTimelineControls() {
     <div className="absolute bottom-1.5 right-1.5 z-40 flex items-center gap-1 h-[24px]">
       <div className="flex items-center border rounded-md bg-muted px-0.5 h-[24px]">
         <Button
-          aria-label="Add"
+          aria-label="Zoom in"
           disabled={zoom >= MAX_ZOOM}
           className="size-5 min-w-5"
           variant="ghost"
@@ -29,7 +29,7 @@ export default function SessionTimelineControls() {
           <Plus className="size-3" />
         </Button>
         <Button
-          aria-label="Remove"
+          aria-label="Zoom out"
           disabled={zoom <= MIN_ZOOM}
           className="size-5 min-w-5"
           variant="ghost"

--- a/frontend/components/traces/session-view/session-timeline/controls.tsx
+++ b/frontend/components/traces/session-view/session-timeline/controls.tsx
@@ -19,6 +19,7 @@ export default function SessionTimelineControls() {
     <div className="absolute bottom-1.5 right-1.5 z-40 flex items-center gap-1 h-[24px]">
       <div className="flex items-center border rounded-md bg-muted px-0.5 h-[24px]">
         <Button
+          aria-label="Add"
           disabled={zoom >= MAX_ZOOM}
           className="size-5 min-w-5"
           variant="ghost"
@@ -28,6 +29,7 @@ export default function SessionTimelineControls() {
           <Plus className="size-3" />
         </Button>
         <Button
+          aria-label="Remove"
           disabled={zoom <= MIN_ZOOM}
           className="size-5 min-w-5"
           variant="ghost"

--- a/frontend/components/traces/session-view/session-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-timeline/index.tsx
@@ -229,7 +229,13 @@ function SessionTimeline() {
 
       {/* Close button — top-right, styled as a flush tab */}
       <div className="absolute top-0 right-0 z-40 h-6 w-7 bg-muted border-b border-l rounded-bl flex items-end overflow-hidden">
-        <Button onClick={() => setSessionTimelineEnabled(false)} variant="ghost" size="icon" className="size-5 min-w-5">
+        <Button
+          aria-label="Close"
+          onClick={() => setSessionTimelineEnabled(false)}
+          variant="ghost"
+          size="icon"
+          className="size-5 min-w-5"
+        >
           <X className="size-3.5" />
         </Button>
       </div>

--- a/frontend/components/traces/span-controls.tsx
+++ b/frontend/components/traces/span-controls.tsx
@@ -86,7 +86,7 @@ export function SpanControls({ children, span, onClose, isAlwaysSelectSpan }: Pr
               onClick={() => track("playgrounds", "experiment_clicked", { source: "span_view" })}
             >
               <Button variant="outlinePrimary" className="px-1.5 text-xs h-6 font-mono bg-primary/10">
-                <PlayCircle className="mr-1" size={14} />
+                <PlayCircle data-icon="inline-start" className="mr-1" size={14} />
                 Experiment in playground
               </Button>
             </Link>

--- a/frontend/components/traces/trace-view/condensed-timeline/controls.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/controls.tsx
@@ -40,10 +40,24 @@ export default function Controls({
         </Tooltip>
       </TooltipProvider>
       <div className="flex items-center border rounded-md bg-muted px-0.5 h-[24px]">
-        <Button disabled={zoom >= MAX_ZOOM} className="size-5 min-w-5" variant="ghost" size="icon" onClick={onZoomIn}>
+        <Button
+          aria-label="Add"
+          disabled={zoom >= MAX_ZOOM}
+          className="size-5 min-w-5"
+          variant="ghost"
+          size="icon"
+          onClick={onZoomIn}
+        >
           <Plus className="size-3" />
         </Button>
-        <Button disabled={zoom <= MIN_ZOOM} className="size-5 min-w-5" variant="ghost" size="icon" onClick={onZoomOut}>
+        <Button
+          aria-label="Remove"
+          disabled={zoom <= MIN_ZOOM}
+          className="size-5 min-w-5"
+          variant="ghost"
+          size="icon"
+          onClick={onZoomOut}
+        >
           <Minus className="size-3" />
         </Button>
       </div>

--- a/frontend/components/traces/trace-view/condensed-timeline/controls.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/controls.tsx
@@ -41,7 +41,7 @@ export default function Controls({
       </TooltipProvider>
       <div className="flex items-center border rounded-md bg-muted px-0.5 h-[24px]">
         <Button
-          aria-label="Add"
+          aria-label="Zoom in"
           disabled={zoom >= MAX_ZOOM}
           className="size-5 min-w-5"
           variant="ghost"
@@ -51,7 +51,7 @@ export default function Controls({
           <Plus className="size-3" />
         </Button>
         <Button
-          aria-label="Remove"
+          aria-label="Zoom out"
           disabled={zoom <= MIN_ZOOM}
           className="size-5 min-w-5"
           variant="ghost"

--- a/frontend/components/traces/trace-view/header/index.tsx
+++ b/frontend/components/traces/trace-view/header/index.tsx
@@ -210,13 +210,13 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
           {!params?.traceId && (
             <span className={cn(HEADER_ITEM_CLS, "gap-0.5")}>
               {handleClose && (
-                <Button variant="ghost" className="h-7 px-0.5" onClick={handleClose}>
+                <Button aria-label="Collapse panel" variant="ghost" className="h-7 px-0.5" onClick={handleClose}>
                   <ChevronsRight className="w-5 h-5" />
                 </Button>
               )}
               {trace && (
                 <NextLink passHref href={`/project/${projectId}/traces/${trace?.id}?${fullScreenParams.toString()}`}>
-                  <Button variant="ghost" className="h-7 px-0.5">
+                  <Button aria-label="Expand" variant="ghost" className="h-7 px-0.5">
                     <Maximize className="w-4 h-4" />
                   </Button>
                 </NextLink>

--- a/frontend/components/traces/trace-view/header/index.tsx
+++ b/frontend/components/traces/trace-view/header/index.tsx
@@ -261,7 +261,7 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
                   agentOpen ? "border-primary text-primary hover:bg-primary/10" : "hover:bg-secondary"
                 )}
               >
-                <Sparkles size={14} className="mr-1" />
+                <Sparkles data-icon="inline-start" size={14} className="mr-1" />
                 Chat
               </Button>
             </span>

--- a/frontend/components/traces/trace-view/header/trace-dropdown.tsx
+++ b/frontend/components/traces/trace-view/header/trace-dropdown.tsx
@@ -49,7 +49,7 @@ export default function TraceDropdown({ traceId }: TraceDropdownProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="h-6 px-1 hover:bg-secondary">
+        <Button aria-label="Expand" variant="ghost" className="h-6 px-1 hover:bg-secondary">
           <ChevronDown className="size-3.5" />
         </Button>
       </DropdownMenuTrigger>

--- a/frontend/components/traces/trace-view/header/trace-dropdown.tsx
+++ b/frontend/components/traces/trace-view/header/trace-dropdown.tsx
@@ -49,7 +49,7 @@ export default function TraceDropdown({ traceId }: TraceDropdownProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button aria-label="Expand" variant="ghost" className="h-6 px-1 hover:bg-secondary">
+        <Button aria-label="Trace actions" variant="ghost" className="h-6 px-1 hover:bg-secondary">
           <ChevronDown className="size-3.5" />
         </Button>
       </DropdownMenuTrigger>

--- a/frontend/components/traces/trace-view/lang-graph-view-trigger.tsx
+++ b/frontend/components/traces/trace-view/lang-graph-view-trigger.tsx
@@ -11,6 +11,7 @@ const LangGraphViewTrigger = ({ open, setOpen }: { open: boolean; setOpen: (b: b
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
+          aria-label="View LangGraph"
           className="hover:bg-secondary px-1.5"
           variant="ghost"
           onClick={() => {

--- a/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
@@ -99,7 +99,7 @@ export default function PanelBody({ traceId, onClose }: Props) {
   const closeButton = (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button variant="ghost" className="h-6 w-6 p-0 shrink-0" onClick={onClose}>
+        <Button aria-label="Close" variant="ghost" className="h-6 w-6 p-0 shrink-0" onClick={onClose}>
           <X className="size-3.5" />
         </Button>
       </TooltipTrigger>

--- a/frontend/components/traces/trace-view/trace-panel.tsx
+++ b/frontend/components/traces/trace-view/trace-panel.tsx
@@ -160,7 +160,7 @@ export default function TracePanel({ traceId, handleClose, handleSpanSelect, fet
                         variant="outline"
                         onClick={() => setBrowserSession(!browserSession)}
                       >
-                        <CirclePlay size={14} className="flex-shrink-0" />
+                        <CirclePlay data-icon="inline-start" size={14} className="flex-shrink-0" />
                         <span className="ml-1 truncate">Media</span>
                       </Button>
                     )}

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -409,7 +409,7 @@ const Transcript = ({ onSpanSelect, isShared = false }: TranscriptProps) => {
               setTab("tree");
             }}
           >
-            <ListTree size={14} className="mr-1" />
+            <ListTree data-icon="inline-start" size={14} className="mr-1" />
             Switch to tree
           </Button>
         )}

--- a/frontend/components/ui/columns-menu/columns-menu-item.tsx
+++ b/frontend/components/ui/columns-menu/columns-menu-item.tsx
@@ -55,6 +55,7 @@ export const ColumnsMenuItem = ({
       <div className="flex items-center gap-2 flex-shrink-0 ml-auto">
         {onEdit && (
           <button
+            aria-label="Edit"
             className="text-muted-foreground hover:text-foreground"
             onClick={(e) => {
               e.stopPropagation();
@@ -66,6 +67,7 @@ export const ColumnsMenuItem = ({
         )}
         {onDelete && (
           <button
+            aria-label="Delete"
             className="text-muted-foreground hover:text-destructive"
             onClick={(e) => {
               e.stopPropagation();

--- a/frontend/components/ui/columns-menu/custom-column-panel.tsx
+++ b/frontend/components/ui/columns-menu/custom-column-panel.tsx
@@ -93,7 +93,7 @@ export const CustomColumnPanel = ({ onBack, onSave, editingColumn, config }: Cus
       <div className="w-md">
         <div className="px-3 py-2 border-b flex items-center">
           <Button variant="ghost" size="sm" className="p-0 h-auto hover:bg-transparent" onClick={onBack}>
-            <ArrowLeft className="size-3.5 mr-1" />
+            <ArrowLeft data-icon="inline-start" className="size-3.5 mr-1" />
             <span>Back</span>
           </Button>
         </div>

--- a/frontend/components/ui/content-renderer/code-sheet.tsx
+++ b/frontend/components/ui/content-renderer/code-sheet.tsx
@@ -45,7 +45,7 @@ const PureCodeSheet = ({ mode, modes, renderedValue, extensions, onModeChange, p
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <Button variant="ghost" size="icon" className="text-foreground/80">
+        <Button aria-label="Expand" variant="ghost" size="icon" className="text-foreground/80">
           <Maximize className="h-3.5 w-3.5" />
         </Button>
       </SheetTrigger>
@@ -67,7 +67,7 @@ const PureCodeSheet = ({ mode, modes, renderedValue, extensions, onModeChange, p
                 text={sheetMode === "markdown" ? getMarkdownSource(renderedValue) : renderedValue}
               />
               <SheetClose asChild>
-                <Button variant="ghost" size="icon">
+                <Button aria-label="Collapse" variant="ghost" size="icon">
                   <Minimize className="h-4 w-4" />
                 </Button>
               </SheetClose>

--- a/frontend/components/ui/content-renderer/index.tsx
+++ b/frontend/components/ui/content-renderer/index.tsx
@@ -274,6 +274,7 @@ const PureContentRenderer = ({
         <Popover onOpenChange={setIsSettingsOpen}>
           <PopoverTrigger asChild>
             <Button
+              aria-label="Settings"
               variant="ghost"
               size="icon"
               className={cn(

--- a/frontend/components/ui/datatable-sorts.tsx
+++ b/frontend/components/ui/datatable-sorts.tsx
@@ -92,7 +92,7 @@ const DataTableSorts = ({ columns }: DataTableSortsProps) => {
                   <p className="text-secondary-foreground">ascending:</p>
                   <Switch onCheckedChange={handleAsc(field)} checked={field.asc} />
                 </div>
-                <Button onClick={() => handleRemove(field.field)} variant="ghost">
+                <Button aria-label="Close" onClick={() => handleRemove(field.field)} variant="ghost">
                   <X className="text-secondary-foreground" size={16} />
                 </Button>
               </div>

--- a/frontend/components/ui/datatable-sorts.tsx
+++ b/frontend/components/ui/datatable-sorts.tsx
@@ -92,7 +92,7 @@ const DataTableSorts = ({ columns }: DataTableSortsProps) => {
                   <p className="text-secondary-foreground">ascending:</p>
                   <Switch onCheckedChange={handleAsc(field)} checked={field.asc} />
                 </div>
-                <Button aria-label="Close" onClick={() => handleRemove(field.field)} variant="ghost">
+                <Button aria-label="Remove sort" onClick={() => handleRemove(field.field)} variant="ghost">
                   <X className="text-secondary-foreground" size={16} />
                 </Button>
               </div>

--- a/frontend/components/ui/date-range-filter/index.tsx
+++ b/frontend/components/ui/date-range-filter/index.tsx
@@ -272,6 +272,7 @@ export const DateRangeFilterInner = ({
     <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
       <PopoverTrigger asChild>
         <Button
+          aria-label="Date range button"
           disabled={buttonDisabled}
           variant="outline"
           className={cn("justify-between text-left font-normal text-xs", className)}

--- a/frontend/components/ui/date-range-filter/index.tsx
+++ b/frontend/components/ui/date-range-filter/index.tsx
@@ -272,7 +272,6 @@ export const DateRangeFilterInner = ({
     <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
       <PopoverTrigger asChild>
         <Button
-          aria-label="Date range button"
           disabled={buttonDisabled}
           variant="outline"
           className={cn("justify-between text-left font-normal text-xs", className)}

--- a/frontend/components/ui/infinite-datatable/ui/datatable-filter/ui.tsx
+++ b/frontend/components/ui/infinite-datatable/ui/datatable-filter/ui.tsx
@@ -366,7 +366,12 @@ const PureFilterList = ({
                 )}{" "}
                 {f.value}
               </span>
-              <Button aria-label="Close" onClick={() => onRemoveFilter(f)} className="p-0 h-fit group" variant="ghost">
+              <Button
+                aria-label={`Remove ${f.column} ${f.value} filter`}
+                onClick={() => onRemoveFilter(f)}
+                className="p-0 h-fit group"
+                variant="ghost"
+              >
                 <X className="w-3 h-3 text-primary/70 group-hover:text-primary" />
               </Button>
             </Badge>

--- a/frontend/components/ui/infinite-datatable/ui/datatable-filter/ui.tsx
+++ b/frontend/components/ui/infinite-datatable/ui/datatable-filter/ui.tsx
@@ -366,7 +366,7 @@ const PureFilterList = ({
                 )}{" "}
                 {f.value}
               </span>
-              <Button onClick={() => onRemoveFilter(f)} className="p-0 h-fit group" variant="ghost">
+              <Button aria-label="Close" onClick={() => onRemoveFilter(f)} className="p-0 h-fit group" variant="ghost">
                 <X className="w-3 h-3 text-primary/70 group-hover:text-primary" />
               </Button>
             </Badge>

--- a/frontend/components/ui/infinite-datatable/ui/selection-panel.tsx
+++ b/frontend/components/ui/infinite-datatable/ui/selection-panel.tsx
@@ -17,7 +17,7 @@ export function SelectionPanel({ selectedRowIds, onClearSelection, selectionPane
         </Label>
         {selectionPanel?.(selectedRowIds)}
       </div>
-      <Button variant="ghost" onClick={onClearSelection} size="icon">
+      <Button aria-label="Close" variant="ghost" onClick={onClearSelection} size="icon">
         <X size={12} />
       </Button>
     </div>

--- a/frontend/components/ui/infinite-datatable/ui/selection-panel.tsx
+++ b/frontend/components/ui/infinite-datatable/ui/selection-panel.tsx
@@ -17,7 +17,7 @@ export function SelectionPanel({ selectedRowIds, onClearSelection, selectionPane
         </Label>
         {selectionPanel?.(selectedRowIds)}
       </div>
-      <Button aria-label="Close" variant="ghost" onClick={onClearSelection} size="icon">
+      <Button aria-label="Clear selection" variant="ghost" onClick={onClearSelection} size="icon">
         <X size={12} />
       </Button>
     </div>

--- a/frontend/components/ui/pdf-renderer.tsx
+++ b/frontend/components/ui/pdf-renderer.tsx
@@ -172,7 +172,7 @@ export default function PdfRenderer({ url, base64, className }: PdfRendererProps
         </div>
         <Sheet>
           <SheetTrigger asChild>
-            <Button variant="ghost" size="icon">
+            <Button aria-label="Expand" variant="ghost" size="icon">
               <Maximize className="h-3.5 w-3.5" />
             </Button>
           </SheetTrigger>

--- a/frontend/components/ui/template-renderer/template-picker.tsx
+++ b/frontend/components/ui/template-renderer/template-picker.tsx
@@ -420,7 +420,7 @@ export const TemplatePickerActions = ({ className }: { className?: string }) => 
         onClick={openEdit}
         title="Edit template"
       >
-        <PencilIcon className="size-3.5" />
+        <PencilIcon data-icon="inline-start" className="size-3.5" />
         Edit template
       </Button>
     </div>
@@ -453,7 +453,7 @@ export const TemplatePickerPreview = ({ data, className, onSelectSpan }: Templat
             : "Create a template to render this content as a custom view."}
         </p>
         <Button variant="secondary" onClick={openCreate}>
-          <Plus className="mr-1.5 size-3.5" />
+          <Plus data-icon="inline-start" className="mr-1.5 size-3.5" />
           Template
         </Button>
       </div>

--- a/frontend/components/workspace/reports/index.tsx
+++ b/frontend/components/workspace/reports/index.tsx
@@ -88,6 +88,7 @@ export default function WorkspaceReports({ workspaceId, slackClientId, slackRedi
               <td className="px-4 w-1/10">
                 <div className="flex justify-end">
                   <Button
+                    aria-label="Edit"
                     variant="ghost"
                     size="icon"
                     onClick={() => {

--- a/frontend/components/workspace/reports/manage-report-sheet.tsx
+++ b/frontend/components/workspace/reports/manage-report-sheet.tsx
@@ -230,7 +230,7 @@ export default function ManageReportSheet({
         </ScrollArea>
         <div className="flex justify-end px-4 py-3 border-t">
           <Button onClick={handleSave} disabled={isSaving || !hasChanges}>
-            <Loader2 className={cn("mr-2 hidden", { "animate-spin block": isSaving })} size={16} />
+            <Loader2 data-icon="inline-start" className={cn("mr-2 hidden", { "animate-spin block": isSaving })} size={16} />
             Save
           </Button>
         </div>

--- a/frontend/components/workspace/usage/warnings/warning-row.tsx
+++ b/frontend/components/workspace/usage/warnings/warning-row.tsx
@@ -142,7 +142,7 @@ export function AddWarningPopover({ workspaceId, usageItem, unit, toRawValue, on
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button type="button" variant="outline" size="sm" className="h-7 gap-1 text-xs">
-          <Plus className="h-3 w-3" />
+          <Plus data-icon="inline-start" className="h-3 w-3" />
           Add
         </Button>
       </PopoverTrigger>
@@ -185,7 +185,7 @@ export function AddWarningPopover({ workspaceId, usageItem, unit, toRawValue, on
             className="w-full"
             disabled={!form.formState.isDirty || form.formState.isSubmitting}
           >
-            <Loader2 className={cn("mr-1 h-3 w-3", form.formState.isSubmitting ? "animate-spin" : "hidden")} />
+            <Loader2 data-icon="inline-start" className={cn("mr-1 h-3 w-3", form.formState.isSubmitting ? "animate-spin" : "hidden")} />
             Add threshold
           </Button>
         </form>

--- a/frontend/components/workspace/workspace-settings.tsx
+++ b/frontend/components/workspace/workspace-settings.tsx
@@ -177,7 +177,7 @@ export default function WorkspaceSettings({ workspace, isOwner }: WorkspaceSetti
         <Dialog open={isRenameDialogOpen} onOpenChange={resetAndCloseRenameDialog}>
           <DialogTrigger asChild>
             <Button disabled={!isOwner} onClick={() => setIsRenameDialogOpen(true)} variant="outline" className="w-fit">
-              <Edit className="w-4 h-4 mr-2" />
+              <Edit data-icon="inline-start" className="w-4 h-4 mr-2" />
               Rename
             </Button>
           </DialogTrigger>
@@ -210,7 +210,7 @@ export default function WorkspaceSettings({ workspace, isOwner }: WorkspaceSetti
               </div>
               <DialogFooter className="mt-4">
                 <Button type="submit" disabled={!renameForm.formState.isValid || renameForm.formState.isSubmitting}>
-                  <Loader2
+                  <Loader2 data-icon="inline-start"
                     className={cn("mr-2 h-4 w-4", renameForm.formState.isSubmitting ? "animate-spin" : "hidden")}
                   />
                   Rename
@@ -235,7 +235,7 @@ export default function WorkspaceSettings({ workspace, isOwner }: WorkspaceSetti
               variant="outline"
               className="w-fit text-destructive border-destructive"
             >
-              <Trash2 className="w-4 h-4 mr-2" />
+              <Trash2 data-icon="inline-start" className="w-4 h-4 mr-2" />
               Delete
             </Button>
           </DialogTrigger>
@@ -289,7 +289,7 @@ export default function WorkspaceSettings({ workspace, isOwner }: WorkspaceSetti
                   Cancel
                 </Button>
                 <Button type="submit" variant="destructive" disabled={!isDeleteEnabled}>
-                  <Loader2
+                  <Loader2 data-icon="inline-start"
                     className={cn("mr-2 h-4 w-4", deleteForm.formState.isSubmitting ? "animate-spin" : "hidden")}
                   />
                   Delete


### PR DESCRIPTION
## Summary

First split-off from #2129 (the large shadscan audit branch). This PR contains **only accessible-label additions** — no behavior changes, so it should need essentially no testing.

- **advanced-search filter tag** — `aria-label="Remove filter"` on the X button
- **chart-builder** — `aria-label="Chart type"` on the chart-type `SelectTrigger`
- **cli-auth `Field`** — wraps its children in a real `<label>` so the nested workspace/project inputs get an accessible name via implicit association
- **email sign-in** — `id`/`htmlFor` association between label and input + `autoComplete="email"`
- **export-chart dialog** — `aria-label="Chart name"` on the name input

## Verification

- `tsc --noEmit` — no new errors in the 5 touched files
- `eslint` — clean on the 5 touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup and ARIA-only changes with no auth, API, or business-logic edits; broad touch surface but low functional risk.
> 
> **Overview**
> Frontend-wide **accessibility cleanup** from the shadscan audit branch. Runtime behavior is unchanged; the work is naming controls for screen readers and tightening a few form associations.
> 
> **Labels and forms:** Icon-only buttons (clear search, close panels, settings/more menus, delete, zoom, etc.) now expose **`aria-label`** across dashboards, traces, playground, settings, SQL, datasets, and related surfaces. **Email sign-in** links label and field via `id`/`htmlFor` and sets `autoComplete="email"`. **CLI auth `Field`** defaults to a wrapping `<label>` for implicit input naming; workspace **Select** uses `as="div"` plus `aria-label="Workspace"` because Radix Select breaks inside `<label>` on mobile.
> 
> **Search and filters:** Advanced-search filter tags build **contextual remove labels** (column, operator, value) so duplicate filters on one column stay distinguishable. Datatable filter badges get similar remove-button labels.
> 
> **Buttons with icons:** Many inline Lucide icons inside buttons gain **`data-icon="inline-start"`** / **`inline-end`** (loaders, chevrons, toolbar icons) for consistent button/icon layout semantics.
> 
> **Misc:** Chart export name input and chart-type select get explicit accessible names; **`spacedColorMap`** in `lib/colors.ts` is reformatted only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb1304e1fcb61ff46898abce4b5d0f6694eeca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->