### PR TITLE
Bound ClickHouse system log retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,28 +69,28 @@ Compose file used by your deployment when it differs:
 docker compose up -d --force-recreate clickhouse
 ```
 
-Disabling a system log stops new writes but does not remove an existing table.
-To reclaim its disk space, drop the disabled log tables after ClickHouse restarts:
+Disabling a system log stops new writes but does not clear an existing table.
+To reclaim its disk space while preserving the table structure, truncate the
+disabled log tables after ClickHouse restarts:
 
 ```sh
-docker compose exec -T clickhouse sh -c \
-  'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --multiquery' <<'SQL'
-DROP TABLE IF EXISTS system.trace_log SYNC;
-DROP TABLE IF EXISTS system.text_log SYNC;
-DROP TABLE IF EXISTS system.part_log SYNC;
-DROP TABLE IF EXISTS system.metric_log SYNC;
-DROP TABLE IF EXISTS system.asynchronous_metric_log SYNC;
-DROP TABLE IF EXISTS system.background_schedule_pool_log SYNC;
-DROP TABLE IF EXISTS system.query_metric_log SYNC;
-DROP TABLE IF EXISTS system.query_thread_log SYNC;
-DROP TABLE IF EXISTS system.query_views_log SYNC;
-DROP TABLE IF EXISTS system.session_log SYNC;
-DROP TABLE IF EXISTS system.crash_log SYNC;
-DROP TABLE IF EXISTS system.opentelemetry_span_log SYNC;
-DROP TABLE IF EXISTS system.zookeeper_log SYNC;
-DROP TABLE IF EXISTS system.blob_storage_log SYNC;
-DROP TABLE IF EXISTS system.processors_profile_log SYNC;
-DROP TABLE IF EXISTS system.asynchronous_insert_log SYNC;
+docker compose exec -T clickhouse clickhouse-client --multiquery <<'SQL'
+TRUNCATE TABLE IF EXISTS system.trace_log;
+TRUNCATE TABLE IF EXISTS system.text_log;
+TRUNCATE TABLE IF EXISTS system.part_log;
+TRUNCATE TABLE IF EXISTS system.metric_log;
+TRUNCATE TABLE IF EXISTS system.asynchronous_metric_log;
+TRUNCATE TABLE IF EXISTS system.background_schedule_pool_log;
+TRUNCATE TABLE IF EXISTS system.query_metric_log;
+TRUNCATE TABLE IF EXISTS system.query_thread_log;
+TRUNCATE TABLE IF EXISTS system.query_views_log;
+TRUNCATE TABLE IF EXISTS system.session_log;
+TRUNCATE TABLE IF EXISTS system.crash_log;
+TRUNCATE TABLE IF EXISTS system.opentelemetry_span_log;
+TRUNCATE TABLE IF EXISTS system.zookeeper_log;
+TRUNCATE TABLE IF EXISTS system.blob_storage_log;
+TRUNCATE TABLE IF EXISTS system.processors_profile_log;
+TRUNCATE TABLE IF EXISTS system.asynchronous_insert_log;
 SQL
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,48 @@ You will also need to properly configure the SDK, with `baseUrl` and correct por
 
 For production environment, we recommend using our [managed platform](https://laminar.sh) or `docker compose -f docker-compose-full.yml up -d`.
 
+#### Upgrading existing self-hosted installations
+
+The ClickHouse configuration disables internal telemetry logs that are not useful
+for a single-node installation and retains query and error logs for three days.
+After pulling this change, recreate the ClickHouse container to apply the
+configuration. The examples below use `docker-compose.yml`; pass `-f` with the
+Compose file used by your deployment when it differs:
+
+```sh
+docker compose up -d --force-recreate clickhouse
+```
+
+Disabling a system log stops new writes but does not remove an existing table.
+To reclaim its disk space, drop the disabled log tables after ClickHouse restarts:
+
+```sh
+docker compose exec -T clickhouse sh -c \
+  'clickhouse-client --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" --multiquery' <<'SQL'
+DROP TABLE IF EXISTS system.trace_log SYNC;
+DROP TABLE IF EXISTS system.text_log SYNC;
+DROP TABLE IF EXISTS system.part_log SYNC;
+DROP TABLE IF EXISTS system.metric_log SYNC;
+DROP TABLE IF EXISTS system.asynchronous_metric_log SYNC;
+DROP TABLE IF EXISTS system.background_schedule_pool_log SYNC;
+DROP TABLE IF EXISTS system.query_metric_log SYNC;
+DROP TABLE IF EXISTS system.query_thread_log SYNC;
+DROP TABLE IF EXISTS system.query_views_log SYNC;
+DROP TABLE IF EXISTS system.session_log SYNC;
+DROP TABLE IF EXISTS system.crash_log SYNC;
+DROP TABLE IF EXISTS system.opentelemetry_span_log SYNC;
+DROP TABLE IF EXISTS system.zookeeper_log SYNC;
+DROP TABLE IF EXISTS system.blob_storage_log SYNC;
+DROP TABLE IF EXISTS system.processors_profile_log SYNC;
+DROP TABLE IF EXISTS system.asynchronous_insert_log SYNC;
+SQL
+```
+
+When ClickHouse applies the new TTL to an existing `query_log` or `error_log`,
+it may rename the previous table with a numeric suffix such as `query_log_0`.
+Inspect any suffixed tables before dropping them if you also want to reclaim
+their historical data.
+
 ### Configuring LLM provider (optional)
 
 Frontend AI features (chat-with-trace, SQL-with-AI) and server-side AI workers require an LLM provider. Configure one in your `.env` file at the repo root.

--- a/clickhouse-server-config.xml
+++ b/clickhouse-server-config.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <!-- Disable internal telemetry that adds storage and I/O overhead on single-node deployments. -->
+    <trace_log remove="1"/>
+    <text_log remove="1"/>
+    <part_log remove="1"/>
+    <metric_log remove="1"/>
+    <asynchronous_metric_log remove="1"/>
+    <background_schedule_pool_log remove="1"/>
+    <query_metric_log remove="1"/>
+    <query_thread_log remove="1"/>
+    <query_views_log remove="1"/>
+    <session_log remove="1"/>
+    <crash_log remove="1"/>
+    <opentelemetry_span_log remove="1"/>
+    <zookeeper_log remove="1"/>
+    <blob_storage_log remove="1"/>
+    <processors_profile_log remove="1"/>
+    <asynchronous_insert_log remove="1"/>
+
+    <!-- Keep operator-facing logs for troubleshooting, but bound their disk usage. -->
+    <query_log>
+        <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
+    </query_log>
+    <error_log>
+        <ttl>event_date + INTERVAL 3 DAY DELETE</ttl>
+    </error_log>
+</clickhouse>

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -31,6 +31,9 @@ services:
       - type: bind
         source: ./clickhouse-profiles-config.xml
         target: /etc/clickhouse-server/users.d/lmnr.xml
+      - type: bind
+        source: ./clickhouse-server-config.xml
+        target: /etc/clickhouse-server/config.d/lmnr.xml
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}

