### PR TITLE
perf(frontend): require trace_id alongside span_id filters on spans

### DIFF
--- a/frontend/.oxlint-plugins/span-id-needs-trace-id.ts
+++ b/frontend/.oxlint-plugins/span-id-needs-trace-id.ts
@@ -1,0 +1,74 @@
+// Require a `trace_id` predicate alongside every `span_id` filter on `spans`.
+//
+// `spans` is ORDER BY (project_id, trace_id, start_time, span_id). A `span_id`
+// filter without `trace_id` cannot prune on the primary key: ClickHouse falls
+// back to a generic exclusion search over every granule in the project and
+// decompresses the heavy input/output/attributes/events columns for all of
+// them. Measured locally this was 67/67 granules and ~1.3s vs 27/67 and ~0.4s
+// on a tiny dataset, and the gap widens with project size. See
+// docs/internal/clickhouse-traces.md.
+//
+// Flagged: a string or template literal that filters on `span_id` (`=` or `IN`)
+// against `spans` and mentions no `trace_id` anywhere in the same literal.
+//
+// Not flagged:
+//   - literals that already mention `trace_id`
+//   - `DELETE FROM spans` — a mutation, not a granule scan on the read path
+//   - a query whose trace scoping arrives as a structured filter rather than
+//     inline SQL; those cannot be seen from the literal, so call sites that
+//     scope via `filters`/`customConditions` carry an eslint-disable with a
+//     one-line reason.
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+const SPAN_ID_PREDICATE = /\bspan_id\s*(?:=|\bIN\b|\bin\b)/i;
+const TRACE_ID = /\btrace_id\b/i;
+const FROM_SPANS = /\b(?:FROM|TABLE)\s+spans\b/i;
+const DELETE_FROM_SPANS = /\bDELETE\s+FROM\s+spans\b/i;
+
+// The raw text of a string or template literal, with `${...}` holes joined by a
+// space so a predicate split across an interpolation still reads as one clause.
+const literalText = (node: any): string | null => {
+  if (node?.type === "TemplateLiteral") {
+    return (node.quasis ?? []).map((q: any) => q?.value?.raw ?? "").join(" ");
+  }
+  if (node?.type === "Literal" && typeof node.value === "string") {
+    return node.value;
+  }
+  return null;
+};
+
+export default eslintCompatPlugin({
+  meta: { name: "lmnr-clickhouse" },
+  rules: {
+    "span-id-needs-trace-id": {
+      meta: {
+        type: "problem",
+        messages: {
+          missingTraceId:
+            "This span_id filter has no trace_id predicate. `spans` is ORDER BY (project_id, trace_id, start_time, span_id), so without trace_id ClickHouse cannot prune the primary key — it scans every granule in the project and decompresses input/output/attributes/events. Add `trace_id IN ({...:Array(UUID)})` alongside it. If the trace scoping is applied structurally (a `filters` entry or `customConditions`), disable this line with a reason.",
+        },
+      },
+      createOnce(context) {
+        const check = (node: any) => {
+          const sql = literalText(node);
+          if (sql === null) {
+            return;
+          }
+          if (!SPAN_ID_PREDICATE.test(sql) || TRACE_ID.test(sql)) {
+            return;
+          }
+          // A fragment may name no table; it is still a spans predicate when it
+          // filters span_id. Only skip when it clearly targets something else.
+          if (/\bFROM\s+(?!spans\b)\w+/i.test(sql) && !FROM_SPANS.test(sql)) {
+            return;
+          }
+          if (DELETE_FROM_SPANS.test(sql)) {
+            return;
+          }
+          context.report({ node, messageId: "missingTraceId" });
+        };
+        return { Literal: check, TemplateLiteral: check };
+      },
+    },
+  },
+});

