### PR TITLE
bump ort crate features API; audit only

### DIFF
--- a/app-server/Cargo.toml
+++ b/app-server/Cargo.toml
@@ -47,7 +47,7 @@ ndarray = {version = "0.17", optional = true}
 num_cpus = "1.17.0"
 opentelemetry = {version = "0.32.0", features = ["trace"]}
 opentelemetry_sdk = {version = "0.32", features = ["trace"]}
-ort = {version = "=2.0.0-rc.13", default-features = false, features = ["std", "ndarray", "tracing", "load-dynamic", "api-24"], optional = true}
+ort = {version = "=2.0.0-rc.13", default-features = false, features = ["std", "ndarray", "tracing", "load-dynamic", "api-28"], optional = true}
 prost = "0.14"
 # `serde` unlocks `Environment::from_client_option`, the only public way to
 # reach `max_frame_size` (the EnvironmentBuilder doesn't expose it). We pass 0 =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the ONNX Runtime API generation for optional inference (`signals`); a mismatch between the new bindings and the shipped native ORT library would break model loading at runtime.
> 
> **Overview**
> Updates the optional **`ort`** dependency in **`app-server`** so its feature flag targets **ONNX Runtime API 1.28** (`api-28`) instead of **1.24** (`api-24`). The crate version stays pinned at **`=2.0.0-rc.13`**; only the API surface / linked runtime generation changes.
> 
> This affects builds that enable the **`signals`** feature (the only path that pulls in **`ort`**). Deployments for those builds need a matching **1.28.x** ONNX Runtime when using **`load-dynamic`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c1f15639530c65973966a0654c4fdabb7d9b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

