### PR TITLE
fix(charts): restore the five brand colors outside evals, simplify palette API

### DIFF
--- a/frontend/components/chart-builder/charts/utils.ts
+++ b/frontend/components/chart-builder/charts/utils.ts
@@ -3,12 +3,20 @@ import { format, isValid } from "date-fns";
 import { isNil, mean } from "lodash";
 
 import { type ChartConfig } from "@/components/ui/chart";
-import { spacedColorMap } from "@/lib/colors";
 
 export const numberFormatter = new Intl.NumberFormat("en-US", {
   notation: "compact",
   maximumFractionDigits: 3,
 });
+
+// Series colors, assigned by position and wrapping past the fifth.
+const CHART_PALETTE = [
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
+];
 
 export const parseUtcTimestamp = (s: string): Date => {
   const hasTimezone = /Z$|[+-]\d{2}:\d{2}$/.test(s);
@@ -124,16 +132,14 @@ export const selectNiceTicksFromData = (
   };
 };
 
-export const generateChartConfig = (columns: string[]): ChartConfig => {
-  const colors = spacedColorMap(columns);
-  return columns.reduce((config, columnName) => {
+export const generateChartConfig = (columns: string[], palette: string[] = CHART_PALETTE): ChartConfig =>
+  columns.reduce((config, columnName, index) => {
     config[columnName] = {
       label: columnName,
-      color: colors.get(columnName),
+      color: palette[index % palette.length],
     };
     return config;
   }, {} as ChartConfig);
-};
 
 export const calculateDataMax = (data: Record<string, any>[], yColumns: string[]): number =>
   data.reduce((max, d) => {
@@ -165,19 +171,17 @@ export const getChartMargins = (yAxisValues?: any[], yAxisFormatter?: (value: an
   };
 };
 
-const createChartConfig = (columns: string[]): ChartConfig => {
-  const colors = spacedColorMap(columns);
-  return Object.fromEntries(
-    columns.map((column) => [
+const createChartConfig = (columns: string[], palette: string[] = CHART_PALETTE): ChartConfig =>
+  Object.fromEntries(
+    columns.map((column, index) => [
       column,
       {
-        color: colors.get(column),
+        color: palette[index % palette.length],
         label: column,
         stackId: "stack",
       },
     ])
   );
-};
 
 export const transformDataForBreakdown = (
   data: Record<string, any>[],

--- a/frontend/components/debugger-sessions/debugger-session-view/debugger-list/eval-block/utils.ts
+++ b/frontend/components/debugger-sessions/debugger-session-view/debugger-list/eval-block/utils.ts
@@ -1,7 +1,7 @@
 import { type ProgressionPoint } from "@/components/evaluations/progression-chart/shared";
 import { type ChartConfig } from "@/components/ui/chart";
 import { type SessionEvaluationRef } from "@/lib/actions/debugger-sessions";
-import { spacedColorMap } from "@/lib/colors";
+import { spacedPalette } from "@/lib/colors";
 
 // The shared progression dataset every eval card in a session renders: one
 // point per evaluation block (timeline order), the union of all score names,
@@ -35,11 +35,11 @@ export const buildSessionEvalProgression = (
     }
     return { timestamp: toIsoTimestamp(e.createdAt), evaluationId: e.id, name: e.name, values };
   });
-  const scores = [...scoreSet];
-  const colors = spacedColorMap(scores);
-  const chartConfig: ChartConfig = Object.fromEntries(
-    scores.map((key) => [key, { color: colors.get(key), label: key }])
-  );
+  // Sorted so a score's position — and therefore its color — doesn't shift when
+  // blocks arrive in a different order or the block that introduced it is gone.
+  const scores = [...scoreSet].sort();
+  const colors = spacedPalette(scores.length);
+  const chartConfig: ChartConfig = Object.fromEntries(scores.map((key, i) => [key, { color: colors[i], label: key }]));
   return { points, scores, chartConfig };
 };
 

--- a/frontend/components/evaluations/progression-chart/index.tsx
+++ b/frontend/components/evaluations/progression-chart/index.tsx
@@ -3,7 +3,7 @@ import { useQueryState } from "nuqs";
 import { useCallback, useMemo, useState } from "react";
 
 import { useLocalStorage } from "@/hooks/use-local-storage.tsx";
-import { spacedColorMap } from "@/lib/colors";
+import { spacedPalette } from "@/lib/colors";
 import { type EvaluationTimeProgression } from "@/lib/evaluation/types";
 import { cn } from "@/lib/utils";
 
@@ -52,7 +52,9 @@ export default function ProgressionChart({
     EMPTY_IDS
   );
 
-  const scoreKeys = useMemo(() => Array.from(new Set(data?.flatMap(({ names }) => names) ?? [])), [data]);
+  // Sorted so a score's position — and therefore its color — doesn't shift when
+  // runs arrive in a different order or the run that introduced it is deleted.
+  const scoreKeys = useMemo(() => Array.from(new Set(data?.flatMap(({ names }) => names) ?? [])).sort(), [data]);
 
   const scores = useMemo(() => scoreKeys.filter((key) => !hiddenScores.includes(key)), [scoreKeys, hiddenScores]);
 
@@ -101,11 +103,8 @@ export default function ProgressionChart({
   );
 
   const chartConfig = useMemo<ChartConfig>(() => {
-    // Golden-ratio spacing spreads scores maximally around the palette's hue
-    // loop; keying on sorted order keeps a score's color stable when the set is
-    // reordered (vs. the old positional `index % 5`, which wrapped after 5).
-    const colors = spacedColorMap(scoreKeys);
-    return Object.fromEntries(scoreKeys.map((key) => [key, { color: colors.get(key), label: key }]));
+    const colors = spacedPalette(scoreKeys.length);
+    return Object.fromEntries(scoreKeys.map((key, i) => [key, { color: colors[i], label: key }]));
   }, [scoreKeys]);
 
   const toggleScore = useCallback(

--- a/frontend/lib/colors.ts
+++ b/frontend/lib/colors.ts
@@ -154,5 +154,11 @@ export const CATEGORICAL_COLOR_PALETTE = [
 // entries ~137.5° apart around the palette's hue loop. Zip the result against a
 // stably-ordered series list — position is what picks the color.
 const GOLDEN_RATIO_CONJUGATE = 0.618033988749895;
+// The palette loop starts at red. Enter it at blue instead, so a lone series
+// reads as data rather than as an error.
+const START_HUE_DEGREES = 240;
 export const spacedPalette = (count: number, palette: readonly string[] = CATEGORICAL_COLOR_PALETTE): string[] =>
-  Array.from({ length: count }, (_, i) => palette[Math.floor(((i * GOLDEN_RATIO_CONJUGATE) % 1) * palette.length)]);
+  Array.from(
+    { length: count },
+    (_, i) => palette[Math.floor(((i * GOLDEN_RATIO_CONJUGATE + START_HUE_DEGREES / 360) % 1) * palette.length)]
+  );

--- a/frontend/lib/colors.ts
+++ b/frontend/lib/colors.ts
@@ -150,22 +150,9 @@ export const CATEGORICAL_COLOR_PALETTE = [
   "#f04348",
 ];
 
-// Golden-ratio low-discrepancy sequence: successive indices land ~137.5° apart
-// around the palette's hue loop, maximizing visual separation between series
-// while staying append-stable (index i → same color regardless of series count).
+// `count` maximally-separated colors: a golden-ratio walk lands successive
+// entries ~137.5° apart around the palette's hue loop. Zip the result against a
+// stably-ordered series list — position is what picks the color.
 const GOLDEN_RATIO_CONJUGATE = 0.618033988749895;
-export const getSpacedColor = (index: number, palette: readonly string[] = CATEGORICAL_COLOR_PALETTE): string =>
-  palette[Math.floor(((index * GOLDEN_RATIO_CONJUGATE) % 1) * palette.length)];
-
-/**
- * Map each key to a maximally-spread color, keyed on the key's position in the
- * SORTED key set rather than its arrival order. Same set of keys → same colors
- * regardless of how they were ordered/reconstructed, so reordering series (or
- * deleting a run that anchored insertion order) no longer recolors the rest.
- * Adding/removing a key still shifts later keys — inherent to spreading N colors
- * evenly — but the color set stays maximally separated.
- */
-export const spacedColorMap = (keys: string[], palette: readonly string[] = CATEGORICAL_COLOR_PALETTE): Map<string, string> => {
-  const order = new Map([...keys].sort().map((key, index) => [key, index] as const));
-  return new Map(keys.map((key) => [key, getSpacedColor(order.get(key) ?? 0, palette)]));
-};
+export const spacedPalette = (count: number, palette: readonly string[] = CATEGORICAL_COLOR_PALETTE): string[] =>
+  Array.from({ length: count }, (_, i) => palette[Math.floor(((i * GOLDEN_RATIO_CONJUGATE) % 1) * palette.length)]);

--- a/frontend/lib/colors.ts
+++ b/frontend/lib/colors.ts
@@ -156,7 +156,7 @@ export const CATEGORICAL_COLOR_PALETTE = [
 const GOLDEN_RATIO_CONJUGATE = 0.618033988749895;
 // The palette loop starts at red. Enter it at blue instead, so a lone series
 // reads as data rather than as an error.
-const START_HUE_DEGREES = 240;
+const START_HUE_DEGREES = 218;
 export const spacedPalette = (count: number, palette: readonly string[] = CATEGORICAL_COLOR_PALETTE): string[] =>
   Array.from(
     { length: count },


### PR DESCRIPTION
## Problem

#2152 swapped the chart palette for a golden-ratio walk over the 100-color categorical palette so eval scores get unique colors. That change landed in `chart-builder/charts/utils.ts`, which isn't evals-specific — `generateChartConfig` and `createChartConfig` feed `ChartRendererCore`, so **every dashboard and SQL-editor chart** (breakdown/stacked bars included) picked it up too.

Since `getSpacedColor(0)` resolves to `palette[0]` = `#ef4444`, single-series charts rendered **red** and read as an error state, with lime and magenta following on multi-series charts.

## Fix

Charts now take a palette as a **plain list of colors**, indexed by position. `chart-builder` owns a local five-token default, so dashboards are back to blue → teal → orange → purple → pink, wrapping at the sixth series exactly as before.

The golden-ratio walk stays with the callers that actually need unbounded unique colors. `spacedColorMap` (Map-returning, palette-parameterized, sorting internally) collapses into `spacedPalette(count) => string[]`, and the two evals call sites zip it against their own score list. Its internal sort moves to where each score list is derived, which keeps colors stable when runs arrive in a different order and makes legend order deterministic as a bonus.

Cluster colors are unaffected — they hash into `CATEGORICAL_COLOR_PALETTE` directly and never went through these helpers.

## Verified

Executed both code paths directly:

| | |
|---|---|
| Dashboard, six series | `--chart-1 … --chart-5`, wraps to `--chart-1` |
| Second series | `--chart-2` (teal), not red/purple |
| Breakdown / stacked | sequential from `--chart-1` |
| Custom list passed in | honored verbatim |
| Evals, two arrival orders | identical color assignment |
| Evals palette | still the spaced hex colors, all distinct |

`tsc --noEmit` clean, eslint clean (7 pre-existing `no-explicit-any` warnings), no circular deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only frontend changes to chart color assignment; no auth, data, or API behavior changes.
> 
> **Overview**
> **Dashboard and SQL chart-builder** no longer use the eval golden-ratio categorical palette. `generateChartConfig` and stacked `createChartConfig` default to a local five-token list (`--chart-1` … `--chart-5`) with **positional** assignment and wrap at six series, and accept an optional custom palette override.
> 
> **Eval progression charts** keep maximally separated colors via a simplified `spacedPalette(count)` API (replacing `spacedColorMap`). Score names are **sorted** at each call site before zipping to palette indices so colors and legend order stay stable when runs or blocks reorder or disappear. The golden-ratio walk now **starts at blue** so a single eval series does not read as an error red.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c43ed5c4c82b5aed2c86d92dd9a74e61086fc117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->