### PR TITLE
fix(probe): use detached context for cleanup step on shutdown [TEAM-2616]

### DIFF
--- a/test/probe/cmd/probe/main.go
+++ b/test/probe/cmd/probe/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/lmnr-ai/lmnr/test/probe/internal/config"
+	"github.com/lmnr-ai/lmnr/test/probe/internal/runner"
+)
+
+func main() {
+	cfg := config.Load()
+
+	// Signal handling: SIGTERM/SIGINT cancel the run context.
+	// Previously, this cancellation propagated into the cleanup step,
+	// causing DeleteRoutine to fail with "context canceled" and leaking
+	// the test routine. The runner now uses a detached context for cleanup.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	slog.Info("probe starting", "target_url", cfg.TargetURL)
+
+	result := runner.Run(ctx, cfg)
+	if !result.Success {
+		fmt.Fprintf(os.Stderr, "probe run failed: %s\n", result.Error)
+		os.Exit(1)
+	}
+
+	slog.Info("probe run completed successfully")
+}

--- a/test/probe/go.mod
+++ b/test/probe/go.mod
@@ -1,0 +1,3 @@
+module github.com/lmnr-ai/lmnr/test/probe
+
+go 1.22.0

--- a/test/probe/internal/config/config.go
+++ b/test/probe/internal/config/config.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"os"
+	"time"
+)
+
+// Config holds probe configuration.
+type Config struct {
+	TargetURL      string
+	AuthToken      string
+	CreateTimeout  time.Duration
+	HealthTimeout  time.Duration
+	ExecTimeout    time.Duration
+	PollInterval   time.Duration
+	CleanupTimeout time.Duration
+}
+
+// Load returns the probe configuration from environment variables with defaults.
+func Load() *Config {
+	cfg := &Config{
+		TargetURL:      envOrDefault("PROBE_TARGET_URL", "http://localhost:8080"),
+		AuthToken:      envOrDefault("PROBE_AUTH_TOKEN", ""),
+		CreateTimeout:  5 * time.Second,
+		HealthTimeout:  2 * time.Second,
+		ExecTimeout:    30 * time.Second,
+		PollInterval:   2 * time.Second,
+		CleanupTimeout: 5 * time.Second,
+	}
+	return cfg
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/test/probe/internal/runner/runner.go
+++ b/test/probe/internal/runner/runner.go
@@ -1,0 +1,98 @@
+package runner
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/lmnr-ai/lmnr/test/probe/internal/config"
+	"github.com/lmnr-ai/lmnr/test/probe/internal/steps"
+)
+
+// Result is the outcome of a complete probe run.
+type Result struct {
+	Success bool
+	Error   string
+}
+
+// Run orchestrates the probe steps in sequence. If a step fails after a resource
+// has been created, we jump to cleanup. The cleanup step always uses a detached
+// context derived from context.Background() to ensure it completes even when the
+// parent context has been cancelled (e.g., by SIGTERM).
+func Run(ctx context.Context, cfg *config.Config) Result {
+	return RunWithSteps(ctx, cfg, nil, nil, nil, nil, nil)
+}
+
+// RunWithSteps allows injecting step implementations for testing.
+func RunWithSteps(
+	ctx context.Context,
+	cfg *config.Config,
+	healthStep steps.Step,
+	createStep steps.Step,
+	triggerStep steps.Step,
+	verifyStep steps.Step,
+	cleanupStep steps.Step,
+) Result {
+	state := &steps.RunState{}
+
+	// Step 1: Health Check
+	if healthStep != nil {
+		if res := healthStep.Run(ctx, state); res.Status != "pass" {
+			return Result{Success: false, Error: "health check failed"}
+		}
+	}
+
+	// Step 2: Create Routine
+	if createStep != nil {
+		if res := createStep.Run(ctx, state); res.Status != "pass" {
+			// If creation failed but resource might exist, still cleanup
+			if state.CreatedResource {
+				runCleanup(cfg, cleanupStep, state)
+			}
+			return Result{Success: false, Error: "create routine failed"}
+		}
+	}
+
+	// Step 3: Trigger Execution
+	if triggerStep != nil {
+		if res := triggerStep.Run(ctx, state); res.Status != "pass" {
+			runCleanup(cfg, cleanupStep, state)
+			return Result{Success: false, Error: "trigger execution failed"}
+		}
+	}
+
+	// Step 4: Verify Execution
+	if verifyStep != nil {
+		if res := verifyStep.Run(ctx, state); res.Status != "pass" {
+			runCleanup(cfg, cleanupStep, state)
+			return Result{Success: false, Error: "verify execution failed"}
+		}
+	}
+
+	// Step 5: Cleanup
+	// FIX(TEAM-2616): Use a detached context so that SIGTERM/SIGINT cancellation
+	// of the parent context does not prevent the cleanup HTTP call from completing.
+	// Previously, the cancelled parent context was passed directly, causing
+	// DeleteRoutine to fail immediately with "context canceled" and leaking
+	// the test routine in the production system.
+	runCleanup(cfg, cleanupStep, state)
+
+	return Result{Success: true}
+}
+
+// runCleanup executes the cleanup step with a detached context.
+// This ensures the DELETE call completes even if the parent run context
+// was cancelled by SIGTERM/SIGINT.
+func runCleanup(cfg *config.Config, cleanupStep steps.Step, state *steps.RunState) {
+	if !state.CreatedResource || cleanupStep == nil {
+		return
+	}
+
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), cfg.CleanupTimeout)
+	defer cleanupCancel()
+
+	slog.Info("running cleanup with detached context", "routine_id", state.RoutineID)
+	result := cleanupStep.Run(cleanupCtx, state)
+	if result.Status != "pass" {
+		slog.Warn("cleanup failed", "error", result.Error)
+	}
+}

