### PR TITLE
fix: prevent body projectId from overriding URL-authorized project

### DIFF
--- a/frontend/app/api/projects/[projectId]/sql/export-job/route.ts
+++ b/frontend/app/api/projects/[projectId]/sql/export-job/route.ts
@@ -11,8 +11,8 @@ export async function POST(req: NextRequest, props: { params: Promise<{ projectI
     const body = await req.json();
 
     const result = await createExportJob({
-      projectId,
       ...body,
+      projectId,
     });
 
     return NextResponse.json({


### PR DESCRIPTION
## Summary

Fixes #2251.

`POST /api/projects/[projectId]/sql/export-job` spread the request body **after** the URL-derived `projectId`, so a client-supplied `projectId` key in the JSON body silently overrode the one `proxy.ts` had already verified membership for. Downstream, that attacker-controlled `projectId` scoped the dataset lookup, SQL query validation, and the actual export dispatch to the data-exporter service  allowing cross-tenant SQL execution and bulk data export (CWE-862, missing authorization).

## Root cause

```ts
// frontend/app/api/projects/[projectId]/sql/export-job/route.ts
const result = await createExportJob({
  projectId,   // from the URL, verified by proxy.ts
  ...body,     // client JSON — a `projectId` key here wins the conflict
});
```

JS object spread is last-write-wins. `proxy.ts` middleware only checks membership against the `projectId` **path segment**; it never inspects the request body. Once the body's `projectId` overwrites the URL-verified one, every downstream operation in `frontend/lib/actions/sql/export-job.ts` — the dataset lookup, the SQL query validator, and the export dispatch to `DATA_EXPORTER_URL` — runs against whatever project the attacker put in the body, not the one they were actually authorized for.

## Fix

Reorder the spread so `projectId` is applied last and cannot be shadowed, matching the safe pattern already used elsewhere in the codebase (e.g. `GET`/`POST`/`PUT` in `signals/route.ts`):

```ts
const result = await createExportJob({
  ...body,
  projectId,
});
```

## Impact

- Any authenticated user with membership in *any* project could run arbitrary validated SQL against, and trigger a bulk export job for, a project they have no membership in, as long as they supplied a valid `datasetId` belonging to that project.
- Bypassed the SQL query engine's stated security boundary (`docs/internal/sql-query-engine.md`) and resulted in actual cross-tenant data exfiltration, not just an unauthorized write.

## Changes

- `frontend/app/api/projects/[projectId]/sql/export-job/route.ts`: swap `{ projectId, ...body }` -> `{ ...body, projectId }`.

## Test plan

- [x] `pnpm lint` clean on the changed file
- [x] `pnpm type-check` clean (full, non-incremental)
- [ ] Manually verify: a request with a `projectId` in the body pointing at a different project no longer scopes the dataset lookup / SQL validation / export dispatch to that project — it uses the URL's `projectId` regardless of the body


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This closes an authenticated cross-tenant SQL export path (CWE-862); the code change is one line but the prior behavior allowed data exfiltration across projects.
> 
> **Overview**
> **Fixes a cross-tenant authorization bypass** on `POST /api/projects/[projectId]/sql/export-job` by applying the URL `projectId` **after** spreading the JSON body instead of before.
> 
> Previously, a client could put `projectId` in the body and override the path segment that `proxy.ts` had already checked for membership, so dataset lookup, SQL validation, and export dispatch could run against another project. The route now matches the safe `{ ...body, projectId }` pattern used on other project-scoped API routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb650883e6139968df5676e2460762ac3944fc05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

