### PR TITLE
feat: add project API Signal CRUD

### DIFF
--- a/app-server/src/api/v1/mod.rs
+++ b/app-server/src/api/v1/mod.rs
@@ -10,6 +10,7 @@ pub mod mcp;
 pub mod metrics;
 pub mod projects;
 pub mod rollouts;
+pub mod signals;
 pub mod spans;
 pub mod sql;
 pub mod tag;

--- a/app-server/src/api/v1/signals.rs
+++ b/app-server/src/api/v1/signals.rs
@@ -1,0 +1,135 @@
+//! Project API key Signal CRUD (`/v1/signals`). Every handler calls the same
+//! `signals::service` functions as the CLI twin (`/v1/cli/signals`); only the
+//! auth extractor differs. A project API key has no user behind it, so create
+//! passes no alert subscriber. Keep this surface in sync with `v1/cli/signals.rs`.
+
+use actix_web::{HttpResponse, delete, get, patch, post, web};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::cache::Cache;
+use crate::db::{DB, project_api_keys::ProjectApiKey};
+use crate::features::{Feature, is_feature_enabled};
+use crate::signals::service::{self, SignalInput, UpdateSignalInput};
+
+#[post("/signals")]
+pub async fn create_signal(
+    project_api_key: ProjectApiKey,
+    body: web::Json<SignalInput>,
+    db: web::Data<DB>,
+    cache: web::Data<Cache>,
+) -> actix_web::Result<HttpResponse> {
+    let result = service::create_signal(
+        &db.pool,
+        cache.get_ref(),
+        project_api_key.project_id,
+        // No user behind a project API key — nobody to subscribe to the
+        // auto-created alert. The CLI twin subscribes its caller.
+        None,
+        body.into_inner(),
+        is_feature_enabled(Feature::Clustering),
+    )
+    .await;
+
+    Ok(match result {
+        Ok(signal) => HttpResponse::Created().json(signal),
+        Err(e) => service::error_response(e),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListSignalsQuery {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[get("/signals")]
+pub async fn list_signals(
+    project_api_key: ProjectApiKey,
+    query: web::Query<ListSignalsQuery>,
+    db: web::Data<DB>,
+) -> actix_web::Result<HttpResponse> {
+    let result =
+        service::list_signals(&db.pool, project_api_key.project_id, query.name.as_deref()).await;
+
+    Ok(match result {
+        Ok(signals) => HttpResponse::Ok().json(serde_json::json!({ "signals": signals })),
+        Err(e) => service::error_response(e),
+    })
+}
+
+#[get("/signals/{signal_id}")]
+pub async fn get_signal(
+    project_api_key: ProjectApiKey,
+    path: web::Path<Uuid>,
+    db: web::Data<DB>,
+) -> actix_web::Result<HttpResponse> {
+    let result = service::get_signal(&db.pool, project_api_key.project_id, path.into_inner()).await;
+
+    Ok(match result {
+        Ok(signal) => HttpResponse::Ok().json(signal),
+        Err(e) => service::error_response(e),
+    })
+}
+
+#[get("/signals/{signal_id}/versions")]
+pub async fn list_signal_versions(
+    project_api_key: ProjectApiKey,
+    path: web::Path<Uuid>,
+    db: web::Data<DB>,
+) -> actix_web::Result<HttpResponse> {
+    let result =
+        service::list_signal_versions(&db.pool, project_api_key.project_id, path.into_inner())
+            .await;
+
+    Ok(match result {
+        Ok(versions) => HttpResponse::Ok().json(serde_json::json!({ "versions": versions })),
+        Err(e) => service::error_response(e),
+    })
+}
+
+#[patch("/signals/{signal_id}")]
+pub async fn update_signal(
+    project_api_key: ProjectApiKey,
+    path: web::Path<Uuid>,
+    body: web::Json<UpdateSignalInput>,
+    db: web::Data<DB>,
+    cache: web::Data<Cache>,
+) -> actix_web::Result<HttpResponse> {
+    let result = service::update_signal(
+        &db.pool,
+        cache.get_ref(),
+        project_api_key.project_id,
+        path.into_inner(),
+        body.into_inner(),
+    )
+    .await;
+
+    Ok(match result {
+        Ok(signal) => HttpResponse::Ok().json(signal),
+        Err(e) => service::error_response(e),
+    })
+}
+
+#[delete("/signals/{signal_id}")]
+pub async fn delete_signal(
+    project_api_key: ProjectApiKey,
+    path: web::Path<Uuid>,
+    db: web::Data<DB>,
+    cache: web::Data<Cache>,
+    clickhouse: web::Data<clickhouse::Client>,
+) -> actix_web::Result<HttpResponse> {
+    let result = service::delete_signal(
+        &db.pool,
+        cache.get_ref(),
+        clickhouse.get_ref(),
+        project_api_key.project_id,
+        path.into_inner(),
+    )
+    .await;
+
+    Ok(match result {
+        Ok(signal) => HttpResponse::Ok().json(signal),
+        Err(e) => service::error_response(e),
+    })
+}

--- a/app-server/src/main.rs
+++ b/app-server/src/main.rs
@@ -2826,6 +2826,12 @@ fn main() -> anyhow::Result<()> {
                                     .service(api::v1::evals::update_eval)
                                     .service(api::v1::evals::save_eval_datapoints)
                                     .service(api::v1::evals::update_eval_datapoint)
+                                    .service(api::v1::signals::create_signal)
+                                    .service(api::v1::signals::list_signals)
+                                    .service(api::v1::signals::list_signal_versions)
+                                    .service(api::v1::signals::get_signal)
+                                    .service(api::v1::signals::update_signal)
+                                    .service(api::v1::signals::delete_signal)
                                     // Debugger session lifecycle — SDK-driven
                                     // (project API key). update_name is CLI-only,
                                     // so it lives under /v1/cli, not here.

--- a/app-server/src/signals/service/tests.rs
+++ b/app-server/src/signals/service/tests.rs
@@ -266,6 +266,21 @@ fn name_is_trimmed_for_storage() {
 }
 
 #[test]
+fn patch_name_uses_create_validation() {
+    assert_eq!(validate_signal_name("  Renamed  ").unwrap(), "Renamed");
+    assert!(validate_signal_name("   ").is_err());
+    assert!(validate_signal_name(&"a".repeat(SIGNAL_NAME_MAX_LEN + 1)).is_err());
+}
+
+#[test]
+fn patch_name_null_and_omitted_are_unchanged() {
+    let omitted: UpdateSignalInput = serde_json::from_value(json!({})).unwrap();
+    let null: UpdateSignalInput = serde_json::from_value(json!({ "name": null })).unwrap();
+    assert!(omitted.name.is_none());
+    assert!(null.name.is_none());
+}
+
+#[test]
 fn blank_name_and_prompt_are_rejected() {
     let mut blank_name = signal_input(valid_schema());
     blank_name.name = "   ".to_string();

--- a/docs/internal/signals.md
+++ b/docs/internal/signals.md
@@ -49,7 +49,9 @@
 - **Clusters deliberately have no version.** A cluster legitimately spans versions; a cluster's version mix is a `GROUP BY` over its events.
 - **Settings → Versions is a read-only changelog.** Newest first; v1 expands to the stored JSON snapshot, later rows expand to a `DiffView` against the previous mint. The collapsed summary lists the fields that changed (`components/signal/versions-section/changelog.ts`). Chart markers (`v2+`) link to `?tab=settings&section=versions&version=N`.
 
-## Signal CRUD in app-server (`signals/service.rs`, `/v1/cli/signals`)
+## Signal CRUD in app-server (`signals/service.rs`, `/v1/cli/signals`, `/v1/signals`)
+
+- **Two auth front-ends, one service.** `/v1/cli/signals` (user token, `CliProjectAuth`) and `/v1/signals` (project API key, `ProjectApiKey`) call the identical `signals::service` functions, so validation, version minting and error mapping cannot drift. Two deliberate differences: the project-key `POST` subscribes nobody to the auto-created alert (`subscriber_email: None` — a key has no user) and answers **201**, while the CLI twin subscribes the creator and answers 200. Both surfaces expose the same five reads/writes plus `GET /signals/{id}/versions`; a new route on one is a bug on the other.
 
 - **Signal CRUD is ungated by the `signals` cargo feature and lives in `signals/service.rs` + `db/signals.rs` + `db/signal_triggers.rs`.** Writing a signal row is a plain DB write; only signal *processing* is enterprise. `db/signals.rs` was previously `#[cfg(feature = "signals")]` — ungating it exposes `SignalMetadata` / `Signal` / `get_signal` as dead code in OSS, so those carry `#[cfg_attr(not(feature = "signals"), allow(dead_code))]`.
 - **`GET /v1/cli/signals/{id}/versions`** returns the append-only snapshot log (`{ versions: [{ version, definition, createdAt }, …] }`, oldest first). 404 if the signal is missing in this project. The scalar `version` on `GET /v1/cli/signals/{id}` is still just the current pointer. `definition.trigger` is Filter[] (drawer JSON), not the tagged `Trigger` on GET `/signals`.


### PR DESCRIPTION
Adds a project-API-key surface for Signal CRUD at `/v1/signals`, mirroring the existing CLI surface at `/v1/cli/signals`.

Moved from lmnr-ai/lmnr-private#1006 — the change is entirely public: Signal CRUD is already ungated by the `signals` cargo feature (only signal *processing* is enterprise), and the CLI twin already lives here.

## What

A thin HTTP shell. Every handler calls the same `signals::service` functions as the CLI twin; only the auth extractor differs (`ProjectApiKey` vs `CliProjectAuth`). No service or db changes.

Route parity is exact:

| | `/v1/cli/signals` | `/v1/signals` |
|---|---|---|
| create | POST | POST |
| list | GET | GET |
| versions | GET `{id}/versions` | GET `{id}/versions` |
| get | GET `{id}` | GET `{id}` |
| update | PATCH `{id}` | PATCH `{id}` |
| delete | DELETE `{id}` | DELETE `{id}` |

## Deliberate differences from the CLI twin

- **Create passes no alert subscriber** (`subscriber_email: None`) — a project API key has no user behind it. The CLI twin subscribes its caller.
- **Create answers 201**; the CLI twin answers 200. Reads are 200 on both.

## Notes for review

- `list_signal_versions` is registered **before** `get_signal` in `main.rs`, mirroring the CLI block — actix matches in registration order, so the reverse would let `/{signal_id}` shadow `/{signal_id}/versions`.
- Project scoping is enforced in the service layer (`WHERE project_id = $1 AND signal_id = $2`), so a signal id lifted from a URL cannot reach another project's prompts.
- Nothing enforces the CLI/project-key route parity mechanically — both lists are hand-maintained in `main.rs`. A test asserting the two sets match would be a good follow-up.

## Testing

- `cargo check` (default features) clean
- `cargo test signals` — 33 passed, 0 failed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

