### PR TITLE
Restyle the signal events card on the trace view

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -111,13 +111,6 @@
 
   --color-subagent: hsl(var(--subagent));
 
-  /* The signal panel's one hue: everything in it that is not a cluster or severity
-     colour is a wash of this. Was three hardcoded `blue-400` opacities. */
-  --color-signal: #75acff;
-  /* The panel's muted text — payload keys, inactive tab labels — mixed 10% toward
-     the hue, so it reads as the card's chrome rather than the page's. */
-  --color-signal-key: color-mix(in oklab, var(--color-signal) 10%, var(--color-muted-foreground));
-
   /* Surface ramp: a 50-step scale from surface-00 (base plane / darkest) to surface-800
      (lightest). OKLCH lightness in ~0.022 steps; surface-50 splits the old base→card jump so the
      ramp is even. surface-450..800 extend past the old top to give room for the dynamic border. */

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -111,14 +111,11 @@
 
   --color-subagent: hsl(var(--subagent));
 
-  /* The signal panel's one hue. Everything in the panel that is not a cluster
-     colour or a severity colour is a wash of this, so the card can be re-keyed
-     from here. Was three separate hardcoded `blue-400` opacities. */
+  /* The signal panel's one hue: everything in it that is not a cluster or severity
+     colour is a wash of this. Was three hardcoded `blue-400` opacities. */
   --color-signal: #75acff;
-  /* The panel's muted text — payload field names, inactive tab labels — pulled
-     10% toward the hue. A neutral grey there reads as the page's chrome rather
-     than the card's. Mixed into each token rather than replacing it, so the
-     existing lightness gap between the two survives. */
+  /* The panel's muted text — payload keys, inactive tab labels — mixed 10% toward
+     the hue, so it reads as the card's chrome rather than the page's. */
   --color-signal-key: color-mix(in oklab, var(--color-signal) 10%, var(--color-muted-foreground));
   --color-signal-tab: color-mix(in oklab, var(--color-signal) 10%, var(--color-secondary-foreground));
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -117,10 +117,6 @@
   /* The panel's muted text — payload keys, inactive tab labels — mixed 10% toward
      the hue, so it reads as the card's chrome rather than the page's. */
   --color-signal-key: color-mix(in oklab, var(--color-signal) 10%, var(--color-muted-foreground));
-  --color-signal-tab: color-mix(in oklab, var(--color-signal) 10%, var(--color-secondary-foreground));
-  /* The active tab: the hue over a surface step, as ONE colour. Not baked to a hex
-     so `--color-surface-up-2` still re-scopes with whatever surface the panel sits on. */
-  --color-signal-tab-active: color-mix(in oklab, var(--color-signal) 8%, var(--color-surface-up-2));
 
   /* Surface ramp: a 50-step scale from surface-00 (base plane / darkest) to surface-800
      (lightest). OKLCH lightness in ~0.022 steps; surface-50 splits the old base→card jump so the

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -118,6 +118,9 @@
      the hue, so it reads as the card's chrome rather than the page's. */
   --color-signal-key: color-mix(in oklab, var(--color-signal) 10%, var(--color-muted-foreground));
   --color-signal-tab: color-mix(in oklab, var(--color-signal) 10%, var(--color-secondary-foreground));
+  /* The active tab: the hue over a surface step, as ONE colour. Not baked to a hex
+     so `--color-surface-up-2` still re-scopes with whatever surface the panel sits on. */
+  --color-signal-tab-active: color-mix(in oklab, var(--color-signal) 8%, var(--color-surface-up-2));
 
   /* Surface ramp: a 50-step scale from surface-00 (base plane / darkest) to surface-800
      (lightest). OKLCH lightness in ~0.022 steps; surface-50 splits the old base→card jump so the

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -111,6 +111,17 @@
 
   --color-subagent: hsl(var(--subagent));
 
+  /* The signal panel's one hue. Everything in the panel that is not a cluster
+     colour or a severity colour is a wash of this, so the card can be re-keyed
+     from here. Was three separate hardcoded `blue-400` opacities. */
+  --color-signal: #75acff;
+  /* The panel's muted text — payload field names, inactive tab labels — pulled
+     10% toward the hue. A neutral grey there reads as the page's chrome rather
+     than the card's. Mixed into each token rather than replacing it, so the
+     existing lightness gap between the two survives. */
+  --color-signal-key: color-mix(in oklab, var(--color-signal) 10%, var(--color-muted-foreground));
+  --color-signal-tab: color-mix(in oklab, var(--color-signal) 10%, var(--color-secondary-foreground));
+
   /* Surface ramp: a 50-step scale from surface-00 (base plane / darkest) to surface-800
      (lightest). OKLCH lightness in ~0.022 steps; surface-50 splits the old base→card jump so the
      ramp is even. surface-450..800 extend past the old top to give room for the dynamic border. */

--- a/frontend/components/traces/trace-view/signal-events-panel/cluster-button.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/cluster-button.tsx
@@ -10,59 +10,37 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { getClusterColorById } from "@/lib/clusters/colors";
 import { cn } from "@/lib/utils";
 
-/** Long enough that crossing a button on the way somewhere else does not summon
- *  anything. The app-wide provider is 0ms, which is right for an icon button and
- *  wrong for a row of them. */
-export const TOOLTIP_DELAY_MS = 300;
+import { CHIP, CHIP_ARROW, TOOLTIP_DELAY_MS } from "./constants";
 
