### PR TITLE
fix: scope playground update to its owning project

### DIFF
--- a/frontend/app/api/projects/[projectId]/playgrounds/[playgroundId]/route.ts
+++ b/frontend/app/api/projects/[projectId]/playgrounds/[playgroundId]/route.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod/v4";
 
 import { db } from "@/lib/db/drizzle";
@@ -42,7 +42,7 @@ export async function POST(req: Request, props: { params: Promise<{ projectId: s
       maxTokens: parsed.data.maxTokens,
       providerOptions: parsed.data.providerOptions,
     })
-    .where(eq(playgrounds.id, params.playgroundId))
+    .where(and(eq(playgrounds.id, params.playgroundId), eq(playgrounds.projectId, params.projectId)))
     .returning();
 
   return new Response(JSON.stringify(res));


### PR DESCRIPTION
Summary

Fixes #2249.

POST /api/projects/[projectId]/playgrounds/[playgroundId] reads projectId out of the URL params but never actually uses it when running the update. The Drizzle query is scoped only by the playground's own id:

.where(eq(playgrounds.id, params.playgroundId))

Any authenticated user who is a member of some project can update a playground belonging to a different project, as long as they know or can guess a valid playgroundId (a UUID). This is a missing-authorization bug (CWE-862).

Why the existing checks don't catch this

- proxy.ts middleware only verifies the caller is a member of the projectId segment in the URL via isUserMemberOfProject. It never checks that the target playgroundId row actually belongs to that project.
- The route handler itself has no independent session/membership recheck.
- The playgrounds table has no Postgres row-level security policy (confirmed by grepping every migration for ENABLE ROW LEVEL SECURITY — it's enabled for api_keys, evaluations, evaluation_results, pipeline_versions, traces, users, spans, and agent_chats, but never playgrounds).

So nothing between the client and the database enforces that the playground being updated belongs to the project named in the URL.

Fix

Add the project scope to the WHERE clause, matching the pattern already used by every other mutation route in the codebase (e.g. tag-classes, signals):

.where(and(eq(playgrounds.id, params.playgroundId), eq(playgrounds.projectId, params.projectId)))

Test plan

- [x] pnpm lint clean on the changed file
- [x] pnpm type-check clean
- [ ] Manually verify: attempt to update a playground from a project the caller is not a member of returns no rows updated

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization on a write API; the change is a one-line query scope fix with no new behavior for in-project updates.
> 
> **Overview**
> **Closes a cross-project authorization gap** on `POST /api/projects/[projectId]/playgrounds/[playgroundId]`: the update previously matched only `playgroundId`, so a member of one project could change another project’s playground if they had the UUID.
> 
> The handler now constrains the Drizzle `update` with **`and(eq(playgrounds.id, …), eq(playgrounds.projectId, params.projectId))`**, using the `projectId` already in the path—the same pattern as other project-scoped mutation routes (e.g. agents, datasets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04210c11d8660fcd849d01d1faa66eb8343a582d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->