### PR TITLE
silence dead_code warnings

### DIFF
--- a/app-server/src/db/agents.rs
+++ b/app-server/src/db/agents.rs
@@ -8,14 +8,10 @@ use crate::utils::sanitize_string;
 /// A single agent version row, identified by `(project_id, version_hash)`.
 #[derive(Debug, Clone, FromRow)]
 pub struct AgentVersion {
-    pub project_id: Uuid,
     pub agent_id: Uuid,
-    /// BLAKE3-256 hash, hex-encoded (64 chars).
-    pub version_hash: String,
     pub system_prompt: String,
-    pub tool_definitions: String,
-    pub model: String,
     pub created_at: DateTime<Utc>,
+    // ... other columns, not used.
 }
 
 /// Find the agent that owns a version with this exact `(project_id,

--- a/app-server/src/db/agents.rs
+++ b/app-server/src/db/agents.rs
@@ -42,7 +42,7 @@ pub async fn list_latest_agent_versions(
 ) -> Result<Vec<AgentVersion>> {
     let agents = sqlx::query_as::<_, AgentVersion>(
         "SELECT DISTINCT ON (agent_id)
-            project_id, agent_id, version_hash, system_prompt, tool_definitions, model, created_at
+            agent_id, system_prompt, created_at
          FROM agent_versions
          WHERE project_id = $1
          ORDER BY agent_id, created_at DESC, version_hash DESC",

--- a/app-server/src/db/projects.rs
+++ b/app-server/src/db/projects.rs
@@ -217,6 +217,7 @@ pub async fn get_projects_for_team(
 }
 
 /// Fetch a single project's name by id.
+#[cfg_attr(not(feature = "signals"), allow(dead_code))]
 pub async fn get_project_name(pool: &PgPool, project_id: &Uuid) -> anyhow::Result<String> {
     let name = sqlx::query_scalar::<_, String>("SELECT name FROM projects WHERE id = $1")
         .bind(project_id)

--- a/app-server/src/notifications/slack/mod.rs
+++ b/app-server/src/notifications/slack/mod.rs
@@ -252,6 +252,7 @@ pub async fn post_thread_message(
 /// context when the agent is first mentioned mid-thread. The caller persists each as a `user` turn
 /// (the agent's own replies are written live as `assistant`), so authorship isn't distinguished here.
 /// Best-effort — the caller treats a failure as "no backfill".
+#[cfg_attr(not(feature = "signals"), allow(dead_code))]
 pub async fn fetch_thread_replies(
     slack_client: &Client,
     token: &str,
@@ -307,6 +308,7 @@ pub async fn fetch_thread_replies(
 /// One backfilled thread message. Persisted as a `user` turn regardless of author (see
 /// `fetch_thread_replies`).
 #[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "signals"), allow(dead_code))]
 pub struct ThreadMessage {
     pub text: String,
     pub ts: Option<String>,
@@ -509,10 +511,7 @@ mod tests {
         let v = format_new_cluster_blocks(&[&kind]);
         let blocks = blocks_of(&v);
         // header names the signal, singular form
-        assert_eq!(
-            blocks[0]["text"]["text"],
-            "`Failure Detector`: New Cluster"
-        );
+        assert_eq!(blocks[0]["text"]["text"], "`Failure Detector`: New Cluster");
         // one cluster section with name, event count, seen dates, severity line
         let section = blocks[1]["text"]["text"].as_str().unwrap();
         assert!(section.contains("Bad args"));
@@ -524,10 +523,7 @@ mod tests {
         assert!(!section.contains("Warning"));
         // per-cluster actions block with a View Cluster button
         assert_eq!(blocks[2]["type"], "actions");
-        assert_eq!(
-            blocks[2]["elements"][0]["text"]["text"],
-            "View Cluster"
-        );
+        assert_eq!(blocks[2]["elements"][0]["text"]["text"], "View Cluster");
         // trailing context (signal + alert links) and divider
         let context = &blocks[blocks.len() - 2];
         assert_eq!(context["type"], "context");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-hygiene and struct/query narrowing with no intended behavior change; list-latest still returns the same logical rows with fewer columns.
> 
> **Overview**
> **Silences `dead_code` warnings** when the app-server is built **without** the `signals` feature by marking Slack thread helpers (`fetch_thread_replies`, `ThreadMessage`, and related paths) and `get_project_name` with `#[cfg_attr(not(feature = "signals"), allow(dead_code))]`, matching the pattern already used for other signals-only Slack/project APIs.
> 
> **Narrows `AgentVersion` and `list_latest_agent_versions`** to the fields callers actually use (`agent_id`, `system_prompt`, `created_at`), dropping `project_id`, `version_hash`, `tool_definitions`, and `model` from the struct and SELECT so unused mapped columns no longer contribute to warnings.
> 
> Minor test-only formatting in Slack new-cluster block assertions (single-line `assert_eq!`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cafc2be8f419646097f57dec7ba76f7165234d93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->