### PR TITLE
fix: Add spacing between trace timeline spans

### DIFF
--- a/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-condensed-timeline/index.tsx
@@ -294,6 +294,11 @@ function SessionCondensedTimeline({ trace, isLoading }: SessionCondensedTimeline
                 condensedSpan={condensedSpan}
                 selectedSpan={selectedSpanForThisTrace}
                 isIncludedInGroupSelection={isIncludedInGroupSelection}
+                isMuted={
+                  !isCostHeatmapVisible &&
+                  selectedSpanForThisTrace != null &&
+                  selectedSpanForThisTrace.spanId !== condensedSpan.span.spanId
+                }
                 maxSpanCost={maxSpanCost}
                 isCostHeatmapVisible={isCostHeatmapVisible}
                 onClick={handleSpanClick}

--- a/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
@@ -11,6 +11,7 @@ interface CondensedTimelineElementProps {
   condensedSpan: CondensedTimelineSpan;
   selectedSpan?: TraceViewSpan;
   isIncludedInGroupSelection: boolean | null;
+  isMuted: boolean;
   maxSpanCost: number;
   isCostHeatmapVisible: boolean;
   onClick: (span: TraceViewSpan) => void;
@@ -20,6 +21,7 @@ const CondensedTimelineElement = ({
   condensedSpan,
   selectedSpan,
   isIncludedInGroupSelection,
+  isMuted,
   maxSpanCost,
   isCostHeatmapVisible,
   onClick,
@@ -27,7 +29,7 @@ const CondensedTimelineElement = ({
   const { span, left, width, row } = condensedSpan;
 
   const isSelected = useMemo(() => selectedSpan?.spanId === span.spanId, [span.spanId, selectedSpan?.spanId]);
-  const opacity = isIncludedInGroupSelection === false ? "opacity-30" : "";
+  const opacity = isIncludedInGroupSelection === false ? "opacity-30" : isMuted ? "opacity-60" : "";
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
@@ -52,7 +52,7 @@ const CondensedTimelineElement = ({
 
   return (
     <div
-      className={cn("@container absolute cursor-pointer @min-[5px]:pr-px", opacity)}
+      className={cn("@container absolute cursor-pointer", opacity)}
       style={{
         left: `${left}%`,
         width: `max(${width}%, 4px)`,
@@ -62,7 +62,7 @@ const CondensedTimelineElement = ({
       onClick={handleClick}
     >
       <div
-        className={cn("relative size-full rounded-xs hover:brightness-110", {
+        className={cn("relative size-full rounded-xs hover:brightness-110 @min-[5px]:w-[calc(100%-1px)]", {
           "border border-white/70 z-20": isSelected,
           "bg-muted": isCostHeatmapVisible,
         })}

--- a/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
@@ -29,7 +29,7 @@ const CondensedTimelineElement = ({
   const { span, left, width, row } = condensedSpan;
 
   const isSelected = useMemo(() => selectedSpan?.spanId === span.spanId, [span.spanId, selectedSpan?.spanId]);
-  const opacity = isIncludedInGroupSelection === false ? "opacity-30" : isMuted ? "opacity-60" : "";
+  const opacity = isIncludedInGroupSelection === false ? "opacity-30" : "";
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -46,11 +46,9 @@ const CondensedTimelineElement = ({
 
   const backgroundColor = useMemo(() => {
     if (isCostHeatmapVisible) return undefined;
-    if (span.status === "error") {
-      return "rgba(204, 51, 51, 1)";
-    }
-    return SPAN_TYPE_TO_COLOR[span.spanType];
-  }, [span.status, span.spanType, isCostHeatmapVisible]);
+    const color = span.status === "error" ? "rgba(204, 51, 51, 1)" : SPAN_TYPE_TO_COLOR[span.spanType];
+    return isMuted ? `color-mix(in oklch, ${color} 60%, var(--color-surface-200))` : color;
+  }, [span.status, span.spanType, isCostHeatmapVisible, isMuted]);
 
   return (
     <div

--- a/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
@@ -63,7 +63,7 @@ const CondensedTimelineElement = ({
     >
       <div
         className={cn("relative size-full rounded-xs hover:brightness-110 @min-[5px]:w-[calc(100%-1px)]", {
-          "border border-white/70 z-20": isSelected,
+          "ring-1 ring-white/70 z-20": isSelected,
           "bg-muted": isCostHeatmapVisible,
         })}
         style={{ backgroundColor }}

--- a/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
@@ -52,27 +52,31 @@ const CondensedTimelineElement = ({
 
   return (
     <div
-      className={cn("absolute rounded-xs cursor-pointer", "hover:brightness-110", opacity, {
-        "border border-white/70 z-20": isSelected,
-        "bg-muted": isCostHeatmapVisible,
-      })}
+      className={cn("@container absolute cursor-pointer @min-[5px]:pr-px", opacity)}
       style={{
         left: `${left}%`,
         width: `max(${width}%, 4px)`,
         top: row * ROW_HEIGHT + 1,
         height: ROW_HEIGHT - 2,
-        backgroundColor,
       }}
       onClick={handleClick}
     >
-      {isCostHeatmapVisible && (
-        <div
-          className="absolute inset-0 rounded-xs"
-          style={{
-            backgroundColor: `rgba(239, 68, 68, ${heatmapOpacity})`,
-          }}
-        />
-      )}
+      <div
+        className={cn("relative size-full rounded-xs hover:brightness-110", {
+          "border border-white/70 z-20": isSelected,
+          "bg-muted": isCostHeatmapVisible,
+        })}
+        style={{ backgroundColor }}
+      >
+        {isCostHeatmapVisible && (
+          <div
+            className="absolute inset-0 rounded-xs"
+            style={{
+              backgroundColor: `rgba(239, 68, 68, ${heatmapOpacity})`,
+            }}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/components/traces/trace-view/condensed-timeline/index.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/index.tsx
@@ -289,6 +289,9 @@ function CondensedTimeline() {
                   condensedSpan={condensedSpan}
                   selectedSpan={selectedSpan}
                   isIncludedInGroupSelection={isIncludedInGroupSelection}
+                  isMuted={
+                    !isCostHeatmapVisible && selectedSpan != null && selectedSpan.spanId !== condensedSpan.span.spanId
+                  }
                   maxSpanCost={maxSpanCost}
                   isCostHeatmapVisible={isCostHeatmapVisible}
                   onClick={handleSpanClick}

--- a/frontend/components/traces/trace-view/store/utils.ts
+++ b/frontend/components/traces/trace-view/store/utils.ts
@@ -858,13 +858,13 @@ export const transformSpansToCondensedTimeline = (spans: TraceViewSpan[]): Conde
 
   // Gravity algorithm: compact spans upward while respecting parent-child invariant
   const rowAssignments = new Map<string, number>();
-  const rowOccupancy: Array<Array<{ left: number; right: number; spanId: string }>> = [];
+  const rowOccupancy: Array<Array<{ startMs: number; endMs: number; spanId: string }>> = [];
 
-  // Helper to check if a span overlaps with any existing span in a row
-  const hasOverlap = (row: number, left: number, right: number, excludeSpanId?: string): boolean => {
+  // Compare source timestamps; percentage geometry can introduce false overlaps through floating-point rounding.
+  const hasOverlap = (row: number, startMs: number, endMs: number, excludeSpanId?: string): boolean => {
     if (!rowOccupancy[row]) return false;
     return rowOccupancy[row].some(
-      (occupant) => occupant.spanId !== excludeSpanId && !(right <= occupant.left || left >= occupant.right)
+      (occupant) => occupant.spanId !== excludeSpanId && !(endMs <= occupant.startMs || startMs >= occupant.endMs)
     );
   };
 
@@ -881,10 +881,7 @@ export const transformSpansToCondensedTimeline = (spans: TraceViewSpan[]): Conde
 
     // Find the lowest valid row (closest to top)
     let targetRow = minRow;
-    const leftBound = item.left;
-    const rightBound = item.left + item.width;
-
-    while (hasOverlap(targetRow, leftBound, rightBound)) {
+    while (hasOverlap(targetRow, item.startMs, item.endMs)) {
       targetRow++;
     }
 
@@ -896,8 +893,8 @@ export const transformSpansToCondensedTimeline = (spans: TraceViewSpan[]): Conde
       rowOccupancy[targetRow] = [];
     }
     rowOccupancy[targetRow].push({
-      left: leftBound,
-      right: rightBound,
+      startMs: item.startMs,
+      endMs: item.endMs,
       spanId: item.span.spanId,
     });
   }

--- a/frontend/tests/condensed-timeline-layout.test.ts
+++ b/frontend/tests/condensed-timeline-layout.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { type TraceViewSpan } from "@/components/traces/trace-view/store/base";
+import { transformSpansToCondensedTimeline } from "@/components/traces/trace-view/store/utils";
+import { SpanType } from "@/lib/traces/types";
+
+const makeSpan = ({
+  spanId,
+  parentSpanId,
+  startMs,
+  endMs,
+}: {
+  spanId: string;
+  parentSpanId?: string;
+  startMs: number;
+  endMs: number;
+}): TraceViewSpan => ({
+  spanId,
+  parentSpanId,
+  traceId: "trace-1",
+  name: spanId,
+  startTime: new Date(startMs).toISOString(),
+  endTime: new Date(endMs).toISOString(),
+  attributes: {},
+  spanType: parentSpanId ? SpanType.TOOL : SpanType.DEFAULT,
+  path: spanId,
+  events: [],
+  collapsed: false,
+  inputTokens: 0,
+  outputTokens: 0,
+  totalTokens: 0,
+  inputCost: 0,
+  outputCost: 0,
+  totalCost: 0,
+});
+
+describe("transformSpansToCondensedTimeline", () => {
+  it("packs adjacent millisecond spans into the same row", () => {
+    const origin = Date.UTC(2025, 0, 1);
+    const root = makeSpan({ spanId: "root", startMs: origin, endMs: origin + 102 });
+    const children = Array.from({ length: 100 }, (_, index) =>
+      makeSpan({
+        spanId: `tool-${index}`,
+        parentSpanId: root.spanId,
+        startMs: origin + index + 1,
+        endMs: origin + index + 2,
+      })
+    );
+
+    const timeline = transformSpansToCondensedTimeline([root, ...children]);
+    const childRows = timeline.spans.filter(({ span }) => span.parentSpanId === root.spanId).map(({ row }) => row);
+
+    assert.deepEqual(new Set(childRows), new Set([1]));
+    assert.equal(timeline.totalRows, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap condensed timeline span visuals in their existing timing bounds
- add a 1px trailing gap when a rendered span is at least 5px wide
- preserve minimum-width bars, click targets, selection, and heatmap styling

Before:
<img width="1040" height="413" alt="image" src="https://github.com/user-attachments/assets/03774de2-f985-4247-a2e0-2cd95ca481a4" />

After:
<img width="754" height="378" alt="image" src="https://github.com/user-attachments/assets/281a9e54-4eba-4dfb-acf5-6614470a00b8" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timeline UI and layout math only; no auth, data, or API changes.
> 
> **Overview**
> Improves condensed trace timeline readability with **visual gaps between spans** and clearer **selection focus**.
> 
> `CondensedTimelineElement` now uses an outer positioning box and an inner bar; when the bar is at least 5px wide (`@container` / `@min-[5px]`), width is `calc(100% - 1px)` so adjacent spans show a 1px gap while keeping the same click bounds and minimum bar width. Selection styling moves to a **ring** on the inner bar; heatmap overlay behavior is unchanged.
> 
> When the cost heatmap is off and a span is selected, other spans get a new **`isMuted`** state (colors mixed toward the surface) in both trace and session condensed timelines.
> 
> **Layout:** `transformSpansToCondensedTimeline` row packing compares **`startMs` / `endMs`** instead of percentage left/width so floating-point geometry does not falsely block packing (e.g. many 1ms sibling tools on one row). A **unit test** locks in that adjacent millisecond children pack into a single row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8605a7744e4c757fa1f3b083dc374f127f82a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->