### PR TITLE
fix: enum filters signal events

### DIFF
--- a/frontend/components/signal/events-table/columns.tsx
+++ b/frontend/components/signal/events-table/columns.tsx
@@ -195,7 +195,8 @@ function createPayloadFilter(field: SchemaField): ColumnFilter {
       return {
         name: field.name,
         key: `payload.${field.name}`,
-        dataType: "string",
+        dataType: "enum",
+        options: (field.enumValues ?? []).map((v) => ({ label: v, value: v })),
       };
     default:
       return {

--- a/frontend/lib/actions/events/utils.ts
+++ b/frontend/lib/actions/events/utils.ts
@@ -1,5 +1,6 @@
 import { OperatorLabelMap } from "@/components/ui/infinite-datatable/ui/datatable-filter/utils";
 import { type Filter } from "@/lib/actions/common/filters";
+import { Operator } from "@/lib/actions/common/operators";
 import {
   buildSelectQuery,
   type ColumnFilterConfig,
@@ -76,10 +77,14 @@ export const eventsColumnFilterConfig: ColumnFilterConfig = {
       };
     }
 
+    // extractString is unquoted, extractRaw keeps JSON quotes. `=` is OR (either
+    // form); `!=` must be AND or a quoted string satisfies extractRaw != value
+    // on every row and the filter becomes a no-op.
+    const join = filter.operator === Operator.Ne ? " AND " : " OR ";
     return {
       condition:
         `(simpleJSONExtractString(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:String}` +
-        ` OR simpleJSONExtractRaw(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:String})`,
+        `${join}simpleJSONExtractRaw(payload, {${paramKey}_key:String}) ${opSymbol} {${paramKey}_val:String})`,
       params: {
         [`${paramKey}_key`]: fieldName,
         [`${paramKey}_val`]: String(value),

--- a/frontend/tests/signal-events-enum-filters.test.ts
+++ b/frontend/tests/signal-events-enum-filters.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { Operator } from "@/lib/actions/common/operators";
+import { buildEventsQueryWithParams } from "@/lib/actions/events/utils";
+
+describe("payload JSON string filters", () => {
+  it("joins extractString/extractRaw with AND for != (OR would match every quoted JSON string)", () => {
+    const { query } = buildEventsQueryWithParams({
+      signalId: "00000000-0000-0000-0000-000000000001",
+      filters: [
+        {
+          column: "payload.status",
+          operator: Operator.Eq,
+          value: "error",
+          dataType: "string",
+        },
+        {
+          column: "payload.category",
+          operator: Operator.Ne,
+          value: "timeout",
+          dataType: "string",
+        },
+      ],
+      limit: 50,
+      offset: 0,
+      pastHours: "72",
+    });
+
+    assert.match(
+      query,
+      /simpleJSONExtractString\(payload, \{payload_status_0_key:String\}\) = \{payload_status_0_val:String\} OR simpleJSONExtractRaw/
+    );
+    assert.match(
+      query,
+      /simpleJSONExtractString\(payload, \{payload_category_1_key:String\}\) != \{payload_category_1_val:String\} AND simpleJSONExtractRaw/
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes event query WHERE clauses for payload string/enum filters; incorrect logic would affect which events appear in the table.
> 
> **Overview**
> **Signal event payload enum fields** now register as `enum` filters with selectable options from the signal schema, instead of free-text string filters.
> 
> **Payload JSON string filtering** in ClickHouse query building fixes a bug where `!=` combined `simpleJSONExtractString` and `simpleJSONExtractRaw` with **OR**, which could match almost every row (quoted raw values never equal the unquoted filter value). Equality still uses **OR** so either extraction form can match; inequality now uses **AND** so both must disagree with the filter value.
> 
> A unit test asserts the generated SQL uses OR for `=` and AND for `!=` on payload string filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f471bd9dfd70f55e24e62af634a7f7289a22314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->