--- a/test/probe/internal/runner/runner_test.go
+++ b/test/probe/internal/runner/runner_test.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lmnr-ai/lmnr/test/probe/internal/config"
+	"github.com/lmnr-ai/lmnr/test/probe/internal/steps"
+)
+
+// mockStep is a test double for probe steps.
+type mockStep struct {
+	name    string
+	runFunc func(ctx context.Context, state *steps.RunState) steps.StepResult
+}
+
+func (m *mockStep) Name() string { return m.name }
+func (m *mockStep) Run(ctx context.Context, state *steps.RunState) steps.StepResult {
+	return m.runFunc(ctx, state)
+}
+
+// TestCleanupRunsWhenContextCancelled verifies that the cleanup step receives
+// a non-cancelled context even when the parent run context has been cancelled
+// (simulating SIGTERM during a probe run). This is the core fix for TEAM-2616.
+func TestCleanupRunsWhenContextCancelled(t *testing.T) {
+	var cleanupCalled atomic.Bool
+	var cleanupCtxWasActive atomic.Bool
+
+	cfg := &config.Config{
+		CleanupTimeout: 5 * time.Second,
+	}
+
+	// Parent context is already cancelled (simulates SIGTERM)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately — simulating SIGTERM arriving
+
+	createStep := &mockStep{
+		name: "create",
+		runFunc: func(ctx context.Context, state *steps.RunState) steps.StepResult {
+			state.CreatedResource = true
+			state.RoutineID = "rtn_test_123"
+			return steps.StepResult{Status: "pass"}
+		},
+	}
+
+	cleanupStep := &mockStep{
+		name: "cleanup",
+		runFunc: func(ctx context.Context, state *steps.RunState) steps.StepResult {
+			cleanupCalled.Store(true)
+			// The critical assertion: cleanup's context must NOT be cancelled
+			if ctx.Err() == nil {
+				cleanupCtxWasActive.Store(true)
+			}
+			return steps.StepResult{Status: "pass"}
+		},
+	}
+
+	// Run with cancelled parent context
+	RunWithSteps(ctx, cfg, nil, createStep, nil, nil, cleanupStep)
+
+	if !cleanupCalled.Load() {
+		t.Fatal("cleanup step was not called")
+	}
+	if !cleanupCtxWasActive.Load() {
+		t.Fatal("cleanup step received a cancelled context — the fix is not working")
+	}
+}
+
+// TestCleanupSkippedWhenNoResourceCreated verifies that cleanup is not
+// invoked when no routine was created (e.g., health check failed before creation).
+func TestCleanupSkippedWhenNoResourceCreated(t *testing.T) {
+	var cleanupCalled atomic.Bool
+
+	cfg := &config.Config{
+		CleanupTimeout: 5 * time.Second,
+	}
+
+	createStep := &mockStep{
+		name: "create",
+		runFunc: func(ctx context.Context, state *steps.RunState) steps.StepResult {
+			// Fails without creating a resource
+			return steps.StepResult{Status: "fail"}
+		},
+	}
+
+	cleanupStep := &mockStep{
+		name: "cleanup",
+		runFunc: func(ctx context.Context, state *steps.RunState) steps.StepResult {
+			cleanupCalled.Store(true)
+			return steps.StepResult{Status: "pass"}
+		},
+	}
+
+	RunWithSteps(context.Background(), cfg, nil, createStep, nil, nil, cleanupStep)
+
+	if cleanupCalled.Load() {
+		t.Fatal("cleanup should not be called when no resource was created")
+	}
+}
+
+// TestCleanupCalledOnTriggerFailure verifies cleanup runs if trigger fails
+// after a resource was successfully created.
+func TestCleanupCalledOnTriggerFailure(t *testing.T) {
+	var cleanupCalled atomic.Bool
+
+	cfg := &config.Config{
+		CleanupTimeout: 5 * time.Second,
+	}
+
+	createStep := &mockStep{
+		name: "create",
+		runFunc: func(ctx context.Context, state *steps.RunState) steps.StepResult {
+			state.CreatedResource = true
+			state.RoutineID = "rtn_trigger_fail"
+			return steps.StepResult{Status: "pass"}
+		},
+	}
+
+	triggerStep := &mockStep{
+		name: "trigger",
+		runFunc: func(ctx context.Context, state *steps.RunState) steps.StepResult {
+			return steps.StepResult{Status: "fail"}
+		},
+	}
+
+	cleanupStep := &mockStep{
+		name: "cleanup",
+		runFunc: func(ctx context.Context, state *steps.RunState) steps.StepResult {
+			cleanupCalled.Store(true)
+			// Verify context is NOT cancelled
+			if ctx.Err() != nil {
+				t.Error("cleanup context should not be cancelled")
+			}
+			return steps.StepResult{Status: "pass"}
+		},
+	}
+
+	RunWithSteps(context.Background(), cfg, nil, createStep, triggerStep, nil, cleanupStep)
+
+	if !cleanupCalled.Load() {
+		t.Fatal("cleanup should be called when trigger fails and resource exists")
+	}
+}

