### PR TITLE
Highlight the hovered score in the evaluations chart

### DIFF
--- a/frontend/components/evaluations/evaluations.tsx
+++ b/frontend/components/evaluations/evaluations.tsx
@@ -11,6 +11,7 @@ import useSWR from "swr";
 import HeatmapValue from "@/components/evaluation/heatmap-value";
 import { formatScoreValue, isValidScore } from "@/components/evaluation/utils";
 import ProgressionChart from "@/components/evaluations/progression-chart";
+import { scoreChartConfig } from "@/components/evaluations/progression-chart/shared";
 import { EvaluationsTableContents } from "@/components/evaluations/table-contents";
 import { EvaluationsTableControls } from "@/components/evaluations/table-controls";
 import { Button } from "@/components/ui/button";
@@ -30,6 +31,7 @@ import { cn, swrFetcher } from "@/lib/utils";
 import ClientTimestampFormatter from "../client-timestamp-formatter";
 import { higherBetterMenuItem } from "../evaluation/columns/score-cell";
 import { useScoreDirections } from "../evaluation/use-score-directions";
+import { type ChartConfig } from "../ui/chart";
 import Header from "../ui/header";
 import Mono from "../ui/mono";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../ui/resizable";
@@ -85,31 +87,41 @@ function buildScoreColumns(
   heatmapEnabled: boolean,
   scoreRanges: Record<string, ScoreRange>,
   isHigherBetter: (scoreName: string) => boolean,
+  chartConfig: ChartConfig,
+  onHoverScore: (scoreName: string | null) => void,
   onToggleScoreDirection?: (scoreName: string) => void
 ): ColumnDef<Evaluation>[] {
   return scoreNames.map((scoreName) => {
     const higherBetter = isHigherBetter(scoreName);
+    const color = chartConfig[scoreName]?.color;
     return {
       id: `score:${scoreName}`,
-      header: scoreName,
+      // Same dot (and color) as the chart legend, so a column can be matched to
+      // its line without hovering.
+      header: () => (
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span className="size-2 rounded-sm shrink-0" style={{ background: color }} />
+          <span className="truncate">{scoreName}</span>
+        </div>
+      ),
       accessorFn: (row) => scoresByEvalId[row.id]?.[scoreName] ?? null,
       cell: (cell) => {
         const v = cell.getValue() as number | null;
-        if (!isValidScore(v)) return <span className="text-muted-foreground">—</span>;
-        const range = scoreRanges[scoreName];
-        if (heatmapEnabled && range) {
-          return (
-            <HeatmapValue
-              value={v}
-              range={range}
-              isHigherBetter={higherBetter}
-              text={<Mono>{formatScoreValue(v)}</Mono>}
-            />
-          );
-        }
-        return <Mono>{Number.isInteger(v) ? v.toString() : v.toFixed(3)}</Mono>;
+        // Hovering the cell spotlights this score's line in the chart; the row
+        // hover already supplies the run, so together they pick out one point.
+        return (
+          <div
+            className="flex h-full w-full min-w-0 items-center"
+            onMouseEnter={() => onHoverScore(scoreName)}
+            onMouseLeave={() => onHoverScore(null)}
+          >
+            {renderScoreValue(v, heatmapEnabled ? scoreRanges[scoreName] : undefined, higherBetter)}
+          </div>
+        );
       },
-      size: 120,
+      // Widened over the other columns' 120 to pay for the header's color dot,
+      // so the score name truncates no earlier than it used to.
+      size: 134,
       meta: onToggleScoreDirection
         ? {
             customDropdownItems: () => [higherBetterMenuItem(higherBetter, () => onToggleScoreDirection(scoreName))],
@@ -117,6 +129,21 @@ function buildScoreColumns(
         : undefined,
     };
   });
+}
+
+function renderScoreValue(value: number | null, range: ScoreRange | undefined, isHigherBetter: boolean) {
+  if (!isValidScore(value)) return <span className="text-muted-foreground">—</span>;
+  if (range) {
+    return (
+      <HeatmapValue
+        value={value}
+        range={range}
+        isHigherBetter={isHigherBetter}
+        text={<Mono>{formatScoreValue(value)}</Mono>}
+      />
+    );
+  }
+  return <Mono>{Number.isInteger(value) ? value.toString() : value.toFixed(3)}</Mono>;
 }
 
 const layoutStorage: LayoutStorage = {
@@ -173,6 +200,8 @@ function EvaluationsContent() {
 
   const [aggregationFunction, setAggregationFunction] = useState<AggregationFunction>(AggregationFunction.AVG);
   const [hoveredEvaluationId, setHoveredEvaluationId] = useState<string | undefined>(undefined);
+  // Spotlighted score — set by the chart legend AND by hovering a score cell.
+  const [hoveredScore, setHoveredScore] = useState<string | null>(null);
   const [heatmapEnabled, setHeatmapEnabled] = useState(true);
   const [chartEvaluations, setChartEvaluations] = useState<{ id: string; name: string }[]>([]);
   // Off (default): 0–1 scores plot on a fixed 0–1 axis, others on their own min/max.
@@ -218,6 +247,9 @@ function EvaluationsContent() {
 
   // Resolved eval-score directions (override > app-wide LLM default > true).
   const { isHigherBetter, toggle: toggleScoreDirection } = useScoreDirections(params?.projectId, scoreNames);
+
+  // One color source for the chart lines, its legend and the table headers.
+  const chartConfig = useMemo(() => scoreChartConfig(scoreNames), [scoreNames]);
 
   const columns = useMemo<ColumnDef<Evaluation>[]>(
     () => [
@@ -276,6 +308,8 @@ function EvaluationsContent() {
         heatmapEnabled,
         scoreRanges,
         isHigherBetter,
+        chartConfig,
+        setHoveredScore,
         toggleScoreDirection
       ),
     ],
@@ -289,6 +323,7 @@ function EvaluationsContent() {
       setHiddenEvaluationIds,
       allRunIds,
       isHigherBetter,
+      chartConfig,
       toggleScoreDirection,
     ]
   );
@@ -387,6 +422,9 @@ function EvaluationsContent() {
                 className="h-full"
                 baselineEvaluationId={selectedEvaluationId}
                 hoveredEvaluationId={hoveredEvaluationId}
+                chartConfig={chartConfig}
+                hoveredScore={hoveredScore}
+                onHoverScore={setHoveredScore}
                 onPointClick={(id) => router.push(`/project/${params?.projectId}/evaluations/${id}`)}
                 fillHeight={fillHeight}
               />

--- a/frontend/components/evaluations/progression-chart/combined-chart.tsx
+++ b/frontend/components/evaluations/progression-chart/combined-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type Key, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { type Key, type RefObject, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis } from "recharts";
 
 import { parseUtcTimestamp } from "@/components/chart-builder/charts/utils";
@@ -14,6 +14,11 @@ import { type ProgressionPoint } from "./shared";
 const MAX_POINT_GAP_PX = 120;
 // LineChart margin.left + margin.right.
 const HORIZONTAL_MARGIN_PX = 24;
+// Dot radii: resting, run-highlighted, and the single (run × score) intersection
+// when a score cell is hovered — it has to read as bigger than the run highlight.
+const DOT_RADIUS = 2.5;
+const HIGHLIGHTED_DOT_RADIUS = 5;
+const EMPHASIZED_DOT_RADIUS = 8;
 
 interface CombinedChartProps {
   data: ProgressionPoint[];
@@ -155,11 +160,31 @@ export default function CombinedChart({
     const plotWidth = Math.max(0, containerWidth - HORIZONTAL_MARGIN_PX);
     const budgetSlots = plotWidth > 0 ? Math.floor(plotWidth / MAX_POINT_GAP_PX) : 0;
     const maxSlots = Math.max(lastIndex, budgetSlots);
-    const pad = (maxSlots - lastIndex) / 2;
+    const spare = (maxSlots - lastIndex) / 2;
+    // `allowDataOverflow` makes recharts clip the series to the plot rect, so a
+    // point sitting exactly on a domain edge loses half its dot. Reserve at
+    // least the largest dot's radius on each side.
+    const pxPerSlot = maxSlots > 0 && plotWidth > 0 ? plotWidth / maxSlots : 0;
+    const edgePad = pxPerSlot > 0 ? (EMPHASIZED_DOT_RADIUS + 1) / pxPerSlot : 0;
+    const pad = Math.max(spare, edgePad);
     return [-pad, lastIndex + pad];
   }, [containerWidth, rows.length]);
 
-  const visible = scores.filter((s) => visibleScores.includes(s));
+  // Recharts paints series in order, so the spotlighted score goes LAST: its
+  // line and its emphasized dot must sit on top. Scores often share a value at
+  // the same run, and a later series' dot would otherwise bury the exact point
+  // the user is pointing at (leaving only a ring of it visible).
+  const visible = useMemo(() => {
+    const shown = scores.filter((s) => visibleScores.includes(s));
+    if (!hoveredScore || !shown.includes(hoveredScore)) return shown;
+    return [...shown.filter((s) => s !== hoveredScore), hoveredScore];
+  }, [scores, visibleScores, hoveredScore]);
+
+  // `${score}|${slotIndex}` → the dot's pixel y, recorded as the dots render.
+  // The tooltip needs it to tell which line the cursor is nearest, and recharts
+  // exposes no per-series geometry to tooltip content. Entries for a rendered
+  // (score, slot) are always rewritten this pass, so a lookup is never stale.
+  const dotPositionsRef = useRef<Map<string, number>>(new Map());
 
   return (
     <div ref={containerRef} className="h-full w-full">
@@ -201,7 +226,7 @@ export default function CombinedChart({
           <YAxis hide domain={[0, 1]} padding={{ top: 10, bottom: 10 }} />
           <Tooltip
             cursor={{ stroke: "hsl(var(--muted-foreground))", strokeOpacity: 0.4 }}
-            content={<NormalizedTooltip ranks={ranks} chartConfig={chartConfig} />}
+            content={<NormalizedTooltip ranks={ranks} chartConfig={chartConfig} dotPositions={dotPositionsRef} />}
           />
           {visible.map((score) => {
             // Legend hover spotlights one score's line; the others fade back.
@@ -226,9 +251,16 @@ export default function CombinedChart({
                   if (typeof cx !== "number" || typeof cy !== "number" || Number.isNaN(cx) || Number.isNaN(cy)) {
                     return <g key={key ?? undefined} />;
                   }
+                  if (payload) dotPositionsRef.current.set(`${score}|${payload.x}`, cy);
                   const isHovered = payload?.evaluationId === hoveredEvaluationId;
-                  const r = isHovered ? 5 : 2.5;
-                  const opacity = scoreDimmed ? 0.15 : hoveredEvaluationId ? (isHovered ? 1 : dimmedOpacity) : 1;
+                  // Both hovers set → a score CELL is hovered, so single out its
+                  // exact point; a run hover alone grows every score's point.
+                  const isEmphasized = isHovered && hoveredScore === score;
+                  const r = isEmphasized ? EMPHASIZED_DOT_RADIUS : isHovered ? HIGHLIGHTED_DOT_RADIUS : DOT_RADIUS;
+                  // The hovered run's dots stay lit on EVERY score, even a dimmed
+                  // one — dimming is about which LINE is spotlighted, and the run
+                  // has to stay readable across all its scores at once.
+                  const opacity = isHovered ? 1 : scoreDimmed ? 0.15 : hoveredEvaluationId ? dimmedOpacity : 1;
                   return (
                     <circle
                       key={key ?? undefined}
@@ -258,17 +290,41 @@ export default function CombinedChart({
 function NormalizedTooltip({
   active,
   payload,
+  coordinate,
   ranks,
   chartConfig,
+  dotPositions,
 }: {
   active?: boolean;
   payload?: Array<{ name?: string | number; payload?: Row }>;
+  // recharts' activeCoordinate: x snaps to the active slot, y is the cursor's.
+  coordinate?: { x?: number; y?: number };
   ranks: Record<string, Record<string, { position: number; total: number }>>;
   chartConfig: ChartConfig;
+  dotPositions: RefObject<Map<string, number>>;
 }) {
   if (!active || !payload || payload.length === 0) return null;
   const row = payload[0]?.payload;
   if (!row) return null;
+
+  // Every score stays listed (that's the value of the tooltip); the one whose
+  // point the cursor is closest to is called out so a dense chart is readable.
+  const cursorY = coordinate?.y;
+  let nearestScore: string | null = null;
+  if (typeof cursorY === "number") {
+    let nearestDistance = Infinity;
+    for (const entry of payload) {
+      const score = String(entry.name ?? "");
+      const dotY = dotPositions.current?.get(`${score}|${row.x}`);
+      if (typeof dotY !== "number") continue;
+      const distance = Math.abs(dotY - cursorY);
+      if (distance < nearestDistance) {
+        nearestDistance = distance;
+        nearestScore = score;
+      }
+    }
+  }
+
   return (
     <div className="rounded-md border bg-background p-2 text-xs shadow-md">
       <div className="font-medium truncate max-w-60">{row.name}</div>
@@ -279,13 +335,21 @@ function NormalizedTooltip({
           const raw = row.__raw[score];
           const rank = ranks[score]?.[row.evaluationId];
           const color = chartConfig[score]?.color;
+          const isNearest = score === nearestScore;
           return (
             <div key={score} className="flex items-center gap-2">
               <span className="size-2 rounded-sm shrink-0" style={{ background: color }} />
-              <span className="text-muted-foreground">{score}</span>
-              <span className="ml-auto font-mono">{raw === null || raw === undefined ? "—" : formatNumber(raw)}</span>
+              <span className={isNearest ? "text-primary-foreground" : "text-muted-foreground"}>{score}</span>
+              <span className={cn("ml-auto font-mono", isNearest && "text-primary-foreground")}>
+                {raw === null || raw === undefined ? "—" : formatNumber(raw)}
+              </span>
               {rank && (
-                <span className="text-muted-foreground/60 font-mono tabular-nums">
+                <span
+                  className={cn(
+                    "font-mono tabular-nums",
+                    isNearest ? "text-primary-foreground/80" : "text-muted-foreground/60"
+                  )}
+                >
                   Rank {rank.position}/{rank.total}
                 </span>
               )}

--- a/frontend/components/evaluations/progression-chart/index.tsx
+++ b/frontend/components/evaluations/progression-chart/index.tsx
@@ -1,9 +1,8 @@
 import { useParams } from "next/navigation";
 import { useQueryState } from "nuqs";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 
 import { useLocalStorage } from "@/hooks/use-local-storage.tsx";
-import { spacedPalette } from "@/lib/colors";
 import { type EvaluationTimeProgression } from "@/lib/evaluation/types";
 import { cn } from "@/lib/utils";
 
@@ -24,6 +23,11 @@ interface ProgressionChartProps {
   hiddenEvaluationIds?: string[];
   baselineEvaluationId?: string;
   hoveredEvaluationId?: string;
+  /** Score → color, owned by the parent so the table's headers match the lines. */
+  chartConfig: ChartConfig;
+  /** Spotlighted score. Set by this chart's legend AND by the table's score cells. */
+  hoveredScore?: string | null;
+  onHoverScore?: (score: string | null) => void;
   onPointClick?: (evaluationId: string) => void;
   /** When on, every score stretches to its own min/max (fills full height). */
   fillHeight?: boolean;
@@ -39,12 +43,14 @@ export default function ProgressionChart({
   hiddenEvaluationIds = EMPTY_IDS,
   baselineEvaluationId,
   hoveredEvaluationId,
+  chartConfig,
+  hoveredScore,
+  onHoverScore,
   onPointClick,
   fillHeight,
 }: ProgressionChartProps) {
   const [groupId] = useQueryState("groupId");
   const params = useParams();
-  const [hoveredScore, setHoveredScore] = useState<string | null>(null);
 
   // Persist deselected scores (not selected) so newly-appearing scores default to visible.
   const [hiddenScores, setHiddenScores] = useLocalStorage<string[]>(
@@ -102,11 +108,6 @@ export default function ProgressionChart({
     [points, hiddenEvaluationIds]
   );
 
-  const chartConfig = useMemo<ChartConfig>(() => {
-    const colors = spacedPalette(scoreKeys.length);
-    return Object.fromEntries(scoreKeys.map((key, i) => [key, { color: colors[i], label: key }]));
-  }, [scoreKeys]);
-
   const toggleScore = useCallback(
     (key: string) => {
       setHiddenScores((prev) => (prev.includes(key) ? prev.filter((s) => s !== key) : [...prev, key]));
@@ -130,7 +131,7 @@ export default function ProgressionChart({
           visibleScores={scores}
           chartConfig={chartConfig}
           onToggle={toggleScore}
-          onHoverScore={setHoveredScore}
+          onHoverScore={onHoverScore}
           className="w-32 shrink-0 overflow-y-auto"
         />
         <div className="min-w-0 flex-1">

--- a/frontend/components/evaluations/progression-chart/shared.ts
+++ b/frontend/components/evaluations/progression-chart/shared.ts
@@ -1,6 +1,20 @@
+import { spacedPalette } from "@/lib/colors";
+
+import { type ChartConfig } from "../../ui/chart";
+
 export interface ProgressionPoint {
   timestamp: string;
   evaluationId: string;
   name: string;
   values: Record<string, number | null>;
+}
+
+/**
+ * Score name → color. Single source for the chart lines, the legend AND the
+ * table's score-column header dots, so a score reads as the same color in all
+ * three. Pass a STABLY ORDERED name list (sorted) — position picks the color.
+ */
+export function scoreChartConfig(scoreNames: string[]): ChartConfig {
+  const colors = spacedPalette(scoreNames.length);
+  return Object.fromEntries(scoreNames.map((name, i) => [name, { color: colors[i], label: name }]));
 }

--- a/frontend/components/traces/session-view/store/base.ts
+++ b/frontend/components/traces/session-view/store/base.ts
@@ -275,7 +275,7 @@ export function createBaseSessionViewSlice<T extends BaseSessionViewStore>(
     timelineOpenTraceIds: new Set<string>(),
     condensedTimelineZoomByTrace: {},
     condensedTimelineVisibleSpanIdsByTrace: {},
-    isCostHeatmapVisible: false,
+    isCostHeatmapVisible: true,
     scrollToGroup: null,
     scrollToTraceId: null,
 

--- a/frontend/components/traces/trace-view/store/base.ts
+++ b/frontend/components/traces/trace-view/store/base.ts
@@ -219,7 +219,7 @@ export function createBaseTraceViewSlice<T extends BaseTraceViewStore>(
     condensedTimelineEnabled: true,
     condensedTimelineVisibleSpanIds: new Set(),
     condensedTimelineZoom: 1,
-    isCostHeatmapVisible: false,
+    isCostHeatmapVisible: true,
     scrollStartTime: undefined,
     scrollEndTime: undefined,
 


### PR DESCRIPTION
The chart and the table did not tell the user which score they looked at. Three changes fix this.

## Hover a score cell in the table

The chart now spotlights that score's line, lights every dot of that run, and grows the one point where the run and the score meet.

The spotlighted score renders last. Recharts paints series in array order, so a later series' dot buried the exact point the user pointed at and left only a ring of it. Two scores often share a value at the same run, which is when this showed.

Row hover and legend hover keep their old behavior.

## Color dots in the score column headers

One helper, `scoreChartConfig`, gives the color to the lines, the legend and the table headers, so the three cannot drift. Score columns are 14px wider to pay for the dot, so the name truncates no earlier than before.

## Tooltip marks the nearest score

The tooltip still lists every score. It now marks the score whose point is nearest the cursor. Recharts gives the tooltip content the cursor's y position (only `x` snaps to the slot), and the chart records each dot's y position as it renders.

## Also

- Cost heatmaps are on by default in the trace view and the session view.
- Edge dots are no longer clipped. `allowDataOverflow` clips the series to the plot rect, so a point on a domain edge lost half its dot.

## Test

Verified in the running app against local data (14 runs, 6 scores): score-cell hover, row hover, legend hover, tooltip tracking between lines at one x, and header colors against the legend. `tsc` and `eslint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only evaluations and trace-view defaults; no API, auth, or data-path changes.
> 
> **Overview**
> **Evaluations chart and table** now share a single `hoveredScore` state (parent-owned) and `scoreChartConfig` colors so legend hover, score-cell hover, and column headers stay aligned.
> 
> Hovering a **score cell** spotlights that score’s line in the chart; combined with row hover it emphasizes the run×score point with a larger dot. The spotlighted series is painted last so overlapping dots at the same run stay visible. **Score column headers** show the same color dot as the chart legend; columns are slightly wider to fit the dot.
> 
> **Chart polish:** tooltip highlights the score whose dot is nearest the cursor (using recorded dot Y positions). X-axis domain padding avoids clipping edge dots. **Trace/session views** default `isCostHeatmapVisible` to on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41d55c8c63ec6e1c5675041fb0aa54fe84204e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

