### PR TITLE
fix: move back to webpack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Some features (Signals evaluation, Laminar Agent, clustering) are enterprise-onl
 ```bash
 cd frontend
 pnpm install        # Install dependencies
-pnpm run dev        # Start dev server with Turbopack
+pnpm run dev        # Start dev server (Turbopack)
 pnpm lint           # oxlint (lint:fix to auto-fix)
 pnpm format:write   # oxfmt
 pnpm type-check     # TypeScript type checking
@@ -33,7 +33,7 @@ pnpm build          # Production build
 
 - In a fresh checkout, `pnpm type-check` (and the husky pre-commit hook) fails with `TS2307: Cannot find module '@/assets/...svg'` errors — `next-env.d.ts` is gitignored. Fix: `npx next typegen` (or any `next dev`/`next build` run).
 - `tsconfig.json` sets `"incremental": true`, so a bare `npx tsc --noEmit` can report **zero errors on files it skipped** and give a false green. When verifying a type fix, run `npx tsc --noEmit --incremental false` (the pre-commit hook does a full check and will catch what you missed otherwise).
-- **Both `next dev` and `next build` run Turbopack with no CLI flag** — it is the default for both in Next 16.3. `--webpack` is the only opt-out. `next dev` generates `frontend/AGENTS.md` on every run; it is gitignored (do not commit it).
+- **Turbopack is the Next 16.3 default for both commands; `build` opts out with `--webpack`, `dev` does not.** Turbopack's production output miscompiled chunks (`module factory is not available` on client navigation). So both bundler blocks in `next.config.ts` are live, and a production repro needs `pnpm build`, not a bare `next build`. `next dev` generates `frontend/AGENTS.md` on every run; it is gitignored (do not commit it).
 
 ### Backend (Rust)
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -95,6 +95,20 @@ const nextConfig: NextConfig = {
     ],
   },
 
+  // react-pdf's pdfjs reaches for the optional native `canvas` module: stub it out of the
+  // browser bundle, keep it external on the server.
+  webpack: (config, { isServer }) => {
+    config.resolve.alias["canvas"] = false;
+
+    if (isServer) {
+      config.externals.push({
+        canvas: "commonjs canvas",
+      });
+    }
+    return config;
+  },
+
+  // Only `dev` runs Turbopack; `build` passes --webpack, so both bundler blocks are live.
   turbopack: {
     resolveExtensions: [".ts", ".tsx", ".js", ".jsx", ".json", ".css", ".scss"],
   },
@@ -124,8 +138,12 @@ if (process.env.ENVIRONMENT === "PRODUCTION" && process.env.FRONTEND_SENTRY_DSN)
     // side errors will fail.
     tunnelRoute: "/monitoring",
 
-    // Tree-shake Sentry logger statements to reduce bundle size. NOT the `webpack.treeshake`
-    // option — that one is a no-op now the build runs on Turbopack.
+    // Tree-shake Sentry logger statements to reduce bundle size.
+    webpack: {
+      treeshake: {
+        removeDebugLogging: true,
+      },
+    },
     bundleSizeOptimizations: {
       excludeDebugStatements: true,
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
-    "preview": "next build && next start",
+    "preview": "next build --webpack && next start",
     "type-check": "tsc --noEmit",
     "check:circular": "madge --circular --extensions ts,tsx --ts-config tsconfig.json components lib app",
     "format:write": "oxfmt --write .",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the production bundler and build scripts, which affects all shipped frontend artifacts; scope is limited to build tooling and known workarounds (canvas, Sentry).
> 
> **Overview**
> Production frontend builds **opt out of Turbopack** (`next build --webpack` in `build` and `preview`) because Turbopack’s production output was breaking client navigation (`module factory is not available`). **Local dev still uses Turbopack** via `next dev`.
> 
> `next.config.ts` adds a **Webpack-only** block to stub the optional native `canvas` module for **react-pdf** (alias `false` client-side, external on the server), and restores **Sentry’s `webpack.treeshake.removeDebugLogging`** now that production builds run through Webpack again. **CLAUDE.md** documents the split bundler setup and that production repros should use `pnpm build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5336851293553f43d497fcc6d2c2414f5bccb17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

