### PR TITLE
fix: stream large evaluation datapoint updates outside SQL

### DIFF
--- a/app-server/src/evaluations/datapoint_update.rs
+++ b/app-server/src/evaluations/datapoint_update.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use clickhouse::Client;
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Serialize)]
+pub(super) struct Update<'a> {
+    pub trace_id: Uuid,
+    pub updated_at: i64,
+    pub executor_output: &'a str,
+    pub group_id: &'a str,
+    pub scores: &'a str,
+}
+
+pub(super) async fn write(
+    clickhouse: &Client,
+    evaluation_id: Uuid,
+    project_id: Uuid,
+    datapoint_id: Uuid,
+    update: &Update<'_>,
+) -> Result<()> {
+    // Stream variable-size values as data, not repeated SQL literals subject to max_query_size.
+    let query = clickhouse
+        .query(
+            "INSERT INTO evaluation_datapoints (
+                id, evaluation_id, project_id, trace_id, updated_at,
+                data, target, metadata, executor_output, `index`,
+                dataset_id, dataset_datapoint_id, dataset_datapoint_created_at,
+                group_id, scores
+            )
+            SELECT
+                existing.id,
+                existing.evaluation_id,
+                existing.project_id,
+                if(empty(incoming.trace_id), existing.trace_id, incoming.trace_id),
+                fromUnixTimestamp64Nano(incoming.updated_at, 'UTC'),
+                existing.data,
+                existing.target,
+                existing.metadata,
+                if(empty(incoming.executor_output), existing.executor_output, incoming.executor_output),
+                existing.`index`,
+                existing.dataset_id,
+                existing.dataset_datapoint_id,
+                existing.dataset_datapoint_created_at,
+                incoming.group_id,
+                if(empty(incoming.scores),
+                    existing.scores,
+                    if(notEmpty(existing.scores),
+                        jsonMergePatch(existing.scores, incoming.scores),
+                        incoming.scores))
+            FROM input('trace_id UUID, updated_at Int64, executor_output String, group_id String, scores String') AS incoming
+            CROSS JOIN (
+                SELECT
+                    id, evaluation_id, project_id, trace_id,
+                    data, target, metadata, executor_output, `index`, scores,
+                    dataset_id, dataset_datapoint_id, dataset_datapoint_created_at
+                FROM evaluation_datapoints FINAL
+                PREWHERE id = ?
+                WHERE project_id = ? AND evaluation_id = ?
+            ) AS existing
+            FORMAT JSONEachRow",
+        )
+        .bind(datapoint_id)
+        .bind(project_id)
+        .bind(evaluation_id);
+
+    let mut insert = clickhouse.insert_formatted_with(query.sql_display().to_string());
+    let payload = serde_json::to_vec(update)?;
+    async {
+        insert.send(payload.into()).await?;
+        insert.end().await
+    }
+    .await
+    .map_err(|e| anyhow::anyhow!("Clickhouse evaluation datapoint update failed: {:?}", e))
+}
+
+#[cfg(test)]
+#[path = "datapoint_update_tests.rs"]
+mod tests;

