### PR TITLE
fix(transcript): prefer gen_ai.agent.name for group titles

### DIFF
--- a/frontend/components/traces/trace-view/store/types.ts
+++ b/frontend/components/traces/trace-view/store/types.ts
@@ -62,6 +62,8 @@ export type TranscriptListGroup = {
   type: "group";
   groupId: string;
   name: string;
+  /** Nearest non-empty `gen_ai.agent.name` on the anchor LLM or its ancestors. */
+  declaredName: string | null;
   path: string;
   firstSpan: TraceViewListSpan;
   firstLlmSpanId: string | null;

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -1,4 +1,9 @@
-import { type TraceViewListSpan, type TraceViewSpan, type TranscriptListEntry } from "./types";
+import {
+  type TraceViewListSpan,
+  type TraceViewSpan,
+  type TranscriptListEntry,
+  type TranscriptListGroup,
+} from "./types";
 
 export type PathInfo = {
   display: Array<{ spanId: string; name: string; count?: number }>;
@@ -596,6 +601,39 @@ const buildSpanToAnchorMap = (allSpans: TraceViewSpan[], grouping: SubagentLlmGr
   return result;
 };
 
+const GEN_AI_AGENT_NAME = "gen_ai.agent.name";
+
+const readDeclaredAgentName = (span: TraceViewSpan | undefined): string | undefined => {
+  const raw = span?.attributes?.[GEN_AI_AGENT_NAME];
+  if (typeof raw !== "string") return undefined;
+  const name = raw.trim();
+  return name.length > 0 ? name : undefined;
+};
+
+/** Nearest non-empty `gen_ai.agent.name` walking `ids_path` leaf-to-root. */
+const declaredAgentNameForSpan = (start: TraceViewSpan, spanMap: Map<string, TraceViewSpan>): string | null => {
+  const idsPathRaw = start.attributes?.["lmnr.span.ids_path"];
+  const idsPath =
+    Array.isArray(idsPathRaw) && idsPathRaw.length > 0
+      ? idsPathRaw.filter((id) => id !== NULL_SPAN_ID)
+      : [start.spanId];
+
+  for (let i = idsPath.length - 1; i >= 0; i--) {
+    const name = readDeclaredAgentName(spanMap.get(idsPath[i]));
+    if (name) return name;
+  }
+  return null;
+};
+
+export const transcriptGroupTitle = (
+  group: TranscriptListGroup,
+  agentNames: Record<string, string | null | undefined>
+): string => {
+  if (group.declaredName) return group.declaredName;
+  const generated = group.firstLlmSpanId ? agentNames[group.firstLlmSpanId] : undefined;
+  return generated || group.name;
+};
+
 /**
  * Builds the flat list of transcript entries. Non-main LLM/CACHED spans anchor
  * subagent group blocks; non-LLM spans bundle in or stay standalone per
@@ -674,6 +712,7 @@ export const buildTranscriptListEntries = (
       type: "group",
       groupId,
       name: anchorSpan?.name ?? groupSpans[0].name,
+      declaredName: declaredAgentNameForSpan(firstLlm, spanMap),
       path: anchorSpan?.path ?? "",
       firstSpan: lightSpans[0],
       firstLlmSpanId: firstLlm.spanId,

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -611,7 +611,11 @@ const readDeclaredAgentName = (span: TraceViewSpan | undefined): string | undefi
 };
 
 /** Nearest non-empty `gen_ai.agent.name` walking `ids_path` leaf-to-root. */
-const declaredAgentNameForSpan = (start: TraceViewSpan, spanMap: Map<string, TraceViewSpan>): string | null => {
+const declaredAgentNameForSpan = (
+  start: TraceViewSpan,
+  spanMap: Map<string, TraceViewSpan>,
+  mainAgentAncestors: Set<string>
+): string | null => {
   const idsPathRaw = start.attributes?.["lmnr.span.ids_path"];
   const idsPath =
     Array.isArray(idsPathRaw) && idsPathRaw.length > 0
@@ -619,6 +623,8 @@ const declaredAgentNameForSpan = (start: TraceViewSpan, spanMap: Map<string, Tra
       : [start.spanId];
 
   for (let i = idsPath.length - 1; i >= 0; i--) {
+    // Ancestors shared with the main agent name the main agent, not this subagent.
+    if (mainAgentAncestors.has(idsPath[i])) return null;
     const name = readDeclaredAgentName(spanMap.get(idsPath[i]));
     if (name) return name;
   }
@@ -712,7 +718,7 @@ export const buildTranscriptListEntries = (
       type: "group",
       groupId,
       name: anchorSpan?.name ?? groupSpans[0].name,
-      declaredName: declaredAgentNameForSpan(firstLlm, spanMap),
+      declaredName: declaredAgentNameForSpan(firstLlm, spanMap, grouping.mainAgentAncestors),
       path: anchorSpan?.path ?? "",
       firstSpan: lightSpans[0],
       firstLlmSpanId: firstLlm.spanId,

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -690,10 +690,12 @@ export const buildTranscriptListEntries = (
     let outputTokens = 0;
     let cacheReadInputTokens = 0;
     let totalCost = 0;
+    const declaredSeen = new Set<string | null>();
     for (const s of groupSpans) {
       if (s.spanType === "LLM" || s.spanType === "CACHED") {
         firstLlm ??= s;
         lastLlm = s;
+        declaredSeen.add(declaredAgentNameForSpan(s, spanMap, grouping.mainAgentAncestors));
       }
       inputTokens += s.inputTokens;
       outputTokens += s.outputTokens;
@@ -718,7 +720,7 @@ export const buildTranscriptListEntries = (
       type: "group",
       groupId,
       name: anchorSpan?.name ?? groupSpans[0].name,
-      declaredName: declaredAgentNameForSpan(firstLlm, spanMap, grouping.mainAgentAncestors),
+      declaredName: declaredSeen.size === 1 ? [...declaredSeen][0] : null,
       path: anchorSpan?.path ?? "",
       firstSpan: lightSpans[0],
       firstLlmSpanId: firstLlm.spanId,

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -172,6 +172,7 @@ const Transcript = ({ onSpanSelect, isShared = false }: TranscriptProps) => {
         const span = spanMap.get(entry.firstLlmSpanId);
         if (span?.pending) continue;
         ids.push(entry.firstLlmSpanId);
+        if (entry.declaredName) continue;
         const hash = span?.attributes?.["lmnr.span.prompt_hash"] as string | undefined;
         if (hash) {
           hashes[entry.firstLlmSpanId] = hash;

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -172,6 +172,7 @@ const Transcript = ({ onSpanSelect, isShared = false }: TranscriptProps) => {
         const span = spanMap.get(entry.firstLlmSpanId);
         if (span?.pending) continue;
         ids.push(entry.firstLlmSpanId);
+        // Declared name wins, no need to generate one from the system prompt.
         if (entry.declaredName) continue;
         const hash = span?.attributes?.["lmnr.span.prompt_hash"] as string | undefined;
         if (hash) {

--- a/frontend/components/traces/trace-view/transcript/item/agent-group-header.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/agent-group-header.tsx
@@ -3,6 +3,7 @@ import React, { memo, useCallback, useMemo } from "react";
 
 import { SpanStatsShield } from "@/components/traces/trace-view/span-stats-shield";
 import { type TranscriptListGroup } from "@/components/traces/trace-view/store/base";
+import { transcriptGroupTitle } from "@/components/traces/trace-view/store/utils";
 import {
   CollapsedPreviewBlock,
   type PreviewMap,
@@ -37,8 +38,6 @@ function AgentGroupHeaderInner({
   const outputSpanId = group.lastLlmSpanId ?? group.firstLlmSpanId;
 
   const { preview, outputPreview, agentName } = useMemo(() => {
-    const name = group.firstLlmSpanId ? agentNames[group.firstLlmSpanId] : undefined;
-
     let inputPreview: string | null | undefined;
     if (collapsed && group.firstLlmSpanId) {
       inputPreview = inputPreviews[group.firstLlmSpanId];
@@ -49,12 +48,15 @@ function AgentGroupHeaderInner({
       output = previews[outputSpanId];
     }
 
-    return { preview: inputPreview, outputPreview: output, agentName: name };
-  }, [collapsed, group.firstLlmSpanId, outputSpanId, previews, inputPreviews, agentNames]);
+    return {
+      preview: inputPreview,
+      outputPreview: output,
+      agentName: transcriptGroupTitle(group, agentNames),
+    };
+  }, [collapsed, group, outputSpanId, previews, inputPreviews, agentNames]);
 
   const isLoadingPreview = preview === undefined;
   const previewText = typeof preview === "string" && preview !== "" ? preview : null;
-  const displayName = agentName || group.name;
 
   const isLoadingOutput = outputPreview === undefined;
   const outputText = typeof outputPreview === "string" && outputPreview !== "" ? outputPreview : null;
@@ -78,7 +80,7 @@ function AgentGroupHeaderInner({
           <div className="flex items-center justify-center z-10 rounded shrink-0 bg-subagent/70 size-5 min-w-5 min-h-5">
             <Bot size={14} />
           </div>
-          <span className="font-medium text-[13px] whitespace-nowrap truncate">{displayName}</span>
+          <span className="font-medium text-[13px] whitespace-nowrap truncate">{agentName}</span>
           <div className="flex items-center shrink-0 ml-auto gap-2">
             <SpanStatsShield
               variant="inline"

--- a/frontend/lib/actions/spans/utils.ts
+++ b/frontend/lib/actions/spans/utils.ts
@@ -110,6 +110,7 @@ export const TRACE_VIEW_ATTRIBUTE_KEYS = [
   "lmnr.span.path",
   "lmnr.span.ids_path",
   "lmnr.span.prompt_hash",
+  "gen_ai.agent.name",
   "lmnr.internal.has_browser_session",
   "lmnr.association.properties.tags",
   "lmnr.association.properties.langgraph.nodes",

--- a/frontend/tests/test-transcript-declared-agent-name.test.ts
+++ b/frontend/tests/test-transcript-declared-agent-name.test.ts
@@ -5,7 +5,7 @@ import { type TraceViewSpan, type TranscriptListGroup } from "@/components/trace
 import { buildTranscriptListEntries, transcriptGroupTitle } from "@/components/traces/trace-view/store/utils";
 import { buildTraceViewAttributesExpression, TRACE_VIEW_ATTRIBUTE_KEYS } from "@/lib/actions/spans/utils";
 
-type FixtureSpanType = "LLM" | "DEFAULT";
+type FixtureSpanType = "LLM" | "DEFAULT" | "TOOL";
 
 interface SpanInput {
   id: string;
@@ -161,6 +161,37 @@ describe("transcript declared agent names", () => {
     const none = groupForLlm(twoWorkers({}), "llm_a1");
     assert.equal(transcriptGroupTitle(none, { llm_a1: "Code Review" }), "Code Review");
     assert.equal(transcriptGroupTitle(none, { llm_a1: null }), "chat");
+  });
+
+  it("does not take gen_ai.agent.name from a main-agent ancestor", () => {
+    const spans = buildSpans([
+      {
+        id: "root",
+        type: "DEFAULT",
+        path: ["root"],
+        idsPath: ["root"],
+        agentName: "MainAgent",
+      },
+      mainLlm(),
+      { id: "tool", parentId: "root", type: "TOOL", path: ["root", "tool"], idsPath: ["root", "tool"] },
+      {
+        id: "sub1",
+        parentId: "tool",
+        type: "LLM",
+        path: ["root", "tool", "chat"],
+        idsPath: ["root", "tool", "sub1"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "sub2",
+        parentId: "tool",
+        type: "LLM",
+        path: ["root", "tool", "chat"],
+        idsPath: ["root", "tool", "sub2"],
+        promptHash: "sub_hash",
+      },
+    ]);
+    assert.equal(groupForLlm(spans, "sub1").declaredName, null);
   });
 
   it("extracts gen_ai.agent.name in the trace-view attributes subset", () => {

--- a/frontend/tests/test-transcript-declared-agent-name.test.ts
+++ b/frontend/tests/test-transcript-declared-agent-name.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { type TraceViewSpan, type TranscriptListGroup } from "@/components/traces/trace-view/store/base";
+import { buildTranscriptListEntries, transcriptGroupTitle } from "@/components/traces/trace-view/store/utils";
+import { buildTraceViewAttributesExpression, TRACE_VIEW_ATTRIBUTE_KEYS } from "@/lib/actions/spans/utils";
+
+type FixtureSpanType = "LLM" | "DEFAULT";
+
+interface SpanInput {
+  id: string;
+  parentId?: string;
+  type: FixtureSpanType;
+  path: string[];
+  idsPath: string[];
+  promptHash?: string;
+  agentName?: string;
+  inputTokens?: number;
+}
+
+const T0 = new Date("2025-01-01T00:00:00.000Z").getTime();
+const toTime = (offsetSeconds: number) => new Date(T0 + offsetSeconds * 1000).toISOString();
+
+const makeSpan = (input: SpanInput, i: number): TraceViewSpan => {
+  assert.equal(input.idsPath[input.idsPath.length - 1], input.id);
+  return {
+    spanId: input.id,
+    parentSpanId: input.parentId,
+    traceId: "trace-1",
+    name: input.path[input.path.length - 1],
+    startTime: toTime(i),
+    endTime: toTime(i + 1),
+    attributes: {
+      "lmnr.span.path": input.path,
+      "lmnr.span.ids_path": input.idsPath,
+      "lmnr.span.prompt_hash": input.promptHash ?? "",
+      ...(input.agentName !== undefined ? { "gen_ai.agent.name": input.agentName } : {}),
+    },
+    spanType: input.type as TraceViewSpan["spanType"],
+    path: input.path.join("."),
+    events: [],
+    collapsed: false,
+    inputTokens: input.inputTokens ?? 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    inputCost: 0,
+    outputCost: 0,
+    totalCost: 0,
+  };
+};
+
+const buildSpans = (inputs: SpanInput[]): TraceViewSpan[] => inputs.map((s, i) => makeSpan(s, i));
+
+const groupForLlm = (spans: TraceViewSpan[], llmId: string): TranscriptListGroup => {
+  const group = buildTranscriptListEntries(spans, new Set()).find(
+    (e): e is TranscriptListGroup => e.type === "group" && e.firstLlmSpanId === llmId
+  );
+  assert.ok(group, `expected a transcript group anchored on ${llmId}`);
+  return group;
+};
+
+const mainLlm = (): SpanInput => ({
+  id: "main_llm",
+  parentId: "root",
+  type: "LLM",
+  path: ["root", "main"],
+  idsPath: ["root", "main_llm"],
+  promptHash: "main_hash",
+  inputTokens: 100,
+});
+
+/** Two invoke_agent runs of the same (path, hash). Two LLMs each so grouping splits them. */
+const twoWorkers = (names: { a?: string; b?: string }): TraceViewSpan[] => {
+  const worker = (id: string, agentName: string | undefined, llms: [string, string]): SpanInput[] => [
+    { id, parentId: "root", type: "DEFAULT", path: ["root", "invoke_agent"], idsPath: ["root", id], agentName },
+    ...llms.map((llmId) => ({
+      id: llmId,
+      parentId: id,
+      type: "LLM" as const,
+      path: ["root", "invoke_agent", "chat"],
+      idsPath: ["root", id, llmId],
+      promptHash: "sub_hash",
+    })),
+  ];
+  return buildSpans([
+    { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+    mainLlm(),
+    ...worker("invoke_a", names.a, ["llm_a1", "llm_a2"]),
+    ...worker("invoke_b", names.b, ["llm_b1", "llm_b2"]),
+  ]);
+};
+
+describe("transcript declared agent names", () => {
+  it("sets declaredName from the nearest ancestor gen_ai.agent.name per instance", () => {
+    const spans = twoWorkers({ a: "Research - Pricing", b: "Research - Competitors" });
+    assert.equal(groupForLlm(spans, "llm_a1").declaredName, "Research - Pricing");
+    assert.equal(groupForLlm(spans, "llm_b1").declaredName, "Research - Competitors");
+  });
+
+  it("prefers a closer ancestor and skips empty gen_ai.agent.name", () => {
+    const nested = (innerName: string) =>
+      buildSpans([
+        { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+        mainLlm(),
+        {
+          id: "outer",
+          parentId: "root",
+          type: "DEFAULT",
+          path: ["root", "outer"],
+          idsPath: ["root", "outer"],
+          agentName: "Outer",
+        },
+        {
+          id: "inner",
+          parentId: "outer",
+          type: "DEFAULT",
+          path: ["root", "outer", "inner"],
+          idsPath: ["root", "outer", "inner"],
+          agentName: innerName,
+        },
+        {
+          id: "sub_llm",
+          parentId: "inner",
+          type: "LLM",
+          path: ["root", "outer", "inner", "chat"],
+          idsPath: ["root", "outer", "inner", "sub_llm"],
+          promptHash: "sub_hash",
+        },
+      ]);
+    assert.equal(groupForLlm(nested("Inner"), "sub_llm").declaredName, "Inner");
+    assert.equal(groupForLlm(nested(""), "sub_llm").declaredName, "Outer");
+  });
+
+  it("leaves declaredName null when nothing is declared", () => {
+    const group = groupForLlm(twoWorkers({}), "llm_a1");
+    assert.equal(group.declaredName, null);
+    assert.equal(group.name, "chat");
+  });
+
+  it("reads gen_ai.agent.name off the LLM span itself", () => {
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      mainLlm(),
+      { id: "wrap", parentId: "root", type: "DEFAULT", path: ["root", "wrap"], idsPath: ["root", "wrap"] },
+      {
+        id: "sub_llm",
+        parentId: "wrap",
+        type: "LLM",
+        path: ["root", "wrap", "chat"],
+        idsPath: ["root", "wrap", "sub_llm"],
+        promptHash: "sub_hash",
+        agentName: "OnLlm",
+      },
+    ]);
+    assert.equal(groupForLlm(spans, "sub_llm").declaredName, "OnLlm");
+  });
+
+  it("title order is declared, then generated, then span name", () => {
+    const declared = groupForLlm(twoWorkers({ a: "Research - Pricing" }), "llm_a1");
+    assert.equal(transcriptGroupTitle(declared, { llm_a1: "Code Review" }), "Research - Pricing");
+    const none = groupForLlm(twoWorkers({}), "llm_a1");
+    assert.equal(transcriptGroupTitle(none, { llm_a1: "Code Review" }), "Code Review");
+    assert.equal(transcriptGroupTitle(none, { llm_a1: null }), "chat");
+  });
+
+  it("extracts gen_ai.agent.name in the trace-view attributes subset", () => {
+    assert.ok(TRACE_VIEW_ATTRIBUTE_KEYS.includes("gen_ai.agent.name"));
+    assert.match(buildTraceViewAttributesExpression(), /gen_ai\.agent\.name/);
+  });
+});

--- a/frontend/tests/test-transcript-declared-agent-name.test.ts
+++ b/frontend/tests/test-transcript-declared-agent-name.test.ts
@@ -194,6 +194,52 @@ describe("transcript declared agent names", () => {
     assert.equal(groupForLlm(spans, "sub1").declaredName, null);
   });
 
+  it("leaves declaredName null when a merged group has conflicting names", () => {
+    const spans = buildSpans([
+      { id: "root", type: "DEFAULT", path: ["root"], idsPath: ["root"] },
+      mainLlm(),
+      {
+        id: "invoke_a",
+        parentId: "root",
+        type: "DEFAULT",
+        path: ["root", "invoke_agent"],
+        idsPath: ["root", "invoke_a"],
+        agentName: "Research - Pricing",
+      },
+      {
+        id: "la",
+        parentId: "invoke_a",
+        type: "LLM",
+        path: ["root", "invoke_agent", "chat"],
+        idsPath: ["root", "invoke_a", "la"],
+        promptHash: "sub_hash",
+      },
+      {
+        id: "invoke_b",
+        parentId: "root",
+        type: "DEFAULT",
+        path: ["root", "invoke_agent"],
+        idsPath: ["root", "invoke_b"],
+        agentName: "Research - Competitors",
+      },
+      {
+        id: "lb",
+        parentId: "invoke_b",
+        type: "LLM",
+        path: ["root", "invoke_agent", "chat"],
+        idsPath: ["root", "invoke_b", "lb"],
+        promptHash: "sub_hash",
+      },
+    ]);
+    const groups = buildTranscriptListEntries(spans, new Set()).filter(
+      (e): e is TranscriptListGroup => e.type === "group"
+    );
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].declaredName, null);
+    assert.equal(groups[0].firstLlmSpanId, "la");
+    assert.equal(groups[0].lastLlmSpanId, "lb");
+  });
+
   it("extracts gen_ai.agent.name in the trace-view attributes subset", () => {
     assert.ok(TRACE_VIEW_ATTRIBUTE_KEYS.includes("gen_ai.agent.name"));
     assert.match(buildTraceViewAttributesExpression(), /gen_ai\.agent\.name/);


### PR DESCRIPTION
Fixes #2082.

Transcript group headers ignore `gen_ai.agent.name`. Ingest renames `invoke_agent` spans from that attribute, but those spans are `Default`, the transcript drops them, and the header keys off `agentNames[firstLlmSpanId]`. Two instances of the same worker (`Research - Pricing`, `Research - Competitors`) both get a generated title or the child LLM span name. `TRACE_VIEW_ATTRIBUTE_KEYS` also never fetched the attribute.

Change: add `gen_ai.agent.name` to `TRACE_VIEW_ATTRIBUTE_KEYS`. In `buildTranscriptListEntries`, walk the anchor LLM's `lmnr.span.ids_path` leaf to root and take the nearest non-empty `gen_ai.agent.name`, stopping at `mainAgentAncestors` so a root agent name (pydantic_ai `agent run`) does not leak onto undeclared subagents. Store it as `TranscriptListGroup.declaredName`. Header title order is declared, generated, `group.name`. Groups with a declared name are skipped in `promptHashes`. Session and debugger reuse the same builder and `AgentGroupHeader`, so they pick this up with no extra walk.

Caveat: one-LLM-per-`invoke_agent` instances that share (path, hash) still merge as before. If their declared names disagree, the group falls back to the generated title.

Tests: `tests/test-transcript-declared-agent-name.test.ts` covers the walk, the `mainAgentAncestors` stop, and the header fallback. Run with `cd frontend && ./node_modules/.bin/tsx --test tests/test-transcript-declared-agent-name.test.ts tests/test-subagent-grouping.test.ts`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Trace transcript display and attribute projection only; behavior is covered by new unit tests with no auth or data-mutation paths.
> 
> **Overview**
> Transcript subagent group headers now show **`gen_ai.agent.name`** when instrumentation sets it on an ancestor (or the anchor LLM), instead of always relying on prompt-derived titles or the child LLM span name.
> 
> **`gen_ai.agent.name`** is included in the trace-view attribute subset so list queries actually return it. When building groups, each LLM’s **`lmnr.span.ids_path`** is walked leaf-to-root for the nearest non-empty name; the walk stops at **main-agent ancestors** so a root agent label does not apply to undeclared subagents. The result is stored as **`declaredName`** (null if LLMs in one merged group disagree). **`transcriptGroupTitle`** resolves **declared → generated → `group.name`**; headers use that helper, and groups with a declared name skip prompt-hash agent-name generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce753a3d8641afc8b02da950debbf153de6b790f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->