### PR TITLE
feat: get rid of react scan

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -73,17 +73,6 @@ export default async function RootLayout({ children }: PropsWithChildren) {
     <html lang="en" className={cn("h-full antialiased", sans.variable, manrope.variable, sansLanding.variable)}>
       <body className="flex flex-col h-full">
         <BasePathFetchShim />
-        {process.env.NODE_ENV === "development" && (
-          <>
-            {/* Off by default: nothing overlays the UI until you enable scanning from the toolbar. */}
-            <script
-              dangerouslySetInnerHTML={{
-                __html: `window.__REACT_SCAN_OPTIONS__ = { enabled: false, showToolbar: true, animationSpeed: "off" };`,
-              }}
-            />
-            <script src="https://unpkg.com/react-scan/dist/auto.global.js" crossOrigin="anonymous" async />
-          </>
-        )}
         <FeatureFlagsProvider flags={featureFlags}>
           <PostHogProvider telemetryEnabled={posthogEnabled} email={email}>
             <TooltipProvider delayDuration={0}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