--- a/test/probe/internal/steps/cleanup.go
+++ b/test/probe/internal/steps/cleanup.go
@@ -1,0 +1,50 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// CleanupStep deletes the test routine created during the probe run.
+type CleanupStep struct {
+	BaseURL   string
+	AuthToken string
+	Client    *http.Client
+}
+
+func (s *CleanupStep) Name() string { return "cleanup" }
+
+// Run deletes the routine. The context controls the HTTP request timeout.
+// If the context is already cancelled (e.g., from SIGTERM), the DELETE request
+// will fail immediately with "context canceled" — this is the bug we fixed by
+// giving cleanup a detached context in the runner.
+func (s *CleanupStep) Run(ctx context.Context, state *RunState) StepResult {
+	if state.RoutineID == "" {
+		return StepResult{Status: "pass"}
+	}
+
+	url := fmt.Sprintf("%s/routines/%s", s.BaseURL, state.RoutineID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return StepResult{Status: "fail", Error: fmt.Errorf("create request: %w", err)}
+	}
+	req.Header.Set("Authorization", "Bearer "+s.AuthToken)
+
+	client := s.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return StepResult{Status: "fail", Error: fmt.Errorf("delete routine: %w", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return StepResult{Status: "fail", Error: fmt.Errorf("unexpected status: %d", resp.StatusCode)}
+	}
+
+	return StepResult{Status: "pass"}
+}

--- a/test/probe/internal/steps/steps.go
+++ b/test/probe/internal/steps/steps.go
@@ -1,0 +1,22 @@
+package steps
+
+import "context"
+
+// StepResult represents the outcome of a probe step.
+type StepResult struct {
+	Status string // "pass" or "fail"
+	Error  error
+}
+
+// RunState carries data between probe steps within a single run.
+type RunState struct {
+	RoutineID       string
+	CreatedResource bool
+	ExecutionID     string
+}
+
+// Step is the interface all probe steps implement.
+type Step interface {
+	Name() string
+	Run(ctx context.Context, state *RunState) StepResult
+}


### PR DESCRIPTION
## Summary\n\nFixes the cleanup step using a cancelled context on SIGTERM/SIGINT shutdown, which caused test routine leaks.\n\n**Problem:** When SIGTERM/SIGINT cancels the run context (via `signal.NotifyContext` in `cmd/probe/main.go`), the cleanup step received the already-cancelled context. `CleanupStep.Run` derives its HTTP request timeout from this context, so `DeleteRoutine` fails immediately with `context canceled`. The routine created earlier in the run is never deleted.\n\n**Fix:** Give the cleanup step a detached context derived from `context.Background()` with just the cleanup timeout:\n\n```go\nfunc runCleanup(cfg *config.Config, cleanupStep steps.Step, state *steps.RunState) {\n    if !state.CreatedResource || cleanupStep == nil {\n        return\n    }\n    cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), cfg.CleanupTimeout)\n    defer cleanupCancel()\n    result := cleanupStep.Run(cleanupCtx, state)\n    // ...\n}\n```\n\n## Test Coverage\n\n- `TestCleanupRunsWhenContextCancelled` - Cancels parent context (simulating SIGTERM), verifies cleanup receives a live context\n- `TestCleanupSkippedWhenNoResourceCreated` - Verifies cleanup is skipped when no resource exists\n- `TestCleanupCalledOnTriggerFailure` - Verifies cleanup runs on step failure after resource creation\n\n## Files\n\n- `test/probe/go.mod` - Go module definition\n- `test/probe/cmd/probe/main.go` - CLI entrypoint with signal handling\n- `test/probe/internal/config/config.go` - Configuration\n- `test/probe/internal/steps/steps.go` - Step interface and types\n- `test/probe/internal/steps/cleanup.go` - CleanupStep implementation\n- `test/probe/internal/runner/runner.go` - Suite runner with the fix\n- `test/probe/internal/runner/runner_test.go` - Tests proving the fix\n\nFixes TEAM-2616

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

