### PR TITLE
fix: don't strip custom xml non-html tags

### DIFF
--- a/frontend/components/traces/trace-view/transcript/markdown.tsx
+++ b/frontend/components/traces/trace-view/transcript/markdown.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { defaultRehypePlugins, Streamdown } from "streamdown";
 
 import { MarkdownSpanBadge, type SpanReferenceCallbacks } from "@/components/traces/trace-view/span-reference";
+import { htmlAsTextRemarkRehypeOptions } from "@/components/ui/content-renderer/html-as-text";
 import { parseSpanLinks } from "@/lib/traces/span-link-parsing";
 import { cn } from "@/lib/utils.ts";
 
@@ -33,7 +34,8 @@ const Markdown = ({ output, className, contentClassName, spanRefCallbacks }: Mar
           parseIncompleteMarkdown={false}
           isAnimating={false}
           className="rounded text-wrap"
-          rehypePlugins={[defaultRehypePlugins.raw, defaultRehypePlugins.sanitize, defaultRehypePlugins.harden]}
+          remarkRehypeOptions={htmlAsTextRemarkRehypeOptions}
+          rehypePlugins={[defaultRehypePlugins.sanitize, defaultRehypePlugins.harden]}
           components={{
             h1: ({ children, className, ...props }) => (
               <h1 {...props} className={cn(className, "text-sm")}>

--- a/frontend/components/ui/content-renderer/html-as-text.ts
+++ b/frontend/components/ui/content-renderer/html-as-text.ts
@@ -1,0 +1,12 @@
+/**
+ * Streamdown 2.1 still emits mdast `html` nodes; without rehype-raw those
+ * become raw HAST and are dropped. Map them to text so XML-like tags stay visible.
+ */
+export const htmlAsTextRemarkRehypeOptions = {
+  handlers: {
+    html: (_state: unknown, node: { value?: string }) => ({
+      type: "text" as const,
+      value: node.value ?? "",
+    }),
+  },
+};

--- a/frontend/components/ui/content-renderer/markdown.tsx
+++ b/frontend/components/ui/content-renderer/markdown.tsx
@@ -1,6 +1,7 @@
 import { memo, type Ref } from "react";
 import { defaultRehypePlugins, Streamdown } from "streamdown";
 
+import { htmlAsTextRemarkRehypeOptions } from "@/components/ui/content-renderer/html-as-text";
 import { cn, tryParseJson } from "@/lib/utils";
 
 export const getMarkdownSource = (value: string): string => {
@@ -28,8 +29,9 @@ const PureMarkdownRenderer = ({ value, className, containerRef }: MarkdownRender
         "[&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:overflow-x-hidden [&_pre_code]:whitespace-pre-wrap text-xs"
       )}
       controls={{ mermaid: { download: false, fullscreen: false } }}
-      // raw renders embedded HTML (else its text is dropped); sanitize strips XSS from untrusted content.
-      rehypePlugins={[defaultRehypePlugins.raw, defaultRehypePlugins.sanitize, defaultRehypePlugins.harden]}
+      // omit raw: XML-like tags render as text. sanitize/harden still cover markdown links.
+      remarkRehypeOptions={htmlAsTextRemarkRehypeOptions}
+      rehypePlugins={[defaultRehypePlugins.sanitize, defaultRehypePlugins.harden]}
       components={{
         h1: ({ node: _node, children, className, ...props }) => (
           <h1 {...props} className={cn(className, "mt-3 mb-1 text-base font-semibold")}>

--- a/frontend/lib/clickhouse/migrations/57_content_tables_point_read_granularity.sql
+++ b/frontend/lib/clickhouse/migrations/57_content_tables_point_read_granularity.sql
@@ -1,5 +1,0 @@
--- LAM-2115: `deduped_content` is a point-lookup table (dict source resolving
--- random content hashes); the default 8192-row granule makes each lookup
--- decompress a multi-MB neighborhood. Applies to NEW parts only — run
--- `OPTIMIZE TABLE deduped_content FINAL` out-of-band to rewrite history.
-ALTER TABLE deduped_content MODIFY SETTING index_granularity = 256, max_compress_block_size = 65536;

--- a/frontend/tests/test-html-as-text.test.ts
+++ b/frontend/tests/test-html-as-text.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { htmlAsTextRemarkRehypeOptions } from "@/components/ui/content-renderer/html-as-text";
+
+describe("htmlAsTextRemarkRehypeOptions", () => {
+  it("maps an html mdast node to a text node with the original source", () => {
+    const { html } = htmlAsTextRemarkRehypeOptions.handlers;
+    assert.deepEqual(html(undefined, { value: '<prompt id="sp_82e0192b" path="v4.run">' }), {
+      type: "text",
+      value: '<prompt id="sp_82e0192b" path="v4.run">',
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

