### PR TITLE
fix: pass system prompt properly

### DIFF
--- a/frontend/lib/actions/chat/index.ts
+++ b/frontend/lib/actions/chat/index.ts
@@ -17,6 +17,7 @@ import { decodeApiKey } from "@/lib/crypto";
 import { db } from "@/lib/db/drizzle";
 import { providerApiKeys } from "@/lib/db/migrations/schema";
 import { getModel } from "@/lib/playground/providersRegistry";
+import { extractInstructions } from "@/lib/playground/utils";
 
 import { type JsonObject } from "./types";
 import { createSpanAttributes, sendSpanData, type SpanData } from "./utils";
@@ -139,6 +140,7 @@ export async function generateChatResponse(
   }
 
   const startTime = new Date();
+  const prompt = extractInstructions(messages);
 
   let result: any;
 
@@ -149,7 +151,7 @@ export async function generateChatResponse(
     result = await generateText({
       abortSignal,
       model: getModel(model as `${Provider}:${string}`, decodedKey),
-      messages,
+      ...prompt,
       maxOutputTokens: maxTokens,
       temperature,
       topK,
@@ -161,7 +163,7 @@ export async function generateChatResponse(
     result = await generateText({
       abortSignal,
       model: getModel(model as `${Provider}:${string}`, decodedKey),
-      messages,
+      ...prompt,
       maxOutputTokens: maxTokens,
       temperature,
       topK,

--- a/frontend/lib/playground/utils.ts
+++ b/frontend/lib/playground/utils.ts
@@ -30,6 +30,30 @@ export const parseSystemMessages = (messages: Message[]): ModelMessage[] =>
     return message as ModelMessage;
   });
 
+const isSystemModelMessage = (message: ModelMessage): message is SystemModelMessage =>
+  message.role === "system" && typeof message.content === "string";
+
+// v7 rejects system messages in `messages`; a system-only prompt can't be empty so it stays there.
+export const extractInstructions = (
+  messages: ModelMessage[]
+): {
+  instructions?: SystemModelMessage[];
+  messages: ModelMessage[];
+  allowSystemInMessages?: true;
+} => {
+  const instructions = messages.filter(isSystemModelMessage);
+  const rest = messages.filter((message) => !isSystemModelMessage(message));
+
+  if (rest.length === 0) {
+    return { messages, allowSystemInMessages: true };
+  }
+
+  return {
+    ...(instructions.length > 0 && { instructions }),
+    messages: rest,
+  };
+};
+
 export const transformFromLegacy = (messages: Message[]): Message[] =>
   messages.map((message) => {
     const content: Message["content"] = Array.isArray(message.content)

--- a/frontend/tests/test-playground-utils.test.ts
+++ b/frontend/tests/test-playground-utils.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { type ModelMessage } from "ai";
+
 import { type Message } from "@/lib/playground/types";
-import { parseSystemMessages, transformFromLegacy } from "@/lib/playground/utils";
+import { extractInstructions, parseSystemMessages, transformFromLegacy } from "@/lib/playground/utils";
 
 // ─── parseSystemMessages ───────────────────────────────────────────────────
 
@@ -72,6 +74,52 @@ describe("parseSystemMessages", () => {
     const result = parseSystemMessages(messages);
     assert.deepStrictEqual((result[0] as any).providerOptions, providerOptions);
     assert.deepStrictEqual((result[1] as any).providerOptions, providerOptions);
+  });
+});
+
+// ─── extractInstructions ───────────────────────────────────────────────────
+
+describe("extractInstructions", () => {
+  it("lifts a leading system message into instructions", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "You are a DOCX editing assistant." },
+      { role: "user", content: "Insert a citation paragraph." },
+    ];
+    const result = extractInstructions(messages);
+    assert.deepStrictEqual(result.instructions, [{ role: "system", content: "You are a DOCX editing assistant." }]);
+    assert.deepStrictEqual(result.messages, [{ role: "user", content: "Insert a citation paragraph." }]);
+    assert.equal(result.allowSystemInMessages, undefined);
+  });
+
+  it("lifts multiple system messages, preserving providerOptions", () => {
+    const providerOptions = { anthropic: { cacheControl: { type: "ephemeral" } } };
+    const messages: ModelMessage[] = [
+      { role: "system", content: "You are helpful.", providerOptions },
+      { role: "system", content: "Be brief." },
+      { role: "user", content: "Hi" },
+    ];
+    const result = extractInstructions(messages);
+    assert.deepStrictEqual(result.instructions, [
+      { role: "system", content: "You are helpful.", providerOptions },
+      { role: "system", content: "Be brief." },
+    ]);
+    assert.deepStrictEqual(result.messages, [{ role: "user", content: "Hi" }]);
+  });
+
+  it("leaves a prompt with no system messages unchanged", () => {
+    const messages: ModelMessage[] = [{ role: "user", content: "Hi" }];
+    const result = extractInstructions(messages);
+    assert.equal(result.instructions, undefined);
+    assert.deepStrictEqual(result.messages, messages);
+    assert.equal(result.allowSystemInMessages, undefined);
+  });
+
+  it("keeps a system-only prompt in messages and opts into allowSystemInMessages", () => {
+    const messages: ModelMessage[] = [{ role: "system", content: "You are helpful." }];
+    const result = extractInstructions(messages);
+    assert.equal(result.instructions, undefined);
+    assert.deepStrictEqual(result.messages, messages);
+    assert.equal(result.allowSystemInMessages, true);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how every playground LLM request is shaped; behavior is narrow and covered by tests, but incorrect splitting could drop or misapply system prompts.
> 
> **Overview**
> Playground chat generation no longer passes system prompts only inside `messages` for **AI SDK v7**, which rejects system roles there.
> 
> A new **`extractInstructions`** helper pulls string `system` messages into an `instructions` array and leaves user/assistant/tool traffic in `messages`. **`generateChatResponse`** spreads that shape into both structured and tool **`generateText`** calls instead of a raw `messages` array.
> 
> When the prompt is **system-only**, messages stay unchanged and **`allowSystemInMessages: true`** is set so the call is not sent with an empty conversation. Unit tests cover lifting one or many system messages (including `providerOptions`), no-system prompts, and the system-only edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1072b6aef564987f49f2811b0e9832210e38662f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