--- a/app-server/src/evaluations/datapoint_update_tests.rs
+++ b/app-server/src/evaluations/datapoint_update_tests.rs
@@ -1,0 +1,256 @@
+use super::*;
+use serde_json::{Value, json};
+use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+
+#[tokio::test]
+async fn sends_large_values_in_body_not_sql() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let client = Client::default()
+        .with_url(server.uri())
+        .with_compression(clickhouse::Compression::None);
+    let output = "payload-only-marker: '\"\\\n雪🦀".repeat(40_000);
+    let scores = json!({"score-only-marker": 0.5}).to_string();
+    let update = Update {
+        trace_id: Uuid::new_v4(),
+        updated_at: 1_700_000_000_000_000_123,
+        executor_output: &output,
+        group_id: "group-only-marker'; SELECT 1; --",
+        scores: &scores,
+    };
+    write(
+        &client,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        &update,
+    )
+    .await
+    .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let request = &requests[0];
+    let query = request
+        .url
+        .query_pairs()
+        .find(|(k, _)| k == "query")
+        .unwrap()
+        .1;
+    assert!(query.len() < 4096);
+    assert!(request.url.as_str().len() < 8192);
+    assert!(!query.contains("only-marker"));
+    assert!(
+        !request
+            .url
+            .query_pairs()
+            .any(|(k, _)| k == "max_query_size")
+    );
+    assert!(query.ends_with("FORMAT JSONEachRow"));
+    assert_eq!(
+        serde_json::from_slice::<Value>(&request.body).unwrap(),
+        json!(update)
+    );
+}
+
+#[tokio::test]
+async fn propagates_clickhouse_write_failure() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("synthetic write failure"))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let client = Client::default().with_url(server.uri());
+    let error = write(
+        &client,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        &Update {
+            trace_id: Uuid::nil(),
+            updated_at: 1,
+            executor_output: "output",
+            group_id: "default",
+            scores: "",
+        },
+    )
+    .await
+    .unwrap_err();
+    let message = error.to_string();
+    assert!(message.contains("Clickhouse evaluation datapoint update failed"));
+    assert!(message.contains("synthetic write failure"));
+}
+
+async fn rows(client: &Client) -> Result<Vec<Value>> {
+    let bytes = client
+        .query("SELECT * FROM evaluation_datapoints FINAL ORDER BY project_id, evaluation_id, id")
+        .fetch_bytes("JSONEachRow")?
+        .collect()
+        .await?;
+    serde_json::Deserializer::from_slice(&bytes)
+        .into_iter::<Value>()
+        .map(|row| row.map_err(Into::into))
+        .collect()
+}
+
+// docker run --rm -p 127.0.0.1:18123:8123 -e CLICKHOUSE_SKIP_USER_SETUP=1 clickhouse/clickhouse-server:26.5
+// cargo test evaluations::datapoint_update::tests::large_update_round_trip -- --ignored --nocapture
+#[tokio::test]
+#[ignore = "requires disposable ClickHouse on 127.0.0.1:18123"]
+async fn large_update_round_trip() -> Result<()> {
+    let root = Client::default().with_url("http://127.0.0.1:18123");
+    let database = format!("eval_update_test_{}", Uuid::new_v4().simple());
+    root.query(&format!("CREATE DATABASE {database}"))
+        .execute()
+        .await?;
+    let client = root.clone().with_database(&database);
+    // Mirrors migration 32; backend-only Docker builds do not contain frontend migrations.
+    client
+        .query(
+            "CREATE TABLE evaluation_datapoints (
+                id UUID, evaluation_id UUID, project_id UUID, trace_id UUID,
+                updated_at DateTime64(9, 'UTC'),
+                data String, target String, metadata String, executor_output String,
+                `index` UInt64, dataset_id UUID, dataset_datapoint_id UUID,
+                dataset_datapoint_created_at DateTime64(9, 'UTC'), group_id String, scores String
+            ) ENGINE = ReplacingMergeTree(updated_at)
+            ORDER BY (project_id, evaluation_id, id)",
+        )
+        .execute()
+        .await?;
+    let project = Uuid::new_v4();
+    let evaluation = Uuid::new_v4();
+    let id = Uuid::new_v4();
+    let original_trace = Uuid::new_v4();
+    let seed = json!({
+        "id": id, "evaluation_id": evaluation, "project_id": project,
+        "trace_id": original_trace, "updated_at": "2026-01-01 00:00:00.000000001",
+        "data": "original data", "target": "original target", "metadata": "original metadata",
+        "executor_output": "original output", "index": 7,
+        "dataset_id": Uuid::new_v4(), "dataset_datapoint_id": Uuid::new_v4(),
+        "dataset_datapoint_created_at": "2025-01-01 00:00:00.123456789",
+        "group_id": "default", "scores": "{\"existing\":0.75,\"replace\":0.1}"
+    });
+    let mut other_project = seed.clone();
+    other_project["project_id"] = json!(Uuid::new_v4());
+    let mut other_evaluation = seed.clone();
+    other_evaluation["evaluation_id"] = json!(Uuid::new_v4());
+    let body = [seed.clone(), other_project, other_evaluation]
+        .iter()
+        .map(Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut insert =
+        client.insert_formatted_with("INSERT INTO evaluation_datapoints FORMAT JSONEachRow");
+    insert.send(body.into()).await?;
+    insert.end().await?;
+    let before = rows(&client).await?;
+
+    // The previous two literal binds fail even below the old 250,000-byte truncation.
+    let output = "x".repeat(200_000);
+    let error = client
+        .query("SELECT if(empty(?), 'old', ?)")
+        .bind(&output)
+        .bind(&output)
+        .execute()
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("Max query size exceeded"));
+
+    let mut update = Update {
+        trace_id: Uuid::nil(),
+        updated_at: 1_800_000_000_000_000_001,
+        executor_output: &output,
+        group_id: "default",
+        scores: "",
+    };
+    write(&client, evaluation, project, id, &update).await?;
+    let current = rows(&client).await?;
+    let current = current
+        .iter()
+        .find(|r| r["project_id"] == json!(project) && r["evaluation_id"] == json!(evaluation))
+        .unwrap();
+    assert_eq!(current["executor_output"], output);
+    assert_eq!(current["trace_id"], json!(original_trace));
+
+    let large_output = json!({"result": "'\"\\\n雪🦀".repeat(200_000)}).to_string();
+    assert!(large_output.len() > 2_000_000);
+    let large_scores = json!({"replace": 0.9, "new": 0.5, "s".repeat(300_000): 0.25}).to_string();
+    update.trace_id = Uuid::new_v4();
+    update.updated_at += 1;
+    update.executor_output = &large_output;
+    update.group_id = "updated'; SELECT 1; --";
+    update.scores = &large_scores;
+    write(&client, evaluation, project, id, &update).await?;
+    // An identical retry must leave the logical row unchanged.
+    write(&client, evaluation, project, id, &update).await?;
+    let after = rows(&client).await?;
+    assert_eq!(after.len(), before.len());
+    for (old, new) in before.iter().zip(&after) {
+        if old["project_id"] != json!(project) || old["evaluation_id"] != json!(evaluation) {
+            assert_eq!(new, old);
+            continue;
+        }
+        for field in [
+            "id",
+            "project_id",
+            "evaluation_id",
+            "data",
+            "target",
+            "metadata",
+            "index",
+            "dataset_id",
+            "dataset_datapoint_id",
+            "dataset_datapoint_created_at",
+        ] {
+            assert_eq!(new[field], old[field], "changed {field}");
+        }
+        assert_eq!(new["executor_output"], large_output);
+        assert_eq!(
+            serde_json::from_str::<Value>(new["executor_output"].as_str().unwrap())?["result"],
+            serde_json::from_str::<Value>(&large_output)?["result"]
+        );
+        assert_eq!(new["trace_id"], json!(update.trace_id));
+        assert_eq!(new["group_id"], update.group_id);
+        let scores: Value = serde_json::from_str(new["scores"].as_str().unwrap())?;
+        assert_eq!(scores["existing"], 0.75);
+        assert_eq!(scores["replace"], 0.9);
+        assert_eq!(scores["new"], 0.5);
+        assert_eq!(scores["s".repeat(300_000)], 0.25);
+    }
+
+    update.updated_at += 1;
+    update.trace_id = Uuid::nil();
+    update.executor_output = "";
+    update.scores = "{\"later\":1}";
+    write(&client, evaluation, project, id, &update).await?;
+    update.updated_at += 1;
+    update.scores = "";
+    write(&client, evaluation, project, id, &update).await?;
+    let final_rows = rows(&client).await?;
+    let final_row = final_rows
+        .iter()
+        .find(|r| r["project_id"] == json!(project) && r["evaluation_id"] == json!(evaluation))
+        .unwrap();
+    let previous = after
+        .iter()
+        .find(|r| r["project_id"] == json!(project) && r["evaluation_id"] == json!(evaluation))
+        .unwrap();
+    assert_eq!(final_row["executor_output"], large_output);
+    assert_eq!(final_row["trace_id"], previous["trace_id"]);
+    let scores: Value = serde_json::from_str(final_row["scores"].as_str().unwrap())?;
+    assert_eq!(scores["later"], 1);
+    assert_eq!(scores["existing"], 0.75);
+    assert_eq!(scores["replace"], 0.9);
+
+    write(&client, evaluation, project, Uuid::new_v4(), &update).await?;
+    assert_eq!(rows(&client).await?, final_rows);
+    root.query(&format!("DROP DATABASE {database}"))
+        .execute()
+        .await?;
+    Ok(())
+}