-/** Height, radius, inset, gap and label size, shared by the three chips in the
- *  panel so they read as one object doing three jobs rather than three chip
- *  designs in one card. */
-const CHIP = "flex h-5.5 items-center gap-1.25 rounded-2xl text-[11px] font-medium";
-
-const ARROW = "size-[13px] shrink-0 opacity-60";
-
-/**
- * The link from an event to a cluster it landed in — and, when an event has been
- * clustered, its only way out of the trace: this is strictly more than "Open in
- * Signals" gives you, being scoped to the cluster and the event as well as the
- * signal.
- *
- * `shrinkable` gives up width and truncates when the row runs out, instead of
- * overflowing it. Grow stays at 0 — a lone cluster sizes to its label rather
- * than stretching across the panel.
- */
-export default function ClusterButton({
-  cluster,
-  href,
-  shrinkable,
-}: {
+interface Props {
   cluster: TraceSignalClusterNode;
   href: string;
+  /** Truncate when the row runs out instead of overflowing it. Grow stays 0, so a
+   *  lone cluster sizes to its label rather than stretching across the panel. */
   shrinkable?: boolean;
-}) {
+}
+
+/** Links an event into the signal page, scoped to the cluster and the event — so
+ *  it replaces "Open in Signals" rather than sitting beside it. */
+export default function ClusterButton({ cluster, href, shrinkable }: Props) {
   const button = (
     <Link
       href={href}
       target="_blank"
       className={cn(
         CHIP,
-        "min-w-0 overflow-hidden px-1.5 text-left transition-colors",
-        "bg-signal/14 hover:bg-signal/24",
+        "min-w-0 overflow-hidden px-1.5 text-left transition-colors bg-signal/14 hover:bg-signal/24",
         shrinkable ? "shrink" : "shrink-0"
       )}
     >
-      {/* The mark never shrinks, so a squeezed button loses the label rather than
-          its identity. */}
+      {/* Never shrinks, so a squeezed button loses the label rather than its identity. */}
       <ClusterIcon iconVariant="box" color={getClusterColorById(cluster.id)} />
       <span className="min-w-0 truncate">{cluster.name}</span>
-      <ArrowUpRight className={ARROW} />
+      <ArrowUpRight className={CHIP_ARROW} />
     </Link>
   );
 
-  // The label truncates, and a cluster name is a phrase — three or four on one
-  // row and each is down to a few words. Portalled because the panel root is
-  // `overflow-hidden` and would otherwise clip it.
+  // Portalled because the panel root is `overflow-hidden` and would clip it.
   return (
     <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
       <TooltipTrigger asChild>{button}</TooltipTrigger>
@@ -71,42 +49,4 @@ export default function ClusterButton({
       </TooltipPortal>
     </Tooltip>
   );
-}
-
-/**
- * "Open in Signals" — the way out of the trace when the event has no cluster to
- * carry one. It sits where a cluster button would sit, so it is the same size as
- * one; what it does not take is a cluster colour, because it stands for no
- * cluster.
- *
- * A cluster button opens with an icon, which stands its label off the left edge.
- * This one opens with the text, so the same inset reads tighter — 2px back on
- * the left only.
- */
-export function OpenInSignalsButton({ href }: { href: string }) {
-  return (
-    <Link
-      href={href}
-      target="_blank"
-      className={cn(
-        CHIP,
-        "min-w-0 shrink-0 overflow-hidden pr-1.5 pl-2 transition-colors bg-signal/14 hover:bg-signal/24"
-      )}
-    >
-      <span className="min-w-0 truncate">Open in Signals</span>
-      <ArrowUpRight className={ARROW} />
-    </Link>
-  );
-}
-
-/**
- * An enum value from the payload — `category: "logic_error"`, and the like.
- *
- * No icon and no arrow: it is a value, not a link, and the arrow is what marks
- * the other two as a way out of the trace. Its inset is wider than a button's
- * because an enum is bare text against a rounded edge, where a button's glyphs
- * already stand its label off the ends — same optical space, two numbers.
- */
-export function EnumPill({ value }: { value: string }) {
-  return <span className={cn(CHIP, "inline-flex px-2.5 text-secondary-foreground bg-signal/14")}>{value}</span>;
 }

--- a/frontend/components/traces/trace-view/signal-events-panel/cluster-button.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/cluster-button.tsx
@@ -10,7 +10,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { getClusterColorById } from "@/lib/clusters/colors";
 import { cn } from "@/lib/utils";
 
-import { CHIP, CHIP_ARROW, TOOLTIP_DELAY_MS } from "./constants";
+import { CHIP, CHIP_ARROW, CHIP_SURFACE, TOOLTIP_DELAY_MS } from "./constants";
 
 interface Props {
   cluster: TraceSignalClusterNode;
@@ -27,11 +27,7 @@ export default function ClusterButton({ cluster, href, shrinkable }: Props) {
     <Link
       href={href}
       target="_blank"
-      className={cn(
-        CHIP,
-        "min-w-0 overflow-hidden px-1.5 text-left transition-colors bg-signal/14 hover:bg-signal/24",
-        shrinkable ? "shrink" : "shrink-0"
-      )}
+      className={cn(CHIP, CHIP_SURFACE, "min-w-0 overflow-hidden px-1.5 text-left", shrinkable ? "shrink" : "shrink-0")}
     >
       {/* Never shrinks, so a squeezed button loses the label rather than its identity. */}
       <ClusterIcon iconVariant="box" color={getClusterColorById(cluster.id)} />

--- a/frontend/components/traces/trace-view/signal-events-panel/cluster-button.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/cluster-button.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { TooltipPortal } from "@radix-ui/react-tooltip";
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+
+import ClusterIcon from "@/components/signal/clusters-section/cluster-list/cluster-icon";
+import { type TraceSignalClusterNode } from "@/components/traces/trace-view/store/base";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { getClusterColorById } from "@/lib/clusters/colors";
+import { cn } from "@/lib/utils";
+
+/** Long enough that crossing a button on the way somewhere else does not summon
+ *  anything. The app-wide provider is 0ms, which is right for an icon button and
+ *  wrong for a row of them. */
+export const TOOLTIP_DELAY_MS = 300;
+
+/** Height, radius, inset, gap and label size, shared by the three chips in the
+ *  panel so they read as one object doing three jobs rather than three chip
+ *  designs in one card. */
+const CHIP = "flex h-5.5 items-center gap-1.25 rounded-2xl text-[11px] font-medium";
+
+const ARROW = "size-[13px] shrink-0 opacity-60";
+
+/**
+ * The link from an event to a cluster it landed in — and, when an event has been
+ * clustered, its only way out of the trace: this is strictly more than "Open in
+ * Signals" gives you, being scoped to the cluster and the event as well as the
+ * signal.
+ *
+ * `shrinkable` gives up width and truncates when the row runs out, instead of
+ * overflowing it. Grow stays at 0 — a lone cluster sizes to its label rather
+ * than stretching across the panel.
+ */
+export default function ClusterButton({
+  cluster,
+  href,
+  shrinkable,
+}: {
+  cluster: TraceSignalClusterNode;
+  href: string;
+  shrinkable?: boolean;
+}) {
+  const button = (
+    <Link
+      href={href}
+      target="_blank"
+      className={cn(
+        CHIP,
+        "min-w-0 overflow-hidden px-1.5 text-left transition-colors",
+        "bg-signal/14 hover:bg-signal/24",
+        shrinkable ? "shrink" : "shrink-0"
+      )}
+    >
+      {/* The mark never shrinks, so a squeezed button loses the label rather than
+          its identity. */}
+      <ClusterIcon iconVariant="box" color={getClusterColorById(cluster.id)} />
+      <span className="min-w-0 truncate">{cluster.name}</span>
+      <ArrowUpRight className={ARROW} />
+    </Link>
+  );
+
+  // The label truncates, and a cluster name is a phrase — three or four on one
+  // row and each is down to a few words. Portalled because the panel root is
+  // `overflow-hidden` and would otherwise clip it.
+  return (
+    <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side="bottom">{cluster.name}</TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+}
+
+/**
+ * "Open in Signals" — the way out of the trace when the event has no cluster to
+ * carry one. It sits where a cluster button would sit, so it is the same size as
+ * one; what it does not take is a cluster colour, because it stands for no
+ * cluster.
+ *
+ * A cluster button opens with an icon, which stands its label off the left edge.
+ * This one opens with the text, so the same inset reads tighter — 2px back on
+ * the left only.
+ */
+export function OpenInSignalsButton({ href }: { href: string }) {
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      className={cn(
+        CHIP,
+        "min-w-0 shrink-0 overflow-hidden pr-1.5 pl-2 transition-colors bg-signal/14 hover:bg-signal/24"
+      )}
+    >
+      <span className="min-w-0 truncate">Open in Signals</span>
+      <ArrowUpRight className={ARROW} />
+    </Link>
+  );
+}
+
+/**
+ * An enum value from the payload — `category: "logic_error"`, and the like.
+ *
+ * No icon and no arrow: it is a value, not a link, and the arrow is what marks
+ * the other two as a way out of the trace. Its inset is wider than a button's
+ * because an enum is bare text against a rounded edge, where a button's glyphs
+ * already stand its label off the ends — same optical space, two numbers.
+ */
+export function EnumPill({ value }: { value: string }) {
+  return <span className={cn(CHIP, "inline-flex px-2.5 text-secondary-foreground bg-signal/14")}>{value}</span>;
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/constants.ts
+++ b/frontend/components/traces/trace-view/signal-events-panel/constants.ts
@@ -1,0 +1,10 @@
+/** The app-wide provider is 0ms, which is right for an icon button and wrong for
+ *  a row of them. */
+export const TOOLTIP_DELAY_MS = 300;
+
+/** Shared by the panel's three chips — cluster button, "Open in Signals", enum
+ *  pill — so they read as one object doing three jobs. Each adds its own inset. */
+export const CHIP = "flex h-5.5 items-center gap-1.25 rounded-2xl text-[11px] font-medium";
+
+/** Marks a chip as a way out of the trace. */
+export const CHIP_ARROW = "size-[13px] shrink-0 opacity-60";

--- a/frontend/components/traces/trace-view/signal-events-panel/constants.ts
+++ b/frontend/components/traces/trace-view/signal-events-panel/constants.ts
@@ -4,7 +4,24 @@ export const TOOLTIP_DELAY_MS = 300;
 
 /** Shared by the panel's three chips — cluster button, "Open in Signals", enum
  *  pill — so they read as one object doing three jobs. Each adds its own inset. */
-export const CHIP = "flex h-5.5 items-center gap-1.25 rounded-2xl text-[11px] font-medium";
+export const CHIP = "flex h-5.5 items-center gap-1.25 rounded-2xl text-[11px] font-medium transition-colors";
 
 /** Marks a chip as a way out of the trace. */
 export const CHIP_ARROW = "size-[13px] shrink-0 opacity-60";
+
+/** The two link chips. A step off the card, not a wash of a hue: the panel is an
+ *  `ElevatedSurface`, so this means "three above THE CARD" wherever the card
+ *  itself ends up on the ramp. */
+export const CHIP_SURFACE = "bg-surface-up-3 hover:bg-surface-up-4";
+
+/**
+ * The span-reference badges inside a payload (`Bash ↗`), which ship as
+ * `bg-foreground-300/20` — a fixed wash of the TEXT colour that ignores the ramp.
+ *
+ * They are rendered by markdown straight from a payload string and take no props,
+ * so the only handle is the `data-slot` on the chip plus a descendant rule from
+ * the payload container. That two-element selector also outranks the chip's own
+ * class, which is what lets the override land without `!important`.
+ */
+export const SPAN_CHIP_SURFACE =
+  "[&_[data-slot=span-chip]]:bg-surface-up-4 [&_[data-slot=span-chip]:hover]:bg-surface-up-5";

--- a/frontend/components/traces/trace-view/signal-events-panel/enum-pill.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/enum-pill.tsx
@@ -2,8 +2,9 @@ import { cn } from "@/lib/utils";
 
 import { CHIP } from "./constants";
 
-/** An enum payload value. No arrow — that marks the other chips as links out, and
- *  this navigates nowhere. Wider inset: bare text has no glyphs to stand it off. */
+/** An enum payload value. A step below the link chips — it is a value, not a way
+ *  out, and no arrow says so. Wider inset: bare text has no glyphs to stand it
+ *  off the rounded ends. */
 export default function EnumPill({ value }: { value: string }) {
-  return <span className={cn(CHIP, "inline-flex px-2.5 text-secondary-foreground bg-signal/14")}>{value}</span>;
+  return <span className={cn(CHIP, "inline-flex bg-surface-up-2 px-2.5 text-secondary-foreground")}>{value}</span>;
 }

--- a/frontend/components/traces/trace-view/signal-events-panel/enum-pill.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/enum-pill.tsx
@@ -1,0 +1,9 @@
+import { cn } from "@/lib/utils";
+
+import { CHIP } from "./constants";
+
+/** An enum payload value. No arrow — that marks the other chips as links out, and
+ *  this navigates nowhere. Wider inset: bare text has no glyphs to stand it off. */
+export default function EnumPill({ value }: { value: string }) {
+  return <span className={cn(CHIP, "inline-flex px-2.5 text-secondary-foreground bg-signal/14")}>{value}</span>;
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/open-in-signals-button.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/open-in-signals-button.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 import { cn } from "@/lib/utils";
 
-import { CHIP, CHIP_ARROW } from "./constants";
+import { CHIP, CHIP_ARROW, CHIP_SURFACE } from "./constants";
 
 /** The way out of the trace when the event has no cluster to carry one. Opens
  *  with text rather than an icon, so it takes 2px more inset on the left. */
@@ -14,10 +14,7 @@ export default function OpenInSignalsButton({ href }: { href: string }) {
     <Link
       href={href}
       target="_blank"
-      className={cn(
-        CHIP,
-        "min-w-0 shrink-0 overflow-hidden pr-1.5 pl-2 transition-colors bg-signal/14 hover:bg-signal/24"
-      )}
+      className={cn(CHIP, CHIP_SURFACE, "min-w-0 shrink-0 overflow-hidden pr-1.5 pl-2")}
     >
       <span className="min-w-0 truncate">Open in Signals</span>
       <ArrowUpRight className={CHIP_ARROW} />

--- a/frontend/components/traces/trace-view/signal-events-panel/open-in-signals-button.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/open-in-signals-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+import { CHIP, CHIP_ARROW } from "./constants";
+
+/** The way out of the trace when the event has no cluster to carry one. Opens
+ *  with text rather than an icon, so it takes 2px more inset on the left. */
+export default function OpenInSignalsButton({ href }: { href: string }) {
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      className={cn(
+        CHIP,
+        "min-w-0 shrink-0 overflow-hidden pr-1.5 pl-2 transition-colors bg-signal/14 hover:bg-signal/24"
+      )}
+    >
+      <span className="min-w-0 truncate">Open in Signals</span>
+      <ArrowUpRight className={CHIP_ARROW} />
+    </Link>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
@@ -141,7 +141,7 @@ export default function PanelBody({ traceId, onClose }: Props) {
               ) : (
                 <TabsList size="sm" className="min-w-0 flex-1 justify-start">
                   {traceSignals.map((signal) => (
-                    <SignalTab key={signal.signalId} signal={signal} active={signal.signalId === effectiveTabId} />
+                    <SignalTab key={signal.signalId} signal={signal} />
                   ))}
                 </TabsList>
               )}

--- a/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
@@ -124,7 +124,11 @@ export default function PanelBody({ traceId, onClose }: Props) {
   );
 
   return (
-    <ElevatedSurface offset={1} className="flex flex-col rounded-lg border overflow-hidden">
+    // Three rungs off the trace view, not one: the card carries a ladder of its
+    // own — header, chips, tabs, span chips — and one step leaves no room under
+    // the top of it. `ElevatedSurface` also publishes `--color-border` at +5, so
+    // the border and the deep-link rule track the card for free.
+    <ElevatedSurface offset={3} className="relative flex flex-col overflow-hidden rounded-md border">
       {isTraceSignalsLoading ? (
         <div className="flex items-center justify-center py-8 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
@@ -135,11 +139,16 @@ export default function PanelBody({ traceId, onClose }: Props) {
             {/* The tab list is a filled pill with its own inset, so under tabs the
                 leading inset matches the trailing one; bare header text keeps the
                 wider one. */}
-            <div className={cn("flex shrink-0 items-center justify-between gap-2 p-1.5", isSingleSignal && "pl-2")}>
+            <div
+              className={cn(
+                "flex shrink-0 items-center justify-between gap-2 bg-surface-up p-1",
+                isSingleSignal && "pl-2"
+              )}
+            >
               {isSingleSignal && activeSignal ? (
                 <SignalHeader signal={activeSignal} />
               ) : (
-                <TabsList size="sm" className="min-w-0 flex-1 justify-start">
+                <TabsList className="h-auto min-w-0 flex-1 justify-start gap-1 bg-transparent p-0">
                   {traceSignals.map((signal) => (
                     <SignalTab key={signal.signalId} signal={signal} />
                   ))}
@@ -168,8 +177,18 @@ export default function PanelBody({ traceId, onClose }: Props) {
               {closeButton}
             </div>
           </TooltipProvider>
+          {/* `scroll-fade-b` on the VIEWPORT, not a painted scrim over it. It is a
+              scroll-driven mask, so the fade only exists while there is more
+              payload below and is gone the moment you reach the bottom — and
+              being a mask it has no colour to keep in step with the ramp. It has
+              to sit on the element that actually scrolls, since the animation is
+              timed to `scroll(self y)`: the Radix viewport, not the root.
+
+              Both classes: `scroll-fade-b` is the mask, `scroll-fade-b-7` only
+              sets `--scroll-fade-b-size` (7 × 4px = 28px). The suffixed one alone
+              is a size for a mask that was never applied. */}
           <ScrollArea
-            className="[&>div>div]:!block [&>[data-radix-scroll-area-viewport]]:!h-full"
+            className="[&>div>div]:!block [&>[data-radix-scroll-area-viewport]]:!h-full [&>[data-radix-scroll-area-viewport]]:scroll-fade-b [&>[data-radix-scroll-area-viewport]]:scroll-fade-b-7"
             style={bodyHeight !== null ? { height: bodyHeight } : undefined}
           >
             <div ref={contentRef}>
@@ -184,13 +203,17 @@ export default function PanelBody({ traceId, onClose }: Props) {
               ))}
             </div>
           </ScrollArea>
+          {/* Absolute, and with no fill of its own: it costs the body no height,
+              and the only thing that reacts is the grip. `--color-border` is the
+              card's elevation +5, so +7 is what reads as a step up from where the
+              grip sits. */}
           <div
             role="separator"
             aria-orientation="horizontal"
             onPointerDown={handleResizePointerDown}
-            className="group flex h-1.5 shrink-0 cursor-row-resize items-center justify-center transition-colors hover:bg-surface-up"
+            className="group/resize absolute inset-x-0 bottom-0 flex h-1.5 cursor-row-resize items-center justify-center"
           >
-            <div className="h-0.5 w-8 rounded-full bg-border" />
+            <div className="h-0.5 w-8 rounded-full bg-border transition-colors group-hover/resize:bg-surface-up-7" />
           </div>
         </Tabs>
       )}

--- a/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
@@ -1,18 +1,25 @@
 "use client";
 
 import { TooltipPortal } from "@radix-ui/react-tooltip";
-import { Loader2, X } from "lucide-react";
+import { Loader2, Sparkles, X } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { shallow } from "zustand/shallow";
 
+import { laminarAgentStore } from "@/components/agent";
 import { useTraceViewStore } from "@/components/traces/trace-view/store";
+import { type TraceSignal } from "@/components/traces/trace-view/store/base";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ElevatedSurface } from "@/components/ui/surface";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useFeatureFlags } from "@/contexts/feature-flags-context.tsx";
+import { Feature } from "@/lib/features/features.ts";
+import { cn } from "@/lib/utils";
 
+import { TOOLTIP_DELAY_MS } from "./cluster-button";
+import SeverityIcon from "./severity-icon";
 import SignalDetails from "./signal-details";
 
 interface Props {
@@ -22,6 +29,57 @@ interface Props {
 
 const MIN_BODY_HEIGHT = 120;
 const MAX_BODY_HEIGHT = 320;
+
+/** The worst event's severity. With several events (a per-span signal) the header
+ *  speaks for the whole card, and the card is as bad as its worst event. */
+const worstSeverity = (signal: TraceSignal) => signal.events.reduce((worst, e) => Math.max(worst, e.severity), 0);
+
+/**
+ * The header when a trace has a single signal: severity, then the signal's name.
+ * Severity is a glyph here rather than a `Critical` pill on the event's row — a
+ * pill is the right shape for a list, and there is no list.
+ */
+function SignalHeader({ signal }: { signal: TraceSignal }) {
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1.5 pl-1">
+      {signal.events.length > 0 && <SeverityIcon severity={worstSeverity(signal)} />}
+      <span className="min-w-0 truncate text-xs font-medium">{signal.signalName}</span>
+    </div>
+  );
+}
+
+/**
+ * One signal tab.
+ *
+ * Its own component because of the tooltip: several tabs in a panel this wide
+ * truncate to a few characters, at which point the row stops naming anything.
+ * The tooltip trigger is a WRAPPER, not the tab itself — both primitives own a
+ * `data-state` (`active`/`inactive` vs `closed`/`delayed-open`) and
+ * `Tabs.Trigger` spreads incoming props after its own attributes, so `asChild`
+ * onto the tab overwrites `active` with `closed` and every `data-[state=active]:`
+ * rule in the trigger's base classes stops matching.
+ */
+function SignalTab({ signal }: { signal: TraceSignal }) {
+  const trigger = (
+    <TabsTrigger value={signal.signalId} className="w-full min-w-0">
+      {/* The tab row REPLACES the header, so without this the severity glyph
+          disappears exactly when there is more than one severity to tell apart. */}
+      {signal.events.length > 0 && <SeverityIcon bare severity={worstSeverity(signal)} />}
+      <span className="min-w-0 truncate">{signal.signalName}</span>
+    </TabsTrigger>
+  );
+
+  return (
+    <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
+      <TooltipTrigger asChild>
+        <span className="flex min-w-0 flex-1">{trigger}</span>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side="bottom">{signal.signalName}</TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+}
 
 export default function PanelBody({ traceId, onClose }: Props) {
   const contentRef = useRef<HTMLDivElement>(null);
@@ -74,6 +132,7 @@ export default function PanelBody({ traceId, onClose }: Props) {
       shallow
     );
 
+  const featureFlags = useFeatureFlags();
   const searchParams = useSearchParams();
   const highlightedEventId = searchParams.get("eventId");
 
@@ -81,8 +140,8 @@ export default function PanelBody({ traceId, onClose }: Props) {
     if (activeSignalTabId && traceSignals.some((s) => s.signalId === activeSignalTabId)) {
       return activeSignalTabId;
     }
-    // A deep link with eventId points at one specific finding — surface the
-    // signal tab that owns it so the highlighted card is visible on open.
+    // A deep link with eventId points at one specific event — surface the signal
+    // tab that owns it so the highlighted event is visible on open.
     if (highlightedEventId) {
       const owner = traceSignals.find((s) => s.events.some((e) => e.id === highlightedEventId));
       if (owner) return owner.signalId;
@@ -123,20 +182,46 @@ export default function PanelBody({ traceId, onClose }: Props) {
         </div>
       ) : (
         <Tabs value={effectiveTabId} onValueChange={setActiveSignalTabId} className="flex flex-col gap-0">
-          <div className="shrink-0 flex items-center gap-2 justify-between px-2 py-1.5">
-            {isSingleSignal && activeSignal ? (
-              <span className="min-w-0 truncate pl-1 text-xs font-medium">{activeSignal.signalName}</span>
-            ) : (
-              <TabsList size="sm" className="min-w-0 max-w-full justify-start overflow-x-auto">
-                {traceSignals.map((signal) => (
-                  <TabsTrigger key={signal.signalId} value={signal.signalId} className="shrink-0">
-                    <span className="max-w-40 truncate">{signal.signalName}</span>
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-            )}
-            {closeButton}
-          </div>
+          <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
+            {/* The leading inset matches the trailing one under tabs — the tab
+                list is a filled pill with its own inset, so it wants to start
+                where the close button ends. The single-signal header is bare
+                text and keeps the wider inset. */}
+            <div className={cn("flex shrink-0 items-center justify-between gap-2 p-1.5", isSingleSignal && "pl-2")}>
+              {isSingleSignal && activeSignal ? (
+                <SignalHeader signal={activeSignal} />
+              ) : (
+                <TabsList size="sm" className="min-w-0 flex-1 justify-start">
+                  {traceSignals.map((signal) => (
+                    <SignalTab key={signal.signalId} signal={signal} />
+                  ))}
+                </TabsList>
+              )}
+              {/* "Open in AI Chat" lost its actions row when that row collapsed
+                  into the header, so it becomes an icon beside the close button:
+                  it is feature-flagged and usually absent, and a second worded
+                  button would outweigh the signal's own name. */}
+              {featureFlags[Feature.AGENT] && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      aria-label="Open in AI Chat"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="shrink-0 hover:bg-surface-up"
+                      onClick={() => laminarAgentStore.getState().open()}
+                    >
+                      <Sparkles className="size-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipPortal>
+                    <TooltipContent side="top">Open in AI Chat</TooltipContent>
+                  </TooltipPortal>
+                </Tooltip>
+              )}
+              {closeButton}
+            </div>
+          </TooltipProvider>
           <ScrollArea
             className="[&>div>div]:!block [&>[data-radix-scroll-area-viewport]]:!h-full"
             style={bodyHeight !== null ? { height: bodyHeight } : undefined}
@@ -157,7 +242,7 @@ export default function PanelBody({ traceId, onClose }: Props) {
             role="separator"
             aria-orientation="horizontal"
             onPointerDown={handleResizePointerDown}
-            className="group h-1.5 shrink-0 cursor-row-resize flex items-center justify-center hover:bg-surface-up transition-colors"
+            className="group flex h-1.5 shrink-0 cursor-row-resize items-center justify-center transition-colors hover:bg-surface-up"
           >
             <div className="h-0.5 w-8 rounded-full bg-border" />
           </div>

--- a/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
@@ -8,19 +8,19 @@ import { shallow } from "zustand/shallow";
 
 import { laminarAgentStore } from "@/components/agent";
 import { useTraceViewStore } from "@/components/traces/trace-view/store";
-import { type TraceSignal } from "@/components/traces/trace-view/store/base";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ElevatedSurface } from "@/components/ui/surface";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useFeatureFlags } from "@/contexts/feature-flags-context.tsx";
 import { Feature } from "@/lib/features/features.ts";
 import { cn } from "@/lib/utils";
 
-import { TOOLTIP_DELAY_MS } from "./cluster-button";
-import SeverityIcon from "./severity-icon";
+import { TOOLTIP_DELAY_MS } from "./constants";
 import SignalDetails from "./signal-details";
+import SignalHeader from "./signal-header";
+import SignalTab from "./signal-tab";
 
 interface Props {
   traceId: string;
@@ -29,57 +29,6 @@ interface Props {
 
 const MIN_BODY_HEIGHT = 120;
 const MAX_BODY_HEIGHT = 320;
-
-/** The worst event's severity. With several events (a per-span signal) the header
- *  speaks for the whole card, and the card is as bad as its worst event. */
-const worstSeverity = (signal: TraceSignal) => signal.events.reduce((worst, e) => Math.max(worst, e.severity), 0);
-
-/**
- * The header when a trace has a single signal: severity, then the signal's name.
- * Severity is a glyph here rather than a `Critical` pill on the event's row — a
- * pill is the right shape for a list, and there is no list.
- */
-function SignalHeader({ signal }: { signal: TraceSignal }) {
-  return (
-    <div className="flex min-w-0 flex-1 items-center gap-1.5 pl-1">
-      {signal.events.length > 0 && <SeverityIcon severity={worstSeverity(signal)} />}
-      <span className="min-w-0 truncate text-xs font-medium">{signal.signalName}</span>
-    </div>
-  );
-}
-
-/**
- * One signal tab.
- *
- * Its own component because of the tooltip: several tabs in a panel this wide
- * truncate to a few characters, at which point the row stops naming anything.
- * The tooltip trigger is a WRAPPER, not the tab itself — both primitives own a
- * `data-state` (`active`/`inactive` vs `closed`/`delayed-open`) and
- * `Tabs.Trigger` spreads incoming props after its own attributes, so `asChild`
- * onto the tab overwrites `active` with `closed` and every `data-[state=active]:`
- * rule in the trigger's base classes stops matching.
- */
-function SignalTab({ signal }: { signal: TraceSignal }) {
-  const trigger = (
-    <TabsTrigger value={signal.signalId} className="w-full min-w-0">
-      {/* The tab row REPLACES the header, so without this the severity glyph
-          disappears exactly when there is more than one severity to tell apart. */}
-      {signal.events.length > 0 && <SeverityIcon bare severity={worstSeverity(signal)} />}
-      <span className="min-w-0 truncate">{signal.signalName}</span>
-    </TabsTrigger>
-  );
-
-  return (
-    <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
-      <TooltipTrigger asChild>
-        <span className="flex min-w-0 flex-1">{trigger}</span>
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent side="bottom">{signal.signalName}</TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
-  );
-}
 
 export default function PanelBody({ traceId, onClose }: Props) {
   const contentRef = useRef<HTMLDivElement>(null);
@@ -183,24 +132,21 @@ export default function PanelBody({ traceId, onClose }: Props) {
       ) : (
         <Tabs value={effectiveTabId} onValueChange={setActiveSignalTabId} className="flex flex-col gap-0">
           <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
-            {/* The leading inset matches the trailing one under tabs — the tab
-                list is a filled pill with its own inset, so it wants to start
-                where the close button ends. The single-signal header is bare
-                text and keeps the wider inset. */}
+            {/* The tab list is a filled pill with its own inset, so under tabs the
+                leading inset matches the trailing one; bare header text keeps the
+                wider one. */}
             <div className={cn("flex shrink-0 items-center justify-between gap-2 p-1.5", isSingleSignal && "pl-2")}>
               {isSingleSignal && activeSignal ? (
                 <SignalHeader signal={activeSignal} />
               ) : (
                 <TabsList size="sm" className="min-w-0 flex-1 justify-start">
                   {traceSignals.map((signal) => (
-                    <SignalTab key={signal.signalId} signal={signal} />
+                    <SignalTab key={signal.signalId} signal={signal} active={signal.signalId === effectiveTabId} />
                   ))}
                 </TabsList>
               )}
-              {/* "Open in AI Chat" lost its actions row when that row collapsed
-                  into the header, so it becomes an icon beside the close button:
-                  it is feature-flagged and usually absent, and a second worded
-                  button would outweigh the signal's own name. */}
+              {/* An icon, not a worded button: it is feature-flagged and usually
+                  absent, and a second label would outweigh the signal's own name. */}
               {featureFlags[Feature.AGENT] && (
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/frontend/components/traces/trace-view/signal-events-panel/payload-value.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/payload-value.tsx
@@ -1,0 +1,32 @@
+import { type SchemaField } from "@/components/signals/utils";
+import { type SpanReferenceCallbacks } from "@/components/traces/trace-view/span-reference";
+import Markdown from "@/components/traces/trace-view/transcript/markdown.tsx";
+
+import EnumPill from "./enum-pill";
+
+interface Props {
+  value: unknown;
+  field: SchemaField;
+  spanRefCallbacks?: SpanReferenceCallbacks;
+}
+
+/** One payload value, rendered per its schema type. */
+export default function PayloadValue({ value, field, spanRefCallbacks }: Props) {
+  if (value === null || value === undefined) {
+    return <span className="text-muted-foreground">&mdash;</span>;
+  }
+  switch (field.type) {
+    case "boolean":
+      return <span>{value ? "true" : "false"}</span>;
+    case "enum":
+      return <EnumPill value={String(value)} />;
+    case "number":
+      return <span className="tabular-nums">{String(value)}</span>;
+    case "string":
+      return (
+        <span className="whitespace-pre-wrap break-words">
+          <Markdown contentClassName="pb-0" output={String(value)} spanRefCallbacks={spanRefCallbacks} />
+        </span>
+      );
+  }
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/severity-icon.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/severity-icon.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { CircleAlert, Info, TriangleAlert } from "lucide-react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { SEVERITY_LABELS } from "@/lib/actions/alerts/types";
+import { cn } from "@/lib/utils";
+
+const ICONS = { 0: Info, 1: TriangleAlert, 2: CircleAlert } as const;
+
+const COLORS: Record<number, string> = {
+  0: "text-muted-foreground/60",
+  1: "text-orange-400/80",
+  2: "text-red-400",
+};
+
+/**
+ * Severity as a glyph beside the signal name.
+ *
+ * A word up here would be a second title competing with the signal's own name,
+ * so the label lives in a tooltip — a colour and a shape are a convention, and
+ * conventions have to be learnable.
+ *
+ * The size is a CLASS, not lucide's `size` prop: `size` becomes a width/height
+ * attribute, which loses to `TabsTrigger`'s `[&_svg:not([class*='size-'])]:size-4`
+ * and pins every glyph inside a tab to 16px.
+ */
+export default function SeverityIcon({ severity, bare }: { severity: number; bare?: boolean }) {
+  const Icon = ICONS[severity as keyof typeof ICONS] ?? Info;
+  const label = SEVERITY_LABELS[severity as keyof typeof SEVERITY_LABELS] ?? "Info";
+  const color = COLORS[severity] ?? COLORS[0];
+
+  // Inside a signal TAB the glyph sits within a button, where a tooltip trigger
+  // would both nest interactive elements and compete with the tab for the click.
+  // The tab's label already names the signal, so the glyph keeps only its label.
+  if (bare) {
+    return (
+      <span className={cn("pointer-events-none shrink-0", color)} aria-label={label}>
+        <Icon className="size-3" />
+      </span>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={color} aria-label={label}>
+          <Icon className="size-3 shrink-0" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/severity-icon.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/severity-icon.tsx
@@ -14,25 +14,22 @@ const COLORS: Record<number, string> = {
   2: "text-red-400",
 };
 
-/**
- * Severity as a glyph beside the signal name.
- *
- * A word up here would be a second title competing with the signal's own name,
- * so the label lives in a tooltip — a colour and a shape are a convention, and
- * conventions have to be learnable.
- *
- * The size is a CLASS, not lucide's `size` prop: `size` becomes a width/height
- * attribute, which loses to `TabsTrigger`'s `[&_svg:not([class*='size-'])]:size-4`
- * and pins every glyph inside a tab to 16px.
- */
-export default function SeverityIcon({ severity, bare }: { severity: number; bare?: boolean }) {
+interface Props {
+  severity: number;
+  /** Skip the tooltip. Inside a tab it would nest interactive elements and
+   *  compete for the click, and the tab's own label already names the signal. */
+  bare?: boolean;
+}
+
+/** Severity beside the signal name. A word there would be a second title, so the
+ *  label lives in a tooltip — a colour and a shape have to be learnable. */
+export default function SeverityIcon({ severity, bare }: Props) {
   const Icon = ICONS[severity as keyof typeof ICONS] ?? Info;
   const label = SEVERITY_LABELS[severity as keyof typeof SEVERITY_LABELS] ?? "Info";
   const color = COLORS[severity] ?? COLORS[0];
 
-  // Inside a signal TAB the glyph sits within a button, where a tooltip trigger
-  // would both nest interactive elements and compete with the tab for the click.
-  // The tab's label already names the signal, so the glyph keeps only its label.
+  // Sized by CLASS: lucide's `size` prop becomes an attribute, which loses to
+  // `TabsTrigger`'s `[&_svg:not([class*='size-'])]:size-4`.
   if (bare) {
     return (
       <span className={cn("pointer-events-none shrink-0", color)} aria-label={label}>

--- a/frontend/components/traces/trace-view/signal-events-panel/severity-icon.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/severity-icon.tsx
@@ -26,25 +26,20 @@ interface Props {
 export default function SeverityIcon({ severity, bare }: Props) {
   const Icon = ICONS[severity as keyof typeof ICONS] ?? Info;
   const label = SEVERITY_LABELS[severity as keyof typeof SEVERITY_LABELS] ?? "Info";
-  const color = COLORS[severity] ?? COLORS[0];
 
   // Sized by CLASS: lucide's `size` prop becomes an attribute, which loses to
   // `TabsTrigger`'s `[&_svg:not([class*='size-'])]:size-4`.
-  if (bare) {
-    return (
-      <span className={cn("pointer-events-none shrink-0", color)} aria-label={label}>
-        <Icon className="size-3" />
-      </span>
-    );
-  }
+  const glyph = (
+    <span className={cn("shrink-0", COLORS[severity] ?? COLORS[0], bare && "pointer-events-none")} aria-label={label}>
+      <Icon className="size-3" />
+    </span>
+  );
+
+  if (bare) return glyph;
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <span className={color} aria-label={label}>
-          <Icon className="size-3 shrink-0" />
-        </span>
-      </TooltipTrigger>
+      <TooltipTrigger asChild>{glyph}</TooltipTrigger>
       <TooltipContent side="bottom">{label}</TooltipContent>
     </Tooltip>
   );

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-details.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-details.tsx
@@ -1,35 +1,19 @@
 "use client";
 
-import { ArrowUpRight, Sparkles } from "lucide-react";
-import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef } from "react";
 import { shallow } from "zustand/shallow";
 
-import { laminarAgentStore } from "@/components/agent";
-import ClusterIcon from "@/components/signal/clusters-section/cluster-list/cluster-icon";
 import { jsonSchemaToSchemaFields, type SchemaField } from "@/components/signals/utils";
 import { type SpanReferenceCallbacks } from "@/components/traces/trace-view/span-reference";
 import { useSpanRefCallbacks } from "@/components/traces/trace-view/span-reference/use-span-ref-callbacks";
 import { useTraceViewStore } from "@/components/traces/trace-view/store";
 import { type TraceSignal, type TraceSignalEvent } from "@/components/traces/trace-view/store/base";
 import Markdown from "@/components/traces/trace-view/transcript/markdown.tsx";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { ElevatedSurface } from "@/components/ui/surface";
-import { useFeatureFlags } from "@/contexts/feature-flags-context.tsx";
-import { SEVERITY_LABELS } from "@/lib/actions/alerts/types";
-import { getClusterColorById } from "@/lib/clusters/colors";
-import { Feature } from "@/lib/features/features.ts";
 import { cn } from "@/lib/utils";
 
+import ClusterButton, { EnumPill, OpenInSignalsButton } from "./cluster-button";
 import { schemaFieldsToStructuredOutput } from "./utils";
-
-const SEVERITY_STYLES: Record<number, string> = {
-  0: "text-muted-foreground/60",
-  1: "text-orange-400/80",
-  2: "text-red-400",
-};
 
 interface Props {
   traceId: string;
@@ -64,7 +48,7 @@ function PayloadValue({
     case "boolean":
       return <span>{value ? "true" : "false"}</span>;
     case "enum":
-      return <Badge variant="secondary">{String(value)}</Badge>;
+      return <EnumPill value={String(value)} />;
     case "number":
       return <span className="tabular-nums">{String(value)}</span>;
     case "string":
@@ -76,9 +60,17 @@ function PayloadValue({
   }
 }
 
-/** One finding card: the event's severity + a link per leaf cluster it belongs to,
- *  then the event payload rendered field-by-field from the signal's schema. */
-function FindingCard({
+/**
+ * One event: the clusters it landed in, then its payload rendered field-by-field
+ * from the signal's schema.
+ *
+ * No card around it. A card is a separator, and a separator needs something to
+ * separate from — but a signal produces one event per trace almost always, so
+ * the box drew a boundary around the only thing in the panel, inside a panel
+ * that already has a border. Severity left this row too: it is a property of the
+ * card, and the card already has a header.
+ */
+function Event({
   event,
   projectId,
   signalId,
@@ -96,8 +88,6 @@ function FindingCard({
   highlighted?: boolean;
 }) {
   const parsed = useMemo(() => parsePayload(event.payload), [event.payload]);
-  const severityLabel = SEVERITY_LABELS[event.severity as keyof typeof SEVERITY_LABELS] ?? "Info";
-  const severityClassName = SEVERITY_STYLES[event.severity] ?? SEVERITY_STYLES[0];
 
   const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -107,50 +97,53 @@ function FindingCard({
   }, [highlighted]);
 
   return (
-    <ElevatedSurface
+    <div
       ref={ref}
-      offset={1}
-      className={cn("flex flex-col gap-2.5 rounded-lg border p-3", highlighted && "border-primary/50 bg-surface-up")}
+      // A deep-linked event still has to be findable, so the highlight is a rule
+      // down the left edge rather than a ring around a box that is no longer drawn.
+      className={cn("flex min-w-0 flex-col", highlighted && "border-l-2 border-signal/60")}
     >
-      <div className="flex items-center gap-1.5 flex-wrap">
-        <Badge variant="outline" className={cn("rounded-full font-medium", severityClassName)}>
-          {severityLabel}
-        </Badge>
-        {event.leafClusters.map((cluster) => (
-          <Link
-            key={cluster.id}
-            href={`/project/${projectId}/signals/${signalId}?clusterId=${cluster.id}&traceId=${traceId}&eventId=${event.id}`}
-            target="_blank"
-            className="group flex items-center gap-1.5 min-w-0 rounded-full bg-blue-400/8 border-blue-400/30 border px-2 py-1 hover:bg-blue-400/12"
-          >
-            <ClusterIcon iconVariant="box" color={getClusterColorById(cluster.id)} />
-            <span className="truncate text-xs font-medium">{cluster.name}</span>
-            <ArrowUpRight className="size-3.5 shrink-0" />
-          </Link>
-        ))}
+      {/* The SIDE inset is the fields' one, not its own: the cluster row and the
+          payload below it are two blocks in one column, and a column has one left
+          edge. Only the vertical inset is the row's own, because that one is
+          genuinely about the buttons. */}
+      <div className="flex min-w-0 items-center gap-1.5 px-3 py-2">
+        {event.leafClusters.length > 0 ? (
+          event.leafClusters.map((cluster) => (
+            <ClusterButton
+              key={cluster.id}
+              shrinkable
+              cluster={cluster}
+              href={`/project/${projectId}/signals/${signalId}?clusterId=${cluster.id}&traceId=${traceId}&eventId=${event.id}`}
+            />
+          ))
+        ) : (
+          // A cluster button already links into the signal page, scoped to that
+          // cluster and that event. Alongside one, the bare link is a second and
+          // worse copy of it; with none, it is the only way out of the trace.
+          <OpenInSignalsButton href={`/project/${projectId}/signals/${signalId}?traceId=${traceId}`} />
+        )}
       </div>
-      <div className="flex flex-col gap-2.5">
+
+      <div className="flex min-w-0 flex-col gap-2.5 px-3 pb-0.5">
         {validFields.map((field) => (
           <div key={field.name} className="flex flex-col gap-0.5">
-            <div className="text-xs font-medium text-muted-foreground/80">{field.name}</div>
+            <div className="text-xs font-medium text-signal-key">{field.name}</div>
             <div className="text-sm leading-relaxed text-secondary-foreground">
               <PayloadValue value={parsed[field.name]} field={field} spanRefCallbacks={spanRefCallbacks} />
             </div>
           </div>
         ))}
       </div>
-    </ElevatedSurface>
+    </div>
   );
 }
 
-/** The per-signal body rendered inside a panel tab: the "Open in Signals" / "Open
- *  in AI Chat" actions plus one finding card per event, each rendered
- *  field-by-field from the schema. */
+/** The per-signal body rendered inside a panel tab. */
 export default function SignalDetails({ traceId, signal }: Props) {
   const { projectId } = useParams();
   const searchParams = useSearchParams();
   const highlightedEventId = searchParams.get("eventId");
-  const featureFlags = useFeatureFlags();
   const { selectSpanById, spans } = useTraceViewStore(
     (state) => ({
       selectSpanById: state.selectSpanById,
@@ -160,12 +153,6 @@ export default function SignalDetails({ traceId, signal }: Props) {
   );
 
   const events = signal.events ?? [];
-
-  // Chat is the global agent column now; open it (already scoped to this trace's context via the
-  // registered trace store). Signal-definition/payload injection was dropped with the old inline chat.
-  const handleOpenInChat = () => {
-    laminarAgentStore.getState().open();
-  };
 
   const schemaFields = useMemo(
     () => jsonSchemaToSchemaFields(schemaFieldsToStructuredOutput(signal.schemaFields)),
@@ -178,30 +165,18 @@ export default function SignalDetails({ traceId, signal }: Props) {
     onSelectSpan: selectSpanById,
   });
 
-  const signalHref = `/project/${projectId}/signals/${signal.signalId}?traceId=${traceId}`;
-
   return (
-    <div className="px-2 pt-2 pb-0.5 flex flex-col gap-3">
-      <div className="flex items-center gap-1.5 flex-wrap">
-        <Button className="gap-1" variant="outline" size="sm" asChild>
-          <Link href={signalHref} target="_blank">
-            Open in Signals
-            <ArrowUpRight className="size-3.5 shrink-0" data-icon="inline-end" />
-          </Link>
-        </Button>
-        {featureFlags[Feature.AGENT] && (
-          <Button className="gap-1" variant="outline" size="sm" onClick={handleOpenInChat}>
-            <Sparkles className="size-3.5 shrink-0" data-icon="inline-start" />
-            <span>Open in AI Chat</span>
-          </Button>
-        )}
-      </div>
+    // No padding here: the cluster row and the field block each carry their own,
+    // so neither is stuck with the other's inset.
+    <div className="flex min-w-0 flex-col">
       {events.length === 0 ? (
-        <div className="py-2 text-sm text-muted-foreground">No events found</div>
+        <div className="px-2 py-2 text-sm text-muted-foreground">No events found</div>
       ) : (
-        <div className="flex flex-col gap-2.5">
+        // Only a per-span signal ever has more than one event, and then they need
+        // telling apart; with one event this gap never renders.
+        <div className="flex min-w-0 flex-col gap-3">
           {events.map((event) => (
-            <FindingCard
+            <Event
               key={event.id}
               event={event}
               projectId={projectId as string}

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-details.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-details.tsx
@@ -1,146 +1,19 @@
 "use client";
 
 import { useParams, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { shallow } from "zustand/shallow";
 
-import { jsonSchemaToSchemaFields, type SchemaField } from "@/components/signals/utils";
-import { type SpanReferenceCallbacks } from "@/components/traces/trace-view/span-reference";
+import { jsonSchemaToSchemaFields } from "@/components/signals/utils";
 import { useSpanRefCallbacks } from "@/components/traces/trace-view/span-reference/use-span-ref-callbacks";
 import { useTraceViewStore } from "@/components/traces/trace-view/store";
-import { type TraceSignal, type TraceSignalEvent } from "@/components/traces/trace-view/store/base";
-import Markdown from "@/components/traces/trace-view/transcript/markdown.tsx";
-import { cn } from "@/lib/utils";
+import { type TraceSignal } from "@/components/traces/trace-view/store/base";
 
-import ClusterButton, { EnumPill, OpenInSignalsButton } from "./cluster-button";
+import SignalEvent from "./signal-event";
 import { schemaFieldsToStructuredOutput } from "./utils";
 
-interface Props {
-  traceId: string;
-  signal: TraceSignal;
-}
-
-function parsePayload(payload: string): Record<string, unknown> {
-  try {
-    const result = JSON.parse(payload);
-    if (result == null || typeof result !== "object" || Array.isArray(result)) {
-      return {};
-    }
-    return result;
-  } catch {
-    return {};
-  }
-}
-
-function PayloadValue({
-  value,
-  field,
-  spanRefCallbacks,
-}: {
-  value: unknown;
-  field: SchemaField;
-  spanRefCallbacks?: SpanReferenceCallbacks;
-}) {
-  if (value === null || value === undefined) {
-    return <span className="text-muted-foreground">&mdash;</span>;
-  }
-  switch (field.type) {
-    case "boolean":
-      return <span>{value ? "true" : "false"}</span>;
-    case "enum":
-      return <EnumPill value={String(value)} />;
-    case "number":
-      return <span className="tabular-nums">{String(value)}</span>;
-    case "string":
-      return (
-        <span className="whitespace-pre-wrap break-words">
-          <Markdown contentClassName="pb-0" output={String(value)} spanRefCallbacks={spanRefCallbacks} />
-        </span>
-      );
-  }
-}
-
-/**
- * One event: the clusters it landed in, then its payload rendered field-by-field
- * from the signal's schema.
- *
- * No card around it. A card is a separator, and a separator needs something to
- * separate from — but a signal produces one event per trace almost always, so
- * the box drew a boundary around the only thing in the panel, inside a panel
- * that already has a border. Severity left this row too: it is a property of the
- * card, and the card already has a header.
- */
-function Event({
-  event,
-  projectId,
-  signalId,
-  traceId,
-  validFields,
-  spanRefCallbacks,
-  highlighted,
-}: {
-  event: TraceSignalEvent;
-  projectId: string;
-  signalId: string;
-  traceId: string;
-  validFields: SchemaField[];
-  spanRefCallbacks?: SpanReferenceCallbacks;
-  highlighted?: boolean;
-}) {
-  const parsed = useMemo(() => parsePayload(event.payload), [event.payload]);
-
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (highlighted) {
-      ref.current?.scrollIntoView({ block: "nearest" });
-    }
-  }, [highlighted]);
-
-  return (
-    <div
-      ref={ref}
-      // A deep-linked event still has to be findable, so the highlight is a rule
-      // down the left edge rather than a ring around a box that is no longer drawn.
-      className={cn("flex min-w-0 flex-col", highlighted && "border-l-2 border-signal/60")}
-    >
-      {/* The SIDE inset is the fields' one, not its own: the cluster row and the
-          payload below it are two blocks in one column, and a column has one left
-          edge. Only the vertical inset is the row's own, because that one is
-          genuinely about the buttons. */}
-      <div className="flex min-w-0 items-center gap-1.5 px-3 py-2">
-        {event.leafClusters.length > 0 ? (
-          event.leafClusters.map((cluster) => (
-            <ClusterButton
-              key={cluster.id}
-              shrinkable
-              cluster={cluster}
-              href={`/project/${projectId}/signals/${signalId}?clusterId=${cluster.id}&traceId=${traceId}&eventId=${event.id}`}
-            />
-          ))
-        ) : (
-          // A cluster button already links into the signal page, scoped to that
-          // cluster and that event. Alongside one, the bare link is a second and
-          // worse copy of it; with none, it is the only way out of the trace.
-          <OpenInSignalsButton href={`/project/${projectId}/signals/${signalId}?traceId=${traceId}`} />
-        )}
-      </div>
-
-      <div className="flex min-w-0 flex-col gap-2.5 px-3 pb-0.5">
-        {validFields.map((field) => (
-          <div key={field.name} className="flex flex-col gap-0.5">
-            <div className="text-xs font-medium text-signal-key">{field.name}</div>
-            <div className="text-sm leading-relaxed text-secondary-foreground">
-              <PayloadValue value={parsed[field.name]} field={field} spanRefCallbacks={spanRefCallbacks} />
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 /** The per-signal body rendered inside a panel tab. */
-export default function SignalDetails({ traceId, signal }: Props) {
+export default function SignalDetails({ traceId, signal }: { traceId: string; signal: TraceSignal }) {
   const { projectId } = useParams();
   const searchParams = useSearchParams();
   const highlightedEventId = searchParams.get("eventId");
@@ -165,18 +38,17 @@ export default function SignalDetails({ traceId, signal }: Props) {
     onSelectSpan: selectSpanById,
   });
 
+  // No padding here: each event carries its own, so neither block is stuck with
+  // the other's inset.
   return (
-    // No padding here: the cluster row and the field block each carry their own,
-    // so neither is stuck with the other's inset.
     <div className="flex min-w-0 flex-col">
       {events.length === 0 ? (
         <div className="px-2 py-2 text-sm text-muted-foreground">No events found</div>
       ) : (
-        // Only a per-span signal ever has more than one event, and then they need
-        // telling apart; with one event this gap never renders.
+        // Only a per-span signal has more than one event; otherwise this never renders.
         <div className="flex min-w-0 flex-col gap-3">
           {events.map((event) => (
-            <Event
+            <SignalEvent
               key={event.id}
               event={event}
               projectId={projectId as string}

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-event.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-event.tsx
@@ -8,6 +8,7 @@ import { type TraceSignalEvent } from "@/components/traces/trace-view/store/base
 import { cn } from "@/lib/utils";
 
 import ClusterButton from "./cluster-button";
+import { SPAN_CHIP_SURFACE } from "./constants";
 import OpenInSignalsButton from "./open-in-signals-button";
 import PayloadValue from "./payload-value";
 
@@ -58,11 +59,13 @@ export default function SignalEvent({
       ref={ref}
       // A deep-linked event still has to be findable, so the highlight is a rule
       // down the left edge rather than a ring around a box that is no longer drawn.
-      className={cn("flex min-w-0 flex-col", highlighted && "border-l-2 border-signal/60")}
+      className={cn("flex min-w-0 flex-col", highlighted && "border-l-2 border-border")}
     >
-      {/* The SIDE inset is the fields' one: this row and the payload are two blocks
-          in one column, and a column has one left edge. Only the vertical is ours. */}
-      <div className="flex min-w-0 items-center gap-1.5 px-3 py-2">
+      {/* Half the fields' inset, because a chip is a filled box with its own:
+          6 + the chip's 6 puts the LABEL on 12, level with the field labels
+          under it. The column keeps its one left edge; the text sits on it
+          rather than the box. */}
+      <div className="flex min-w-0 items-center gap-1.5 px-1.5 py-2">
         {event.leafClusters.length > 0 ? (
           event.leafClusters.map((cluster) => (
             <ClusterButton
@@ -77,10 +80,13 @@ export default function SignalEvent({
         )}
       </div>
 
-      <div className="flex min-w-0 flex-col gap-2.5 px-3 pb-0.5">
+      {/* The span-chip override rides here: the chips come out of shipping
+          markdown, so a descendant rule is the only way to reach them. The bottom
+          inset clears the resize grip, which is absolute and sits over this. */}
+      <div className={cn("flex min-w-0 flex-col gap-2.5 px-3 pb-2", SPAN_CHIP_SURFACE)}>
         {validFields.map((field) => (
           <div key={field.name} className="flex flex-col gap-0.5">
-            <div className="text-xs font-medium text-signal-key">{field.name}</div>
+            <div className="text-xs font-medium text-muted-foreground">{field.name}</div>
             <div className="text-sm leading-relaxed text-secondary-foreground">
               <PayloadValue value={parsed[field.name]} field={field} spanRefCallbacks={spanRefCallbacks} />
             </div>

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-event.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-event.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+
+import { type SchemaField } from "@/components/signals/utils";
+import { type SpanReferenceCallbacks } from "@/components/traces/trace-view/span-reference";
+import { type TraceSignalEvent } from "@/components/traces/trace-view/store/base";
+import { cn } from "@/lib/utils";
+
+import ClusterButton from "./cluster-button";
+import OpenInSignalsButton from "./open-in-signals-button";
+import PayloadValue from "./payload-value";
+
+function parsePayload(payload: string): Record<string, unknown> {
+  try {
+    const result = JSON.parse(payload);
+    if (result == null || typeof result !== "object" || Array.isArray(result)) {
+      return {};
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+interface Props {
+  event: TraceSignalEvent;
+  projectId: string;
+  signalId: string;
+  traceId: string;
+  validFields: SchemaField[];
+  spanRefCallbacks?: SpanReferenceCallbacks;
+  highlighted?: boolean;
+}
+
+/** One event, with no card around it: a signal produces one event per trace in
+ *  all but a handful of cases, so the box bordered the panel's only content. */
+export default function SignalEvent({
+  event,
+  projectId,
+  signalId,
+  traceId,
+  validFields,
+  spanRefCallbacks,
+  highlighted,
+}: Props) {
+  const parsed = useMemo(() => parsePayload(event.payload), [event.payload]);
+
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (highlighted) {
+      ref.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlighted]);
+
+  return (
+    <div
+      ref={ref}
+      // A deep-linked event still has to be findable, so the highlight is a rule
+      // down the left edge rather than a ring around a box that is no longer drawn.
+      className={cn("flex min-w-0 flex-col", highlighted && "border-l-2 border-signal/60")}
+    >
+      {/* The SIDE inset is the fields' one: this row and the payload are two blocks
+          in one column, and a column has one left edge. Only the vertical is ours. */}
+      <div className="flex min-w-0 items-center gap-1.5 px-3 py-2">
+        {event.leafClusters.length > 0 ? (
+          event.leafClusters.map((cluster) => (
+            <ClusterButton
+              key={cluster.id}
+              shrinkable
+              cluster={cluster}
+              href={`/project/${projectId}/signals/${signalId}?clusterId=${cluster.id}&traceId=${traceId}&eventId=${event.id}`}
+            />
+          ))
+        ) : (
+          <OpenInSignalsButton href={`/project/${projectId}/signals/${signalId}?traceId=${traceId}`} />
+        )}
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2.5 px-3 pb-0.5">
+        {validFields.map((field) => (
+          <div key={field.name} className="flex flex-col gap-0.5">
+            <div className="text-xs font-medium text-signal-key">{field.name}</div>
+            <div className="text-sm leading-relaxed text-secondary-foreground">
+              <PayloadValue value={parsed[field.name]} field={field} spanRefCallbacks={spanRefCallbacks} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-header.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-header.tsx
@@ -1,0 +1,15 @@
+import { type TraceSignal } from "@/components/traces/trace-view/store/base";
+
+import SeverityIcon from "./severity-icon";
+import { worstSeverity } from "./utils";
+
+/** The header when a trace has a single signal. The tab row replaces it when
+ *  there are several. */
+export default function SignalHeader({ signal }: { signal: TraceSignal }) {
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1.5 pl-1">
+      {signal.events.length > 0 && <SeverityIcon severity={worstSeverity(signal)} />}
+      <span className="min-w-0 truncate text-xs font-medium">{signal.signalName}</span>
+    </div>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
@@ -23,8 +23,10 @@ export default function SignalTab({ signal, active }: { signal: TraceSignal; act
         "h-5.5 w-full min-w-0 rounded-md px-2 text-[11px] shadow-none",
         // A step off the panel's elevation, not `bg-gray-900`: a fixed near-black
         // that ignores the surface ladder and reads as a hole in the header.
+        // Both variants, or `TabsTrigger`'s own `data-[state=active]:bg-background`
+        // and `dark:...:bg-input/30` outrank a plain `bg-*` and twMerge keeps them.
         active
-          ? "bg-surface-up-2 text-foreground dark:text-foreground"
+          ? "data-[state=active]:bg-surface-up-2 dark:data-[state=active]:bg-surface-up-2 text-foreground dark:text-foreground"
           : // `dark:` on ours too — `TabsTrigger` ships `dark:text-muted-foreground`,
             // and a bare `text-*` never outranks a variant.
             "text-signal-tab hover:text-foreground dark:text-signal-tab dark:hover:text-foreground"

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { TooltipPortal } from "@radix-ui/react-tooltip";
+
+import { type TraceSignal } from "@/components/traces/trace-view/store/base";
+import { TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+import { TOOLTIP_DELAY_MS } from "./constants";
+import SeverityIcon from "./severity-icon";
+import { worstSeverity } from "./utils";
+
+/** The active tab's wash, laid OVER its surface step as a flat gradient —
+ *  `background-color` would replace the step instead of sitting on it. */
+const ACTIVE_WASH = "color-mix(in oklab, var(--color-signal) 8%, transparent)";
+
+export default function SignalTab({ signal, active }: { signal: TraceSignal; active: boolean }) {
+  const trigger = (
+    <TabsTrigger
+      value={signal.signalId}
+      className={cn(
+        "h-5.5 w-full min-w-0 rounded-md px-2 text-[11px] shadow-none",
+        // A step off the panel's elevation, not `bg-gray-900`: a fixed near-black
+        // that ignores the surface ladder and reads as a hole in the header.
+        active
+          ? "bg-surface-up-2 text-foreground dark:text-foreground"
+          : // `dark:` on ours too — `TabsTrigger` ships `dark:text-muted-foreground`,
+            // and a bare `text-*` never outranks a variant.
+            "text-signal-tab hover:text-foreground dark:text-signal-tab dark:hover:text-foreground"
+      )}
+      style={active ? { backgroundImage: `linear-gradient(${ACTIVE_WASH}, ${ACTIVE_WASH})` } : undefined}
+    >
+      {/* The tab row replaces the header, so without this the severity glyph
+          disappears exactly when there are several severities to tell apart. */}
+      <span className="flex min-w-0 items-center justify-center gap-1.5">
+        {signal.events.length > 0 && <SeverityIcon bare severity={worstSeverity(signal)} />}
+        <span className="min-w-0 truncate">{signal.signalName}</span>
+      </span>
+    </TabsTrigger>
+  );
+
+  // The trigger is a WRAPPER, not the tab: both primitives own a `data-state` and
+  // `Tabs.Trigger` spreads props after its own, so `asChild` would clobber it.
+  return (
+    <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
+      <TooltipTrigger asChild>
+        <span className="flex min-w-0 flex-1">{trigger}</span>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side="bottom">{signal.signalName}</TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
@@ -5,18 +5,43 @@ import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { type TraceSignal } from "@/components/traces/trace-view/store/base";
 import { TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 
 import { TOOLTIP_DELAY_MS } from "./constants";
 import SeverityIcon from "./severity-icon";
 import { worstSeverity } from "./utils";
 
+/**
+ * The active tab as a step off the card, not `bg-gray-900` — a fixed near-black
+ * that ignores the surface ladder and reads as a hole punched in the header.
+ *
+ * Both variants on ours, and `data-[state=active]:` on the overrides, because
+ * `TabsTrigger`'s own rules are variant-qualified: `dark:data-[state=active]:bg-input/30`
+ * and `dark:text-muted-foreground` outrank any plain utility, and
+ * `data-[state=active]:shadow-sm` outranks a plain `shadow-none`. Match the
+ * variant or the rule never lands.
+ */
+const TAB = cn(
+  "h-5.5 w-full min-w-0 rounded-md px-2 text-[11px]",
+  "data-[state=active]:bg-surface-up-5 dark:data-[state=active]:bg-surface-up-5",
+  "data-[state=active]:text-foreground dark:data-[state=active]:text-foreground",
+  "data-[state=active]:shadow-none",
+  "text-secondary-foreground dark:text-secondary-foreground",
+  "hover:bg-surface-up-2 hover:text-foreground dark:hover:text-foreground",
+  // The active tab is already the painted one; lighting it further on hover
+  // would promise the click does something.
+  "data-[state=active]:hover:bg-surface-up-5"
+);
+
 export default function SignalTab({ signal }: { signal: TraceSignal }) {
   const trigger = (
-    <TabsTrigger value={signal.signalId} className="w-full min-w-0">
+    <TabsTrigger value={signal.signalId} className={TAB}>
       {/* The tab row replaces the header, so without this the severity glyph
           disappears exactly when there are several severities to tell apart. */}
-      {signal.events.length > 0 && <SeverityIcon bare severity={worstSeverity(signal)} />}
-      <span className="min-w-0 truncate">{signal.signalName}</span>
+      <span className="flex min-w-0 items-center justify-center gap-1.5">
+        {signal.events.length > 0 && <SeverityIcon bare severity={worstSeverity(signal)} />}
+        <span className="min-w-0 truncate">{signal.signalName}</span>
+      </span>
     </TabsTrigger>
   );
 

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
@@ -5,31 +5,18 @@ import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { type TraceSignal } from "@/components/traces/trace-view/store/base";
 import { TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
 
 import { TOOLTIP_DELAY_MS } from "./constants";
 import SeverityIcon from "./severity-icon";
 import { worstSeverity } from "./utils";
 
-export default function SignalTab({ signal, active }: { signal: TraceSignal; active: boolean }) {
+export default function SignalTab({ signal }: { signal: TraceSignal }) {
   const trigger = (
-    <TabsTrigger
-      value={signal.signalId}
-      className={cn(
-        "h-5.5 w-full min-w-0 rounded-md px-2 text-[11px] shadow-none",
-        // Both variants on ours, or `TabsTrigger`'s own `data-[state=active]:bg-background`
-        // / `dark:text-muted-foreground` outrank a plain utility and twMerge keeps them.
-        active
-          ? "data-[state=active]:bg-signal-tab-active dark:data-[state=active]:bg-signal-tab-active text-foreground dark:text-foreground"
-          : "text-signal-tab hover:text-foreground dark:text-signal-tab dark:hover:text-foreground"
-      )}
-    >
+    <TabsTrigger value={signal.signalId} className="w-full min-w-0">
       {/* The tab row replaces the header, so without this the severity glyph
           disappears exactly when there are several severities to tell apart. */}
-      <span className="flex min-w-0 items-center justify-center gap-1.5">
-        {signal.events.length > 0 && <SeverityIcon bare severity={worstSeverity(signal)} />}
-        <span className="min-w-0 truncate">{signal.signalName}</span>
-      </span>
+      {signal.events.length > 0 && <SeverityIcon bare severity={worstSeverity(signal)} />}
+      <span className="min-w-0 truncate">{signal.signalName}</span>
     </TabsTrigger>
   );
 

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
@@ -11,27 +11,18 @@ import { TOOLTIP_DELAY_MS } from "./constants";
 import SeverityIcon from "./severity-icon";
 import { worstSeverity } from "./utils";
 
-/** The active tab's wash, laid OVER its surface step as a flat gradient —
- *  `background-color` would replace the step instead of sitting on it. */
-const ACTIVE_WASH = "color-mix(in oklab, var(--color-signal) 8%, transparent)";
-
 export default function SignalTab({ signal, active }: { signal: TraceSignal; active: boolean }) {
   const trigger = (
     <TabsTrigger
       value={signal.signalId}
       className={cn(
         "h-5.5 w-full min-w-0 rounded-md px-2 text-[11px] shadow-none",
-        // A step off the panel's elevation, not `bg-gray-900`: a fixed near-black
-        // that ignores the surface ladder and reads as a hole in the header.
-        // Both variants, or `TabsTrigger`'s own `data-[state=active]:bg-background`
-        // and `dark:...:bg-input/30` outrank a plain `bg-*` and twMerge keeps them.
+        // Both variants on ours, or `TabsTrigger`'s own `data-[state=active]:bg-background`
+        // / `dark:text-muted-foreground` outrank a plain utility and twMerge keeps them.
         active
-          ? "data-[state=active]:bg-surface-up-2 dark:data-[state=active]:bg-surface-up-2 text-foreground dark:text-foreground"
-          : // `dark:` on ours too — `TabsTrigger` ships `dark:text-muted-foreground`,
-            // and a bare `text-*` never outranks a variant.
-            "text-signal-tab hover:text-foreground dark:text-signal-tab dark:hover:text-foreground"
+          ? "data-[state=active]:bg-signal-tab-active dark:data-[state=active]:bg-signal-tab-active text-foreground dark:text-foreground"
+          : "text-signal-tab hover:text-foreground dark:text-signal-tab dark:hover:text-foreground"
       )}
-      style={active ? { backgroundImage: `linear-gradient(${ACTIVE_WASH}, ${ACTIVE_WASH})` } : undefined}
     >
       {/* The tab row replaces the header, so without this the severity glyph
           disappears exactly when there are several severities to tell apart. */}

--- a/frontend/components/traces/trace-view/signal-events-panel/utils.ts
+++ b/frontend/components/traces/trace-view/signal-events-panel/utils.ts
@@ -1,5 +1,10 @@
 import { type TraceSignal } from "@/components/traces/trace-view/store/base";
 
+/** The worst event's severity. With several events (a per-span signal) the header
+ *  speaks for the whole card, and the card is as bad as its worst event. */
+export const worstSeverity = (signal: TraceSignal) =>
+  signal.events.reduce((worst, e) => Math.max(worst, e.severity), 0);
+
 export function schemaFieldsToStructuredOutput(fields: TraceSignal["schemaFields"]): {
   type: string;
   properties: Record<string, { type: string; description: string }>;

--- a/frontend/components/traces/trace-view/span-reference/index.tsx
+++ b/frontend/components/traces/trace-view/span-reference/index.tsx
@@ -49,6 +49,10 @@ function SpanChip({
         e.preventDefault();
         onClick();
       }}
+      // A styling hook, not a behaviour one: the signal-events panel re-paints
+      // these onto the surface ramp, and the chip has nothing else stable to
+      // select on. Purely additive — no rule in shipping CSS matches it.
+      data-slot="span-chip"
       className="inline-flex items-center gap-1 rounded px-1 py-0.25 align-middle bg-foreground-300/20 hover:bg-foreground-300/30 transition-colors cursor-pointer"
     >
       <span


### PR DESCRIPTION
> Stacked on **`feat/design-cleanup`**, not `dev` — that branch rewrites this panel too (surface ramp instead of `blue-400`, a real `TabsList` pill, `size="icon-sm"` ghost buttons), so this sits on top of it and adopts its primitives rather than fighting them. Review the last five commits; merge after `feat/design-cleanup`.

The signal events panel is a card with one event in it, but it was drawn as a list — a severity pill and an actions row per event, each event inside its own bordered box, inside a panel that already has a border. Signals produce one event per trace in all but a handful of cases, so every one of those separators was separating the only thing there. This is that pass: the same information, a lot less furniture around it.

## One signal

![Single signal, before and after](https://gist.githubusercontent.com/kolbeyang/5a4e0c36a366ab5d7923cacc36036ee1/raw/c2688d206caef7d917b8644e8877e870f3c69bc0/compare-single.png)

## Several signals

![Multiple signals, before and after](https://gist.githubusercontent.com/kolbeyang/5a4e0c36a366ab5d7923cacc36036ee1/raw/98ee9bc2dd516bdcdd8efcde125e13bd9d31d18e/compare-multi.png)

## What changed

- **The event loses its card.** A deep-linked event still has to be findable, so the highlight becomes a rule down the left edge rather than a ring around a box that is no longer drawn.
- **Severity becomes a glyph beside the signal name.** A word was the right shape for a list, where each item restates its own severity; as a property of the *card*, it belongs in the header the card already has, and a second word there would compete with the signal's name. The label survives as a tooltip. Per tab when there is a tab row, since that row replaces the header exactly when there is more than one severity to tell apart.
- **"Open in Signals" only when the event has no cluster.** A cluster button already links into the signal page scoped to the cluster *and* the event, which is strictly more than the bare link gives you. Alongside one it is a second and worse copy of it; with none it is the only way out of the trace.
- **"Open in AI Chat" becomes an icon** beside the close button, its actions row having gone. It is feature-flagged and usually absent, and a second worded button would outweigh the signal's own name.
- **Cluster buttons size to their labels** (grow 0, shrink 1) instead of stretching across the panel, and share the payload's left edge — the cluster row and the fields are two blocks in one column, and a column has one left edge.
- **Tooltips on the truncated names**, at 300ms, on both the cluster buttons and the signal tabs. The app-wide provider is 0ms, which is right for an icon button and wrong for a row of them. The glyphs make the tab row tighter, so this earns its keep more than it did on `dev`.

![Tab tooltip](https://gist.githubusercontent.com/kolbeyang/5a4e0c36a366ab5d7923cacc36036ee1/raw/4e38098820b91035a1b2946a4f757b45d2fee4b0/after-tab-tooltip.png)

## Colour: none of its own

Three hardcoded `blue-400` opacities are gone and **nothing replaces them**. An intermediate pass kept the hue as an accent on the chips and the payload keys; on a card whose body, header and tabs are all neutral steps that read as decoration rather than as meaning, and it competed with the two things here that *are* meaning — the severity glyph and the cluster icons. So every fill is a step off the card, and `--color-signal` / `--color-signal-key` are deleted.

**The card sits three rungs off the trace view, not one.** It carries a ladder of its own and one step leaves no room under the top of it:

| element | rung |
| --- | --- |
| header strip | +1 |
| enum pill | +2 |
| cluster / "Open in Signals" chips | +3, hover +4 |
| span-reference badges | +4, hover +5 |
| active tab | +5 |
| border, deep-link rule | +5 (`--color-border`, published by `ElevatedSurface`) |
| resize grip on hover | +7 |

Everything is relative, so moving the card moves the card — no rung is pinned to a shade.

**The tab row loses the filled `TabsList` pill.** The tabs carry their own step now, and a container behind them was a second boundary saying the same thing. Both the active fill and the shadow need `data-[state=active]:` (and `dark:`) on our side to land at all — `TabsTrigger`'s own rules are variant-qualified and outrank a plain utility.

**The resize handle is absolute and has no fill**, so it costs the body no height and only the grip reacts.

**The body fades out at its foot with `scroll-fade-b`**, on the scroll *viewport*. Being a mask it has no colour to keep in step with the ramp, and being scroll-driven it is gone the moment you reach the bottom — so nothing is cut off at rest.

**The span-reference badges** (`Bash ↗`) ship as `bg-foreground-300/20`, a fixed wash of the *text* colour. They are rendered by markdown from a payload string and take no props, so they get a `data-slot="span-chip"` hook (purely additive — no shipping rule matches it) plus a descendant rule from the payload container, whose two-element selector also outranks the chip's own class.

**The cluster row takes half the fields' inset (6).** A chip is a filled box with its own 6, so this puts its *label* on 12, level with the field labels under it — the column keeps one left edge, and the text sits on it rather than the box.

## What came from the rebase

`feat/design-cleanup` had already solved things this PR was working around on `dev`, so those were handed over rather than kept: `ElevatedSurface` for the panel fill and its neighbour vars, and `size="icon-sm"` + `hover:bg-surface-up` for the ghost buttons. The `TabsList size="sm"` pill went in and then back out again — see above.

## Testing

Verified in a local dev build against real signal events (`my-project`), at the panel's natural width, with `feat/design-cleanup` checked out for the before shots:

- single-signal header, multi-signal tab row, tab switching;
- one and two cluster buttons, each sizing to its label;
- tab and cluster-button tooltips resolving the truncated names;
- the bottom fade appearing only while the payload overflows, and clearing at the bottom;
- span-reference badges repainted, verified by computed style rather than by eye;
- `tsc --noEmit --incremental false` clean, oxlint clean (one pre-existing `useLayoutEffect` warning, unchanged).

Not visually covered: the no-cluster "Open in Signals" fallback — every signal event in the local dataset is clustered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Trace-view UI and styling only; navigation URLs and payload rendering behavior are preserved with no backend or auth changes.
> 
> **Overview**
> **Restyles the trace view signal-events panel** so it reads as one card instead of nested list boxes, and splits the old monolithic `signal-details` into focused components (`SignalEvent`, chips, tabs, payload rendering).
> 
> **Layout and chrome:** The panel uses a higher `ElevatedSurface` offset, a surface-ramp header (single-signal `SignalHeader` vs multi-signal `SignalTab` row), bottom **scroll-driven fade** on the Radix viewport, and an **absolute** resize grip. **Open in AI Chat** moves to a feature-flagged sparkles icon beside close; tooltips use a **300ms** local `TooltipProvider`.
> 
> **Per-event UI:** Events lose bordered cards; deep links highlight with a **left border rule**. Per-event severity badges go away; **worst severity** shows as a glyph in the header or tab (tooltip on the icon). **Cluster** links become shared-style chips that replace **Open in Signals** when clusters exist; enum fields use **EnumPill** instead of badges. Span-reference chips get `data-slot="span-chip"` so payload markdown can be re-themed via descendant CSS in the panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09e4d2725010b0f11605fb43edad0919d9814bf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->