### PR TITLE
remove 'most runs have no errors' from default signal template

### DIFF
--- a/frontend/components/signals/prompts.ts
+++ b/frontend/components/signals/prompts.ts
@@ -17,8 +17,7 @@ const templates: EventTemplate[] = [
     prompt: `Find the most significant error the agent made in this run, if any: \
 a wrong action, flawed logic, or failure that affected the outcome or wasted \
 significant work. Minor issues the agent immediately recovered from are not \
-findings. Cite the specific spans and quote the decisive evidence. \
-Most runs have no reportable error.`,
+findings. Cite the specific spans and quote the decisive evidence.`,
     structuredOutputSchema: JSON.stringify(
       {
         type: "object",

--- a/frontend/lib/db/default-signals.ts
+++ b/frontend/lib/db/default-signals.ts
@@ -4,8 +4,7 @@ export const DEFAULT_SIGNAL = {
   prompt: `Find the most significant error the agent made in this run, if any: \
 a wrong action, flawed logic, or failure that affected the outcome or wasted \
 significant work. Minor issues the agent immediately recovered from are not \
-findings. Cite the specific spans and quote the decisive evidence. \
-Most runs have no reportable error.`,
+findings. Cite the specific spans and quote the decisive evidence.`,
   structuredOutputSchema: {
     type: "object",
     required: ["description"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

