### PR TITLE
bring frontend models in sync to backend

### DIFF
--- a/frontend/lib/ai/model.ts
+++ b/frontend/lib/ai/model.ts
@@ -17,14 +17,14 @@ type LlmDefaultHeaders = Record<string, string>;
 // Per-provider defaults. Used when LLM_MODEL_<TIER> is not set.
 const DEFAULT_MODELS: Record<LLMProvider, Record<ModelTier, string>> = {
   gemini: {
-    small: "gemini-3.1-flash-lite",
+    small: "gemini-3.5-flash-lite",
     medium: "gemini-3-flash-preview",
     large: "gemini-3.1-pro-preview",
   },
   bedrock: {
     small: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-    medium: "us.anthropic.claude-sonnet-4-6",
-    large: "us.anthropic.claude-opus-4-7",
+    medium: "us.anthropic.claude-sonnet-5",
+    large: "us.anthropic.claude-opus-5",
   },
   openai: {
     small: "gpt-5.6-luna",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only default model string updates with no logic changes; deployments that set `LLM_MODEL_*` are unaffected.
> 
> **Overview**
> Updates **`DEFAULT_MODELS`** in `frontend/lib/ai/model.ts` so tier fallbacks match the app-server when `LLM_MODEL_*` env vars are unset.
> 
> **Gemini** small default moves from `gemini-3.1-flash-lite` to **`gemini-3.5-flash-lite`**. **Bedrock** medium/large defaults move from Claude 4.x IDs to **`us.anthropic.claude-sonnet-5`** and **`us.anthropic.claude-opus-5`**. OpenAI and Azure entries are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48919a4d35f7ee5f82025f76f15cd923e833da27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

