### PR TITLE
Rename p50_ms to avg_ms in Full SQL access card illustration

### DIFF
--- a/frontend/components/landing/sections/features-for-every-step/graphics/sql.tsx
+++ b/frontend/components/landing/sections/features-for-every-step/graphics/sql.tsx
@@ -4,7 +4,7 @@
 const COLS = [
   { key: "model", w: "w-[86px]", align: "" },
   { key: "runs", w: "w-[46px]", align: "text-right" },
-  { key: "p50_ms", w: "w-[52px]", align: "text-right" },
+  { key: "avg_ms", w: "w-[52px]", align: "text-right" },
   { key: "tokens", w: "w-[52px]", align: "text-right" },
   { key: "cost", w: "w-[46px]", align: "text-right" },
 ];
@@ -29,7 +29,7 @@ const Sql = () => (
       </p>
       <p className="pl-5 text-foreground-200">
         count(*) <span className="text-primary-300">AS</span> runs, avg(duration){" "}
-        <span className="text-primary-300">AS</span> p50_ms,
+        <span className="text-primary-300">AS</span> avg_ms,
       </p>
       <p className="pl-5 text-foreground-200">
         sum(total_tokens) <span className="text-primary-300">AS</span> tokens, sum(total_cost){" "}


### PR DESCRIPTION
## What

The "Full SQL access" landing-page card illustration aliases `avg(duration)` as `p50_ms`. Since `avg()` returns an average and not a p50, the alias is misleading.

Renamed all `p50_ms` mentions in that section to `avg_ms` (the query alias and the result-table column header).

## Files
- `frontend/components/landing/sections/features-for-every-step/graphics/sql.tsx`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

