### PR TITLE
fix(spans): drop empty AI SDK reasoning parts in convertOne

### DIFF
--- a/frontend/lib/spans/types/ai-sdk.ts
+++ b/frontend/lib/spans/types/ai-sdk.ts
@@ -298,6 +298,7 @@ const convertOne = (message: AiSdkMessage): Omit<ModelMessage, "role"> & { role?
     };
     switch (p.type) {
       case "text":
+      case "reasoning":
         if (typeof p.text === "string" && p.text.length > 0) content.push(part);
         break;
       case "image": {


### PR DESCRIPTION
Fixes #2295.

`convertOne` in `frontend/lib/spans/types/ai-sdk.ts` is commented to drop empty text and reasoning. Empty `text` is skipped. Empty `{type:"reasoning", text:""}` is kept, so `parseAiSdkMessages` returns an extra part.

Change: handle `reasoning` next to `text` and skip when `text` is empty. Non-empty reasoning parts still pass through.

Tests: `cd frontend && ./node_modules/.bin/tsx --test tests/test-ai-sdk-parser.test.ts tests/test-normalize-messages.test.ts`. Those two tests were already on `dev` and failing (`content.length` expected 1, got 2). No test file changes. With the case, 32 pass. PR is against `dev`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow parsing fix in span message normalization with no auth, security, or persistence impact.
> 
> **Overview**
> **`convertOne`** in `ai-sdk.ts` is meant to omit empty text and reasoning when normalizing AI SDK assistant content. Empty **`text`** parts were already filtered out; empty **`{ type: "reasoning", text: "" }`** parts still flowed through **`parseAiSdkMessages`**, so message **`content`** could include a spurious extra part.
> 
> The switch now treats **`reasoning`** like **`text`**: only parts with non-empty **`text`** are kept. Non-empty reasoning is unchanged. This aligns **`convertOne`** with the playground converter and fixes failing parser/normalize tests that expected a single content part when reasoning was empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75218dcf87d50abb1ecdd82a75888c5f9a621b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

