### PR TITLE
feat: mirror cluster naming into OSS

### DIFF
--- a/app-server/src/env/connections.rs
+++ b/app-server/src/env/connections.rs
@@ -18,6 +18,9 @@ pub const CHECKPOINTS_INTERNAL_PROJECT_ID: &str = "CHECKPOINTS_INTERNAL_PROJECT_
 pub const STATIC_SP_INTERNAL_PROJECT_ID: &str = "STATIC_SP_INTERNAL_PROJECT_ID";
 /// Signal job self-tracing destination project id.
 pub const SIGNALS_INTERNAL_PROJECT_ID: &str = "SIGNAL_JOB_INTERNAL_PROJECT_ID";
+/// Cluster-naming self-tracing destination project id; invalid or unset disables export.
+#[cfg_attr(not(feature = "signals"), allow(dead_code))]
+pub const CLUSTERING_INTERNAL_PROJECT_ID: &str = "CLUSTERING_INTERNAL_PROJECT_ID";
 
 /// `producer` | `consumer` | unset (= both). Selects which halves run.
 pub const OPERATION_MODE: &str = "OPERATION_MODE";

--- a/app-server/src/instrumentation/spans.rs
+++ b/app-server/src/instrumentation/spans.rs
@@ -204,6 +204,14 @@ impl InternalSpan {
         self
     }
 
+    /// Numeric trace metadata (range-filterable in the trace UI). Like
+    /// [`Self::metadata_str`], the value must be uniform across the trace —
+    /// ingest keeps only one span's metadata per export batch.
+    pub fn metadata_i64(self, key: &str, value: i64) -> Self {
+        set_metadata_i64(&self.span, key, value);
+        self
+    }
+
     pub fn build(self) -> tracing::Span {
         self.span
     }


### PR DESCRIPTION
Mirrors the public-repo-visible parts of lmnr-private#1017 (`feat(): trace cluster-naming`).

## What's mirrored
- `app-server/src/env/connections.rs` — register `CLUSTERING_INTERNAL_PROJECT_ID` (self-tracing destination project id for cluster naming). Registered here per the convention that every env var lives in `src/env/`; gated with `allow(dead_code)` off the `signals` feature since only the private clustering code reads it.
- `app-server/src/instrumentation/spans.rs` — add `InternalSpan::metadata_i64`, the builder counterpart to the already-public `set_metadata_i64` free function (used by the private code to stamp cluster `level` as trace metadata).

## What's not mirrored
Everything under `app-server/src/clustering/private/` (clusterer, naming adapter, new `self_tracing.rs`) and `docs/internal/clustering.md` — enterprise-only, lives in `lmnr-private`.

Verified with `cargo check` (default features).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive constants and a thin span-builder helper with no runtime behavior change until private clustering code consumes them.
> 
> **Overview**
> Adds public scaffolding so cluster-naming self-tracing can mirror other internal jobs (checkpoints, signals, static-prompt).
> 
> Registers **`CLUSTERING_INTERNAL_PROJECT_ID`** in `connections.rs` as the env key for the cluster-naming trace export destination; it is annotated with `allow(dead_code)` when the `signals` feature is off because only private clustering code will read it. Extends **`InternalSpan`** with **`metadata_i64`**, a fluent wrapper around the existing `set_metadata_i64` helper so numeric trace metadata (e.g. cluster `level`) can be stamped during span construction and range-filtered in the trace UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92476d5fe6978bfc88aca4bc8dbc1da051cc19da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->