### PR TITLE
feat: update debugger to agg traces

### DIFF
--- a/app-server/src/db/debugger_session_blocks.rs
+++ b/app-server/src/db/debugger_session_blocks.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use super::trace::Trace;
+use crate::ch::traces::TraceAggregation;
 
 pub const TRACE_BLOCK_TYPE: &str = "trace";
 pub const EVALUATION_BLOCK_TYPE: &str = "evaluation";
@@ -13,7 +13,7 @@ pub const EVALUATION_BLOCK_TYPE: &str = "evaluation";
 const SESSION_ID_METADATA_KEY: &str = "rollout.session_id";
 
 // `traces.type` DEFAULT (see `Into<u8> for TraceType` in `ch/spans.rs`).
-const DEFAULT_TRACE_TYPE: i16 = 0;
+const DEFAULT_TRACE_TYPE: u8 = 0;
 
 /// Deterministic block id: re-processing the same entity for the same session
 /// always lands on the same row, so ingest retries and repeated span flushes
@@ -140,37 +140,36 @@ fn session_id_from_metadata(metadata: Option<&Value>) -> Option<Uuid> {
         .and_then(|s| Uuid::parse_str(s).ok())
 }
 
-/// Upsert a `trace` block for every trace carrying the `rollout.session_id`
-/// metadata key. Best-effort: a failed upsert is logged and never fails ingest.
-pub async fn upsert_blocks_for_traces(pool: &PgPool, traces: &[Trace]) {
-    for trace in traces {
+/// Upsert a `trace` block for every trace whose per-batch span aggregation
+/// carries the `rollout.session_id` metadata key. Best-effort: a failed upsert
+/// is logged and never fails ingest.
+pub async fn upsert_blocks_for_traces(pool: &PgPool, aggregations: &[TraceAggregation]) {
+    for agg in aggregations {
         // Only DEFAULT traces become trace blocks (eval traces → evaluation blocks).
-        if trace.trace_type() != DEFAULT_TRACE_TYPE {
+        if agg.trace_type != DEFAULT_TRACE_TYPE {
             continue;
         }
 
-        let Some(session_id) = session_id_from_metadata(trace.metadata()) else {
+        let Some(session_id) = session_id_from_metadata(agg.metadata.as_ref()) else {
             continue;
         };
 
-        // Trace blocks are pure references — notes live only in standalone text
-        // blocks, not folded from trace `rollout.note` metadata.
-        let content = serde_json::json!({ "traceId": trace.id().to_string() });
+        let content = serde_json::json!({ "traceId": agg.trace_id.to_string() });
 
         if let Err(e) = upsert_block(
             pool,
-            &trace.project_id(),
+            &agg.project_id,
             &session_id,
             TRACE_BLOCK_TYPE,
-            &trace.id(),
+            &agg.trace_id,
             &content,
-            &trace.start_time().unwrap_or(Utc::now()),
+            &agg.start_time.unwrap_or_else(Utc::now),
         )
         .await
         {
             log::error!(
                 "Failed to upsert trace debugger session block. trace_id: {}, session_id: {}, error: {:?}",
-                trace.id(),
+                agg.trace_id,
                 session_id,
                 e
             );

--- a/app-server/src/db/debugger_session_blocks.rs
+++ b/app-server/src/db/debugger_session_blocks.rs
@@ -33,11 +33,9 @@ pub fn evaluation_block_id(session_id: &Uuid, evaluation_id: &Uuid) -> Uuid {
 /// the entity happened, not when ingestion ran. The insert is gated on the
 /// session existing in the same project (sessions are registered explicitly),
 /// so an unregistered or cross-project session id is a silent no-op instead of
-/// an FK error. On conflict only `content` is refreshed (e.g. a live note
-/// update); `created_at` is written once at first insert and never overwritten,
-/// so a trace block keeps the original trace start_time and ordering stays
-/// stable across re-ingest / repeated span flushes.
-pub async fn upsert_block(
+/// an FK error. On conflict `content` is refreshed and `created_at` keeps the
+/// earliest seen, so ordering stays stable across re-ingest / repeated flushes.
+pub async fn upsert_session_block(
     pool: &PgPool,
     project_id: &Uuid,
     session_id: &Uuid,
@@ -51,7 +49,8 @@ pub async fn upsert_block(
         SELECT $1, $2, $3, $4, $5, $6
         WHERE EXISTS (SELECT 1 FROM debugger_sessions WHERE id = $3 AND project_id = $2)
         ON CONFLICT (id) DO UPDATE
-            SET content = EXCLUDED.content
+            SET content = EXCLUDED.content,
+                created_at = LEAST(debugger_session_blocks.created_at, EXCLUDED.created_at)
             WHERE debugger_session_blocks.project_id = $2
                 AND debugger_session_blocks.session_id = $3",
     )
@@ -69,10 +68,10 @@ pub async fn upsert_block(
 
 /// Append a standalone block to a session, returning the new block id.
 ///
-/// Unlike `upsert_block` (deterministic id keyed on a source trace / eval so
-/// re-ingest collapses onto one row), this mints a fresh `entity_id` per call
-/// so repeated notes append distinct blocks rather than overwriting. Like
-/// `upsert_block`, the insert is gated on the session existing in the same
+/// Unlike `upsert_session_block` (deterministic id keyed on a source trace /
+/// eval so re-ingest collapses onto one row), this mints a fresh `entity_id`
+/// per call so repeated notes append distinct blocks rather than overwriting.
+/// Like `upsert_session_block`, the insert is gated on the session existing in the same
 /// project via `WHERE EXISTS`; when it doesn't, no row is written and `None` is
 /// returned so the caller can surface a real 404.
 pub async fn insert_block(
@@ -156,7 +155,7 @@ pub async fn upsert_blocks_for_traces(pool: &PgPool, aggregations: &[TraceAggreg
 
         let content = serde_json::json!({ "traceId": agg.trace_id.to_string() });
 
-        if let Err(e) = upsert_block(
+        if let Err(e) = upsert_session_block(
             pool,
             &agg.project_id,
             &session_id,
@@ -193,7 +192,7 @@ pub async fn upsert_block_for_evaluation(
     // Eval blocks are pure references — notes live only in standalone text blocks.
     let content = serde_json::json!({ "evaluationId": evaluation_id.to_string() });
 
-    if let Err(e) = upsert_block(
+    if let Err(e) = upsert_session_block(
         pool,
         project_id,
         &session_id,

--- a/app-server/src/traces/processor.rs
+++ b/app-server/src/traces/processor.rs
@@ -640,6 +640,11 @@ pub async fn process_span_messages(
             true
         };
 
+        if had_aggregations {
+            debugger_session_blocks::upsert_blocks_for_traces(&db.pool, &trace_aggregations).await;
+            dispatch_trace_realtime_updates(&trace_aggregations, cache.clone(), &pubsub).await;
+        }
+
         // Patches that beat the trace's span batch create a virtual row that
         // the aggregation upsert later fills in — see
         // `merge_trace_metadata_batch` for the known stub-row caveat.
@@ -708,10 +713,6 @@ pub async fn process_span_messages(
                     e
                 );
             }
-
-            debugger_session_blocks::upsert_blocks_for_traces(&db.pool, &updated_traces).await;
-
-            dispatch_trace_realtime_updates(&trace_aggregations, cache.clone(), &pubsub).await;
         }
 
         // Dual-write partial rows to `traces_agg` (AggregatingMergeTree,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ingest timing and inputs for debugger blocks changed (aggregation vs PG-merged traces), and conflict `created_at` semantics differ; impact is limited to debugger session ordering/UI, not core trace storage.
> 
> **Overview**
> Debugger **trace session blocks** are now built from in-memory **`TraceAggregation`** batches (metadata, start time, trace type) instead of merged PostgreSQL **`Trace`** rows, matching the agg-traces ingest path and the realtime debugger channel.
> 
> In **`process_span_messages`**, **`upsert_blocks_for_traces`** and **`dispatch_trace_realtime_updates`** run immediately after a successful span-batch stats upsert when the batch has aggregations—using **`trace_aggregations`**—rather than after the ClickHouse trace dual-write on **`updated_traces`**.
> 
> **`upsert_block`** is renamed **`upsert_session_block`**. On conflict, **`created_at`** is updated with **`LEAST(existing, new)`** so re-ingest keeps the earliest timestamp instead of freezing the first insert value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05a8cb54d66b492513fb33c327d14699fa65b93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->