--- a/app-server/src/evaluations/mod.rs
+++ b/app-server/src/evaluations/mod.rs
@@ -1,3 +1,4 @@
+mod datapoint_update;
 pub mod realtime;
 
 use std::collections::HashMap;
@@ -90,20 +91,11 @@ fn scores_to_json_string(scores: &HashMap<String, Option<f64>>) -> String {
 }
 
 /// Convert a Value to a ClickHouse string, returning "" for falsey values.
-/// Truncates the value to a limit of 250K chars, because the limit for
-/// parameters bound to non-canonical insert queries is 256KB
-fn value_to_ch_string_trunc(v: &Value) -> String {
+fn value_to_ch_string(v: &Value) -> String {
     if is_falsey_value(v) {
         String::new()
     } else {
-        let s = json_value_to_string(v);
-        let max_bytes = 250000;
-        s.char_indices()
-            .take_while(|(i, _)| *i < max_bytes)
-            .last()
-            .map(|(i, c)| &s[..i + c.len_utf8()])
-            .unwrap_or("")
-            .to_string()
+        json_value_to_string(v)
     }
 }
 
@@ -197,80 +189,25 @@ pub async fn update_evaluation_datapoint(
     let new_trace_id = trace_id.unwrap_or(Uuid::nil());
     let new_executor_output = executor_output
         .as_ref()
-        .map(|v| value_to_ch_string_trunc(v))
+        .map(value_to_ch_string)
         .unwrap_or_default();
     let new_scores = scores_to_json_string(&scores);
     let now_nanos = chrono_to_nanoseconds(Utc::now());
 
-    // The existing row MUST exist (verified above). We SELECT from it and override
-    // only the columns being updated. ClickHouse empty() detects falsey new values
-    // (empty string, nil UUID) so the existing value is preserved.
-    // We use prewhere id here, so that we hit the bloom_filter skip index on the
-    // project_id, evaluation_id, id BEFORE we execute FINAL
-    let query = "INSERT INTO evaluation_datapoints (
-            id, evaluation_id, project_id, trace_id, updated_at,
-            data, target, metadata, executor_output, `index`,
-            dataset_id, dataset_datapoint_id, dataset_datapoint_created_at,
-            group_id, scores
-        )
-        SELECT
-            existing.id,
-            existing.evaluation_id,
-            existing.project_id,
-            if(empty(toUUID(?)), existing.trace_id, toUUID(?)),
-            fromUnixTimestamp64Nano(toInt64(?), 'UTC'),
-            existing.data,
-            existing.target,
-            existing.metadata,
-            if(empty(?), existing.executor_output, ?),
-            existing.`index`,
-            existing.dataset_id,
-            existing.dataset_datapoint_id,
-            existing.dataset_datapoint_created_at,
-            ?,
-            if(empty(?),
-                existing.scores,
-                if(notEmpty(existing.scores),
-                    jsonMergePatch(existing.scores, ?),
-                    ?))
-        FROM (
-            SELECT
-                id,
-                evaluation_id,
-                project_id,
-                trace_id,
-                data,
-                target,
-                metadata,
-                executor_output,
-                `index`,
-                scores,
-                dataset_id,
-                dataset_datapoint_id,
-                dataset_datapoint_created_at,
-                group_id
-            FROM evaluation_datapoints FINAL
-            PREWHERE id = ?
-            WHERE project_id = ? AND evaluation_id = ?
-        ) AS existing";
-
-    clickhouse
-        .query(query)
-        .bind(new_trace_id)
-        .bind(new_trace_id)
-        .bind(now_nanos)
-        .bind(new_executor_output.as_str())
-        .bind(new_executor_output.as_str())
-        .bind(group_id.as_str())
-        .bind(new_scores.as_str())
-        .bind(new_scores.as_str())
-        .bind(new_scores.as_str())
-        .bind(datapoint_id)
-        .bind(project_id)
-        .bind(evaluation_id)
-        .execute()
-        .await
-        .map_err(|e| anyhow::anyhow!("Clickhouse evaluation datapoint update failed: {:?}", e))?;
+    datapoint_update::write(
+        &clickhouse,
+        evaluation_id,
+        project_id,
+        datapoint_id,
+        &datapoint_update::Update {
+            trace_id: new_trace_id,
+            updated_at: now_nanos,
+            executor_output: &new_executor_output,
+            group_id,
+            scores: &new_scores,
+        },
+    )
+    .await?;
 
     Ok(UpdatedDatapointStrings {
         executor_output: new_executor_output,


### PR DESCRIPTION
## Problem

An evaluation can finish its executor and judge, then fail when publishing the final datapoint to Laminar:

```text
Clickhouse evaluation datapoint update failed:
Code: 62. DB::Exception: Max query size exceeded
```

This is a **result-publication failure**, not a model or browser failure. In the observed runs, execution had already incurred its cost, but the final output and scores could not replace the pre-created datapoint. Retrying the same update does not help: it generates the same oversized SQL statement.

### Why the existing limit does not protect this path

The update uses `INSERT ... SELECT` to preserve the existing row while changing output, trace, and scores. However, the Rust ClickHouse client's `.bind()` expands values into escaped SQL literals. For example:

```sql
if(empty(?), existing.executor_output, ?)
```

The output is bound **twice** in that expression; scores are bound **three times** elsewhere in the same query. The existing truncation caps output at approximately 250,000 bytes, but ClickHouse's default 262,144-byte limit applies to the **whole SQL query**, not each bound value.

A synthetic 200,000-byte ASCII output therefore becomes roughly 400,000 bytes of SQL literals, plus the rest of the statement, and fails even though it is below the truncation threshold. Escaping quotes/backslashes and embedding scores can grow the query further. Truncation also risks cutting serialized JSON mid-value, so merely shrinking the cap would lose evaluation evidence.

## Change

Keep the server-side `INSERT ... SELECT` merge, but stream one `JSONEachRow` record through `input()` using the existing ClickHouse client. Output, scores, and group values travel in the request body as data; only the three UUID filters remain SQL binds. This keeps SQL size independent of output size without raising the global query limit or fetching the existing row into application memory.

Remove the now-unnecessary output truncation. The existing HTTP request-size limit still applies; this is not an unlimited-payload change.

`API normalization -> JSONEachRow request body -> input() x scoped FINAL row -> INSERT`

## Proof

Three added tests passed using the **actual changed Rust writer module**, compiled in an isolated test crate with clickhouse 0.15.1, against a disposable local ClickHouse **26.5.7.64**:

- Old repeated-literal pattern: reproduced `Max query size exceeded` with a 200,000-byte output. New writer: same output round-trips.
- 2,800,013-byte JSON output with quotes, backslashes, newlines, and Unicode, plus a >300 KB scores map: exact output survives; scores merge correctly.
- Empty output/scores and nil trace preserve existing values; identical retry preserves the logical row; dataset links and other immutable fields survive; same datapoint UUID in other projects/evaluations stays unchanged; missing row is not inserted.
- HTTP-level tests verify payloads stay out of SQL/URL, SQL stays <4 KiB, URL stays <8 KiB, no `max_query_size` override, and write failures propagate.
- Per-file rustfmt and `git diff --check` pass.

Full backend `cargo check --locked` is **blocked locally**: installed rustc is 1.90.0; locked AWS dependencies require 1.94.1 and sqlx requires 1.94.0. Full backend tests/API/UI end-to-end tests were **not run**. The isolated tests are not a substitute for the backend CI gate.

To run the database regression with a compatible Rust toolchain:

```sh
docker run --rm -p 127.0.0.1:18123:8123 -e CLICKHOUSE_SKIP_USER_SETUP=1 clickhouse/clickhouse-server:26.5
# In another terminal, from app-server:
cargo test evaluations::datapoint_update::tests -- --include-ignored --nocapture
```

The database test uses only loopback and a UUID-named disposable database. Fixtures are synthetic; no production data or credentials are included.

## Compatibility / risk

- No schema, API, configuration, global query-limit, or dependency changes. Existing missing-datapoint checks, shared-trace handling, null-score filtering, and partial-update semantics remain in place.
- Full accepted outputs are now stored instead of silently clipped. This increases storage and per-request memory relative to truncated output; the existing HTTP payload limit (5 MiB by default) still applies. Realtime output previews remain capped at 200 characters.
- The merge still reads the existing row inside ClickHouse. This does not add a client-side read/merge/write or claim to solve pre-existing concurrent updates to the same datapoint.
- Default-compression database path tested. Managed/staging ClickHouse and the complete API/Postgres/shared-evaluation path still need maintainer validation.

## Rollout / rollback / recovery

Draft for review and CI. Maintainers should validate/backport to the deployment source (`lmnr-private`) before deploying; this PR does not change the hosted service. No migration is required. Rollback is an application revert; existing stored values remain compatible, but old large-update failures/truncation return.

After deployment, failed datapoint publications can be retried from retained results without rerunning the model. This PR does not replay or alter existing evaluation data.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how evaluation results are persisted in ClickHouse and removes silent output truncation, affecting storage size and a critical publish path; merge semantics are intended to stay the same but need CI/staging validation.
> 
> **Overview**
> Fixes evaluation datapoint publication failing with **Max query size exceeded** when executor output or scores are large. The old path inlined output and scores multiple times through `.bind()`, so payloads well under the prior ~250KB truncation cap could still blow past ClickHouse’s ~256KB SQL limit.
> 
> **Evaluation datapoint updates** now go through a dedicated `datapoint_update::write` that keeps the same `INSERT … SELECT` merge semantics (preserve immutable columns, empty incoming values keep existing fields, `jsonMergePatch` for scores) but feeds variable-size fields through ClickHouse `input()` and a **JSONEachRow** request body via `insert_formatted_with`. Only the datapoint/project/evaluation UUID filters stay as SQL binds.
> 
> Removes **250KB output truncation** (`value_to_ch_string_trunc` → full `value_to_ch_string`), so full executor output can be stored within existing HTTP limits. Adds wiremock tests for payload placement and error propagation, plus an optional local ClickHouse round-trip test for large payloads and merge/partial-update behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89564b6388a46e005c3d898dffa66f269a5ebfdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->