### PR TITLE
remove v2 suffix from triggers cache key

### DIFF
--- a/app-server/src/cache/keys.rs
+++ b/app-server/src/cache/keys.rs
@@ -5,11 +5,8 @@ pub const CUSTOM_MODEL_COSTS_CACHE_KEY: &str = "custom_model_costs";
 pub const MODEL_COSTS_CACHE_KEY: &str = "model_costs";
 pub const PROJECT_API_KEY_CACHE_KEY: &str = "project_api_key";
 pub const PROJECT_CACHE_KEY: &str = "project";
-// `_v2`: signal `sample_rate` moved into `metadata` jsonb (migration 0099),
-// changing the cached `Signal` shape. Bumping abandons legacy-shaped entries
-// (which have no TTL) rather than deserializing them with sampling silently lost.
 #[cfg_attr(not(feature = "signals"), allow(dead_code))]
-pub const SIGNAL_TRIGGERS_CACHE_KEY: &str = "signal_triggers_v2";
+pub const SIGNAL_TRIGGERS_CACHE_KEY: &str = "signal_triggers";
 #[cfg_attr(not(feature = "signals"), allow(dead_code))]
 pub const SIGNAL_TRIGGER_LOCK_CACHE_KEY: &str = "signal_trigger_lock";
 #[cfg_attr(not(feature = "signals"), allow(dead_code))]

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -252,9 +252,7 @@ export const WORKSPACE_SIGNAL_CACHE_READ_TOKENS_USAGE_CACHE_KEY = "workspace_sig
 export const WORKSPACE_SIGNAL_OUTPUT_TOKENS_USAGE_CACHE_KEY = "workspace_signal_runs_usage_output_tokens";
 export const TRACE_CHATS_CACHE_KEY = "trace_chats";
 export const TRACE_SUMMARIES_CACHE_KEY = "trace_summaries";
-// `_v2`: must match app-server `SIGNAL_TRIGGERS_CACHE_KEY` (signal sample_rate
-// moved into metadata jsonb in migration 0099 — see app-server cache/keys.rs).
-export const SIGNAL_TRIGGERS_CACHE_KEY = "signal_triggers_v2";
+export const SIGNAL_TRIGGERS_CACHE_KEY = "signal_triggers";
 export const ALERT_FILTERS_CACHE_KEY = "alert_filters";
 export const SUMMARY_TRIGGER_SPANS_CACHE_KEY = "summary_trigger_spans";
 export const WORKSPACE_DEPLOYMENTS_CACHE_KEY = "workspace_deployment_config";


### PR DESCRIPTION
The old ones are manually cleared, and we are changing the shape, so this is intentional

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cache key rename only, with frontend and Rust kept in sync; impact is limited to signal-trigger cache misses until repopulated after manual invalidation.
> 
> **Overview**
> Aligns the **signal triggers** Redis cache namespace back to `signal_triggers` on both **app-server** (`SIGNAL_TRIGGERS_CACHE_KEY`) and **frontend** (`frontend/lib/cache.ts`), replacing the temporary `signal_triggers_v2` key used after the cached `Signal` shape changed (e.g. `sample_rate` in metadata).
> 
> The explanatory comments about the `_v2` bump and migration 0099 are removed; stale entries are expected to be cleared manually before deploy so readers/writers use the new key and shape together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16a421329428a9fccd02efb2ff6a06d489924911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->