### PR TITLE
fix(api): scope playground update to project to prevent cross-tenant writes

### DIFF
--- a/frontend/app/api/projects/[projectId]/playgrounds/[playgroundId]/route.ts
+++ b/frontend/app/api/projects/[projectId]/playgrounds/[playgroundId]/route.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod/v4";
 
 import { db } from "@/lib/db/drizzle";
@@ -42,7 +42,7 @@ export async function POST(req: Request, props: { params: Promise<{ projectId: s
       maxTokens: parsed.data.maxTokens,
       providerOptions: parsed.data.providerOptions,
     })
-    .where(eq(playgrounds.id, params.playgroundId))
+    .where(and(eq(playgrounds.id, params.playgroundId), eq(playgrounds.projectId, params.projectId)))
     .returning();
 
   return new Response(JSON.stringify(res));


### PR DESCRIPTION
## Summary

The `POST /api/projects/[projectId]/playgrounds/[playgroundId]` route destructures `projectId` from URL params but never uses it in the Drizzle `WHERE` clause. The update is scoped only by `playgrounds.id`:

```ts
// before — any authenticated user who knows a playgroundId can mutate it
.where(eq(playgrounds.id, params.playgroundId))
```

Any authenticated user who is a member of **any** project can update a playground belonging to a **different** project/tenant — a cross-tenant authorization bypass (CWE-862). This is inconsistent with every other mutation route in the codebase (tag-classes, signals, datasets, evaluations), which all include an `eq(<table>.projectId, projectId)` guard.

## Fix

Add `eq(playgrounds.projectId, params.projectId)` to the `WHERE` condition:

```ts
// after — update only when both id and projectId match
.where(and(eq(playgrounds.id, params.playgroundId), eq(playgrounds.projectId, params.projectId)))
```

This matches the established pattern elsewhere, e.g.:

```ts
// datasets/[datasetId]/route.ts
where: and(eq(datasets.id, datasetId), eq(datasets.projectId, projectId)),
```

Closes #2249

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Closes an authorization bypass (CWE-862) on a write path; the change is a targeted guard with low regression risk but high security impact if left unfixed.
> 
> **Overview**
> **Fixes a cross-tenant authorization gap** on playground updates: the `POST` handler for `/api/projects/[projectId]/playgrounds/[playgroundId]` now requires both `playgroundId` and URL `projectId` to match before applying changes.
> 
> Previously the Drizzle `UPDATE` only filtered on `playgrounds.id`, so a user in one project could mutate another tenant’s playground if they knew its ID. The `WHERE` clause now uses `and(eq(playgrounds.id, …), eq(playgrounds.projectId, …))`, consistent with other project-scoped mutation routes (datasets, agents, evaluations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f867e657a479cb58dfed9202ec69f040071797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->