--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "jsPlugins": ["./.oxlint-plugins/span-id-needs-trace-id.ts"],
   "plugins": ["typescript", "react", "nextjs", "import", "unicorn", "oxc"],
   "categories": {
     "correctness": "warn"
@@ -29,7 +30,9 @@
 
     "react/rules-of-hooks": "error",
     "react/exhaustive-deps": "warn",
-    "react/preserve-manual-memoization": "warn"
+    "react/preserve-manual-memoization": "warn",
+
+    "lmnr-clickhouse/span-id-needs-trace-id": "error"
   },
   "overrides": [
     {

--- a/frontend/lib/actions/events/index.ts
+++ b/frontend/lib/actions/events/index.ts
@@ -34,17 +34,23 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 export async function attachSpanTypes(projectId: string, items: EventRow[]): Promise<EventRow[]> {
   const idsByRow = new Map<string, string[]>();
   const allSpanIds = new Set<string>();
+  // Collected alongside the span ids so the lookup can scope to the spans
+  // primary key; a span_id-only filter scans every granule in the project.
+  const allTraceIds = new Set<string>();
 
   for (const item of items) {
     // The span-link regex matches `[0-9a-f-]+`, which can capture non-UUID
     // fragments — keep only well-formed ids so the `Array(UUID)` query (and its
-    // schema) don't reject the whole batch.
-    const ids = parseSpanLinks(item.payload)
-      .map((link) => link.spanId)
-      .filter((id): id is string => Boolean(id) && UUID_REGEX.test(id!));
+    // schema) don't reject the whole batch. A link needs both ids to be usable.
+    const links = parseSpanLinks(item.payload).filter(
+      (link) =>
+        Boolean(link.spanId) && UUID_REGEX.test(link.spanId!) && Boolean(link.traceId) && UUID_REGEX.test(link.traceId!)
+    );
+    const ids = links.map((link) => link.spanId!);
     if (ids.length > 0) {
       idsByRow.set(item.id, ids);
       ids.forEach((id) => allSpanIds.add(id));
+      links.forEach((link) => allTraceIds.add(link.traceId!));
     }
   }
 
@@ -52,7 +58,11 @@ export async function attachSpanTypes(projectId: string, items: EventRow[]): Pro
     return items;
   }
 
-  const typeMap = await getSpanTypes({ projectId, spanIds: [...allSpanIds] });
+  const typeMap = await getSpanTypes({
+    projectId,
+    spanIds: [...allSpanIds],
+    traceIds: [...allTraceIds],
+  });
 
   return items.map((item) => {
     const ids = idsByRow.get(item.id);

--- a/frontend/lib/actions/span/index.ts
+++ b/frontend/lib/actions/span/index.ts
@@ -35,6 +35,7 @@ export const PushSpanSchema = z.object({
 export async function getSpan(input: z.infer<typeof GetSpanSchema>) {
   const { spanId, traceId, projectId } = GetSpanSchema.parse(input);
 
+  // eslint-disable-next-line lmnr-clickhouse/span-id-needs-trace-id -- trace_id is appended just below when the caller has it; `exportSpanToDataset` / `pushSpanToLabelingQueue` reach this from span-scoped routes that carry no trace id.
   const whereConditions = [`span_id = {spanId: UUID}`];
   const parameters: Record<string, any> = { spanId };
 
@@ -174,12 +175,13 @@ export async function getSpanType(input: z.infer<typeof GetSpanTypeSchema>): Pro
 export const GetSpanTypesSchema = z.object({
   projectId: z.guid(),
   spanIds: z.array(z.string()),
+  traceIds: z.array(z.string()),
 });
 
 export async function getSpanTypes(input: z.infer<typeof GetSpanTypesSchema>): Promise<Record<string, SpanType>> {
-  const { projectId, spanIds } = GetSpanTypesSchema.parse(input);
+  const { projectId, spanIds, traceIds } = GetSpanTypesSchema.parse(input);
 
-  if (spanIds.length === 0) {
+  if (spanIds.length === 0 || traceIds.length === 0) {
     return {};
   }
 
@@ -188,9 +190,9 @@ export async function getSpanTypes(input: z.infer<typeof GetSpanTypesSchema>): P
     query: `
       SELECT span_id as spanId, span_type as spanType
       FROM spans
-      WHERE span_id IN ({spanIds: Array(UUID)})
+      WHERE trace_id IN ({traceIds: Array(UUID)}) AND span_id IN ({spanIds: Array(UUID)})
     `,
-    parameters: { spanIds },
+    parameters: { spanIds, traceIds },
   });
 
   return Object.fromEntries(rows.map((r) => [r.spanId, r.spanType]));

--- a/frontend/lib/actions/spans/index.ts
+++ b/frontend/lib/actions/spans/index.ts
@@ -117,6 +117,9 @@ export async function getSpans(input: z.infer<typeof GetSpansSchema>): Promise<{
       })
     : [];
   const spanIds = spanHits.map((span) => span.span_id);
+  // Search hits carry their trace id; passing it lets the span_id filter prune
+  // the spans primary key instead of scanning every granule in the project.
+  const spanTraceIds = [...new Set(spanHits.map((span) => span.trace_id))];
 
   if (search) {
     if (spanIds?.length === 0) {
@@ -131,6 +134,7 @@ export async function getSpans(input: z.infer<typeof GetSpansSchema>): Promise<{
   const { query: mainQuery, parameters: mainParams } = buildSpansQueryWithParams({
     projectId,
     spanIds,
+    traceIds: spanTraceIds,
     filters,
     limit,
     offset,

--- a/frontend/lib/actions/spans/utils.ts
+++ b/frontend/lib/actions/spans/utils.ts
@@ -125,6 +125,11 @@ export interface BuildSpansQueryOptions {
   columns?: string[];
   projectId: string;
   spanIds?: string[];
+  /** Trace ids owning `spanIds`. `spans` is ORDER BY (project_id, trace_id,
+   *  start_time, span_id), so a span_id filter without these cannot prune the
+   *  primary key and scans every granule in the project. Omit only when the
+   *  caller already scopes traces via `filters` / `customConditions`. */
+  traceIds?: string[];
   filters: Filter[];
   limit?: number;
   offset?: number;
@@ -141,9 +146,30 @@ export interface BuildSpansQueryOptions {
   }>;
 }
 
+// A span_id filter is always paired with its owning trace ids when the caller
+// has them: `spans` is ORDER BY (project_id, trace_id, start_time, span_id), so
+// span_id alone cannot prune the primary key and ClickHouse scans every granule
+// in the project. Callers that scope traces structurally pass no `traceIds`.
+const spanIdConditions = (spanIds: string[], traceIds: string[]): Array<{ condition: string; params: QueryParams }> => {
+  if (!spanIds?.length) {
+    return [];
+  }
+  if (traceIds?.length) {
+    return [
+      {
+        condition: `trace_id IN ({spanTraceIds:Array(UUID)}) AND span_id IN ({spanIds:Array(UUID)})`,
+        params: { spanIds, spanTraceIds: traceIds },
+      },
+    ];
+  }
+  // eslint-disable-next-line lmnr-clickhouse/span-id-needs-trace-id -- trace scoping is supplied by the caller via `filters` / `customConditions`; see callers in lib/actions/spans/index.ts and lib/actions/sessions/search-spans.ts.
+  return [{ condition: `span_id IN ({spanIds:Array(UUID)})`, params: { spanIds } }];
+};
+
 export const buildSpansQueryWithParams = (options: BuildSpansQueryOptions): QueryResult => {
   const {
     spanIds = [],
+    traceIds = [],
     filters,
     limit,
     offset,
@@ -158,17 +184,7 @@ export const buildSpansQueryWithParams = (options: BuildSpansQueryOptions): Quer
   const customConditions: Array<{
     condition: string;
     params: QueryParams;
-  }> = [
-    ...additionalConditions,
-    ...(spanIds?.length > 0
-      ? [
-          {
-            condition: `span_id IN ({spanIds:Array(UUID)})`,
-            params: { spanIds },
-          },
-        ]
-      : []),
-  ];
+  }> = [...additionalConditions, ...spanIdConditions(spanIds, traceIds)];
 
   const queryOptions: SelectQueryOptions = {
     select: {
@@ -205,22 +221,20 @@ export const buildSpansQueryWithParams = (options: BuildSpansQueryOptions): Quer
 export const buildSpansCountQueryWithParams = (
   options: Omit<BuildSpansQueryOptions, "limit" | "offset">
 ): QueryResult => {
-  const { spanIds = [], filters, startTime, endTime, pastHours, customConditions: additionalConditions = [] } = options;
+  const {
+    spanIds = [],
+    traceIds = [],
+    filters,
+    startTime,
+    endTime,
+    pastHours,
+    customConditions: additionalConditions = [],
+  } = options;
 
   const customConditions: Array<{
     condition: string;
     params: QueryParams;
-  }> = [
-    ...additionalConditions,
-    ...(spanIds?.length > 0
-      ? [
-          {
-            condition: `span_id IN ({spanIds:Array(UUID)})`,
-            params: { spanIds },
-          },
-        ]
-      : []),
-  ];
+  }> = [...additionalConditions, ...spanIdConditions(spanIds, traceIds)];
 
   const queryOptions: SelectQueryOptions = {
     select: {

--- a/frontend/lib/actions/tags/index.ts
+++ b/frontend/lib/actions/tags/index.ts
@@ -59,6 +59,7 @@ export const addTagToCHSpan = async (input: z.infer<typeof AddTagToSpanSchema>):
 
   // With mutations_sync=0, this returns immediately while the mutation runs in the background.
   await clickhouseClient.command({
+    // eslint-disable-next-line lmnr-clickhouse/span-id-needs-trace-id -- ALTER..UPDATE mutation, not a read-path granule scan; the tags route is span-scoped and carries no trace id.
     query: `
       ALTER TABLE spans
       UPDATE tags_array = arrayDistinct(arrayConcat(tags_array, [{tag: String}]))
@@ -86,6 +87,7 @@ export const removeTagFromCHSpan = async (input: z.infer<typeof RemoveTagFromSpa
 
   // With mutations_sync=0, this returns immediately while the mutation runs in the background.
   await clickhouseClient.command({
+    // eslint-disable-next-line lmnr-clickhouse/span-id-needs-trace-id -- ALTER..UPDATE mutation, not a read-path granule scan; the tags route is span-scoped and carries no trace id.
     query: `
       ALTER TABLE spans
       UPDATE tags_array = arrayFilter(x -> x != {tag: String}, tags_array)
@@ -110,6 +112,7 @@ export const getSpanTags = async (
   const { spanId, projectId } = GetSpanTagsSchema.parse(input);
 
   const chResponse = await clickhouseClient.query({
+    // eslint-disable-next-line lmnr-clickhouse/span-id-needs-trace-id -- reached from GET /projects/:projectId/spans/:spanId/tags, whose URL contract carries no trace id; threading one through is an API change, tracked separately.
     query: `
       SELECT DISTINCT arrayJoin(tags_array) as name
       FROM spans

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -152,6 +152,7 @@
     "zustand": "^4.5.7"
   },
   "devDependencies": {
+    "@oxlint/plugins": "1.80.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@tailwindcss/typography": "^0.5.16",
     "@types/d3-scale": "^4.0.9",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
         specifier: ^4.5.7
         version: 4.5.7(@types/react@19.2.8)(react@19.2.3)
     devDependencies:
+      '@oxlint/plugins':
+        specifier: 1.80.0
+        version: 1.80.0
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -2689,6 +2692,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxlint/plugins@1.80.0':
+    resolution: {integrity: sha512-QRgH1XqQEYNHa4f1vvPQ5fAdNdncHGIUG1ZWLlGIZHky3qwCEeAKYitZNbZMtaXtAQAAFFTOwqUfzESvimqZNA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@posthog/core@1.35.1':
     resolution: {integrity: sha512-2a9JgJgR+Ow8lrUQHVZYXH9EgXskYDlpbgNW6UvtsVxp8pEEFD8PxjZMnzq73Dx3NhAwNUrnVpb8KeZzHAtoSA==}
@@ -9204,6 +9211,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.80.0':
     optional: true
+
+  '@oxlint/plugins@1.80.0': {}
 
   '@posthog/core@1.35.1':
     dependencies:


### PR DESCRIPTION
> **Stacked on #2246** (`feat/oxlint`). Review that one first; this PR's diff is only the last commit.

`spans` is `ORDER BY (project_id, trace_id, start_time, span_id)`. A `span_id` filter with no `trace_id` cannot prune the primary key — ClickHouse falls back to a generic exclusion search over every granule in the project and decompresses the heavy `input`/`output`/`attributes`/`events` columns for all of them.

`docs/internal/clickhouse-traces.md` already documents this, with numbers: **67/67 granules and ~1.3s vs 27/67 and ~0.4s** on a tiny dataset, and the gap widens with project size. It calls this "the dominant cost on the trace/span read routes." The guidance existed; nothing enforced it.

This adds an oxlint JS plugin that flags the pattern, plus the fixes.

## The fixes

Three call sites had the trace ids in hand and threw them away:

| Site | What was wrong |
|---|---|
| `getSpanTypes` | `attachSpanTypes` calls `parseSpanLinks`, which returns `{ label, traceId, spanId }` — the `traceId` was parsed and dropped by `.map(link => link.spanId)`. Now collected and passed. |
| `buildSpansQueryWithParams` / `…CountQueryWithParams` | New optional `traceIds` pairs into the `span_id` predicate. **Behaviour is unchanged when omitted**, so callers that scope traces structurally are unaffected. |
| `getSpans` | `spanHits` is typed `{ trace_id: string; span_id: string }[]`; the trace ids were mapped away. Now deduped and passed. |

Link filtering in `attachSpanTypes` tightened to require *both* ids to be well-formed UUIDs, since a link with only a span id can no longer be scoped.

## The suppressions

Four sites keep the old shape, each with an inline reason:

- **`addTagToCHSpan` / `removeTagFromCHSpan`** — `ALTER TABLE … UPDATE` mutations, not read-path granule scans.
- **`getSpanTags`** — reached from `GET /projects/:projectId/spans/:spanId/tags`, whose URL contract carries no trace id. `span.traceId` *is* available at the `<SpanTagsList>` call site, so this is fixable, but it changes an API route contract — deliberately out of scope here.
- **`getSpan`** — already appends `trace_id` when the caller supplies one; two internal callers (`exportSpanToDataset`, `pushSpanToLabelingQueue`) arrive from span-scoped routes without one.

I verified the suppressions are load-bearing: deleting one makes the rule fire again.

## Verification

- `oxlint .` — **0 errors** (rule active; confirmed it still fires on a synthetic violation)
- `tsc --noEmit --incremental false` — clean
- `oxfmt --check .` — clean
- `check:circular` — clean
- husky pre-commit hook ran end-to-end
- `pnpm test` — 269/271. The 2 failures (`parseAiSdkMessages`, `normalizeToMessages`) are **pre-existing**, confirmed at merge-base `8e99035`.

## Notes

- Adds `@oxlint/plugins@1.80.0` (exact pin, matching `oxlint`). JS plugins are the non-native path, but this one is a string-literal shape match — full-repo lint is unchanged at ~1.5s.
- The rule reads SQL string/template literals, so it cannot see trace scoping applied structurally (a `filters` entry or `customConditions`). That is why the shared builder carries a suppression rather than the rule attempting dataflow.
- Not verified against a real ClickHouse instance — the granule numbers quoted are from the existing internal doc, not re-measured here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ClickHouse read queries and tightens event span-link handling (both UUIDs required), which could alter batch type lookups or empty results if callers omit trace ids; lint rule may need ongoing suppressions for edge cases.
> 
> **Overview**
> Adds an **oxlint** custom rule (`lmnr-clickhouse/span-id-needs-trace-id`) that errors on SQL string/template literals that filter `spans` by `span_id` without any `trace_id`, because that pattern prevents ClickHouse primary-key pruning on `ORDER BY (project_id, trace_id, …)`.
> 
> **Query fixes** where trace ids were already available but not used: `getSpanTypes` now requires `traceIds` and uses `trace_id IN … AND span_id IN …`; `attachSpanTypes` collects trace ids from span links (links must have both UUIDs); `getSpans` passes deduped trace ids from search hits into `buildSpansQueryWithParams` / count builders via new optional `traceIds` and shared `spanIdConditions`.
> 
> **Documented suppressions** for mutations (`ALTER TABLE … UPDATE`), span-only URL routes (`getSpan`, `getSpanTags`), and builders that scope traces via `filters` / `customConditions` instead of inline SQL. Adds `@oxlint/plugins` and registers the plugin in `.oxlintrc.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ab93e3a717122e687d6298b04be58ab7ea951e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->