### PR TITLE
fix: eval stat shields ignore the aggregation picker (always show average)

### DIFF
--- a/frontend/components/evaluation/metrics-panel/utils.ts
+++ b/frontend/components/evaluation/metrics-panel/utils.ts
@@ -1,7 +1,7 @@
-import { type EvaluationScoreDistributionBucket, type EvaluationScoreStatistics } from "@/lib/evaluation/types";
+import { type ScoreAggregation } from "@/lib/evaluation/aggregation";
 import { isValidNumber } from "@/lib/utils";
 
-export type AggregationKind = "avg" | "sum" | "min" | "max" | "median" | "p90" | "p95" | "p99";
+export type AggregationKind = ScoreAggregation;
 
 export const AGGREGATION_OPTIONS: { value: AggregationKind; label: string }[] = [
   { value: "avg", label: "Average" },
@@ -15,125 +15,6 @@ export const AGGREGATION_OPTIONS: { value: AggregationKind; label: string }[] = 
 ];
 
 export const DEFAULT_AGGREGATION: AggregationKind = "avg";
-
-const QUANTILE_FOR: Record<Exclude<AggregationKind, "avg" | "sum" | "min" | "max">, number> = {
-  median: 0.5,
-  p90: 0.9,
-  p95: 0.95,
-  p99: 0.99,
-};
-
-const bucketMid = (b: EvaluationScoreDistributionBucket): number => {
-  // upperBound is required by the type but defensively coerce if missing
-  const lo = b.lowerBound;
-  const hi = typeof b.upperBound === "number" ? b.upperBound : lo;
-  return (lo + hi) / 2;
-};
-
-const bucketCount = (b: EvaluationScoreDistributionBucket): number => {
-  const h = b?.heights?.[0];
-  return typeof h === "number" && isFinite(h) ? h : 0;
-};
-
-// Linear-interpolate a quantile from histogram buckets. Returns null when total mass == 0.
-function quantileFromBuckets(distribution: EvaluationScoreDistributionBucket[], q: number): number | null {
-  if (!distribution || distribution.length === 0) return null;
-  const counts = distribution.map(bucketCount);
-  const total = counts.reduce((acc, c) => acc + c, 0);
-  if (total <= 0) return null;
-  const target = q * total;
-  let cum = 0;
-  for (let i = 0; i < distribution.length; i++) {
-    const c = counts[i];
-    if (c <= 0) continue;
-    const next = cum + c;
-    if (target <= next) {
-      const within = c > 0 ? (target - cum) / c : 0;
-      const b = distribution[i];
-      const lo = b.lowerBound;
-      const hi = typeof b.upperBound === "number" ? b.upperBound : lo;
-      return lo + within * (hi - lo);
-    }
-    cum = next;
-  }
-  // Fallback to the last non-empty bucket midpoint.
-  for (let i = distribution.length - 1; i >= 0; i--) {
-    if (counts[i] > 0) return bucketMid(distribution[i]);
-  }
-  return null;
-}
-
-/**
- * Compute an aggregation scalar from the per-score distribution buckets.
- * `avg` is taken from server stats when available; everything else is
- * derived client-side from bucket midpoints + counts.
- */
-export function aggregateScalar(
-  aggregation: AggregationKind,
-  statistics: EvaluationScoreStatistics | null | undefined,
-  distribution: EvaluationScoreDistributionBucket[] | null | undefined
-): number | undefined {
-  if (aggregation === "avg") {
-    return statistics?.averageValue;
-  }
-  if (!distribution || distribution.length === 0) return undefined;
-
-  if (aggregation === "sum") {
-    let s = 0;
-    let any = false;
-    for (const b of distribution) {
-      const c = bucketCount(b);
-      if (c <= 0) continue;
-      s += bucketMid(b) * c;
-      any = true;
-    }
-    return any ? s : undefined;
-  }
-
-  if (aggregation === "min") {
-    for (const b of distribution) {
-      if (bucketCount(b) > 0) return bucketMid(b);
-    }
-    return undefined;
-  }
-
-  if (aggregation === "max") {
-    for (let i = distribution.length - 1; i >= 0; i--) {
-      if (bucketCount(distribution[i]) > 0) return bucketMid(distribution[i]);
-    }
-    return undefined;
-  }
-
-  const q = QUANTILE_FOR[aggregation];
-  const r = quantileFromBuckets(distribution, q);
-  return r ?? undefined;
-}
-
-// "Binary" = all non-zero mass sits in the first and last buckets only (pass/fail evaluators).
-export function isBinaryDistribution(distribution: EvaluationScoreDistributionBucket[] | null | undefined): boolean {
-  if (!distribution || distribution.length < 2) return false;
-  const last = distribution.length - 1;
-  let anyMiddle = false;
-  let anyExtreme = false;
-  for (let i = 0; i < distribution.length; i++) {
-    const h = distribution[i]?.heights[0] ?? 0;
-    if (h <= 0) continue;
-    if (i === 0 || i === last) anyExtreme = true;
-    else anyMiddle = true;
-  }
-  return anyExtreme && !anyMiddle;
-}
-
-export function binaryCounts(distribution: EvaluationScoreDistributionBucket[] | null | undefined): {
-  negative: number;
-  positive: number;
-  total: number;
-} {
-  if (!distribution || distribution.length < 2) return { negative: 0, positive: 0, total: 0 };
-  const negative = distribution[0]?.heights[0] ?? 0;
-  const positive = distribution[distribution.length - 1]?.heights[0] ?? 0;
-  return { negative, positive, total: negative + positive };
-}
 
 export function pctChange(current: number, base: number): number | null {
   if (!isValidNumber(current) || !isValidNumber(base) || base === 0) return null;

--- a/frontend/components/evaluation/run-score-card/index.tsx
+++ b/frontend/components/evaluation/run-score-card/index.tsx
@@ -46,12 +46,12 @@ export default function RunScoreCard({
   evaluationId,
   scoreNames,
   allStatistics,
-  allDistributions,
   comparedAllStatistics,
-  comparedAllDistributions,
   isComparison,
   scoreDirections,
 }: RunScoreCardProps) {
+  // allDistributions/comparedAllDistributions are still accepted (and shipped by
+  // the API) for future histogram charts; the shields read exact stats now.
   const [aggregation] = useAggregation();
 
   const [storedOrder, setStoredOrder] = useLocalStorage<string[]>(
@@ -95,9 +95,7 @@ export default function RunScoreCard({
             name={name}
             aggregation={aggregation}
             statistics={allStatistics?.[name] ?? null}
-            distribution={allDistributions?.[name] ?? null}
             comparedStatistics={comparedAllStatistics?.[name] ?? null}
-            comparedDistribution={comparedAllDistributions?.[name] ?? null}
             isComparison={isComparison}
             isHigherBetter={scoreDirections?.[name] ?? true}
           />

--- a/frontend/components/evaluation/run-score-card/score-card-item.tsx
+++ b/frontend/components/evaluation/run-score-card/score-card-item.tsx
@@ -2,23 +2,15 @@
 
 import { ArrowRight } from "lucide-react";
 
-import {
-  aggregateScalar,
-  type AggregationKind,
-  binaryCounts,
-  isBinaryDistribution,
-  pctChange,
-} from "@/components/evaluation/metrics-panel/utils";
-import { type EvaluationScoreDistributionBucket, type EvaluationScoreStatistics } from "@/lib/evaluation/types";
+import { type AggregationKind, pctChange } from "@/components/evaluation/metrics-panel/utils";
+import { type EvaluationScoreStatistics } from "@/lib/evaluation/types";
 import { cn, isValidNumber } from "@/lib/utils";
 
 interface ScoreCardItemProps {
   name: string;
   aggregation: AggregationKind;
   statistics: EvaluationScoreStatistics | null;
-  distribution: EvaluationScoreDistributionBucket[] | null;
   comparedStatistics: EvaluationScoreStatistics | null;
-  comparedDistribution: EvaluationScoreDistributionBucket[] | null;
   isComparison?: boolean;
   /** Resolved score direction. Absent = higher is better. */
   isHigherBetter?: boolean;
@@ -26,19 +18,11 @@ interface ScoreCardItemProps {
 
 const fmt = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
 
-// Binary (pass/fail) scores read as a positive rate; the aggregation picker
-// doesn't apply to them.
-function scalarFor(
-  isBinary: boolean,
-  aggregation: AggregationKind,
-  statistics: EvaluationScoreStatistics | null,
-  distribution: EvaluationScoreDistributionBucket[] | null
-): number | undefined {
-  if (isBinary) {
-    const counts = binaryCounts(distribution);
-    return counts.total > 0 ? counts.positive / counts.total : statistics?.averageValue;
-  }
-  return aggregateScalar(aggregation, statistics, distribution);
+// Exact per-run aggregate for the selected function. Values are computed
+// server-side over the raw datapoint scores (see lib/evaluation/aggregation.ts).
+function scalarFor(aggregation: AggregationKind, statistics: EvaluationScoreStatistics | null): number | undefined {
+  if (!statistics) return undefined;
+  return aggregation === "avg" ? statistics.averageValue : statistics[aggregation];
 }
 
 // One score's whole-run aggregate: name on top, big number below, and (in
@@ -48,16 +32,12 @@ export default function ScoreCardItem({
   name,
   aggregation,
   statistics,
-  distribution,
   comparedStatistics,
-  comparedDistribution,
   isComparison,
   isHigherBetter = true,
 }: ScoreCardItemProps) {
-  const isBinary = isBinaryDistribution(distribution);
-
-  const cur = scalarFor(isBinary, aggregation, statistics, distribution);
-  const cmp = isComparison ? scalarFor(isBinary, aggregation, comparedStatistics, comparedDistribution) : undefined;
+  const cur = scalarFor(aggregation, statistics);
+  const cmp = isComparison ? scalarFor(aggregation, comparedStatistics) : undefined;
 
   const validCur = isValidNumber(cur);
   const validCmp = isComparison && isValidNumber(cmp);

--- a/frontend/lib/actions/evaluation/utils.ts
+++ b/frontend/lib/actions/evaluation/utils.ts
@@ -1,3 +1,4 @@
+import { computeScoreAggregates } from "@/lib/evaluation/aggregation";
 import { type EvaluationScoreDistributionBucket, type EvaluationScoreStatistics } from "@/lib/evaluation/types";
 
 // Constants for distribution calculation
@@ -16,14 +17,21 @@ export function calculateScoreStatistics(
     })
     .filter((score): score is number => typeof score === "number" && !isNaN(score));
 
-  if (scores.length === 0) {
+  const agg = computeScoreAggregates(scores);
+  if (!agg) {
     return { averageValue: 0 };
   }
 
-  const sum = scores.reduce((acc, score) => acc + score, 0);
-  const averageValue = sum / scores.length;
-
-  return { averageValue };
+  return {
+    averageValue: agg.avg,
+    min: agg.min,
+    max: agg.max,
+    sum: agg.sum,
+    median: agg.median,
+    p90: agg.p90,
+    p95: agg.p95,
+    p99: agg.p99,
+  };
 }
 
 // Helper function to calculate score distribution
@@ -57,8 +65,8 @@ export function calculateScoreDistribution(
   // All scores are the same value. This branch only fires when that value sits
   // at the lower bound (<= 0, since lowerBound = min(value, 0)), e.g. a binary
   // score filtered to `= 0`. Put the mass in the FIRST bucket — the last bucket
-  // is the "positive"/high end, so dumping all-zero rows there makes
-  // `binaryCounts` report a 100% positive rate instead of 0%.
+  // is the "positive"/high end, so dumping all-zero rows there would misrepresent
+  // an all-fail run as all-pass in the histogram.
   if (lowerBound === upperBound) {
     const buckets: EvaluationScoreDistributionBucket[] = Array.from({ length: DEFAULT_BUCKET_COUNT }, () => ({
       lowerBound,

--- a/frontend/lib/clickhouse/evaluation-scores.ts
+++ b/frontend/lib/clickhouse/evaluation-scores.ts
@@ -1,7 +1,21 @@
 import { executeQuery } from "@/lib/actions/sql";
 import { type AggregationFunction } from "@/lib/clickhouse/types";
 
+import { aggregateScore, type ScoreAggregation } from "../evaluation/aggregation";
 import { type EvaluationTimeProgression } from "../evaluation/types";
+
+// Map the uppercase wire enum onto the shared aggregation kinds. Keeps the group
+// progression and the single-eval shields on identical formulas (incl. quantiles).
+const AGGREGATION_KIND: Record<AggregationFunction, ScoreAggregation> = {
+  AVG: "avg",
+  SUM: "sum",
+  MIN: "min",
+  MAX: "max",
+  MEDIAN: "median",
+  p90: "p90",
+  p95: "p95",
+  p99: "p99",
+} as Record<AggregationFunction, ScoreAggregation>;
 
 export const getEvaluationTimeProgression = async (
   projectId: string,
@@ -78,51 +92,8 @@ export const getEvaluationTimeProgression = async (
     for (const [name, scoreValues] of evalData.scoresByName.entries()) {
       if (scoreValues.length === 0) continue;
 
-      let aggregatedValue: number;
-      switch (aggregationFunction) {
-        case "AVG":
-          aggregatedValue = scoreValues.reduce((a, b) => a + b, 0) / scoreValues.length;
-          break;
-        case "SUM":
-          aggregatedValue = scoreValues.reduce((a, b) => a + b, 0);
-          break;
-        case "MIN":
-          aggregatedValue = Math.min(...scoreValues);
-          break;
-        case "MAX":
-          aggregatedValue = Math.max(...scoreValues);
-          break;
-        case "MEDIAN":
-          {
-            const sorted = [...scoreValues].sort((a, b) => a - b);
-            const mid = Math.floor(sorted.length / 2);
-            aggregatedValue = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-          }
-          break;
-        case "p90":
-          {
-            const sorted = [...scoreValues].sort((a, b) => a - b);
-            const idx = Math.ceil(sorted.length * 0.9) - 1;
-            aggregatedValue = sorted[Math.max(0, idx)];
-          }
-          break;
-        case "p95":
-          {
-            const sorted = [...scoreValues].sort((a, b) => a - b);
-            const idx = Math.ceil(sorted.length * 0.95) - 1;
-            aggregatedValue = sorted[Math.max(0, idx)];
-          }
-          break;
-        case "p99":
-          {
-            const sorted = [...scoreValues].sort((a, b) => a - b);
-            const idx = Math.ceil(sorted.length * 0.99) - 1;
-            aggregatedValue = sorted[Math.max(0, idx)];
-          }
-          break;
-        default:
-          aggregatedValue = scoreValues.reduce((a, b) => a + b, 0) / scoreValues.length;
-      }
+      const kind = AGGREGATION_KIND[aggregationFunction] ?? "avg";
+      const aggregatedValue = aggregateScore(scoreValues, kind) ?? 0;
 
       names.push(name);
       values.push(String(aggregatedValue));

--- a/frontend/lib/evaluation/aggregation.ts
+++ b/frontend/lib/evaluation/aggregation.ts
@@ -42,6 +42,30 @@ export function computeScoreAggregates(values: number[]): Record<ScoreAggregatio
 }
 
 // Single-aggregation convenience (the group progression picks one fn per run+score).
+// avg/sum/min/max stay O(n) with no allocation; only quantiles pay the sort.
 export function aggregateScore(values: number[], fn: ScoreAggregation): number | undefined {
-  return computeScoreAggregates(values)?.[fn];
+  if (values.length === 0) return undefined;
+  switch (fn) {
+    case "avg":
+    case "sum": {
+      let sum = 0;
+      for (const v of values) sum += v;
+      return fn === "avg" ? sum / values.length : sum;
+    }
+    case "min": {
+      let m = values[0];
+      for (const v of values) if (v < m) m = v;
+      return m;
+    }
+    case "max": {
+      let m = values[0];
+      for (const v of values) if (v > m) m = v;
+      return m;
+    }
+    default: {
+      // median / p90 / p95 / p99 need order.
+      const sorted = [...values].sort((a, b) => a - b);
+      return quantile(sorted, QUANTILE_FOR[fn]);
+    }
+  }
 }

--- a/frontend/lib/evaluation/aggregation.ts
+++ b/frontend/lib/evaluation/aggregation.ts
@@ -1,0 +1,47 @@
+// Single source of truth for evaluation score aggregation over the raw
+// per-datapoint values. Used by BOTH the single-eval stat shields
+// (lib/actions/evaluation/utils.ts) and the group progression chart
+// (lib/clickhouse/evaluation-scores.ts) so the two surfaces never disagree.
+
+export type ScoreAggregation = "avg" | "sum" | "min" | "max" | "median" | "p90" | "p95" | "p99";
+
+const QUANTILE_FOR: Record<"median" | "p90" | "p95" | "p99", number> = {
+  median: 0.5,
+  p90: 0.9,
+  p95: 0.95,
+  p99: 0.99,
+};
+
+// Linear-interpolation quantile (numpy 'linear' / Excel PERCENTILE.INC), q in [0, 1].
+// `sorted` MUST be ascending and non-empty. median (q=0.5) collapses to the
+// average of the two middle values for even-length inputs.
+export function quantile(sorted: number[], q: number): number {
+  if (sorted.length === 1) return sorted[0];
+  const pos = (sorted.length - 1) * q;
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo);
+}
+
+// Exact aggregates over the raw values. Returns null for an empty input.
+export function computeScoreAggregates(values: number[]): Record<ScoreAggregation, number> | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const sum = values.reduce((acc, v) => acc + v, 0);
+  return {
+    avg: sum / values.length,
+    sum,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    median: quantile(sorted, QUANTILE_FOR.median),
+    p90: quantile(sorted, QUANTILE_FOR.p90),
+    p95: quantile(sorted, QUANTILE_FOR.p95),
+    p99: quantile(sorted, QUANTILE_FOR.p99),
+  };
+}
+
+// Single-aggregation convenience (the group progression picks one fn per run+score).
+export function aggregateScore(values: number[], fn: ScoreAggregation): number | undefined {
+  return computeScoreAggregates(values)?.[fn];
+}

--- a/frontend/lib/evaluation/types.ts
+++ b/frontend/lib/evaluation/types.ts
@@ -17,6 +17,15 @@ export type LinkedDataset = {
 
 export type EvaluationScoreStatistics = {
   averageValue: number;
+  // Exact aggregates over the raw per-datapoint values so the shield respects
+  // the aggregation picker. Absent when there were no scores.
+  min?: number;
+  max?: number;
+  sum?: number;
+  median?: number;
+  p90?: number;
+  p95?: number;
+  p99?: number;
 };
 
 export type EvaluationScoreDistributionBucket = {


### PR DESCRIPTION
## Problem

On the single-evaluation page, the stat shields (the big score numbers at the top) ignore the aggregation picker. Selecting **Max** on a `0/1` accuracy score shows **0.9** (the average) instead of **1**.

Root cause: the shields never received real aggregates.
- The server computed **only the average** (`calculateScoreStatistics` returned `{ averageValue }`).
- Every other aggregation was **faked client-side from a coarse 10-bucket histogram** (bucket midpoints), so even for continuous scores "Max" was an approximation, never the true max.
- Binary (`0/1`) scores took a **hardcoded short-circuit** in `scalarFor` that returned the positive rate (= the mean) and **discarded the aggregation choice entirely**.

Confirmed against the reported eval (accuracy: 108 datapoints, min 0, max 1, avg 0.898 → rendered as 0.9).

## Fix

- Compute **exact** aggregates server-side from the raw datapoint scores that `calculateScoreStatistics` already had in hand, and ship all of them in the `/stats` response (no refetch on dropdown change).
- The shield now reads `statistics[aggregation]` for the selected function; deleted the binary short-circuit and the histogram-bucket approximation helpers.
- **Standardized** the quantile formulas (median + p90/p95/p99) into one shared module (`lib/evaluation/aggregation.ts`) used by **both** the single-eval shields **and** the group progression chart, so the two surfaces can't disagree.

The histogram (`calculateScoreDistribution` / `allDistributions`) is left fully intact — it still feeds the shared/public eval view's `<Chart>` and is available for future charts.

### Behavior note
The group progression's `p90/p95/p99` switch from nearest-rank to linear interpolation as part of the standardization (median is unchanged). Flagging since it's a visible-number change on that chart.

## Files
- `lib/evaluation/aggregation.ts` (new) — shared exact-aggregation + quantile helper
- `lib/evaluation/types.ts` — extend `EvaluationScoreStatistics` with `min/max/sum/median/p90/p95/p99`
- `lib/actions/evaluation/utils.ts` — compute all aggregates server-side
- `lib/clickhouse/evaluation-scores.ts` — group progression routes through the shared helper
- `components/evaluation/run-score-card/{score-card-item,index}.tsx` — shield reads exact stat; drop distribution props
- `components/evaluation/metrics-panel/utils.ts` — remove dead histogram-scalar helpers

## Testing
- `tsc --noEmit` + eslint clean (pre-commit passed).
- Verified the math on the exact failing data (97 ones + 11 zeros): `max: 1`, `min: 0`, `avg: 0.898`, `median: 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible evaluation metrics and quantile definitions on the group progression chart, but logic is consolidated and scoped to evaluation score display—not auth or data mutation paths.
> 
> **Overview**
> **Fixes stat shields on the single-evaluation page ignoring the aggregation picker** (e.g. **Max** on a 0/1 accuracy score showing the average instead of **1**).
> 
> **Server-side stats** now compute **min, max, sum, median, p90, p95, and p99** from raw per-datapoint scores in `calculateScoreStatistics` and return them on `EvaluationScoreStatistics`. The run score cards read `statistics[aggregation]` (or `averageValue` for avg) with **no client-side histogram math** and **no binary pass-rate override**.
> 
> A new **`lib/evaluation/aggregation.ts`** module centralizes aggregation and **linear-interpolation quantiles** for both the shields and the **group evaluation time progression** chart (`evaluation-scores.ts`), replacing duplicated switch logic there. Client helpers **`aggregateScalar`**, **`isBinaryDistribution`**, and **`binaryCounts`** are removed from the metrics panel utils; distribution payloads remain for charts but are no longer passed into score card items.
> 
> **Note:** Group progression **p90/p95/p99** values may shift slightly because quantiles move from nearest-rank to linear interpolation as part of the shared formula.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cdbfeed898472e23c8a02fbcd18a95676b4c8bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

