### PR TITLE
feat/search trace uuid

### DIFF
--- a/frontend/components/common/advanced-search/components/search-input.tsx
+++ b/frontend/components/common/advanced-search/components/search-input.tsx
@@ -246,11 +246,9 @@ const FilterSearchInput = ({
                 : Operator.Eq;
               addCompleteTag(suggestion.field, defaultOperator, suggestion.value);
             } else {
-              // User explicitly picked "Full text search" — honor it even
-              // when the value looks like a UUID.
               setInputValue(suggestion.value);
               setIsOpen(false);
-              submit({ skipUuidPromotion: true });
+              submit();
             }
           }
         } else {

--- a/frontend/components/common/advanced-search/components/search-input.tsx
+++ b/frontend/components/common/advanced-search/components/search-input.tsx
@@ -246,9 +246,11 @@ const FilterSearchInput = ({
                 : Operator.Eq;
               addCompleteTag(suggestion.field, defaultOperator, suggestion.value);
             } else {
+              // User explicitly picked "Full text search" — honor it even
+              // when the value looks like a UUID.
               setInputValue(suggestion.value);
               setIsOpen(false);
-              submit();
+              submit({ skipUuidPromotion: true });
             }
           }
         } else {

--- a/frontend/components/common/advanced-search/components/search-input.tsx
+++ b/frontend/components/common/advanced-search/components/search-input.tsx
@@ -44,6 +44,7 @@ const FilterSearchInput = ({
   const autocompleteData = useAdvancedSearchContext((state) => state.autocompleteData);
   const activeTagId = useAdvancedSearchContext((state) => state.getActiveTagId());
   const recentSearches = useAdvancedSearchContext((state) => state.recentSearches);
+  const uuidFilterColumn = useAdvancedSearchContext((state) => state.uuidFilterColumn);
 
   const {
     setInputValue,
@@ -123,7 +124,7 @@ const FilterSearchInput = ({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       const input = mainInputRef.current;
-      const count = getSuggestionsCount(filters, inputValue, autocompleteData);
+      const count = getSuggestionsCount(filters, inputValue, autocompleteData, uuidFilterColumn);
       const showRecent = !inputValue.trim() && tags.length === 0 && recentSearches.length > 0;
 
       if ((e.metaKey || e.ctrlKey) && e.key === "z") {
@@ -234,7 +235,7 @@ const FilterSearchInput = ({
       if (e.key === "Enter") {
         e.preventDefault();
         if (isOpen && count > 0 && activeIndex >= 0) {
-          const suggestion = getSuggestionAtIndex(filters, inputValue, activeIndex, autocompleteData);
+          const suggestion = getSuggestionAtIndex(filters, inputValue, activeIndex, autocompleteData, uuidFilterColumn);
           if (suggestion) {
             if (suggestion.type === "field") {
               addTag(suggestion.filter.key);
@@ -296,6 +297,7 @@ const FilterSearchInput = ({
       activeRecentIndex,
       autocompleteData,
       recentSearches,
+      uuidFilterColumn,
       setInputValue,
       setIsOpen,
       setActiveIndex,

--- a/frontend/components/common/advanced-search/components/suggestions.tsx
+++ b/frontend/components/common/advanced-search/components/suggestions.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 
 import { type RecentSearch, useAdvancedSearchContext, useAdvancedSearchRefsContext } from "../store";
 import { type ColumnFilter, createTagFromFilter } from "../types";
-import { buildValueSuggestions, isUuid } from "../utils";
+import { buildValueSuggestions, hasUuidSuggestion } from "../utils";
 
 interface FieldSuggestion {
   type: "field";
@@ -44,10 +44,9 @@ export const buildSuggestions = (
   }
 
   // A pasted UUID is an id, not prose — offer the exact-match filter first.
-  const uuidSuggestions: Suggestion[] =
-    uuidFilterColumn && isUuid(input) && filters.some((f) => f.key === uuidFilterColumn)
-      ? [{ type: "value" as const, field: uuidFilterColumn, value: inputValue.trim() }]
-      : [];
+  const uuidSuggestions: Suggestion[] = hasUuidSuggestion(input, filters, uuidFilterColumn)
+    ? [{ type: "value" as const, field: uuidFilterColumn as string, value: inputValue.trim() }]
+    : [];
 
   const matchingFields = filters.filter(
     (f) => f.name.toLowerCase().includes(input) || f.key.toLowerCase().includes(input)
@@ -215,11 +214,9 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
 
   const handleRawSearchSelect = useCallback(
     (value: string) => {
-      // User explicitly picked "Full text search" — honor it even when the
-      // value looks like a UUID.
       setInputValue(value);
       setIsOpen(false);
-      submit({ skipUuidPromotion: true });
+      submit();
     },
     [setInputValue, setIsOpen, submit]
   );

--- a/frontend/components/common/advanced-search/components/suggestions.tsx
+++ b/frontend/components/common/advanced-search/components/suggestions.tsx
@@ -215,9 +215,11 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
 
   const handleRawSearchSelect = useCallback(
     (value: string) => {
+      // User explicitly picked "Full text search" — honor it even when the
+      // value looks like a UUID.
       setInputValue(value);
       setIsOpen(false);
-      submit();
+      submit({ skipUuidPromotion: true });
     },
     [setInputValue, setIsOpen, submit]
   );

--- a/frontend/components/common/advanced-search/components/suggestions.tsx
+++ b/frontend/components/common/advanced-search/components/suggestions.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 
 import { type RecentSearch, useAdvancedSearchContext, useAdvancedSearchRefsContext } from "../store";
 import { type ColumnFilter, createTagFromFilter } from "../types";
-import { buildValueSuggestions } from "../utils";
+import { buildValueSuggestions, isUuid } from "../utils";
 
 interface FieldSuggestion {
   type: "field";
@@ -34,13 +34,20 @@ export type Suggestion = FieldSuggestion | ValueSuggestion | RawSearchSuggestion
 export const buildSuggestions = (
   inputValue: string,
   filters: ColumnFilter[],
-  autocompleteData: Map<string, string[]>
+  autocompleteData: Map<string, string[]>,
+  uuidFilterColumn?: string
 ): Suggestion[] => {
   const input = inputValue.trim().toLowerCase();
 
   if (!input) {
     return filters.map((filter) => ({ type: "field" as const, filter }));
   }
+
+  // A pasted UUID is an id, not prose — offer the exact-match filter first.
+  const uuidSuggestions: Suggestion[] =
+    uuidFilterColumn && isUuid(input) && filters.some((f) => f.key === uuidFilterColumn)
+      ? [{ type: "value" as const, field: uuidFilterColumn, value: inputValue.trim() }]
+      : [];
 
   const matchingFields = filters.filter(
     (f) => f.name.toLowerCase().includes(input) || f.key.toLowerCase().includes(input)
@@ -55,22 +62,29 @@ export const buildSuggestions = (
     ({ field, value, label }) => ({ type: "value" as const, field, value, label })
   );
 
-  return [...fieldSuggestions, ...valueSuggestions, { type: "raw_search" as const, value: inputValue.trim() }];
+  return [
+    ...uuidSuggestions,
+    ...fieldSuggestions,
+    ...valueSuggestions,
+    { type: "raw_search" as const, value: inputValue.trim() },
+  ];
 };
 
 export const getSuggestionsCount = (
   filters: ColumnFilter[],
   inputValue: string,
-  autocompleteData: Map<string, string[]>
-): number => buildSuggestions(inputValue, filters, autocompleteData).length;
+  autocompleteData: Map<string, string[]>,
+  uuidFilterColumn?: string
+): number => buildSuggestions(inputValue, filters, autocompleteData, uuidFilterColumn).length;
 
 export const getSuggestionAtIndex = (
   filters: ColumnFilter[],
   inputValue: string,
   index: number,
-  autocompleteData: Map<string, string[]>
+  autocompleteData: Map<string, string[]>,
+  uuidFilterColumn?: string
 ): Suggestion | null => {
-  const suggestions = buildSuggestions(inputValue, filters, autocompleteData);
+  const suggestions = buildSuggestions(inputValue, filters, autocompleteData, uuidFilterColumn);
   return suggestions[index] ?? null;
 };
 
@@ -136,6 +150,7 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
   const autocompleteData = useAdvancedSearchContext((state) => state.autocompleteData);
   const tags = useAdvancedSearchContext((state) => state.tags);
   const recentSearches = useAdvancedSearchContext((state) => state.recentSearches);
+  const uuidFilterColumn = useAdvancedSearchContext((state) => state.uuidFilterColumn);
 
   const { addTag, addCompleteTag, setInputValue, setIsOpen, submit, applyRecentSearch } = useAdvancedSearchContext(
     (state) => ({
@@ -155,8 +170,8 @@ const FilterSuggestions = ({ className }: FilterSuggestionsProps) => {
   const recentContainerRef = useRef<HTMLDivElement>(null);
 
   const suggestions = useMemo(
-    () => buildSuggestions(inputValue, filters, autocompleteData),
-    [inputValue, filters, autocompleteData]
+    () => buildSuggestions(inputValue, filters, autocompleteData, uuidFilterColumn),
+    [inputValue, filters, autocompleteData, uuidFilterColumn]
   );
 
   const showRecent = !inputValue.trim() && tags.length === 0 && recentSearches.length > 0;

--- a/frontend/components/common/advanced-search/index.tsx
+++ b/frontend/components/common/advanced-search/index.tsx
@@ -100,6 +100,9 @@ interface AdvancedSearchProps {
   value: AdvancedSearchValue;
   onChange: (next: AdvancedSearchValue) => void;
   storageKey?: string;
+  // When set, a bare UUID typed into the search box is committed as an
+  // exact-match filter on this column instead of a full-text search.
+  uuidFilterColumn?: string;
   options?: {
     // If provided, autocomplete won't fetch suggestions.
     suggestions?: Map<string, string[]>;
@@ -116,6 +119,7 @@ const AdvancedSearch = ({
   value,
   onChange,
   storageKey,
+  uuidFilterColumn,
   options: { suggestions, disableHotKey } = { disableHotKey: false },
 }: AdvancedSearchProps) => (
   <AdvancedSearchStoreProvider
@@ -126,6 +130,7 @@ const AdvancedSearch = ({
     suggestions={suggestions}
     storageKey={storageKey}
     resource={resource}
+    uuidFilterColumn={uuidFilterColumn}
   >
     <AdvancedSearchInner
       resource={resource}

--- a/frontend/components/common/advanced-search/index.tsx
+++ b/frontend/components/common/advanced-search/index.tsx
@@ -100,8 +100,10 @@ interface AdvancedSearchProps {
   value: AdvancedSearchValue;
   onChange: (next: AdvancedSearchValue) => void;
   storageKey?: string;
-  // When set, a bare UUID typed into the search box is committed as an
-  // exact-match filter on this column instead of a full-text search.
+  // When set, a bare UUID typed into the search box pre-selects an
+  // exact-match filter suggestion on this column, so Enter applies it
+  // without an extra arrow-down. Explicitly picking full-text search (or
+  // blurring without selecting anything) still searches the raw value.
   uuidFilterColumn?: string;
   options?: {
     // If provided, autocomplete won't fetch suggestions.

--- a/frontend/components/common/advanced-search/store/index.tsx
+++ b/frontend/components/common/advanced-search/store/index.tsx
@@ -28,7 +28,7 @@ import {
   type FilterTagRef,
   type TagFocusPosition,
 } from "../types";
-import { getNextField, getPreviousField } from "../utils";
+import { getNextField, getPreviousField, isUuid } from "../utils";
 import { createRecentsSlice, type RecentsSlice } from "./recents-slice";
 import type { AdvancedSearchStore, SliceContext, StoreGet, StoreSet } from "./types";
 import { createUndoRedoSlice, type UndoRedoSlice, type UndoSnapshot } from "./undo-redo-slice";
@@ -78,13 +78,43 @@ function buildCommit(get: StoreGet, context: SliceContext, resource?: string) {
   };
 }
 
+// A pasted UUID is an id, not prose — full-text search on it never matches, so
+// turn it into an exact-match tag on `uuidFilterColumn` before committing.
+function promoteUuidToTag(set: StoreSet, get: StoreGet, uuidFilterColumn?: string) {
+  if (!uuidFilterColumn) return;
+
+  const { inputValue, tags, filters: columnFilters } = get();
+  const value = inputValue.trim();
+  if (!isUuid(value)) return;
+
+  const columnFilter = columnFilters.find((f) => f.key === uuidFilterColumn);
+  if (!columnFilter) return;
+
+  const operator = dataTypeOperationsMap[columnFilter.dataType]?.[0]?.key ?? Operator.Eq;
+  const isDuplicate = tags.some((t) => t.field === uuidFilterColumn && t.operator === operator && t.value === value);
+
+  const newTag: FilterTag = {
+    id: `tag-${uniqueId()}`,
+    field: uuidFilterColumn,
+    dataType: toFilterDataType(columnFilter.dataType),
+    operator,
+    value,
+  };
+
+  set((state) => ({
+    tags: isDuplicate ? state.tags : [...state.tags, newTag],
+    inputValue: "",
+  }));
+}
+
 function createCoreSlice(
   set: StoreSet,
   get: StoreGet,
   context: SliceContext,
   filters: ColumnFilter[],
   suggestions?: Map<string, string[]>,
-  resource?: string
+  resource?: string,
+  uuidFilterColumn?: string
 ): Omit<AdvancedSearchStore, keyof RecentsSlice | keyof UndoRedoSlice> {
   const commit = buildCommit(get, context, resource);
 
@@ -101,6 +131,7 @@ function createCoreSlice(
 
     filters,
     resource,
+    uuidFilterColumn,
 
     getActiveTagId: () => {
       const { tagFocusStates } = get();
@@ -236,6 +267,7 @@ function createCoreSlice(
 
     submit: () => {
       set({ isOpen: false, activeIndex: -1, activeRecentIndex: -1 });
+      promoteUuidToTag(set, get, uuidFilterColumn);
       commit();
     },
 
@@ -298,7 +330,8 @@ const createAdvancedSearchStore = (
   getOnChange: () => (value: { filters: Filter[]; search: string }) => void,
   suggestions?: Map<string, string[]>,
   storageKey?: string,
-  resource?: string
+  resource?: string,
+  uuidFilterColumn?: string
 ) => {
   let lastSubmitted = {
     filters: initialTags.map(createFilterFromTag),
@@ -326,7 +359,7 @@ const createAdvancedSearchStore = (
   };
 
   const storeConfig = (set: StoreSet, get: StoreGet): AdvancedSearchStore => ({
-    ...createCoreSlice(set, get, context, filters, suggestions, resource),
+    ...createCoreSlice(set, get, context, filters, suggestions, resource, uuidFilterColumn),
     ...createRecentsSlice(set, get, context),
     ...createUndoRedoSlice(set, get, context),
   });
@@ -380,6 +413,9 @@ interface AdvancedSearchStoreProviderProps {
   suggestions?: Map<string, string[]>;
   storageKey?: string;
   resource?: string;
+  // When set, a bare UUID typed into the search box is committed as an
+  // exact-match filter on this column instead of a full-text search.
+  uuidFilterColumn?: string;
 }
 
 export const AdvancedSearchStoreProvider = ({
@@ -391,6 +427,7 @@ export const AdvancedSearchStoreProvider = ({
   suggestions,
   storageKey,
   resource,
+  uuidFilterColumn,
 }: PropsWithChildren<AdvancedSearchStoreProviderProps>) => {
   // Keep a live ref to the latest onChange so the store can call it without
   // being recreated every render. The store's actions only read via the
@@ -411,7 +448,8 @@ export const AdvancedSearchStoreProvider = ({
       () => onChangeRef.current,
       suggestions,
       storageKey,
-      resource
+      resource,
+      uuidFilterColumn
     )
   );
 

--- a/frontend/components/common/advanced-search/store/index.tsx
+++ b/frontend/components/common/advanced-search/store/index.tsx
@@ -28,7 +28,7 @@ import {
   type FilterTagRef,
   type TagFocusPosition,
 } from "../types";
-import { getNextField, getPreviousField, isUuid } from "../utils";
+import { getNextField, getPreviousField, hasUuidSuggestion } from "../utils";
 import { createRecentsSlice, type RecentsSlice } from "./recents-slice";
 import type { AdvancedSearchStore, SliceContext, StoreGet, StoreSet } from "./types";
 import { createUndoRedoSlice, type UndoRedoSlice, type UndoSnapshot } from "./undo-redo-slice";
@@ -78,44 +78,6 @@ function buildCommit(get: StoreGet, context: SliceContext, resource?: string) {
   };
 }
 
-// A pasted UUID is an id, not prose — full-text search on it never matches, so
-// turn it into an exact-match tag on `uuidFilterColumn` before committing.
-function promoteUuidToTag(set: StoreSet, get: StoreGet, context: SliceContext, uuidFilterColumn?: string) {
-  if (!uuidFilterColumn) return;
-
-  const { inputValue, tags, filters: columnFilters } = get();
-  const value = inputValue.trim();
-  if (!isUuid(value)) return;
-
-  // Already committed exactly as-is — e.g. the user explicitly chose full-text
-  // search for this value from the suggestions list. A redundant submit (blur
-  // re-fires it, since the box still shows the UUID text) must not silently
-  // revert that choice back to an id filter.
-  const completeTags = tags.filter((t) => (Array.isArray(t.value) ? t.value.length > 0 : t.value !== ""));
-  const currentFilters = completeTags.map(createFilterFromTag);
-  const last = context.getLastSubmitted();
-  if (last.search === value && isEqual(last.filters, currentFilters)) return;
-
-  const columnFilter = columnFilters.find((f) => f.key === uuidFilterColumn);
-  if (!columnFilter) return;
-
-  const operator = dataTypeOperationsMap[columnFilter.dataType]?.[0]?.key ?? Operator.Eq;
-  const isDuplicate = tags.some((t) => t.field === uuidFilterColumn && t.operator === operator && t.value === value);
-
-  const newTag: FilterTag = {
-    id: `tag-${uniqueId()}`,
-    field: uuidFilterColumn,
-    dataType: toFilterDataType(columnFilter.dataType),
-    operator,
-    value,
-  };
-
-  set((state) => ({
-    tags: isDuplicate ? state.tags : [...state.tags, newTag],
-    inputValue: "",
-  }));
-}
-
 function createCoreSlice(
   set: StoreSet,
   get: StoreGet,
@@ -152,7 +114,20 @@ function createCoreSlice(
 
     setAutocompleteData: (data) => set({ autocompleteData: data }),
     setInputValue: (value) => set({ inputValue: value, activeIndex: -1, activeRecentIndex: -1 }),
-    setIsOpen: (isOpen) => set({ isOpen, activeIndex: -1, activeRecentIndex: -1 }),
+    // Opening onto a UUID pre-selects the id suggestion (always index 0, see
+    // `buildSuggestions`) so Enter applies the id filter without an explicit
+    // arrow-down — the common case for pasting an id. Re-derived from current
+    // state on every open rather than cached, so it stays correct whether the
+    // dropdown opens from typing, focus, or a click.
+    setIsOpen: (isOpen) => {
+      if (!isOpen) {
+        set({ isOpen, activeIndex: -1, activeRecentIndex: -1 });
+        return;
+      }
+      const { inputValue, filters: columnFilters, uuidFilterColumn } = get();
+      const activeIndex = hasUuidSuggestion(inputValue, columnFilters, uuidFilterColumn) ? 0 : -1;
+      set({ isOpen, activeIndex, activeRecentIndex: -1 });
+    },
     setActiveIndex: (activeIndex) => set({ activeIndex, activeRecentIndex: -1 }),
     setActiveRecentIndex: (activeRecentIndex) => set({ activeRecentIndex, activeIndex: -1 }),
     setOpenSelectId: (openSelectId) => set({ openSelectId }),
@@ -274,11 +249,8 @@ function createCoreSlice(
 
     getTagFocusState: (tagId) => get().tagFocusStates.get(tagId) || { type: "idle" },
 
-    submit: (options) => {
+    submit: () => {
       set({ isOpen: false, activeIndex: -1, activeRecentIndex: -1 });
-      if (!options?.skipUuidPromotion) {
-        promoteUuidToTag(set, get, context, uuidFilterColumn);
-      }
       commit();
     },
 
@@ -424,8 +396,10 @@ interface AdvancedSearchStoreProviderProps {
   suggestions?: Map<string, string[]>;
   storageKey?: string;
   resource?: string;
-  // When set, a bare UUID typed into the search box is committed as an
-  // exact-match filter on this column instead of a full-text search.
+  // When set, a bare UUID typed into the search box pre-selects an
+  // exact-match filter suggestion on this column, so Enter applies it
+  // without an extra arrow-down. Explicitly picking full-text search (or
+  // blurring without selecting anything) still searches the raw value.
   uuidFilterColumn?: string;
 }
 

--- a/frontend/components/common/advanced-search/store/index.tsx
+++ b/frontend/components/common/advanced-search/store/index.tsx
@@ -80,12 +80,21 @@ function buildCommit(get: StoreGet, context: SliceContext, resource?: string) {
 
 // A pasted UUID is an id, not prose — full-text search on it never matches, so
 // turn it into an exact-match tag on `uuidFilterColumn` before committing.
-function promoteUuidToTag(set: StoreSet, get: StoreGet, uuidFilterColumn?: string) {
+function promoteUuidToTag(set: StoreSet, get: StoreGet, context: SliceContext, uuidFilterColumn?: string) {
   if (!uuidFilterColumn) return;
 
   const { inputValue, tags, filters: columnFilters } = get();
   const value = inputValue.trim();
   if (!isUuid(value)) return;
+
+  // Already committed exactly as-is — e.g. the user explicitly chose full-text
+  // search for this value from the suggestions list. A redundant submit (blur
+  // re-fires it, since the box still shows the UUID text) must not silently
+  // revert that choice back to an id filter.
+  const completeTags = tags.filter((t) => (Array.isArray(t.value) ? t.value.length > 0 : t.value !== ""));
+  const currentFilters = completeTags.map(createFilterFromTag);
+  const last = context.getLastSubmitted();
+  if (last.search === value && isEqual(last.filters, currentFilters)) return;
 
   const columnFilter = columnFilters.find((f) => f.key === uuidFilterColumn);
   if (!columnFilter) return;
@@ -265,9 +274,11 @@ function createCoreSlice(
 
     getTagFocusState: (tagId) => get().tagFocusStates.get(tagId) || { type: "idle" },
 
-    submit: () => {
+    submit: (options) => {
       set({ isOpen: false, activeIndex: -1, activeRecentIndex: -1 });
-      promoteUuidToTag(set, get, uuidFilterColumn);
+      if (!options?.skipUuidPromotion) {
+        promoteUuidToTag(set, get, context, uuidFilterColumn);
+      }
       commit();
     },
 

--- a/frontend/components/common/advanced-search/store/types.ts
+++ b/frontend/components/common/advanced-search/store/types.ts
@@ -55,6 +55,7 @@ export interface AdvancedSearchStore extends RecentsSlice, UndoRedoSlice {
   tagFocusStates: Map<string, FilterTagFocusState>;
   filters: ColumnFilter[];
   resource?: string;
+  uuidFilterColumn?: string;
 
   getActiveTagId: () => string | null;
   setAutocompleteData: (data: AutocompleteCache) => void;

--- a/frontend/components/common/advanced-search/store/types.ts
+++ b/frontend/components/common/advanced-search/store/types.ts
@@ -76,9 +76,7 @@ export interface AdvancedSearchStore extends RecentsSlice, UndoRedoSlice {
   removeSelectedTags: () => void;
   setTagFocusState: (tagId: string, state: FilterTagFocusState) => void;
   getTagFocusState: (tagId: string) => FilterTagFocusState;
-  // `skipUuidPromotion` is set when the user explicitly chose full-text search
-  // over the UUID suggestion — respect that choice instead of re-promoting.
-  submit: (options?: { skipUuidPromotion?: boolean }) => void;
+  submit: () => void;
   clearAll: () => void;
   // External reflow: parent's controlled `value` changed (view switch / discard
   // / undo from a sibling). Bypasses commit so we don't echo the change back.

--- a/frontend/components/common/advanced-search/store/types.ts
+++ b/frontend/components/common/advanced-search/store/types.ts
@@ -76,7 +76,9 @@ export interface AdvancedSearchStore extends RecentsSlice, UndoRedoSlice {
   removeSelectedTags: () => void;
   setTagFocusState: (tagId: string, state: FilterTagFocusState) => void;
   getTagFocusState: (tagId: string) => FilterTagFocusState;
-  submit: () => void;
+  // `skipUuidPromotion` is set when the user explicitly chose full-text search
+  // over the UUID suggestion — respect that choice instead of re-promoting.
+  submit: (options?: { skipUuidPromotion?: boolean }) => void;
   clearAll: () => void;
   // External reflow: parent's controlled `value` changed (view switch / discard
   // / undo from a sibling). Bypasses commit so we don't echo the change back.

--- a/frontend/components/common/advanced-search/utils.ts
+++ b/frontend/components/common/advanced-search/utils.ts
@@ -6,6 +6,12 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 export const isUuid = (value: string): boolean => UUID_REGEX.test(value.trim());
 
+// Single source of truth for "does this input resolve to the id suggestion",
+// shared by the suggestion list builder and the store's pre-selection so the
+// two can never drift apart.
+export const hasUuidSuggestion = (value: string, filters: ColumnFilter[], uuidFilterColumn?: string): boolean =>
+  !!uuidFilterColumn && isUuid(value) && filters.some((f) => f.key === uuidFilterColumn);
+
 export const getNextField = (current: TagFocusPosition): TagFocusPosition | null => {
   const index = FIELD_ORDER.indexOf(current);
   return index < FIELD_ORDER.length - 1 ? FIELD_ORDER[index + 1] : null;

--- a/frontend/components/common/advanced-search/utils.ts
+++ b/frontend/components/common/advanced-search/utils.ts
@@ -2,6 +2,10 @@ import { type ColumnFilter, type TagFocusPosition } from "@/components/common/ad
 
 const FIELD_ORDER: TagFocusPosition[] = ["field", "operator", "value", "remove"];
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const isUuid = (value: string): boolean => UUID_REGEX.test(value.trim());
+
 export const getNextField = (current: TagFocusPosition): TagFocusPosition | null => {
   const index = FIELD_ORDER.indexOf(current);
   return index < FIELD_ORDER.length - 1 ? FIELD_ORDER[index + 1] : null;

--- a/frontend/components/evaluations/table-controls.tsx
+++ b/frontend/components/evaluations/table-controls.tsx
@@ -84,6 +84,7 @@ export function EvaluationsTableControls({
           onChange={onSearchChange}
           storageKey={`evaluations-${projectId}`}
           filters={filters}
+          uuidFilterColumn="id"
           placeholder="Search evaluations..."
           className="w-full flex-1"
         />

--- a/frontend/components/traces/traces-table/empty-row.tsx
+++ b/frontend/components/traces/traces-table/empty-row.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { useFeatureFlags } from "@/contexts/feature-flags-context";
+import { useProjectContext } from "@/contexts/project-context";
+import { Feature } from "@/lib/features/features";
+
+const PAST_90_DAYS_HOURS = String(24 * 90);
+
+const findHorizontalScrollParent = (element: HTMLElement | null): HTMLElement | null => {
+  let node = element?.parentElement ?? null;
+  while (node) {
+    if (/auto|scroll/.test(getComputedStyle(node).overflowX)) return node;
+    node = node.parentElement;
+  }
+  return null;
+};
+
+// The row spans the full table width, which is usually wider than what's on
+// screen — centering against it lands off to the right. Track the scroll
+// viewport instead so the empty state is centered on what the user can see.
+const useVisibleWidth = (element: HTMLElement | null) => {
+  const [width, setWidth] = useState<number>();
+
+  useEffect(() => {
+    const scrollParent = findHorizontalScrollParent(element);
+    if (!scrollParent) return;
+
+    const observer = new ResizeObserver(() => setWidth(scrollParent.clientWidth));
+    observer.observe(scrollParent);
+    return () => observer.disconnect();
+  }, [element]);
+
+  return width;
+};
+
+export function TracesEmptyRow() {
+  const router = useRouter();
+  const pathName = usePathname();
+  const searchParams = useSearchParams();
+  const { project } = useProjectContext();
+  const featureFlags = useFeatureFlags();
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const visibleWidth = useVisibleWidth(container);
+
+  const hasFilters = searchParams.get("filter") !== null;
+  const retentionDays = featureFlags[Feature.SUBSCRIPTION] ? project?.logRetentionDays : null;
+  // Hide the widen-range shortcut when the plan can't reach back that far, or
+  // when we're already looking at 90 days.
+  const canSearch90Days =
+    (retentionDays == null || retentionDays >= 90) && searchParams.get("pastHours") !== PAST_90_DAYS_HOURS;
+
+  const searchPast90Days = useCallback(() => {
+    const sp = new URLSearchParams(searchParams.toString());
+    sp.delete("startDate");
+    sp.delete("endDate");
+    sp.delete("groupByInterval");
+    sp.set("pastHours", PAST_90_DAYS_HOURS);
+    sp.set("pageNumber", "0");
+    router.push(`${pathName}?${sp.toString()}`);
+  }, [pathName, router, searchParams]);
+
+  const clearFilters = useCallback(() => {
+    const sp = new URLSearchParams(searchParams.toString());
+    sp.delete("filter");
+    router.push(`${pathName}?${sp.toString()}`);
+  }, [pathName, router, searchParams]);
+
+  return (
+    <TableRow className="flex">
+      <TableCell className="w-full h-auto p-0 rounded-b">
+        <div
+          ref={setContainer}
+          style={{ width: visibleWidth }}
+          className="sticky left-0 flex flex-col items-center gap-2 p-10"
+        >
+          <span className="text-sm text-secondary-foreground">No results in selected time window</span>
+          <div className="flex items-center gap-2">
+            {canSearch90Days && (
+              <Button variant="outline" className="text-secondary-foreground" onClick={searchPast90Days}>
+                Search in the past 90 days
+              </Button>
+            )}
+            {hasFilters && (
+              <Button variant="outline" className="text-secondary-foreground" onClick={clearFilters}>
+                Clear filters
+              </Button>
+            )}
+          </div>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/frontend/components/traces/traces-table/table-contents.tsx
+++ b/frontend/components/traces/traces-table/table-contents.tsx
@@ -9,6 +9,7 @@ import { useSWRConfig } from "swr";
 import { useTraceViewNavigation } from "@/components/traces/trace-view/navigation-context";
 import { useTracesStoreContext } from "@/components/traces/traces-store";
 import { FETCH_SIZE } from "@/components/traces/traces-table/constants";
+import { TracesEmptyRow } from "@/components/traces/traces-table/empty-row";
 import { type buildColumnDefs, buildFetchParams } from "@/components/traces/traces-table/traces-table-store";
 import { InfiniteDataTable } from "@/components/ui/infinite-datatable";
 import { useInfiniteScroll } from "@/components/ui/infinite-datatable/hooks";
@@ -318,6 +319,7 @@ export const TracesTableContents = memo(function TracesTableContents({
       isLoading={isLoading || isViewLoading}
       fetchNextPage={fetchNextPage}
       getRowHref={getRowHref}
+      emptyRow={<TracesEmptyRow />}
       pinnedColumns={pinnedColumns}
       sortBy={sortBy}
       sortDirection={sortDirection}

--- a/frontend/components/traces/traces-table/table-controls.tsx
+++ b/frontend/components/traces/traces-table/table-controls.tsx
@@ -61,6 +61,7 @@ export function TracesTableControls({
           filters={allFilters}
           storageKey={`traces-${projectId}`}
           resource="traces"
+          uuidFilterColumn="id"
           placeholder="Search by root span name, tokens, tags, full text and more..."
           className="w-full flex-1"
         />


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared AdvancedSearch suggestion/keyboard behavior used across tables; UUID preselection is opt-in but changes Enter semantics when active. Empty-state UI is low risk.
> 
> **Overview**
> Pasting a UUID into advanced search can now jump straight to an exact-match **id** filter. When `uuidFilterColumn` is set, a bare UUID becomes the first suggestion and is pre-selected on open so Enter applies it without an arrow-down; full-text search remains available.
> 
> This is enabled for **traces** and **evaluations** via `uuidFilterColumn="id"`.
> 
> Also adds a traces empty state with **Search in the past 90 days** (when retention allows) and **Clear filters**, centered to the visible viewport rather than the full table width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdcece8be6ea8ac80623de1dda231050715bdf3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->