--- a/docker-compose-local-build.yml
+++ b/docker-compose-local-build.yml
@@ -29,6 +29,9 @@ services:
       - type: bind
         source: ./clickhouse-profiles-config.xml
         target: /etc/clickhouse-server/users.d/lmnr.xml
+      - type: bind
+        source: ./clickhouse-server-config.xml
+        target: /etc/clickhouse-server/config.d/lmnr.xml
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}

--- a/docker-compose-local-dev-full.yml
+++ b/docker-compose-local-dev-full.yml
@@ -34,6 +34,9 @@ services:
       - type: bind
         source: ./clickhouse-profiles-config.xml
         target: /etc/clickhouse-server/users.d/lmnr.xml
+      - type: bind
+        source: ./clickhouse-server-config.xml
+        target: /etc/clickhouse-server/config.d/lmnr.xml
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}

--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -40,6 +40,9 @@ services:
       - type: bind
         source: ./clickhouse-profiles-config.xml
         target: /etc/clickhouse-server/users.d/lmnr.xml
+      - type: bind
+        source: ./clickhouse-server-config.xml
+        target: /etc/clickhouse-server/config.d/lmnr.xml
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ services:
       - type: bind
         source: ./clickhouse-profiles-config.xml
         target: /etc/clickhouse-server/users.d/lmnr.xml
+      - type: bind
+        source: ./clickhouse-server-config.xml
+        target: /etc/clickhouse-server/config.d/lmnr.xml
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}


### PR DESCRIPTION
## Summary
- add a ClickHouse server configuration that disables unused internal system log tables
- retain `query_log` and `error_log` with a three-day TTL
- mount the configuration in every self-hosted Docker Compose variant
- document cleanup steps for existing installations

## Validation
- validated all five Docker Compose configurations
- started ClickHouse 26.5 with the mounted configuration
- confirmed disabled log tables are not created and retained log TTLs are applied

Closes #2176

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure-only change to ClickHouse logging and Docker mounts; no application code paths, with documented one-time operator steps for upgrades.
> 
> **Overview**
> Self-hosted ClickHouse deployments get a new **`clickhouse-server-config.xml`** that turns off many internal `system.*` telemetry logs (trace, metric, session, OpenTelemetry, etc.) to cut disk and I/O on single-node installs, while keeping **`query_log`** and **`error_log`** with a **3-day TTL**.
> 
> All five Docker Compose variants now bind-mount that file into `/etc/clickhouse-server/config.d/lmnr.xml`. The **README** adds an **“Upgrading existing self-hosted installations”** section: recreate the ClickHouse service after pull, optionally **TRUNCATE** the disabled log tables to reclaim space, and a note that TTL changes may leave suffixed tables like `query_log_0` to inspect before dropping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ee8b30559e4e2bd641b97d6cf7838955ed5fa8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->