### PR TITLE
feat(traces): focused trace view cleanup

### DIFF
--- a/frontend/components/common/advanced-search/components/search-input.tsx
+++ b/frontend/components/common/advanced-search/components/search-input.tsx
@@ -349,8 +349,8 @@ const FilterSearchInput = ({
     <div
       ref={containerRef}
       className={cn(
-        "flex items-start gap-2 px-1 rounded-md border border-input relative",
-        "bg-muted/80 transition duration-250 py-0.75",
+        "flex items-start gap-2 px-1 rounded-md border relative",
+        "bg-surface-up-2 transition duration-250 py-0.75",
         disabled && "opacity-50 pointer-events-none",
         className
       )}
@@ -394,8 +394,9 @@ const FilterSearchInput = ({
         <Button
           type="button"
           variant="ghost"
+          size="icon-sm"
           onClick={() => clearAll()}
-          className="text-secondary-foreground h-6 px-1 py-1 w-fit hover:bg-muted"
+          className="text-secondary-foreground hover:bg-muted"
           aria-label="Clear all filters"
         >
           <X className="size-4" />

--- a/frontend/components/common/advanced-search/components/search-input.tsx
+++ b/frontend/components/common/advanced-search/components/search-input.tsx
@@ -349,8 +349,8 @@ const FilterSearchInput = ({
     <div
       ref={containerRef}
       className={cn(
-        "flex items-start gap-2 px-1 rounded-md border relative",
-        "bg-surface-up-2 transition duration-250 py-0.75",
+        "flex items-start gap-2 px-1 rounded-md border border-input relative",
+        "bg-muted/80 transition duration-250 py-0.75",
         disabled && "opacity-50 pointer-events-none",
         className
       )}
@@ -394,9 +394,8 @@ const FilterSearchInput = ({
         <Button
           type="button"
           variant="ghost"
-          size="icon-sm"
           onClick={() => clearAll()}
-          className="text-secondary-foreground hover:bg-muted"
+          className="text-secondary-foreground h-6 px-1 py-1 w-fit hover:bg-muted"
           aria-label="Clear all filters"
         >
           <X className="size-4" />

--- a/frontend/components/shared/traces/header.tsx
+++ b/frontend/components/shared/traces/header.tsx
@@ -55,12 +55,12 @@ const Header = ({ onClose, isHideTimelineControls = false }: HeaderProps) => {
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center min-w-0 gap-2">
           <div className="flex items-center flex-shrink-0 gap-0.5">
-            <Button aria-label="Collapse panel" variant="ghost" className="px-0.5" onClick={onClose}>
+            <Button variant="ghost" size="icon" onClick={onClose}>
               <ChevronsRight className="w-5 h-5" />
             </Button>
             {trace && (
               <Link passHref href={`/shared/traces/${trace.id}`}>
-                <Button aria-label="Expand" variant="ghost" className="px-0.5">
+                <Button variant="ghost" size="icon">
                   <Maximize className="w-4 h-4" />
                 </Button>
               </Link>
@@ -71,7 +71,7 @@ const Header = ({ onClose, isHideTimelineControls = false }: HeaderProps) => {
               <span className="text-base font-medium ml-2 flex-shrink-0">Trace</span>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button aria-label="Trace actions" variant="ghost" className="h-6 px-1 hover:bg-secondary">
+                  <Button variant="ghost" size="icon-sm" className="hover:bg-secondary">
                     <ChevronDown className="size-3.5" />
                   </Button>
                 </DropdownMenuTrigger>

--- a/frontend/components/shared/traces/span-view.tsx
+++ b/frontend/components/shared/traces/span-view.tsx
@@ -4,7 +4,7 @@ import React, { useMemo } from "react";
 import useSWR from "swr";
 
 import ErrorCard from "@/components/traces/error-card";
-import { ModelIndicator } from "@/components/traces/model-indicator";
+import { getSpanModel, ModelIndicator } from "@/components/traces/model-indicator";
 import SpanTypeIcon from "@/components/traces/span-type-icon";
 import SpanContent from "@/components/traces/span-view/span-content.tsx";
 import SpanStatsShields from "@/components/traces/stats-shields";
@@ -43,6 +43,9 @@ export function SpanView({ spanId, traceId, onClose }: SpanViewProps) {
     );
   }
 
+  const tools = resolveTools(span);
+  const schema = span.attributes?.["gen_ai.request.structured_output_schema"] || span.attributes?.["ai.schema"];
+
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">
       <div className="flex flex-col px-2 pt-2 gap-1">
@@ -65,36 +68,28 @@ export function SpanView({ spanId, traceId, onClose }: SpanViewProps) {
         </div>
         <div className="flex flex-col gap-1.5 py-1">
           <div className="flex items-center gap-2 flex-wrap">
-            <SpanStatsShields span={span} variant="outline" />
+            <SpanStatsShields span={span} />
             <div className="text-xs font-mono rounded-md py-0.5 px-2 border border-muted">
               {new Date(span.startTime).toLocaleString()}
             </div>
           </div>
-          <div className="flex items-center gap-2 flex-wrap">
-            <ModelIndicator attributes={span.attributes} />
-            <ToolList tools={resolveTools(span)} />
-            <StructuredOutputSchema
-              schema={span.attributes?.["gen_ai.request.structured_output_schema"] || span.attributes?.["ai.schema"]}
-            />
-          </div>
+          {(getSpanModel(span.attributes) || tools.length > 0 || schema) && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <ModelIndicator attributes={span.attributes} />
+              <ToolList tools={tools} />
+              <StructuredOutputSchema schema={schema} />
+            </div>
+          )}
         </div>
         {errorEventAttributes && <ErrorCard attributes={errorEventAttributes} />}
       </div>
       <Tabs className="flex flex-col grow overflow-hidden gap-0" defaultValue="span-input">
         <div className="px-2 pb-2 mt-2 border-b w-full">
-          <TabsList className="border-none text-xs h-7">
-            <TabsTrigger value="span-input" className="text-xs">
-              Span Input
-            </TabsTrigger>
-            <TabsTrigger value="span-output" className="text-xs">
-              Span Output
-            </TabsTrigger>
-            <TabsTrigger value="attributes" className="text-xs">
-              Attributes
-            </TabsTrigger>
-            <TabsTrigger value="events" className="text-xs">
-              Events
-            </TabsTrigger>
+          <TabsList size="sm">
+            <TabsTrigger value="span-input">Span Input</TabsTrigger>
+            <TabsTrigger value="span-output">Span Output</TabsTrigger>
+            <TabsTrigger value="attributes">Attributes</TabsTrigger>
+            <TabsTrigger value="events">Events</TabsTrigger>
           </TabsList>
         </div>
         <div className="grow flex overflow-hidden">

--- a/frontend/components/tags/span-tags-list.tsx
+++ b/frontend/components/tags/span-tags-list.tsx
@@ -38,7 +38,11 @@ const SpanTagsList = ({ traceId, spanId }: SpanTagsListProps) => {
   return (
     <>
       {tags.map(({ name, color, id }) => (
-        <Badge key={id} variant="outline" className="rounded-full gap-1">
+        <Badge
+          key={id}
+          variant="outline"
+          className="gap-1 rounded-full border-0 bg-surface-up-2 text-secondary-foreground"
+        >
           <div className="rounded-full size-2.5 bg-gray-300" style={color ? { backgroundColor: color } : undefined} />
           {name}
         </Badge>

--- a/frontend/components/tags/tags-dropdown.tsx
+++ b/frontend/components/tags/tags-dropdown.tsx
@@ -20,6 +20,7 @@ export interface TagsDropdownCallbacks {
 interface TagsDropdownProps extends TagsDropdownCallbacks {
   tags: Tag[];
   tagClasses: TagClass[];
+  onOpenChange?: (open: boolean) => void;
 }
 
 const TagsDropdown = ({
@@ -29,19 +30,23 @@ const TagsDropdown = ({
   onAttach,
   onDetach,
   onCreateAndAttach,
+  onOpenChange,
 }: PropsWithChildren<TagsDropdownProps>) => {
   const [step, setStep] = useState<0 | 1>(0);
   const [query, setQuery] = useState("");
 
   return (
     <DropdownMenu
-      onOpenChange={() => {
-        setQuery("");
-        setStep(0);
+      onOpenChange={(open) => {
+        if (!open) {
+          setQuery("");
+          setStep(0);
+        }
+        onOpenChange?.(open);
       }}
     >
       {children}
-      <DropdownMenuContent className="max-h-96" side="bottom" align="start">
+      <DropdownMenuContent className="max-h-96" side="bottom" align="end">
         {step === 0 ? (
           <PickTag
             tags={tags}

--- a/frontend/components/tags/trace-tags-list.tsx
+++ b/frontend/components/tags/trace-tags-list.tsx
@@ -2,14 +2,14 @@
 
 import { Tag } from "lucide-react";
 import { useParams } from "next/navigation";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import useSWR from "swr";
 
-import { Button } from "@/components/ui/button";
+import { HeaderIconButton } from "@/components/traces/trace-view/header/header-icon-button";
 import { DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/lib/hooks/use-toast";
 import { type TagClass } from "@/lib/traces/types";
-import { cn, swrFetcher } from "@/lib/utils";
+import { swrFetcher } from "@/lib/utils";
 
 import { Badge } from "../ui/badge";
 import TagsDropdown, { type Tag as TagType } from "./tags-dropdown";
@@ -48,6 +48,7 @@ interface TraceTagsProps {
 export const TraceTagsButton = ({ traceId, className }: TraceTagsProps) => {
   const { projectId, tagClasses, rawTags, tags, mutateTagClasses, mutateTags } = useTraceTags(traceId);
   const { toast } = useToast();
+  const [open, setOpen] = useState(false);
 
   const onAttach = async (tagClassName: string) => {
     try {
@@ -153,12 +154,10 @@ export const TraceTagsButton = ({ traceId, className }: TraceTagsProps) => {
       onAttach={onAttach}
       onDetach={onDetach}
       onCreateAndAttach={onCreateAndAttach}
+      onOpenChange={setOpen}
     >
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" className={cn("h-6 text-xs px-1.5 gap-1.5", className)}>
-          <Tag data-icon="inline-start" className="size-3.5" />
-          Tags
-        </Button>
+        <HeaderIconButton icon={<Tag className="size-3.5" />} label="Tags" active={open} className={className} />
       </DropdownMenuTrigger>
     </TagsDropdown>
   );

--- a/frontend/components/tags/trace-tags-list.tsx
+++ b/frontend/components/tags/trace-tags-list.tsx
@@ -169,7 +169,11 @@ export const TraceTagsPills = ({ traceId }: TraceTagsProps) => {
   return (
     <>
       {tags.map(({ name, color, id }) => (
-        <Badge key={id} variant="outline" className="rounded-full gap-1">
+        <Badge
+          key={id}
+          variant="outline"
+          className="gap-1 rounded-full border-0 bg-surface-up-2 text-secondary-foreground"
+        >
           <div className="rounded-full size-2.5 bg-gray-300" style={{ backgroundColor: color }} />
           {name}
         </Badge>

--- a/frontend/components/traces/add-to-labeling-queue-dialog.tsx
+++ b/frontend/components/traces/add-to-labeling-queue-dialog.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import AddToLabelingQueueForm, {
+  type AddToLabelingQueueFormProps,
+} from "@/components/traces/add-to-labeling-queue-form";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+interface AddToLabelingQueueDialogProps extends Omit<AddToLabelingQueueFormProps, "onAdded" | "submitInFooter"> {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function AddToLabelingQueueDialog({ open, onOpenChange, ...formProps }: AddToLabelingQueueDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-96">
+        <DialogHeader>
+          <DialogTitle>Add to Queue</DialogTitle>
+        </DialogHeader>
+        <AddToLabelingQueueForm {...formProps} submitInFooter onAdded={() => onOpenChange(false)} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/components/traces/add-to-labeling-queue-form.tsx
+++ b/frontend/components/traces/add-to-labeling-queue-form.tsx
@@ -1,0 +1,182 @@
+import { Loader2, Plus } from "lucide-react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useCallback, useState } from "react";
+import useSWR from "swr";
+
+import CreateQueueDialog from "@/components/queues/create-queue-dialog";
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/lib/hooks/use-toast";
+import { track } from "@/lib/posthog";
+import { type LabelingQueue } from "@/lib/queue/types";
+import { type PaginatedResponse } from "@/lib/types";
+import { swrFetcher } from "@/lib/utils";
+
+export interface AddToLabelingQueueFormProps {
+  data?: {
+    metadata: Record<string, unknown>;
+    payload: {
+      data: Record<string, unknown>;
+      target: Record<string, unknown>;
+      metadata: Record<string, unknown> | null;
+    };
+  }[];
+  datapointIds?: string[];
+  datasetId?: string;
+  spanId?: string;
+  traceId?: string;
+  onAdded: () => void;
+  submitInFooter?: boolean;
+}
+
+export default function AddToLabelingQueueForm({
+  data,
+  datapointIds,
+  datasetId,
+  spanId,
+  traceId,
+  onAdded,
+  submitInFooter = false,
+}: AddToLabelingQueueFormProps) {
+  const [selectedQueue, setSelectedQueue] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(false);
+  const { projectId } = useParams();
+  const { toast } = useToast();
+
+  const isDatapointMode = datapointIds && datasetId;
+  const isSpanMode = !!spanId;
+
+  const { data: labelingQueues, isLoading: isQueuesLoading } = useSWR<PaginatedResponse<LabelingQueue>>(
+    `/api/projects/${projectId}/queues`,
+    swrFetcher
+  );
+
+  const handleAddToQueue = useCallback(async () => {
+    if (!selectedQueue) return;
+    setIsLoading(true);
+
+    try {
+      const response = await (async () => {
+        if (isSpanMode) {
+          return fetch(`/api/projects/${projectId}/spans/${spanId}/push`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              queueId: selectedQueue,
+              metadata: {
+                source: "span",
+                id: spanId,
+                traceId,
+              },
+            }),
+          });
+        }
+
+        if (isDatapointMode) {
+          return fetch(`/api/projects/${projectId}/datasets/${datasetId}/datapoints/push-to-queue`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ datapointIds, queueId: selectedQueue }),
+          });
+        }
+
+        return fetch(`/api/projects/${projectId}/queues/${selectedQueue}/push`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(data),
+        });
+      })();
+
+      if (response.ok) {
+        track("labeling_queues", "added", {
+          source: isSpanMode ? "span" : isDatapointMode ? "datapoint" : "queue",
+        });
+        toast({
+          title: "Success",
+          description: (
+            <span>
+              Successfully added to queue.{" "}
+              <Link className="text-primary" href={`/project/${projectId}/labeling-queues/${selectedQueue}`}>
+                Go to queue.
+              </Link>
+            </span>
+          ),
+        });
+        onAdded();
+      } else {
+        toast({
+          title: "Error",
+          description: "Failed to add to labeling queue",
+          variant: "destructive",
+        });
+        console.error("Failed to add to labeling queue:", response.statusText);
+      }
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to add to labeling queue",
+        variant: "destructive",
+      });
+      console.error("Failed to add to labeling queue:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    data,
+    datapointIds,
+    datasetId,
+    spanId,
+    traceId,
+    projectId,
+    selectedQueue,
+    toast,
+    isDatapointMode,
+    isSpanMode,
+    onAdded,
+  ]);
+
+  const submit = (
+    <Button
+      className={submitInFooter ? undefined : "ml-auto"}
+      handleEnter
+      onClick={handleAddToQueue}
+      disabled={!selectedQueue || isLoading}
+    >
+      {isLoading && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
+      Add
+    </Button>
+  );
+
+  return (
+    <>
+      <Select disabled={isQueuesLoading} value={selectedQueue} onValueChange={setSelectedQueue}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select a labeling queue" />
+        </SelectTrigger>
+        <SelectContent>
+          {labelingQueues?.items &&
+            labelingQueues.items.map((queue) => (
+              <SelectItem key={queue.id} value={queue.id}>
+                {queue.name}
+              </SelectItem>
+            ))}
+          <CreateQueueDialog>
+            <div className="relative flex w-full cursor-pointer hover:bg-secondary items-center rounded-sm py-1.5 pl-2 pr-8 text-sm">
+              <Plus className="w-3 h-3 mr-2" />
+              <span className="text-xs">Create queue</span>
+            </div>
+          </CreateQueueDialog>
+        </SelectContent>
+      </Select>
+      {submitInFooter ? <DialogFooter>{submit}</DialogFooter> : submit}
+    </>
+  );
+}

--- a/frontend/components/traces/add-to-labeling-queue-popover.tsx
+++ b/frontend/components/traces/add-to-labeling-queue-popover.tsx
@@ -1,174 +1,43 @@
-import { Loader2, Plus } from "lucide-react";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { type PropsWithChildren, useCallback, useState } from "react";
-import useSWR from "swr";
+import { type PropsWithChildren, useState } from "react";
 
-import CreateQueueDialog from "@/components/queues/create-queue-dialog";
+import AddToLabelingQueueForm, {
+  type AddToLabelingQueueFormProps,
+} from "@/components/traces/add-to-labeling-queue-form";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { useToast } from "@/lib/hooks/use-toast";
-import { track } from "@/lib/posthog";
-import { type LabelingQueue } from "@/lib/queue/types";
-import { type PaginatedResponse } from "@/lib/types";
-import { swrFetcher } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
-interface AddToLabelingQueuePopoverProps {
-  data?: {
-    metadata: Record<string, unknown>;
-    payload: {
-      data: Record<string, unknown>;
-      target: Record<string, unknown>;
-      metadata: Record<string, unknown> | null;
-    };
-  }[];
-  datapointIds?: string[];
-  datasetId?: string;
-  spanId?: string;
-  traceId?: string;
+interface AddToLabelingQueuePopoverProps extends Omit<AddToLabelingQueueFormProps, "onAdded" | "submitInFooter"> {
   buttonVariant?: "default" | "secondary" | "outline" | "ghost" | "link" | "destructive";
   buttonSize?: "default" | "sm" | "lg" | "icon";
 }
 
 export default function AddToLabelingQueuePopover({
-  data,
-  datapointIds,
-  datasetId,
-  spanId,
-  traceId,
   buttonVariant = "secondary",
   buttonSize = "sm",
   children,
+  ...formProps
 }: PropsWithChildren<AddToLabelingQueuePopoverProps>) {
-  const [selectedQueue, setSelectedQueue] = useState<string>("");
-  const [isLoading, setIsLoading] = useState(false);
   const [open, setOpen] = useState(false);
-  const { projectId } = useParams();
-  const { toast } = useToast();
-
-  const isDatapointMode = datapointIds && datasetId;
-  const isSpanMode = !!spanId;
-
-  const { data: labelingQueues, isLoading: isQueuesLoading } = useSWR<PaginatedResponse<LabelingQueue>>(
-    `/api/projects/${projectId}/queues`,
-    swrFetcher
-  );
-
-  const handleAddToQueue = useCallback(async () => {
-    if (!selectedQueue) return;
-    setIsLoading(true);
-
-    try {
-      const response = await (async () => {
-        if (isSpanMode) {
-          return fetch(`/api/projects/${projectId}/spans/${spanId}/push`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              queueId: selectedQueue,
-              metadata: {
-                source: "span",
-                id: spanId,
-                traceId,
-              },
-            }),
-          });
-        }
-
-        if (isDatapointMode) {
-          return fetch(`/api/projects/${projectId}/datasets/${datasetId}/datapoints/push-to-queue`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ datapointIds, queueId: selectedQueue }),
-          });
-        }
-
-        return fetch(`/api/projects/${projectId}/queues/${selectedQueue}/push`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(data),
-        });
-      })();
-
-      if (response.ok) {
-        track("labeling_queues", "added", {
-          source: isSpanMode ? "span" : isDatapointMode ? "datapoint" : "queue",
-        });
-        toast({
-          title: "Success",
-          description: (
-            <span>
-              Successfully added to queue.{" "}
-              <Link className="text-primary" href={`/project/${projectId}/labeling-queues/${selectedQueue}`}>
-                Go to queue.
-              </Link>
-            </span>
-          ),
-        });
-        setOpen(false);
-      } else {
-        toast({
-          title: "Error",
-          description: "Failed to add to labeling queue",
-          variant: "destructive",
-        });
-        console.error("Failed to add to labeling queue:", response.statusText);
-      }
-    } catch (error) {
-      toast({
-        title: "Error",
-        description: "Failed to add to labeling queue",
-        variant: "destructive",
-      });
-      console.error("Failed to add to labeling queue:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [data, datapointIds, datasetId, spanId, traceId, projectId, selectedQueue, toast, isDatapointMode, isSpanMode]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         {children || (
-          <Button size={buttonSize} icon="pen" className="w-fit" variant={buttonVariant}>
+          <Button
+            size={buttonSize}
+            icon="pen"
+            className={cn("w-fit", buttonVariant === "ghost" && "hover:bg-secondary")}
+            variant={buttonVariant}
+          >
             <span className="text-xs truncate block min-w-0">Add to labeling queue</span>
           </Button>
         )}
       </PopoverTrigger>
-
       <PopoverContent className="w-80" align="start" side="bottom">
         <div className="flex flex-col space-y-4">
           <span className="font-medium">Add to Queue</span>
-          <Select disabled={isQueuesLoading} value={selectedQueue} onValueChange={setSelectedQueue}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select a labeling queue" />
-            </SelectTrigger>
-            <SelectContent>
-              {labelingQueues?.items &&
-                labelingQueues.items.map((queue) => (
-                  <SelectItem key={queue.id} value={queue.id}>
-                    {queue.name}
-                  </SelectItem>
-                ))}
-              <CreateQueueDialog>
-                <div className="relative flex w-full cursor-pointer hover:bg-secondary items-center rounded-sm py-1.5 pl-2 pr-8 text-sm">
-                  <Plus className="w-3 h-3 mr-2" />
-                  <span className="text-xs">Create queue</span>
-                </div>
-              </CreateQueueDialog>
-            </SelectContent>
-          </Select>
-          <Button className="ml-auto" onClick={handleAddToQueue} disabled={!selectedQueue || isLoading}>
-            {isLoading && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
-            Add
-          </Button>
+          <AddToLabelingQueueForm {...formProps} onAdded={() => setOpen(false)} />
         </div>
       </PopoverContent>
     </Popover>

--- a/frontend/components/traces/cells/cost-cell.tsx
+++ b/frontend/components/traces/cells/cost-cell.tsx
@@ -3,7 +3,7 @@
 import { TooltipPortal } from "@radix-ui/react-tooltip";
 
 import { CostBreakdown } from "@/components/traces/cells/cost-breakdown";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { type CostStats, currencyFormatter } from "@/lib/traces/format";
 import { cn } from "@/lib/utils";
 
@@ -20,15 +20,17 @@ export function CostCell({ stats, className }: CostCellProps) {
   }
 
   return (
-    <Tooltip delayDuration={250}>
-      <TooltipTrigger asChild>
-        <span className={cn("truncate", className)}>{currencyFormatter.format(totalCost)}</span>
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent className="flex flex-col border gap-1 p-2">
-          <CostBreakdown stats={stats} />
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={cn("truncate", className)}>{currencyFormatter.format(totalCost)}</span>
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent className="flex flex-col gap-1 p-2">
+            <CostBreakdown stats={stats} />
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/frontend/components/traces/cells/duration-cell.tsx
+++ b/frontend/components/traces/cells/duration-cell.tsx
@@ -3,7 +3,7 @@
 import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { useMemo } from "react";
 
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { durationMsBetween, formatDurationExact, formatDurationMs } from "@/lib/traces/format";
 import { cn } from "@/lib/utils";
 
@@ -26,13 +26,15 @@ export function DurationCell({ durationMs, startTime, endTime, className }: Dura
   }
 
   return (
-    <Tooltip delayDuration={250}>
-      <TooltipTrigger asChild>
-        <span className={cn("truncate", className)}>{formatDurationMs(ms)}</span>
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent className="border p-2">{formatDurationExact(ms)}</TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={cn("truncate", className)}>{formatDurationMs(ms)}</span>
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent className="p-2">{formatDurationExact(ms)}</TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/frontend/components/traces/cells/tokens-cell.tsx
+++ b/frontend/components/traces/cells/tokens-cell.tsx
@@ -3,7 +3,7 @@
 import { TooltipPortal } from "@radix-ui/react-tooltip";
 
 import { TokensBreakdown } from "@/components/traces/cells/tokens-breakdown";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatTokensCompact, type TokenStats } from "@/lib/traces/format";
 import { cn } from "@/lib/utils";
 
@@ -24,22 +24,24 @@ export function TokensCell({ stats, className, showCacheInline = false }: Tokens
   }
 
   return (
-    <Tooltip delayDuration={250}>
-      <TooltipTrigger asChild>
-        <span className={cn("truncate", className)}>
-          {formatTokensCompact(stats.inputTokens)}
-          {showCacheInline && cacheReadInputTokens > 0 && (
-            <span className="text-success-bright"> ({formatTokensCompact(cacheReadInputTokens)})</span>
-          )}{" "}
-          {"→"} {formatTokensCompact(stats.outputTokens)} <span className="text-muted-foreground">/ </span>
-          <span className="text-muted-foreground">{formatTokensCompact(totalTokens)}</span>
-        </span>
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent className="flex flex-col border gap-1 p-2">
-          <TokensBreakdown stats={stats} />
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={cn("truncate", className)}>
+            {formatTokensCompact(stats.inputTokens)}
+            {showCacheInline && cacheReadInputTokens > 0 && (
+              <span className="text-success-bright"> ({formatTokensCompact(cacheReadInputTokens)})</span>
+            )}{" "}
+            {"→"} {formatTokensCompact(stats.outputTokens)} <span className="text-muted-foreground">/ </span>
+            <span className="text-muted-foreground">{formatTokensCompact(totalTokens)}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent className="flex flex-col gap-1 p-2">
+            <TokensBreakdown stats={stats} />
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/frontend/components/traces/export-spans-dialog.tsx
+++ b/frontend/components/traces/export-spans-dialog.tsx
@@ -1,10 +1,13 @@
+"use client";
+
 import { Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { type PropsWithChildren, useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { type Dataset } from "@/lib/dataset/types";
 import { useToast } from "@/lib/hooks/use-toast";
 import { track } from "@/lib/posthog";
@@ -14,15 +17,26 @@ import DatasetSelect from "../ui/dataset-select";
 
 interface ExportSpansDialogProps {
   span: Span;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
-export default function ExportSpansPopover({ children, span }: PropsWithChildren<ExportSpansDialogProps>) {
+export default function ExportSpansDialog({ span, open, onOpenChange }: ExportSpansDialogProps) {
   const { projectId } = useParams();
-  const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null);
-
   const { toast } = useToast();
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      onOpenChange(next);
+      if (!next) {
+        setSelectedDataset(null);
+        setIsLoading(false);
+      }
+    },
+    [onOpenChange]
+  );
 
   const exportSpan = useCallback(async () => {
     try {
@@ -67,38 +81,25 @@ export default function ExportSpansPopover({ children, span }: PropsWithChildren
     } finally {
       setIsLoading(false);
     }
-  }, [projectId, selectedDataset, span.spanId, toast]);
+  }, [projectId, selectedDataset, setOpen, span.spanId, toast]);
 
   return (
-    <>
-      <Popover
-        open={open}
-        onOpenChange={(open) => {
-          setOpen(open);
-          if (!open) {
-            setSelectedDataset(null);
-            setIsLoading(false);
-          }
-        }}
-      >
-        <PopoverTrigger asChild>
-          {children || (
-            <Button icon="database" size="sm" variant="secondary">
-              <span>Add to dataset</span>
-            </Button>
-          )}
-        </PopoverTrigger>
-        <PopoverContent className="w-80" align="end" side="bottom">
-          <div className="flex flex-col space-y-4">
-            <span className="font-medium">Export span to dataset</span>
-            <DatasetSelect onChange={(dataset) => setSelectedDataset(dataset)} />
-            <Button className="ml-auto" onClick={exportSpan} disabled={!selectedDataset || isLoading}>
-              {isLoading && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
-              Add to dataset
-            </Button>
-          </div>
-        </PopoverContent>
-      </Popover>
-    </>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-96">
+        <DialogHeader>
+          <DialogTitle>Add to dataset</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-2">
+          <Label>Dataset</Label>
+          <DatasetSelect value={selectedDataset?.id} onChange={(dataset) => setSelectedDataset(dataset)} />
+        </div>
+        <DialogFooter>
+          <Button handleEnter onClick={exportSpan} disabled={!selectedDataset || isLoading}>
+            {isLoading && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
+            Add to dataset
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/components/traces/model-indicator.tsx
+++ b/frontend/components/traces/model-indicator.tsx
@@ -1,19 +1,22 @@
 import { get } from "lodash";
-
-import { Label } from "../ui/label";
+import { MessageCircle } from "lucide-react";
 
 interface ModelIndicatorProps {
   attributes: Record<string, any>;
 }
 
+export const getSpanModel = (attributes?: Record<string, any>): string =>
+  get(attributes, "gen_ai.response.model") || get(attributes, "gen_ai.request.model") || "";
+
 export const ModelIndicator = ({ attributes }: ModelIndicatorProps) => {
-  const model = get(attributes, "gen_ai.response.model") || get(attributes, "gen_ai.request.model") || "";
+  const model = getSpanModel(attributes);
 
   if (!model) return null;
 
   return (
-    <Label className="h-6 w-fit flex items-center text-xs truncate font-mono border rounded-md px-2 border-llm-foreground bg-llm-foreground/10 text-llm-foreground">
+    <span className="h-[26px] w-fit flex items-center gap-1 rounded-md px-2 text-xs font-mono bg-llm-foreground/15 text-llm-foreground">
+      <MessageCircle size={12} className="min-w-3" />
       {model}
-    </Label>
+    </span>
   );
 };

--- a/frontend/components/traces/model-indicator.tsx
+++ b/frontend/components/traces/model-indicator.tsx
@@ -14,7 +14,7 @@ export const ModelIndicator = ({ attributes }: ModelIndicatorProps) => {
   if (!model) return null;
 
   return (
-    <span className="h-[26px] w-fit flex items-center gap-1 rounded-md px-2 text-xs font-mono bg-llm-foreground/15 text-llm-foreground">
+    <span className="h-6 w-fit flex items-center gap-1 rounded-md px-2 text-xs font-mono bg-llm-foreground/15 text-llm-foreground">
       <MessageCircle size={12} className="min-w-3" />
       {model}
     </span>

--- a/frontend/components/traces/no-span-tooltip.tsx
+++ b/frontend/components/traces/no-span-tooltip.tsx
@@ -1,18 +1,17 @@
-import { TooltipPortal } from "@radix-ui/react-tooltip";
-
-import { cn } from "@/lib/utils.ts";
-
-import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+import { cn } from "../../lib/utils";
+import { Tooltip, TooltipContent, TooltipPortal, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
 
 export function NoSpanTooltip({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
-    <Tooltip delayDuration={100}>
-      <TooltipTrigger>{children}</TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent side="bottom" className={cn("p-0 border", className)}>
-          <div className="p-1 whitespace-pre-wrap text-secondary-foreground">Top level span was not received</div>
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger>{children}</TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent side="bottom" className={cn("p-0", className)}>
+            <div className="p-1 whitespace-pre-wrap text-secondary-foreground">Top level span was not received</div>
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/frontend/components/traces/placeholder/tabs-section.tsx
+++ b/frontend/components/traces/placeholder/tabs-section.tsx
@@ -12,7 +12,7 @@ export function InstallTabsSection() {
 
   return (
     <Tabs defaultValue="typescript" value={tabValue} onValueChange={setTabValue}>
-      <TabsList className="border-none flex">
+      <TabsList className="flex">
         <TabsTrigger value="typescript">TypeScript</TabsTrigger>
         <TabsTrigger value="python">Python</TabsTrigger>
       </TabsList>
@@ -48,7 +48,7 @@ Laminar.initialize();
 
   return (
     <Tabs value={tabValue} onValueChange={setTabValue} defaultValue="typescript">
-      <TabsList className="border-none flex">
+      <TabsList className="flex">
         <TabsTrigger value="typescript">TypeScript</TabsTrigger>
         <TabsTrigger value="python">Python</TabsTrigger>
       </TabsList>

--- a/frontend/components/traces/session-view/session-condensed-timeline/close-button.tsx
+++ b/frontend/components/traces/session-view/session-condensed-timeline/close-button.tsx
@@ -12,7 +12,7 @@ interface CloseButtonProps {
 export default function CloseButton({ onClose }: CloseButtonProps) {
   return (
     <div className="absolute z-40 top-0 right-0 flex items-end overflow-hidden h-6 w-7 bg-muted border-b border-l rounded-none rounded-bl">
-      <Button aria-label="Close" onClick={onClose} variant="ghost" size="icon" className="size-5 min-w-5">
+      <Button onClick={onClose} variant="ghost" size="icon-xs" className="min-w-5">
         <X className="size-3.5" />
       </Button>
     </div>

--- a/frontend/components/traces/session-view/session-panel/regular-timeline-toggle.tsx
+++ b/frontend/components/traces/session-view/session-panel/regular-timeline-toggle.tsx
@@ -19,11 +19,9 @@ export default function RegularTimelineToggle() {
   return (
     <Button
       onClick={() => setSessionTimelineEnabled(!sessionTimelineEnabled)}
-      variant="outline"
-      className={cn(
-        "h-6 text-xs px-1.5",
-        sessionTimelineEnabled ? "border-primary text-primary hover:bg-primary/10" : "hover:bg-secondary"
-      )}
+      variant={sessionTimelineEnabled ? "outlinePrimary" : "outline"}
+      size="sm"
+      className={cn(!sessionTimelineEnabled && "hover:bg-secondary")}
     >
       <GanttChart data-icon="inline-start" size={14} className="mr-1" />
       Timeline

--- a/frontend/components/traces/session-view/session-panel/trace-control-bar.tsx
+++ b/frontend/components/traces/session-view/session-panel/trace-control-bar.tsx
@@ -78,11 +78,9 @@ export default function TraceControlBar({ trace, analyticsFeature = "sessions" }
       {isDebugger && (
         <Button
           onClick={handleToggleTimeline}
-          variant="outline"
-          className={cn(
-            "h-6 text-xs px-1.5 bg-transparent",
-            isTimelineOpen ? "border-primary text-primary hover:bg-primary/10" : "hover:bg-secondary"
-          )}
+          variant={isTimelineOpen ? "outlinePrimary" : "outline"}
+          size="sm"
+          className={cn("bg-transparent", !isTimelineOpen && "hover:bg-secondary")}
         >
           <GanttChart data-icon="inline-start" size={14} className="mr-1" />
           Timeline

--- a/frontend/components/traces/session-view/session-timeline/controls.tsx
+++ b/frontend/components/traces/session-view/session-timeline/controls.tsx
@@ -21,9 +21,9 @@ export default function SessionTimelineControls() {
         <Button
           aria-label="Zoom in"
           disabled={zoom >= MAX_ZOOM}
-          className="size-5 min-w-5"
+          className="min-w-5"
           variant="ghost"
-          size="icon"
+          size="icon-xs"
           onClick={() => setZoom(zoom + ZOOM_INCREMENT)}
         >
           <Plus className="size-3" />
@@ -31,9 +31,9 @@ export default function SessionTimelineControls() {
         <Button
           aria-label="Zoom out"
           disabled={zoom <= MIN_ZOOM}
-          className="size-5 min-w-5"
+          className="min-w-5"
           variant="ghost"
-          size="icon"
+          size="icon-xs"
           onClick={() => setZoom(zoom - ZOOM_INCREMENT)}
         >
           <Minus className="size-3" />

--- a/frontend/components/traces/session-view/session-timeline/index.tsx
+++ b/frontend/components/traces/session-view/session-timeline/index.tsx
@@ -229,13 +229,7 @@ function SessionTimeline() {
 
       {/* Close button — top-right, styled as a flush tab */}
       <div className="absolute top-0 right-0 z-40 h-6 w-7 bg-muted border-b border-l rounded-bl flex items-end overflow-hidden">
-        <Button
-          aria-label="Close"
-          onClick={() => setSessionTimelineEnabled(false)}
-          variant="ghost"
-          size="icon"
-          className="size-5 min-w-5"
-        >
+        <Button onClick={() => setSessionTimelineEnabled(false)} variant="ghost" size="icon-xs" className="min-w-5">
           <X className="size-3.5" />
         </Button>
       </div>

--- a/frontend/components/traces/share-trace-button.tsx
+++ b/frontend/components/traces/share-trace-button.tsx
@@ -1,156 +1,138 @@
 "use client";
+
 import { TooltipPortal } from "@radix-ui/react-tooltip";
-import { Globe, Link, Loader2, Lock, Share } from "lucide-react";
-import React, { useState } from "react";
+import { Copy, Globe, Loader2, Lock, Share } from "lucide-react";
+import { useState } from "react";
 import { shallow } from "zustand/shallow";
 
 import { useTraceViewStore } from "@/components/traces/trace-view/store";
 import { Button } from "@/components/ui/button";
-import { CopyButton } from "@/components/ui/copy-button";
-import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useToast } from "@/lib/hooks/use-toast";
 import { track } from "@/lib/posthog";
 
-const ShareTraceButton = ({ projectId }: { projectId: string; refetch?: () => void }) => {
+const ShareTraceButton = ({ projectId }: { projectId: string }) => {
   const { trace, updateTraceVisibility } = useTraceViewStore(
-    (state) => ({
-      trace: state.trace,
-      updateTraceVisibility: state.updateTraceVisibility,
-    }),
+    (state) => ({ trace: state.trace, updateTraceVisibility: state.updateTraceVisibility }),
     shallow
   );
-
-  const url = typeof window !== "undefined" ? `${window.location.origin}/shared/traces/${trace?.id}` : "";
-  const [isLoading, setIsLoading] = useState(false);
-
+  const [isVisibilityLoading, setIsVisibilityLoading] = useState(false);
   const { toast } = useToast();
-  const handleChangeVisibility = async (value: "private" | "public") => {
+  const handleChangeVisibility = async (visibility: "private" | "public") => {
+    if (!trace || trace.visibility === visibility) return;
     try {
-      setIsLoading(true);
-      const res = await fetch(`/api/projects/${projectId}/traces/${trace?.id}`, {
+      setIsVisibilityLoading(true);
+      const res = await fetch(`/api/projects/${projectId}/traces/${trace.id}`, {
         method: "PUT",
-        body: JSON.stringify({
-          visibility: value,
-        }),
+        body: JSON.stringify({ visibility }),
       });
-
-      if (res.ok) {
-        toast({
-          title: "Trace privacy updated.",
-        });
-        updateTraceVisibility(value);
-        track("traces", "visibility_changed", { visibility: value });
-      } else {
-        const text = await res.json();
-        if ("error" in text) {
-          toast({ variant: "destructive", title: "Error", description: String(text.error) });
-        }
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error ?? "Failed to update trace privacy");
       }
-    } catch (e) {
+      updateTraceVisibility(visibility);
+      track("traces", "visibility_changed", { visibility });
+      toast({ title: "Trace privacy updated." });
+    } catch (error) {
       toast({
         variant: "destructive",
         title: "Error",
-        description: "Failed to update trace privacy. Please try again.",
+        description: error instanceof Error ? error.message : "Failed to update trace privacy. Please try again.",
       });
     } finally {
-      setIsLoading(false);
+      setIsVisibilityLoading(false);
     }
   };
 
-  if (!trace) {
-    return null;
-  }
+  const handleCopyLink = async () => {
+    if (!trace) return;
+    await navigator.clipboard.writeText(`${window.location.origin}/shared/traces/${trace.id}`);
+    track("traces", "share_link_copied");
+    toast({ title: "Copied share link", duration: 1000 });
+  };
+
+  if (!trace) return null;
 
   return (
-    <TooltipProvider delayDuration={0}>
-      <Popover>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <PopoverTrigger asChild>
-              <Button className="relative hover:bg-secondary px-1.5" variant="ghost">
-                {trace.visibility === "public" ? <Globe className="h-4 w-4" /> : <Share className="h-4 w-4" />}
-              </Button>
-            </PopoverTrigger>
-          </TooltipTrigger>
-          <TooltipPortal>
-            <TooltipContent>Share Trace</TooltipContent>
-          </TooltipPortal>
-        </Tooltip>
-        <PopoverContent className="flex flex-col gap-4 w-96" align="end">
-          <div>
-            <h2 className="text-md font-medium">Share trace</h2>
-            <span className="text-sm text-secondary-foreground mt-2">Configure who has access to this trace.</span>
-          </div>
-          <div className="flex items-center space-x-2">
-            <Select value={trace.visibility || "private"} onValueChange={handleChangeVisibility}>
-              <SelectTrigger
-                disabled={isLoading}
-                value={trace.visibility || "private"}
-                className="text-sm min-w-4 h-8 focus:ring-0"
-              >
-                <SelectValue placeholder="Select access">
-                  <div className="flex items-center">
-                    {isLoading ? (
-                      <>
-                        <Loader2 className="animate-spin w-4 h-4 mr-2" />
-                        <span>Loading...</span>
-                      </>
-                    ) : trace.visibility === "public" ? (
-                      <>
-                        <Globe className="text-secondary-foreground h-4 w-4 mr-2" />
-                        <span>Public</span>
-                      </>
+    <DropdownMenu>
+      <Tooltip delayDuration={400}>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button className="relative hover:bg-surface-up" variant="ghost" size="icon" aria-label="Share trace">
+              {trace.visibility === "public" ? <Globe className="size-3.5" /> : <Share className="size-3.5" />}
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent>Share trace</TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+      <DropdownMenuContent className="w-56" align="end">
+        <DropdownMenuLabel className="pb-1 text-xs font-normal text-muted-foreground">Share trace</DropdownMenuLabel>
+        <div className="px-1 pb-1" onKeyDown={(event) => event.stopPropagation()}>
+          <Select
+            value={trace.visibility ?? "private"}
+            disabled={isVisibilityLoading}
+            onValueChange={(visibility: "private" | "public") => handleChangeVisibility(visibility)}
+          >
+            <SelectTrigger className="h-7 border-0 bg-surface-up-2 px-2 shadow-none hover:bg-muted">
+              {isVisibilityLoading ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <SelectValue>
+                  <span className="flex items-center gap-2">
+                    {trace.visibility === "public" ? (
+                      <Globe className="size-3.5 text-muted-foreground" />
                     ) : (
-                      <>
-                        <Lock className="text-secondary-foreground h-4 w-4 mr-2" />
-                        <span>Private</span>
-                      </>
+                      <Lock className="size-3.5 text-muted-foreground" />
                     )}
-                  </div>
+                    <span>{trace.visibility === "public" ? "Public" : "Private"}</span>
+                  </span>
                 </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem key="private" value="private">
-                  <div className="flex items-center">
-                    <Lock className="text-secondary-foreground h-4 w-4 mr-2" />
-                    <div className="flex flex-col gap-1">
-                      <span>Private</span>
-                      <span className="text-xs text-secondary-foreground">Only you can access this trace</span>
-                    </div>
-                  </div>
-                </SelectItem>
-                <SelectItem key="public" value="public">
-                  <div className="flex items-center">
-                    <Globe className="text-secondary-foreground h-4 w-4 mr-2" />
-                    <div className="flex flex-col gap-1">
-                      <span>Public</span>
-                      <span className="text-xs text-secondary-foreground">Everyone can view this trace</span>
-                    </div>
-                  </div>
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex flex-row-reverse gap-2">
-            <PopoverClose asChild>
-              <Button variant="outline">Done</Button>
-            </PopoverClose>
-            {trace.visibility === "public" && (
-              <CopyButton
-                variant="lightSecondary"
-                icon={<Link className="h-4 w-4 mr-2" />}
-                text={url}
-                onCopy={() => track("traces", "share_link_copied")}
-              >
-                <span>Copy link</span>
-              </CopyButton>
-            )}
-          </div>
-        </PopoverContent>
-      </Popover>
-    </TooltipProvider>
+              )}
+            </SelectTrigger>
+            <SelectContent className="w-56">
+              <SelectItem value="private" className="py-2">
+                <span className="flex items-start gap-2">
+                  <Lock className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="flex flex-col">
+                    <span className="font-medium">Private</span>
+                    <span className="text-[11px] leading-tight text-muted-foreground">
+                      Only you can access this trace
+                    </span>
+                  </span>
+                </span>
+              </SelectItem>
+              <SelectItem value="public" className="py-2">
+                <span className="flex items-start gap-2">
+                  <Globe className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="flex flex-col">
+                    <span className="font-medium">Public</span>
+                    <span className="text-[11px] leading-tight text-muted-foreground">
+                      Anyone with a link can view this trace
+                    </span>
+                  </span>
+                </span>
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {trace.visibility === "public" && (
+          <DropdownMenuItem onClick={handleCopyLink}>
+            <Copy className="size-3.5" />
+            Copy share link
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/frontend/components/traces/span-actions-dropdown.tsx
+++ b/frontend/components/traces/span-actions-dropdown.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { ChevronDown, Copy, Database, ListPlus, Loader, PlayCircle } from "lucide-react";
+import Link from "next/link";
+import { useRef, useState } from "react";
+
+import AddToLabelingQueueDialog from "@/components/traces/add-to-labeling-queue-dialog";
+import ExportSpansDialog from "@/components/traces/export-spans-dialog";
+import { useOpenInSql } from "@/components/traces/trace-view/use-open-in-sql";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useToast } from "@/lib/hooks/use-toast";
+import { track } from "@/lib/posthog";
+import { type Span, SpanType } from "@/lib/traces/types";
+
+interface SpanActionsDropdownProps {
+  projectId: string;
+  span: Span;
+}
+
+export default function SpanActionsDropdown({ projectId, span }: SpanActionsDropdownProps) {
+  const { toast } = useToast();
+  const { openInSql, isLoading } = useOpenInSql({
+    projectId,
+    params: { type: "span", spanId: span.spanId, traceId: span.traceId },
+  });
+  const [queueOpen, setQueueOpen] = useState(false);
+  const [datasetOpen, setDatasetOpen] = useState(false);
+  const skipMenuFocusRestore = useRef(false);
+
+  const handleCopySpanId = async () => {
+    await navigator.clipboard.writeText(span.spanId);
+    toast({ title: "Copied span ID", duration: 1000 });
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            aria-label="Span actions"
+            className="min-w-0 justify-start gap-1 px-1 text-base font-medium hover:bg-surface-up"
+          >
+            <span className="truncate">{span.name}</span>
+            <ChevronDown className="size-3.5 shrink-0" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          onCloseAutoFocus={(event) => {
+            if (skipMenuFocusRestore.current) {
+              event.preventDefault();
+              skipMenuFocusRestore.current = false;
+            }
+          }}
+        >
+          <DropdownMenuItem onClick={handleCopySpanId}>
+            <Copy className="size-3.5" />
+            Copy span ID
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled={isLoading} onClick={openInSql}>
+            {isLoading ? <Loader className="size-3.5 animate-spin" /> : <Database className="size-3.5" />}
+            Open in SQL editor
+          </DropdownMenuItem>
+          {span.spanType === SpanType.LLM && (
+            <DropdownMenuItem asChild>
+              <Link
+                href={{ pathname: `/project/${projectId}/playgrounds/create`, query: { spanId: span.spanId } }}
+                onClick={() => track("playgrounds", "experiment_clicked", { source: "span_view" })}
+              >
+                <PlayCircle className="size-3.5" />
+                Experiment in playground
+              </Link>
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem
+            onSelect={() => {
+              skipMenuFocusRestore.current = true;
+              setDatasetOpen(false);
+              setQueueOpen(true);
+            }}
+          >
+            <ListPlus className="size-3.5" />
+            Add to labeling queue
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              skipMenuFocusRestore.current = true;
+              setQueueOpen(false);
+              setDatasetOpen(true);
+            }}
+          >
+            <Database className="size-3.5" />
+            Add to dataset
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AddToLabelingQueueDialog
+        spanId={span.spanId}
+        traceId={span.traceId}
+        open={queueOpen}
+        onOpenChange={setQueueOpen}
+      />
+      <ExportSpansDialog span={span} open={datasetOpen} onOpenChange={setDatasetOpen} />
+    </>
+  );
+}

--- a/frontend/components/traces/span-controls.tsx
+++ b/frontend/components/traces/span-controls.tsx
@@ -38,7 +38,7 @@ export function SpanControls({ children, span, onClose, isAlwaysSelectSpan }: Pr
       <div className="flex flex-col px-2 pt-2 gap-2">
         <div className="flex flex-none items-center gap-2">
           <SpanTypeIcon spanType={span.spanType} />
-          <div className="min-w-0 flex-1">
+          <div className="min-w-0">
             <SpanActionsDropdown projectId={projectId as string} span={span} />
           </div>
           <div className="ml-auto flex shrink-0 items-center gap-1">

--- a/frontend/components/traces/span-controls.tsx
+++ b/frontend/components/traces/span-controls.tsx
@@ -57,15 +57,15 @@ export function SpanControls({ children, span, onClose, isAlwaysSelectSpan }: Pr
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <ModelIndicator attributes={span.attributes} />
+          <ToolList tools={tools} />
           <SpanStatsShields span={span} className="w-fit" />
-          <div className="flex h-[26px] w-fit items-center rounded-md bg-surface-up-2 px-2">
+          <div className="flex h-6 w-fit items-center rounded-md bg-surface-up-2 px-2">
             <ClientTimestampFormatter
               absolute
               timestamp={span.startTime}
               className="text-xs text-secondary-foreground"
             />
           </div>
-          <ToolList tools={tools} />
           <StructuredOutputSchema schema={schema} />
           <SpanTagsList traceId={span.traceId} spanId={span.spanId} />
         </div>

--- a/frontend/components/traces/span-controls.tsx
+++ b/frontend/components/traces/span-controls.tsx
@@ -1,23 +1,13 @@
-import { ChevronDown, Copy, Database, Loader, PlayCircle, X } from "lucide-react";
-import Link from "next/link";
+import { X } from "lucide-react";
 import { useParams } from "next/navigation";
-import { type PropsWithChildren, useCallback, useMemo } from "react";
+import { type PropsWithChildren, useMemo } from "react";
 
+import ClientTimestampFormatter from "@/components/client-timestamp-formatter";
 import SpanTagsList from "@/components/tags/span-tags-list";
-import AddToLabelingQueuePopover from "@/components/traces/add-to-labeling-queue-popover";
 import ErrorCard from "@/components/traces/error-card";
-import ExportSpansPopover from "@/components/traces/export-spans-popover";
-import { useOpenInSql } from "@/components/traces/trace-view/use-open-in-sql.tsx";
+import SpanActionsDropdown from "@/components/traces/span-actions-dropdown";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { useToast } from "@/lib/hooks/use-toast";
-import { track } from "@/lib/posthog";
-import { type Span, SpanType } from "@/lib/traces/types";
+import { type Span } from "@/lib/traces/types";
 import { type ErrorEventAttributes } from "@/lib/types";
 
 import { ModelIndicator } from "./model-indicator";
@@ -40,88 +30,44 @@ export function SpanControls({ children, span, onClose, isAlwaysSelectSpan }: Pr
     [span.events]
   );
 
-  const { toast } = useToast();
-  const { openInSql, isLoading } = useOpenInSql({
-    projectId: projectId as string,
-    params: { type: "span", spanId: span.spanId, traceId: span.traceId },
-  });
-
-  const handleCopySpanId = useCallback(async () => {
-    if (span?.spanId) {
-      await navigator.clipboard.writeText(span.spanId);
-      toast({ title: "Copied span ID", duration: 1000 });
-    }
-  }, [span?.spanId, toast]);
+  const tools = resolveTools(span);
+  const schema = span.attributes?.["gen_ai.request.structured_output_schema"] || span.attributes?.["ai.schema"];
 
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">
       <div className="flex flex-col px-2 pt-2 gap-2">
-        <div className="flex flex-none items-center space-x-2">
+        <div className="flex flex-none items-center gap-2">
           <SpanTypeIcon spanType={span.spanType} />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+          <div className="min-w-0 flex-1">
+            <SpanActionsDropdown projectId={projectId as string} span={span} />
+          </div>
+          <div className="ml-auto flex shrink-0 items-center gap-1">
+            {!isAlwaysSelectSpan && onClose && (
               <Button
                 variant="ghost"
-                className="h-6 px-1 text-base font-medium focus-visible:outline-0 truncate text-left min-w-0"
+                size="icon-sm"
+                className="flex-shrink-0 hover:bg-surface-up"
+                onClick={onClose}
+                aria-label="Close span panel"
               >
-                <span className="truncate">{span.name}</span>
-                <ChevronDown className="ml-1 min-w-3.5 size-3.5" />
+                <X className="w-4 h-4" />
               </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
-              <DropdownMenuItem onClick={handleCopySpanId}>
-                <Copy size={14} />
-                Copy span ID
-              </DropdownMenuItem>
-              <DropdownMenuItem disabled={isLoading} onClick={openInSql}>
-                {isLoading ? <Loader className="size-3.5" /> : <Database className="size-3.5" />}
-                Open in SQL editor
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {span.spanType === SpanType.LLM && (
-            <Link
-              href={{ pathname: `/project/${projectId}/playgrounds/create`, query: { spanId: span.spanId } }}
-              passHref
-              onClick={() => track("playgrounds", "experiment_clicked", { source: "span_view" })}
-            >
-              <Button variant="outlinePrimary" className="px-1.5 text-xs h-6 font-mono bg-primary/10">
-                <PlayCircle data-icon="inline-start" className="mr-1" size={14} />
-                Experiment in playground
-              </Button>
-            </Link>
-          )}
-          {!isAlwaysSelectSpan && onClose && (
-            <Button
-              variant="ghost"
-              className="ml-auto px-0.5 h-6 w-6 flex-shrink-0"
-              onClick={onClose}
-              aria-label="Close span panel"
-            >
-              <X className="w-4 h-4" />
-            </Button>
-          )}
-        </div>
-        <div className="flex flex-col flex-wrap gap-1.5">
-          <div className="flex items-center gap-2 flex-wrap">
-            <SpanStatsShields span={span} variant="outline" />
-            <div className="text-xs font-mono rounded-md py-0.5 truncate px-2 border border-muted">
-              {new Date(span.startTime).toLocaleString()}
-            </div>
+            )}
           </div>
-          <div className="flex items-center gap-2 flex-wrap">
-            <ModelIndicator attributes={span.attributes} />
-            <ToolList tools={resolveTools(span)} />
-            <StructuredOutputSchema
-              schema={span.attributes?.["gen_ai.request.structured_output_schema"] || span.attributes?.["ai.schema"]}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <ModelIndicator attributes={span.attributes} />
+          <SpanStatsShields span={span} className="w-fit" />
+          <div className="flex h-[26px] w-fit items-center rounded-md bg-surface-up-2 px-2">
+            <ClientTimestampFormatter
+              absolute
+              timestamp={span.startTime}
+              className="text-xs text-secondary-foreground"
             />
           </div>
-
-          <div className="flex gap-2 gap-y-1 flex-wrap items-center">
-            <AddToLabelingQueuePopover spanId={span.spanId} traceId={span.traceId} />
-            <ExportSpansPopover span={span} />
-            <SpanTagsList traceId={span.traceId} spanId={span.spanId} />
-          </div>
+          <ToolList tools={tools} />
+          <StructuredOutputSchema schema={schema} />
+          <SpanTagsList traceId={span.traceId} spanId={span.spanId} />
         </div>
 
         {errorEventAttributes && <ErrorCard attributes={errorEventAttributes} />}

--- a/frontend/components/traces/span-view/common.tsx
+++ b/frontend/components/traces/span-view/common.tsx
@@ -7,6 +7,7 @@ import ContentRenderer from "@/components/ui/content-renderer/index";
 import { spanViewTheme } from "@/components/ui/content-renderer/utils";
 import DownloadButton from "@/components/ui/download-button";
 import PdfRenderer from "@/components/ui/pdf-renderer";
+import { ElevatedSurface } from "@/components/ui/surface";
 import { resolveContentMode } from "@/lib/spans/resolve-content-mode";
 import { cn } from "@/lib/utils";
 
@@ -76,7 +77,7 @@ const PureToolCallContentPart = ({
 }: ToolCallContentPartProps) => {
   const { mode, modes, value } = resolveContentMode(content);
   return (
-    <div className="flex flex-col gap-2 p-2 bg-background rounded-b">
+    <div className="flex flex-col gap-2 p-2">
       <span
         className="flex items-center gap-1.5 text-xs font-medium"
         style={{ color: ROLE_COLORS.tool.badgeText, opacity: 0.85 }}
@@ -92,7 +93,7 @@ const PureToolCallContentPart = ({
         codeEditorClassName="rounded"
         value={value}
         presetKey={`editor-${presetKey}`}
-        className="border-0 bg-card"
+        className="border-0"
         messageIndex={messageIndex}
         contentPartIndex={contentPartIndex}
         customTheme={spanViewTheme}
@@ -122,7 +123,7 @@ const PureToolResultContentPart = ({
 }: ToolResultContentPartProps) => {
   const { mode, modes, value } = resolveContentMode(content);
   return (
-    <div className="flex flex-col gap-2 p-2 bg-background rounded-b">
+    <div className="flex flex-col gap-2 p-2">
       <span
         className="flex items-center gap-1.5 text-xs font-medium"
         style={{ color: ROLE_COLORS.tool.badgeText, opacity: 0.85 }}
@@ -139,7 +140,7 @@ const PureToolResultContentPart = ({
           codeEditorClassName="rounded"
           value={value}
           presetKey={`editor-${presetKey}`}
-          className="border-0 bg-card"
+          className="border-0"
           messageIndex={messageIndex}
           contentPartIndex={contentPartIndex}
           customTheme={spanViewTheme}
@@ -189,7 +190,7 @@ const PureTextContentPart = ({
         readOnly
         value={value}
         presetKey={`editor-${presetKey}`}
-        className={cn("border-0 bg-card", className)}
+        className={cn("border-0", className)}
         codeEditorClassName={codeEditorClassName}
         messageIndex={messageIndex}
         contentPartIndex={contentPartIndex}
@@ -208,7 +209,7 @@ export const RoleHeader = ({ role, className }: RoleHeaderProps) => {
   if (role) {
     const colors = getRoleColors(role);
     return (
-      <div className={cn("flex items-center px-2 py-1 gap-2 border-b bg-background rounded-t", className)}>
+      <div className={cn("flex items-center px-2 py-1 gap-2 border-b rounded-t", className)}>
         <span className="text-sm font-medium" style={{ color: colors.badgeText }}>
           {capitalize(role)}
         </span>
@@ -245,7 +246,7 @@ const PureThinkingContentPart = ({
   messageIndex = 0,
   contentPartIndex = 0,
 }: ThinkingContentPartProps) => (
-  <div className="flex flex-col gap-2 p-2 bg-background rounded-b">
+  <div className="flex flex-col gap-2 p-2">
     <span className="flex items-center text-xs">
       <Brain size={12} className="min-w-3 mr-2" />
       {label}
@@ -257,7 +258,7 @@ const PureThinkingContentPart = ({
       codeEditorClassName="rounded"
       value={content}
       presetKey={`editor-${presetKey}`}
-      className="border-0 bg-card"
+      className="border-0"
       messageIndex={messageIndex}
       contentPartIndex={contentPartIndex}
       customTheme={spanViewTheme}
@@ -279,15 +280,17 @@ export const MessageWrapper = ({
   role,
   maxHeight = DEFAULT_MESSAGE_MAX_HEIGHT,
   stickyHeader = true,
+  defaultExpanded = false,
 }: PropsWithChildren<{
   role?: string;
   presetKey: string;
   maxHeight?: number;
   stickyHeader?: boolean;
+  defaultExpanded?: boolean;
 }>) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
   const checkOverflow = useCallback(() => {
     const el = containerRef.current;
@@ -307,28 +310,33 @@ export const MessageWrapper = ({
     return () => resizeObserver.disconnect();
   }, [checkOverflow]);
 
-  const showToggle = isOverflowing || isExpanded;
+  const showToggle = isOverflowing;
 
   return (
-    <div className={cn("relative border rounded", { "border-b-0": showToggle })}>
-      <RoleHeader role={role} className={stickyHeader ? "sticky top-0 z-10" : undefined} />
-      <div ref={containerRef} className="overflow-hidden" style={!isExpanded ? { maxHeight } : undefined}>
+    // overflow-clip (not hidden): clips to radius without creating a scroll
+    // container, so sticky can still pin to the messages list.
+    <ElevatedSurface offset={1} className="relative border rounded-lg overflow-clip">
+      <RoleHeader role={role} className={stickyHeader ? "sticky top-0 z-10 bg-surface" : undefined} />
+      <div
+        ref={containerRef}
+        className="overflow-hidden bg-surface-down"
+        style={!isExpanded ? { maxHeight } : undefined}
+      >
         <div className="flex flex-col divide-y">{children}</div>
       </div>
       {showToggle && (
-        <div className="sticky bottom-0 z-30 flex flex-col items-center rounded-b">
+        <div className="sticky bottom-0 z-30 flex flex-col items-center rounded-b-lg">
           <div
-            className="w-full pointer-events-none"
+            className="w-full pointer-events-none bg-gradient-to-b from-background/0 to-background"
             style={{
               height: isExpanded ? 16 : 36,
               marginTop: isExpanded ? -8 : -36,
-              background: "linear-gradient(to bottom, transparent, hsl(var(--background) / 1))",
             }}
           />
-          <div className="w-full bg-background rounded-b">
+          <div className="w-full bg-background rounded-b-lg">
             <button
               onClick={() => setIsExpanded((prev) => !prev)}
-              className="h-3 relative w-full flex items-center justify-center text-secondary-foreground cursor-pointer rounded-b border-b transition-colors"
+              className="h-3 relative w-full flex items-center justify-center cursor-pointer rounded-b-lg"
             >
               <span className="absolute -top-2.5 w-full flex justify-center">
                 {isExpanded ? <ChevronUp className="size-3.5" /> : <ChevronDown className="size-3.5" />}
@@ -337,6 +345,6 @@ export const MessageWrapper = ({
           </div>
         </div>
       )}
-    </div>
+    </ElevatedSurface>
   );
 };

--- a/frontend/components/traces/span-view/index.tsx
+++ b/frontend/components/traces/span-view/index.tsx
@@ -68,24 +68,12 @@ const SpanViewTabs = ({
       tabIndex={0}
     >
       <div className="px-2 pb-2 mt-2 border-b w-full">
-        <TabsList className="border-none text-xs h-7">
-          {isLLM && (
-            <TabsTrigger value="overview" className="text-xs">
-              Overview
-            </TabsTrigger>
-          )}
-          <TabsTrigger value="span-input" className="text-xs">
-            Span Input
-          </TabsTrigger>
-          <TabsTrigger value="span-output" className="text-xs">
-            Span Output
-          </TabsTrigger>
-          <TabsTrigger value="attributes" className="text-xs">
-            Attributes
-          </TabsTrigger>
-          <TabsTrigger value="events" className="text-xs">
-            Events
-          </TabsTrigger>
+        <TabsList size="sm">
+          {isLLM && <TabsTrigger value="overview">Overview</TabsTrigger>}
+          <TabsTrigger value="span-input">Span Input</TabsTrigger>
+          <TabsTrigger value="span-output">Span Output</TabsTrigger>
+          <TabsTrigger value="attributes">Attributes</TabsTrigger>
+          <TabsTrigger value="events">Events</TabsTrigger>
         </TabsList>
       </div>
       <SpanViewSearchBar ref={searchRef} open={searchOpen} setOpen={setSearchOpen} />
@@ -104,7 +92,7 @@ const SpanViewTabs = ({
         <TabsContent value="attributes" className="w-full h-full">
           <ContentRenderer
             className="rounded-none border-0"
-            codeEditorClassName="rounded-none border-none bg-background contain-strict"
+            codeEditorClassName="rounded-none border-none contain-strict"
             readOnly
             value={JSON.stringify(span.attributes)}
             defaultMode="yaml"
@@ -114,7 +102,7 @@ const SpanViewTabs = ({
         <TabsContent value="events" className="w-full h-full">
           <ContentRenderer
             className="rounded-none border-0"
-            codeEditorClassName="rounded-none border-none bg-background contain-strict"
+            codeEditorClassName="rounded-none border-none contain-strict"
             readOnly
             value={JSON.stringify(span.events)}
             defaultMode="yaml"
@@ -183,7 +171,7 @@ export function SpanView({
 
   if (span && get(span.attributes, "gen_ai.prompt.user")) {
     return (
-      <div className="whitespace-pre-wrap p-4 border rounded-md bg-muted/50">
+      <div className="whitespace-pre-wrap p-4 m-2 border rounded-md bg-surface-up">
         {get(span.attributes, "gen_ai.prompt.user")}
       </div>
     );

--- a/frontend/components/traces/span-view/messages.tsx
+++ b/frontend/components/traces/span-view/messages.tsx
@@ -12,6 +12,7 @@ import OpenAIContentParts from "@/components/traces/span-view/openai-parts";
 import OpenAIResponsesContentParts from "@/components/traces/span-view/openai-responses-parts";
 import { useSpanSearchState } from "@/components/traces/span-view/span-search-context";
 import { Button } from "@/components/ui/button";
+import { ElevatedSurface } from "@/components/ui/surface";
 // Detection logic lives in `lib/spans/process-messages.ts` (a plain TS module)
 // so tests can import it without pulling component CSS into the module graph.
 import { type ProcessedMessages, processMessages, responsesItemRole } from "@/lib/spans/process-messages";
@@ -169,6 +170,9 @@ interface MessagesProps {
   labels?: MessageLabel[];
   // Pre-detected messages; when set, detection is skipped (used by the Overview).
   processed?: ProcessedMessages;
+  defaultExpanded?: boolean;
+  /** Expand messages at this index and after (Overview output). */
+  expandFromIndex?: number;
 }
 
 type VirtualItem =
@@ -205,6 +209,8 @@ function PureMessages({
   maxHeight,
   labels,
   processed,
+  defaultExpanded = false,
+  expandFromIndex,
 }: MessagesProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -309,13 +315,13 @@ function PureMessages({
       <div className="size-full relative">
         <div
           // adjust for scrollbar on the right
-          className="absolute top-0 left-0 right-[15px] z-20 bg-background transition-opacity duration-150"
+          className="absolute top-0 left-0 right-[15px] z-20 bg-surface transition-opacity duration-150"
           ref={overlayRef}
           style={{ opacity: 0, pointerEvents: "none" }}
         >
-          <div className="mx-2 flex items-center px-2 py-1 gap-2 border bg-background rounded-t shadow-sm">
+          <ElevatedSurface offset={1} className="mx-2 flex items-center px-2 py-1 gap-2 border rounded-t-lg">
             <span ref={labelRef} className="text-sm font-medium" />
-          </div>
+          </ElevatedSurface>
         </div>
         <div
           ref={parentRef}
@@ -372,6 +378,7 @@ function PureMessages({
                       presetKey={`collapse-${messageIndex}-${presetKey}`}
                       maxHeight={maxHeight}
                       stickyHeader={false}
+                      defaultExpanded={defaultExpanded || (expandFromIndex != null && messageIndex >= expandFromIndex)}
                     >
                       {renderMessageContent(processedResult, messageIndex, presetKey, toolNameMap)}
                     </MessageWrapper>
@@ -397,6 +404,9 @@ function PureMessages({
 }
 const Messages = memo(PureMessages, (prevProps, nextProps) => {
   if (prevProps.processed !== nextProps.processed) return false;
+  if (prevProps.defaultExpanded !== nextProps.defaultExpanded) return false;
+  if (prevProps.expandFromIndex !== nextProps.expandFromIndex) return false;
+  if (prevProps.maxHeight !== nextProps.maxHeight) return false;
   if (!isEqual(prevProps.labels, nextProps.labels)) return false;
   if (isNil(prevProps.messages) && isNil(nextProps.messages)) return true;
   if (isNil(prevProps.messages) || isNil(nextProps.messages)) return false;

--- a/frontend/components/traces/span-view/search-bar.tsx
+++ b/frontend/components/traces/span-view/search-bar.tsx
@@ -103,8 +103,8 @@ const SpanViewSearchBar = ({ open, setOpen, ref }: SpanViewSearchBarProps) => {
           <span className="text-xs text-muted-foreground whitespace-nowrap">
             {currentIndex === 0 ? `${totalMatches} found` : `${currentIndex} of ${totalMatches}`}
           </span>
-          <Button className="size-5" icon="chevronUp" variant="ghost" size="icon" onClick={goToPrev} />
-          <Button className="size-5" icon="chevronDown" variant="ghost" size="icon" onClick={goToNext} />
+          <Button icon="chevronUp" variant="ghost" size="icon-xs" onClick={goToPrev} />
+          <Button icon="chevronDown" variant="ghost" size="icon-xs" onClick={goToNext} />
         </>
       )}
     </div>

--- a/frontend/components/traces/span-view/span-content.tsx
+++ b/frontend/components/traces/span-view/span-content.tsx
@@ -38,7 +38,7 @@ const SpanContent = ({ span, type }: SpanContentProps) => {
       <ContentRenderer
         className="rounded border-0"
         readOnly
-        codeEditorClassName="rounded-none border-none bg-background contain-strict"
+        codeEditorClassName="rounded-none border-none contain-strict"
         value={JSON.stringify(normalizedData)}
         defaultMode="messages"
         modes={["MESSAGES", "JSON", "YAML", "TEXT", "CUSTOM"]}
@@ -49,6 +49,7 @@ const SpanContent = ({ span, type }: SpanContentProps) => {
             messages={tryParseJson(ctx.value) ?? []}
             presetKey={ctx.presetKey}
             maxHeight={type === "input" ? 320 : 560}
+            defaultExpanded={type === "output"}
           />
         )}
       />
@@ -57,8 +58,8 @@ const SpanContent = ({ span, type }: SpanContentProps) => {
 
   return (
     <ContentRenderer
-      className="rounded-none border-none bg-background"
-      codeEditorClassName="rounded-none border-none bg-background contain-strict"
+      className="rounded-none border-none"
+      codeEditorClassName="rounded-none border-none contain-strict"
       readOnly
       modes={["JSON", "YAML", "TEXT", "CUSTOM"]}
       value={JSON.stringify(normalizedData)}

--- a/frontend/components/traces/span-view/span-overview.tsx
+++ b/frontend/components/traces/span-view/span-overview.tsx
@@ -20,7 +20,7 @@ const PureSpanOverview = ({ span }: { span: Span }) => {
   return (
     <ContentRenderer
       className="rounded-none border-0"
-      codeEditorClassName="rounded-none border-none bg-background contain-strict"
+      codeEditorClassName="rounded-none border-none contain-strict"
       readOnly
       value={mergedValue}
       defaultMode="messages"
@@ -34,6 +34,7 @@ const PureSpanOverview = ({ span }: { span: Span }) => {
           presetKey={ctx.presetKey}
           maxHeight={560}
           labels={messageLabels}
+          expandFromIndex={messageLabels.find((label) => label.text === "Output")?.beforeIndex}
         />
       )}
     />

--- a/frontend/components/traces/stats-shields.tsx
+++ b/frontend/components/traces/stats-shields.tsx
@@ -192,7 +192,7 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
       <Tooltip>
         <TooltipTrigger className="min-w-8">
           <div className="flex space-x-1 items-center">
-            <Clock3 size={12} className="min-w-3 min-h-3" />
+            <Clock3 size={14} className="min-w-3 min-h-3" />
             <Label className={cn("text-xs truncate", { "text-white": variant === "outline" })}>
               {formatDurationMs(durationMs)}
             </Label>
@@ -208,9 +208,9 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
   const tokensContent = (
     <TooltipProvider delayDuration={250}>
       <Tooltip>
-        <TooltipTrigger className="min-w-8">
+        <TooltipTrigger>
           <div className="flex space-x-1 items-center">
-            <Coins className="min-w-3" size={12} />
+            <Coins className="min-w-3" size={14} />
             <Label className={cn("text-xs truncate", { "text-white": variant === "outline" })}>
               {formatTokensCompact(stats.totalTokens)}
             </Label>
@@ -234,7 +234,7 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
       <Tooltip>
         <TooltipTrigger className="min-w-8">
           <div className="flex space-x-1 items-center">
-            <CircleDollarSign className="min-w-3" size={12} />
+            <CircleDollarSign className="min-w-3" size={14} />
             <Label className={cn("text-xs truncate", { "text-white": variant === "outline" })}>
               {formatCostNumber(stats.totalCost)}
             </Label>
@@ -252,7 +252,7 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
   return (
     <div
       className={cn(
-        "flex h-[26px] items-center gap-2 px-2 rounded-md overflow-hidden text-xs min-w-0",
+        "flex h-6 items-center gap-2.5 px-2 rounded-md overflow-hidden text-xs min-w-0",
         variant === "outline" ? "border border-muted text-white" : "bg-surface-up-2 text-secondary-foreground",
         className
       )}

--- a/frontend/components/traces/stats-shields.tsx
+++ b/frontend/components/traces/stats-shields.tsx
@@ -199,7 +199,7 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
           </div>
         </TooltipTrigger>
         <TooltipPortal>
-          <TooltipContent className="border">{formatDurationExact(durationMs)}</TooltipContent>
+          <TooltipContent>{formatDurationExact(durationMs)}</TooltipContent>
         </TooltipPortal>
       </Tooltip>
     </TooltipProvider>
@@ -217,7 +217,7 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
           </div>
         </TooltipTrigger>
         <TooltipPortal>
-          <TooltipContent side="bottom" className="flex flex-col border gap-1 min-w-55 p-2">
+          <TooltipContent side="bottom" className="flex flex-col gap-1 min-w-55 p-2">
             {span && (span.spanType === SpanType.LLM || span?.spanType === SpanType.CACHED) ? (
               <InputTokenBreakdown span={span} />
             ) : (
@@ -241,7 +241,7 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
           </div>
         </TooltipTrigger>
         <TooltipPortal>
-          <TooltipContent className="flex flex-col border gap-1 p-2">
+          <TooltipContent className="flex flex-col gap-1 p-2">
             <CostBreakdown stats={stats} labelPrefix={labelPrefix} />
           </TooltipContent>
         </TooltipPortal>
@@ -252,8 +252,8 @@ export function StatsShields({ stats, className, variant = "filled", labelPrefix
   return (
     <div
       className={cn(
-        "flex items-center gap-2 px-1.5 py-0.5 rounded-md overflow-hidden text-xs font-mono min-w-0",
-        variant === "outline" ? "border border-muted text-white" : "bg-muted text-secondary-foreground",
+        "flex h-[26px] items-center gap-2 px-2 rounded-md overflow-hidden text-xs min-w-0",
+        variant === "outline" ? "border border-muted text-white" : "bg-surface-up-2 text-secondary-foreground",
         className
       )}
     >

--- a/frontend/components/traces/structured-output-schema.tsx
+++ b/frontend/components/traces/structured-output-schema.tsx
@@ -10,7 +10,7 @@ export const StructuredOutputSchema = ({ schema }: { schema: string }) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="focus:outline-hidden flex h-6 w-fit items-center border-tool bg-tool/10 gap-1 text-xs font-mono border rounded-md px-2 text-tool hover:bg-tool/20 transition-colors">
+        <button className="focus:outline-hidden flex h-6 w-fit items-center gap-1 rounded-md px-2 text-xs font-mono bg-tool/20 text-tool hover:bg-tool/30 transition-colors">
           <Braces size={12} className="min-w-3" />
           <span>output schema</span>
           <ChevronDown size={12} />

--- a/frontend/components/traces/structured-output-schema.tsx
+++ b/frontend/components/traces/structured-output-schema.tsx
@@ -1,4 +1,4 @@
-import { Braces, ChevronDown } from "lucide-react";
+import { Braces, ChevronDown, ChevronRight } from "lucide-react";
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
@@ -10,10 +10,11 @@ export const StructuredOutputSchema = ({ schema }: { schema: string }) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="focus:outline-hidden flex h-6 w-fit items-center gap-1 rounded-md px-2 text-xs font-mono bg-tool/20 text-tool hover:bg-tool/30 transition-colors">
+        <button className="flex h-6 w-fit items-center gap-1 rounded-md bg-tool/15 pl-2 pr-1.5 text-xs font-mono text-tool transition-colors outline-0 hover:bg-tool/25 data-[state=open]:bg-tool/35 [&[data-state=open]_.trigger-closed]:hidden [&:not([data-state=open])_.trigger-open]:hidden">
           <Braces size={12} className="min-w-3" />
           <span>output schema</span>
-          <ChevronDown size={12} />
+          <ChevronRight className="trigger-closed size-3" />
+          <ChevronDown className="trigger-open size-3" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="max-w-[600px] p-0" align="end" side="bottom">

--- a/frontend/components/traces/tool-list.tsx
+++ b/frontend/components/traces/tool-list.tsx
@@ -123,7 +123,7 @@ export const ToolList = ({ tools }: { tools: Tool[] }) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="flex h-6 w-fit items-center gap-1 text-xs font-mono border rounded-md px-2 border-tool bg-tool/20 text-tool hover:bg-tool/30 transition-colors">
+        <button className="flex h-6 w-fit items-center gap-1 rounded-md px-2 text-xs font-mono bg-tool/20 text-tool hover:bg-tool/30 transition-colors outline-0">
           <Bolt size={12} className="min-w-3" />
           <span>{pluralize(tools.length, "tool", "tools")}</span>
           <ChevronDown size={12} />

--- a/frontend/components/traces/tool-list.tsx
+++ b/frontend/components/traces/tool-list.tsx
@@ -1,5 +1,5 @@
 import { compact, get, isNil, sortBy, uniq } from "lodash";
-import { Bolt, ChevronDown } from "lucide-react";
+import { Bolt, ChevronDown, ChevronRight } from "lucide-react";
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -123,33 +123,46 @@ export const ToolList = ({ tools }: { tools: Tool[] }) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="flex h-6 w-fit items-center gap-1 rounded-md px-2 text-xs font-mono bg-tool/20 text-tool hover:bg-tool/30 transition-colors outline-0">
+        <button className="flex h-6 w-fit items-center gap-1 rounded-md pl-2 pr-1.5 text-xs bg-tool/15 text-tool hover:bg-tool/25 data-[state=open]:bg-tool/35 transition-colors outline-0 [&[data-state=open]_.trigger-closed]:hidden [&:not([data-state=open])_.trigger-open]:hidden">
           <Bolt size={12} className="min-w-3" />
           <span>{pluralize(tools.length, "tool", "tools")}</span>
-          <ChevronDown size={12} />
+          <ChevronRight className="trigger-closed size-3" />
+          <ChevronDown className="trigger-open size-3" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="max-w-96 p-0" align="start" side="bottom">
-        <ScrollArea className="pb-2">
-          <div className="max-h-[50vh] flex flex-col gap-2 p-2">
+      <DropdownMenuContent className="max-w-96 p-0 overflow-hidden" align="start" side="bottom">
+        <ScrollArea className="max-h-[50vh]" viewportClassName="max-h-[50vh]">
+          <div className="flex flex-col gap-1 p-1">
             {tools.map((tool, index) => (
-              <div key={index} className="border rounded-md p-2 bg-muted/20">
-                <div className="flex items-center gap-2 mb-1">
-                  <Bolt size={10} className="text-tool" />
-                  <Label className="text-xs font-mono font-semibold text-tool">{tool.name}</Label>
-                </div>
-                {tool.description && (
-                  <p className="text-xs text-muted-foreground mb-2 leading-relaxed">{tool.description}</p>
-                )}
-                {tool.parameters && (
-                  <details className="text-xs">
-                    <summary className="cursor-pointer text-muted-foreground hover:text-foreground mb-1">
+              <details
+                key={index}
+                className="overflow-hidden rounded-md bg-surface-up text-xs [&[open]_.parameters-closed]:hidden [&:not([open])_.parameters-open]:hidden"
+              >
+                <summary className={tool.parameters ? "group cursor-pointer list-none p-2 pb-1" : "list-none p-2 pb-1"}>
+                  <div className="mb-1 flex items-center gap-2">
+                    <Bolt size={10} className="text-tool" />
+                    <Label className="text-xs font-mono text-tool">{tool.name}</Label>
+                  </div>
+                  {tool.description && (
+                    <p className="mb-1 text-xs leading-relaxed text-muted-foreground">{tool.description}</p>
+                  )}
+                  {tool.parameters && (
+                    <span className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground select-none">
                       Parameters
-                    </summary>
-                    <ContentRenderer readOnly value={tool.parameters} defaultMode="json" />
-                  </details>
+                      <ChevronRight className="parameters-closed size-3" />
+                      <ChevronDown className="parameters-open size-3" />
+                    </span>
+                  )}
+                </summary>
+                {tool.parameters && (
+                  <ContentRenderer
+                    readOnly
+                    value={tool.parameters}
+                    defaultMode="json"
+                    className="rounded-none border-x-0 border-b-0 bg-surface-up-2 border-none"
+                  />
                 )}
-              </div>
+              </details>
             ))}
           </div>
         </ScrollArea>

--- a/frontend/components/traces/trace-view/condensed-timeline/controls.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/controls.tsx
@@ -2,7 +2,6 @@ import { DollarSign, Minus, Plus } from "lucide-react";
 
 import { MAX_ZOOM, MIN_ZOOM } from "@/components/traces/trace-view/store";
 import { Button } from "@/components/ui/button";
-import { useElevation } from "@/components/ui/surface";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
@@ -21,9 +20,6 @@ export default function Controls({
   isCostHeatmapVisible,
   onToggleCostHeatmap,
 }: ControlsProps) {
-  // Controls sit one level above the timeline surface they float over. Each chip paints
-  // that raised surface (fill + neighbour vars, no shadow), so hover steps up from it.
-  const { className: raisedSurface } = useElevation({ offset: 2 });
   return (
     <div className="absolute bottom-1.5 right-1.5 z-40 flex items-center gap-1 h-[24px]">
       <TooltipProvider delayDuration={300}>
@@ -31,9 +27,8 @@ export default function Controls({
           <TooltipTrigger asChild>
             <button
               className={cn(
-                "flex items-center gap-0.5 h-[24px] px-1.5 rounded-md text-xs text-muted-foreground hover:bg-surface-up-2 transition-colors border",
-                raisedSurface,
-                isCostHeatmapVisible && "border-primary/50 text-primary"
+                "flex items-center gap-0.5 h-[24px] px-1.5 rounded-md bg-muted text-xs text-muted-foreground hover:bg-secondary transition-colors border",
+                isCostHeatmapVisible && "border-primary/50 text-primary bg-muted"
               )}
               onClick={() => onToggleCostHeatmap(!isCostHeatmapVisible)}
             >
@@ -41,28 +36,14 @@ export default function Controls({
               <span>Cost heatmap</span>
             </button>
           </TooltipTrigger>
-          <TooltipContent className="border">Toggle cost heatmap</TooltipContent>
+          <TooltipContent>Toggle cost heatmap</TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <div className={cn("flex items-center border rounded-md px-0.5 h-[24px]", raisedSurface)}>
-        <Button
-          aria-label="Zoom in"
-          disabled={zoom >= MAX_ZOOM}
-          className="size-5 min-w-5"
-          variant="ghost"
-          size="icon"
-          onClick={onZoomIn}
-        >
+      <div className="flex items-center border rounded-md bg-muted px-0.5 h-[24px]">
+        <Button disabled={zoom >= MAX_ZOOM} className="min-w-5" variant="ghost" size="icon-xs" onClick={onZoomIn}>
           <Plus className="size-3" />
         </Button>
-        <Button
-          aria-label="Zoom out"
-          disabled={zoom <= MIN_ZOOM}
-          className="size-5 min-w-5"
-          variant="ghost"
-          size="icon"
-          onClick={onZoomOut}
-        >
+        <Button disabled={zoom <= MIN_ZOOM} className="min-w-5" variant="ghost" size="icon-xs" onClick={onZoomOut}>
           <Minus className="size-3" />
         </Button>
       </div>

--- a/frontend/components/traces/trace-view/header/header-icon-button.tsx
+++ b/frontend/components/traces/trace-view/header/header-icon-button.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { type ComponentProps, forwardRef, type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface HeaderIconButtonProps extends Omit<ComponentProps<typeof Button>, "icon"> {
+  icon: ReactNode;
+  label: string;
+  active?: boolean;
+}
+
+export const HeaderIconButton = forwardRef<HTMLButtonElement, HeaderIconButtonProps>(
+  ({ icon, label, active = false, className, ...props }, ref) => (
+    <Tooltip delayDuration={400}>
+      <TooltipTrigger asChild>
+        <Button
+          ref={ref}
+          variant="ghost"
+          size="icon"
+          aria-label={label}
+          className={cn("hover:bg-surface-up-3", active && "bg-surface-up-2 text-primary", className)}
+          {...props}
+        >
+          {icon}
+        </Button>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side="bottom">{label}</TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  )
+);
+
+HeaderIconButton.displayName = "HeaderIconButton";

--- a/frontend/components/traces/trace-view/header/header-link-button.tsx
+++ b/frontend/components/traces/trace-view/header/header-link-button.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ArrowUpRight } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface HeaderLinkButtonProps {
+  icon: ReactNode;
+  label: string;
+  tooltip: string;
+  onClick: () => void;
+  className?: string;
+}
+
+export const HeaderLinkButton = ({ icon, label, tooltip, onClick, className }: HeaderLinkButtonProps) => (
+  <Tooltip delayDuration={400}>
+    <TooltipTrigger asChild>
+      <Button variant="ghost" size="sm" onClick={onClick} className={cn("h-7 hover:bg-surface-up", className)}>
+        {icon}
+        <span className="truncate ml-1">{label}</span>
+        <ArrowUpRight size={12} className="ml-1 flex-shrink-0" />
+      </Button>
+    </TooltipTrigger>
+    <TooltipPortal>
+      <TooltipContent side="bottom">{tooltip}</TooltipContent>
+    </TooltipPortal>
+  </Tooltip>
+);

--- a/frontend/components/traces/trace-view/header/index.tsx
+++ b/frontend/components/traces/trace-view/header/index.tsx
@@ -207,9 +207,9 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
     <div className="relative flex flex-col px-2 pt-1.5 pb-2 flex-shrink-0">
       {/* Row 1: core trace controls + actions (share justified to end) */}
       <div className="flex items-center gap-1">
-        <div className="flex items-center gap-1 flex-1 min-w-0">
+        <div className="flex items-center flex-1 min-w-0">
           {!params?.traceId && (
-            <span className={cn(HEADER_ITEM_CLS, "gap-0.5")}>
+            <span className={cn(HEADER_ITEM_CLS)}>
               {handleClose && (
                 <Button
                   aria-label="Collapse panel"

--- a/frontend/components/traces/trace-view/header/index.tsx
+++ b/frontend/components/traces/trace-view/header/index.tsx
@@ -1,9 +1,9 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowUpRight, ChevronsRight, Layers, Maximize, Radio, Sparkles, User } from "lucide-react";
+import { ChevronsRight, Layers, Maximize, Radio, Sparkles, User } from "lucide-react";
 import NextLink from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { createSerializer, parseAsArrayOf, parseAsString } from "nuqs";
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { shallow } from "zustand/shallow";
 
 import { useLaminarAgentStore } from "@/components/agent";
@@ -14,7 +14,6 @@ import TraceViewSearch from "@/components/traces/trace-view/search";
 import { type TraceViewSpan, useTraceViewStore } from "@/components/traces/trace-view/store";
 import { type TraceSignal, type TraceSignalClusterNode } from "@/components/traces/trace-view/store/base";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useFeatureFlags } from "@/contexts/feature-flags-context";
 import { useProjectContext } from "@/contexts/project-context";
 import { type Filter } from "@/lib/actions/common/filters";
@@ -27,6 +26,8 @@ import { cn } from "@/lib/utils";
 
 import Metadata from "../metadata";
 import SignalEventsPanel from "../signal-events-panel";
+import { HeaderIconButton } from "./header-icon-button";
+import { HeaderLinkButton } from "./header-link-button";
 import CondensedTimelineControls from "./timeline-toggle";
 import TraceDropdown from "./trace-dropdown";
 
@@ -60,6 +61,7 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
   const agentOpen = useLaminarAgentStore((s) => s.viewMode === "open");
   const openAgent = useLaminarAgentStore((s) => s.open);
   const collapseAgent = useLaminarAgentStore((s) => s.collapse);
+  const [isSearchAnimating, setIsSearchAnimating] = useState(false);
 
   const {
     trace,
@@ -209,14 +211,20 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
           {!params?.traceId && (
             <span className={cn(HEADER_ITEM_CLS, "gap-0.5")}>
               {handleClose && (
-                <Button aria-label="Collapse panel" variant="ghost" className="h-7 px-0.5" onClick={handleClose}>
-                  <ChevronsRight className="w-5 h-5" />
+                <Button
+                  aria-label="Collapse panel"
+                  variant="ghost"
+                  size="icon"
+                  className="hover:bg-surface-up"
+                  onClick={handleClose}
+                >
+                  <ChevronsRight className="w-4.5 h-4.5" />
                 </Button>
               )}
               {trace && (
                 <NextLink passHref href={`/project/${projectId}/traces/${trace?.id}?${fullScreenParams.toString()}`}>
-                  <Button aria-label="Expand" variant="ghost" className="h-7 px-0.5">
-                    <Maximize className="w-4 h-4" />
+                  <Button aria-label="Expand" variant="ghost" size="icon" className="hover:bg-surface-up">
+                    <Maximize className="w-3.5 h-3.5" />
                   </Button>
                 </NextLink>
               )}
@@ -224,28 +232,27 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
           )}
           {trace && (
             <span className={HEADER_ITEM_CLS}>
-              <span className="text-base font-medium pl-2 flex-shrink-0">Trace</span>
               <TraceDropdown traceId={traceId} />
             </span>
           )}
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0">
           {signalCount > 0 && (
             <span className={HEADER_ITEM_CLS}>
-              <Button
+              <HeaderIconButton
+                icon={<Radio className={cn({ "text-primary": signalsPanelOpen })} size={14} />}
+                label={`Signals (${signalCount})`}
+                active={signalsPanelOpen}
                 onClick={() => setSignalsPanelOpen(!signalsPanelOpen)}
-                variant="outline"
-                className={cn(
-                  "h-6 text-xs px-1.5",
-                  signalsPanelOpen ? "border-primary text-primary hover:bg-primary/10" : "hover:bg-secondary"
-                )}
-              >
-                <Radio size={14} className="mr-1" />
-                Signals ({signalCount})
-              </Button>
+              />
             </span>
           )}
           {featureFlags[Feature.AGENT] && spans.length > 0 && (
             <span className={HEADER_ITEM_CLS}>
-              <Button
+              <HeaderIconButton
+                icon={<Sparkles className={cn({ "text-primary": agentOpen })} size={14} />}
+                label="Chat"
+                active={agentOpen}
                 onClick={() => {
                   if (agentOpen) {
                     collapseAgent();
@@ -254,67 +261,43 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
                     openAgent();
                   }
                 }}
-                variant="outline"
-                className={cn(
-                  "h-6 text-xs px-1.5",
-                  agentOpen ? "border-primary text-primary hover:bg-primary/10" : "hover:bg-secondary"
-                )}
-              >
-                <Sparkles data-icon="inline-start" size={14} className="mr-1" />
-                Chat
-              </Button>
+              />
+            </span>
+          )}
+          {trace?.metadata && (
+            <span className={HEADER_ITEM_CLS}>
+              <Metadata metadata={trace?.metadata} />
             </span>
           )}
           <span className={HEADER_ITEM_CLS}>
-            <Metadata metadata={trace?.metadata} />
-          </span>
-          <span className={HEADER_ITEM_CLS}>
             <TraceTagsButton traceId={traceId} />
           </span>
+          {trace && <ShareTraceButton projectId={projectId} />}
         </div>
-        {trace && <ShareTraceButton projectId={projectId} />}
       </div>
       {/* Row 2: context pills (session, user, tags) */}
       {hasRow2 && (
         <div className="flex flex-wrap items-center gap-1 mt-1.5">
           {hasSession && (
             <span className={HEADER_ITEM_CLS}>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      onClick={handleOpenSession}
-                      variant="outline"
-                      className="h-6 text-xs px-1.5 hover:bg-secondary max-w-56"
-                    >
-                      <Layers size={14} className="mr-1 flex-shrink-0" />
-                      <span className="truncate">{sessionId}</span>
-                      <ArrowUpRight size={16} className="ml-1 flex-shrink-0 text-muted-foreground" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Open session in a new tab</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <HeaderLinkButton
+                icon={<Layers size={14} className="flex-shrink-0" />}
+                label={sessionId}
+                tooltip="Open session in a new tab"
+                onClick={handleOpenSession}
+                className="max-w-56"
+              />
             </span>
           )}
           {hasUser && (
             <span className={HEADER_ITEM_CLS}>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      onClick={handleOpenUserTraces}
-                      variant="outline"
-                      className="h-6 text-xs px-1.5 hover:bg-secondary max-w-40"
-                    >
-                      <User size={14} className="mr-1 flex-shrink-0" />
-                      <span className="truncate">{userId}</span>
-                      <ArrowUpRight size={16} className="ml-1 flex-shrink-0 text-muted-foreground" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">See user traces in a new tab</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <HeaderLinkButton
+                icon={<User size={14} className="flex-shrink-0" />}
+                label={userId}
+                tooltip="See user traces in a new tab"
+                onClick={handleOpenUserTraces}
+                className="max-w-40"
+              />
             </span>
           )}
           <TraceTagsPills traceId={traceId} />
@@ -336,11 +319,15 @@ const Header = ({ handleClose, spans, onSearch, traceId }: HeaderProps) => {
       <AnimatePresence initial={false}>
         {tab !== "custom" && (
           <motion.div
-            className="flex items-center gap-2 overflow-hidden"
+            // Clip only while the height animates — a persistent overflow-hidden
+            // would cut off the search suggestions dropdown.
+            className={cn("flex items-center gap-2", isSearchAnimating && "overflow-hidden")}
             initial={{ height: 0, opacity: 0, marginTop: 0 }}
             animate={{ height: "auto", opacity: 1, marginTop: 8 }}
             exit={{ height: 0, opacity: 0, marginTop: 0 }}
             transition={{ duration: 0.2, ease: "easeInOut" }}
+            onAnimationStart={() => setIsSearchAnimating(true)}
+            onAnimationComplete={() => setIsSearchAnimating(false)}
           >
             <TraceViewSearch
               spans={spans}

--- a/frontend/components/traces/trace-view/header/timeline-toggle.tsx
+++ b/frontend/components/traces/trace-view/header/timeline-toggle.tsx
@@ -13,10 +13,8 @@ export default function CondensedTimelineControls({ enabled, setEnabled, classNa
   return (
     <div
       className={cn(
-        "absolute z-40 top-full flex items-end overflow-hidden transition-all duration-200",
-        enabled
-          ? "right-0 h-6 w-7 bg-muted border-b border-l rounded-none rounded-bl "
-          : "right-2 h-6 bg-background border rounded-md hover:bg-muted",
+        "absolute z-40 top-full flex items-center overflow-hidden transition-all duration-200",
+        enabled ? "right-0 h-[26px] w-[26px] rounded-none rounded-bl" : "right-2 h-[26px] rounded-md",
         className
       )}
     >
@@ -24,12 +22,15 @@ export default function CondensedTimelineControls({ enabled, setEnabled, classNa
         onClick={() => setEnabled(!enabled)}
         variant="ghost"
         size="icon"
-        className={cn("transition-all duration-200", enabled ? "size-5 min-w-5" : "h-6 w-auto px-1.5 text-xs")}
+        className={cn(
+          "transition-all duration-200 hover:bg-surface-up-3",
+          enabled ? "size-[26px] min-w-[26px] rounded-none rounded-bl" : "h-full w-auto px-2 py-0 text-xs"
+        )}
       >
         {enabled ? (
           <X className="size-3.5" />
         ) : (
-          <span className="flex items-center text-xs h-6 gap-1">
+          <span className="flex h-[26px] items-center gap-1 text-xs">
             <GanttChart size={14} />
             Timeline
           </span>

--- a/frontend/components/traces/trace-view/header/trace-dropdown.tsx
+++ b/frontend/components/traces/trace-view/header/trace-dropdown.tsx
@@ -44,12 +44,21 @@ export default function TraceDropdown({ traceId }: TraceDropdownProps) {
     }
   }, [sessionId, toast]);
 
-  // TODO: add userId to TraceViewTrace to enable "Copy user ID"
+  const userId = trace?.userId;
+  const hasUser = userId && userId !== "<null>" && userId !== "";
+
+  const handleCopyUserId = useCallback(async () => {
+    if (userId) {
+      await navigator.clipboard.writeText(userId);
+      toast({ title: "Copied user ID", duration: 1000 });
+    }
+  }, [userId, toast]);
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button aria-label="Trace actions" variant="ghost" className="h-6 px-1 hover:bg-secondary">
+        <Button aria-label="Trace actions" variant="ghost" className="gap-1 text-base font-medium hover:bg-surface-up">
+          Trace
           <ChevronDown className="size-3.5" />
         </Button>
       </DropdownMenuTrigger>
@@ -64,7 +73,12 @@ export default function TraceDropdown({ traceId }: TraceDropdownProps) {
             Copy session ID
           </DropdownMenuItem>
         )}
-        {/* TODO: add userId to TraceViewTrace to enable "Copy user ID" */}
+        {hasUser && (
+          <DropdownMenuItem onClick={handleCopyUserId}>
+            <Copy size={14} />
+            Copy user ID
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem disabled={isSqlLoading} onClick={openInSql}>
           {isSqlLoading ? <Loader className="size-3.5 animate-spin" /> : <Database className="size-3.5" />}
           Open in SQL editor

--- a/frontend/components/traces/trace-view/human-evaluator-span-view.tsx
+++ b/frontend/components/traces/trace-view/human-evaluator-span-view.tsx
@@ -28,7 +28,7 @@ export function HumanEvaluatorSpanView({ spanId, traceId, onClose, isAlwaysSelec
 
   if (isLoading || !span) {
     return (
-      <div className="flex flex-col space-y-2 p-4">
+      <div className="flex flex-col gap-2 p-4">
         <Skeleton className="h-8 w-full" />
         <Skeleton className="h-8 w-full" />
         <Skeleton className="h-8 w-full" />
@@ -38,7 +38,7 @@ export function HumanEvaluatorSpanView({ spanId, traceId, onClose, isAlwaysSelec
 
   if (span.attributes["gen_ai.prompt.user"]) {
     return (
-      <div className="whitespace-pre-wrap p-4 border rounded-md bg-muted/50">
+      <div className="whitespace-pre-wrap p-4 m-2 border rounded-md bg-surface-up">
         {span.attributes["gen_ai.prompt.user"]}
       </div>
     );
@@ -48,16 +48,10 @@ export function HumanEvaluatorSpanView({ spanId, traceId, onClose, isAlwaysSelec
     <SpanControls span={span} onClose={onClose} isAlwaysSelectSpan={isAlwaysSelectSpan}>
       <Tabs className="flex flex-col flex-1 w-full overflow-hidden" defaultValue="span">
         <div className="px-2 pb-2 mt-2 border-b w-full">
-          <TabsList className="border-none text-xs h-7">
-            <TabsTrigger value="span" className="text-xs">
-              Span Input
-            </TabsTrigger>
-            <TabsTrigger value="attributes" className="text-xs">
-              Attributes
-            </TabsTrigger>
-            <TabsTrigger value="events" className="text-xs">
-              Events
-            </TabsTrigger>
+          <TabsList size="sm">
+            <TabsTrigger value="span">Span Input</TabsTrigger>
+            <TabsTrigger value="attributes">Attributes</TabsTrigger>
+            <TabsTrigger value="events">Events</TabsTrigger>
           </TabsList>
         </div>
         <div className="flex-1 flex overflow-hidden">

--- a/frontend/components/traces/trace-view/metadata.tsx
+++ b/frontend/components/traces/trace-view/metadata.tsx
@@ -1,7 +1,9 @@
-import { FileText } from "lucide-react";
-import React from "react";
+"use client";
 
-import { Button } from "@/components/ui/button.tsx";
+import { FileText } from "lucide-react";
+import { useState } from "react";
+
+import { HeaderIconButton } from "@/components/traces/trace-view/header/header-icon-button";
 import ContentRenderer from "@/components/ui/content-renderer/index";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover.tsx";
 import { cn } from "@/lib/utils.ts";
@@ -11,23 +13,27 @@ interface MetadataProps {
 }
 
 const Metadata = ({ metadata }: MetadataProps) => {
+  const [open, setOpen] = useState(false);
+
   if (!metadata) {
     return null;
   }
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button variant="outline" className={cn("h-6 text-xs px-1.5 bg-transparent")}>
-          <FileText size={14} className="mr-1" />
-          <span>Metadata</span>
-        </Button>
+        <HeaderIconButton
+          icon={<FileText className={cn({ "text-primary": open })} size={14} />}
+          label="Metadata"
+          active={open}
+        />
       </PopoverTrigger>
-      <PopoverContent className="p-0 overflow-hidden">
+      <PopoverContent align="end" className="p-0 overflow-hidden">
         <ContentRenderer
           value={metadata}
           readOnly={true}
           defaultMode="json"
+          codeEditorClassName="pr-1"
           className="max-h-[50vh] border-none bg-muted/30"
           placeholder=""
         />

--- a/frontend/components/traces/trace-view/signal-events-panel/cluster-button.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/cluster-button.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { TooltipPortal } from "@radix-ui/react-tooltip";
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+
+import ClusterIcon from "@/components/signal/clusters-section/cluster-icon";
+import { type TraceSignalClusterNode } from "@/components/traces/trace-view/store/base";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { getClusterColorById } from "@/lib/clusters/colors";
+import { cn } from "@/lib/utils";
+
+import { CHIP, CHIP_ARROW, CHIP_SURFACE, TOOLTIP_DELAY_MS } from "./constants";
+
+interface Props {
+  cluster: TraceSignalClusterNode;
+  href: string;
+  /** Truncate when the row runs out instead of overflowing it. Grow stays 0, so a
+   *  lone cluster sizes to its label rather than stretching across the panel. */
+  shrinkable?: boolean;
+}
+
+/** Links an event into the signal page, scoped to the cluster and the event — so
+ *  it replaces "Open in Signals" rather than sitting beside it. */
+export default function ClusterButton({ cluster, href, shrinkable }: Props) {
+  const button = (
+    <Link
+      href={href}
+      target="_blank"
+      className={cn(CHIP, CHIP_SURFACE, "min-w-0 overflow-hidden px-1.5 text-left", shrinkable ? "shrink" : "shrink-0")}
+    >
+      {/* Never shrinks, so a squeezed button loses the label rather than its identity. */}
+      <ClusterIcon iconVariant="box" color={getClusterColorById(cluster.id)} />
+      <span className="min-w-0 truncate">{cluster.name}</span>
+      <ArrowUpRight className={CHIP_ARROW} />
+    </Link>
+  );
+
+  // Portalled because the panel root is `overflow-hidden` and would clip it.
+  return (
+    <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side="bottom">{cluster.name}</TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/constants.ts
+++ b/frontend/components/traces/trace-view/signal-events-panel/constants.ts
@@ -1,0 +1,27 @@
+/** The app-wide provider is 0ms, which is right for an icon button and wrong for
+ *  a row of them. */
+export const TOOLTIP_DELAY_MS = 300;
+
+/** Shared by the panel's three chips — cluster button, "Open in Signals", enum
+ *  pill — so they read as one object doing three jobs. Each adds its own inset. */
+export const CHIP = "flex h-5.5 items-center gap-1.25 rounded-2xl text-[11px] font-medium transition-colors";
+
+/** Marks a chip as a way out of the trace. */
+export const CHIP_ARROW = "size-[13px] shrink-0 opacity-60";
+
+/** The two link chips. A step off the card, not a wash of a hue: the panel is an
+ *  `ElevatedSurface`, so this means "three above THE CARD" wherever the card
+ *  itself ends up on the ramp. */
+export const CHIP_SURFACE = "bg-surface-up-3 hover:bg-surface-up-4";
+
+/**
+ * The span-reference badges inside a payload (`Bash ↗`), which ship as
+ * `bg-foreground-300/20` — a fixed wash of the TEXT colour that ignores the ramp.
+ *
+ * They are rendered by markdown straight from a payload string and take no props,
+ * so the only handle is the `data-slot` on the chip plus a descendant rule from
+ * the payload container. That two-element selector also outranks the chip's own
+ * class, which is what lets the override land without `!important`.
+ */
+export const SPAN_CHIP_SURFACE =
+  "[&_[data-slot=span-chip]]:bg-surface-up-4 [&_[data-slot=span-chip]:hover]:bg-surface-up-5";

--- a/frontend/components/traces/trace-view/signal-events-panel/enum-pill.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/enum-pill.tsx
@@ -1,0 +1,10 @@
+import { cn } from "@/lib/utils";
+
+import { CHIP } from "./constants";
+
+/** An enum payload value. A step below the link chips — it is a value, not a way
+ *  out, and no arrow says so. Wider inset: bare text has no glyphs to stand it
+ *  off the rounded ends. */
+export default function EnumPill({ value }: { value: string }) {
+  return <span className={cn(CHIP, "inline-flex bg-surface-up-2 px-2.5 text-secondary-foreground")}>{value}</span>;
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/open-in-signals-button.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/open-in-signals-button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+import { CHIP, CHIP_ARROW, CHIP_SURFACE } from "./constants";
+
+/** The way out of the trace when the event has no cluster to carry one. Opens
+ *  with text rather than an icon, so it takes 2px more inset on the left. */
+export default function OpenInSignalsButton({ href }: { href: string }) {
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      className={cn(CHIP, CHIP_SURFACE, "min-w-0 shrink-0 overflow-hidden pr-1.5 pl-2")}
+    >
+      <span className="min-w-0 truncate">Open in Signals</span>
+      <ArrowUpRight className={CHIP_ARROW} />
+    </Link>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/panel-body.tsx
@@ -1,19 +1,26 @@
 "use client";
 
 import { TooltipPortal } from "@radix-ui/react-tooltip";
-import { Loader2, X } from "lucide-react";
+import { Loader2, Sparkles, X } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { shallow } from "zustand/shallow";
 
+import { laminarAgentStore } from "@/components/agent";
 import { useTraceViewStore } from "@/components/traces/trace-view/store";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ElevatedSurface } from "@/components/ui/surface";
+import { Tabs, TabsContent, TabsList } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useFeatureFlags } from "@/contexts/feature-flags-context.tsx";
+import { Feature } from "@/lib/features/features.ts";
 import { cn } from "@/lib/utils";
 
+import { TOOLTIP_DELAY_MS } from "./constants";
 import SignalDetails from "./signal-details";
+import SignalHeader from "./signal-header";
+import SignalTab from "./signal-tab";
 
 interface Props {
   traceId: string;
@@ -74,6 +81,7 @@ export default function PanelBody({ traceId, onClose }: Props) {
       shallow
     );
 
+  const featureFlags = useFeatureFlags();
   const searchParams = useSearchParams();
   const highlightedEventId = searchParams.get("eventId");
 
@@ -81,8 +89,8 @@ export default function PanelBody({ traceId, onClose }: Props) {
     if (activeSignalTabId && traceSignals.some((s) => s.signalId === activeSignalTabId)) {
       return activeSignalTabId;
     }
-    // A deep link with eventId points at one specific finding — surface the
-    // signal tab that owns it so the highlighted card is visible on open.
+    // A deep link with eventId points at one specific event — surface the signal
+    // tab that owns it so the highlighted event is visible on open.
     if (highlightedEventId) {
       const owner = traceSignals.find((s) => s.events.some((e) => e.id === highlightedEventId));
       if (owner) return owner.signalId;
@@ -97,9 +105,15 @@ export default function PanelBody({ traceId, onClose }: Props) {
   const activeSignal = traceSignals.find((s) => s.signalId === effectiveTabId);
 
   const closeButton = (
-    <Tooltip>
+    <Tooltip delayDuration={400}>
       <TooltipTrigger asChild>
-        <Button aria-label="Close" variant="ghost" className="h-6 w-6 p-0 shrink-0" onClick={onClose}>
+        <Button
+          aria-label="Close"
+          variant="ghost"
+          size="icon-sm"
+          className="shrink-0 hover:bg-surface-up"
+          onClick={onClose}
+        >
           <X className="size-3.5" />
         </Button>
       </TooltipTrigger>
@@ -110,41 +124,71 @@ export default function PanelBody({ traceId, onClose }: Props) {
   );
 
   return (
-    <div className="flex flex-col rounded-md border bg-blue-400/12 overflow-hidden border-blue-400/30">
+    // Three rungs off the trace view, not one: the card carries a ladder of its
+    // own — header, chips, tabs, span chips — and one step leaves no room under
+    // the top of it. `ElevatedSurface` also publishes `--color-border` at +5, so
+    // the border and the deep-link rule track the card for free.
+    <ElevatedSurface offset={3} className="relative flex flex-col overflow-hidden rounded-md border">
       {isTraceSignalsLoading ? (
         <div className="flex items-center justify-center py-8 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
         </div>
       ) : (
         <Tabs value={effectiveTabId} onValueChange={setActiveSignalTabId} className="flex flex-col gap-0">
-          <TooltipProvider delayDuration={300}>
-            <div className="shrink-0 flex items-center gap-2 justify-between px-2 py-1 bg-blue-400/12">
+          <TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
+            {/* The tab list is a filled pill with its own inset, so under tabs the
+                leading inset matches the trailing one; bare header text keeps the
+                wider one. */}
+            <div
+              className={cn(
+                "flex shrink-0 items-center justify-between gap-2 bg-surface-up p-1",
+                isSingleSignal && "pl-2"
+              )}
+            >
               {isSingleSignal && activeSignal ? (
-                <span className="flex items-center min-w-0 pl-1 text-xs font-medium">
-                  <span className="truncate">{activeSignal.signalName}</span>
-                </span>
+                <SignalHeader signal={activeSignal} />
               ) : (
-                <TabsList className="flex-1 min-w-0 h-auto bg-transparent p-0 gap-1 justify-start">
+                <TabsList className="h-auto min-w-0 flex-1 justify-start gap-1 bg-transparent p-0">
                   {traceSignals.map((signal) => (
-                    <TabsTrigger
-                      key={signal.signalId}
-                      value={signal.signalId}
-                      className={cn(
-                        "flex-1 min-w-0 h-auto px-2 py-1 text-xs rounded-md",
-                        "data-[state=active]:bg-gray-900 data-[state=active]:shadow-none data-[state=active]:text-foreground",
-                        "text-secondary-foreground hover:text-foreground"
-                      )}
-                    >
-                      <span className="block w-full truncate text-center">{signal.signalName}</span>
-                    </TabsTrigger>
+                    <SignalTab key={signal.signalId} signal={signal} />
                   ))}
                 </TabsList>
+              )}
+              {/* An icon, not a worded button: it is feature-flagged and usually
+                  absent, and a second label would outweigh the signal's own name. */}
+              {featureFlags[Feature.AGENT] && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      aria-label="Open in AI Chat"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="shrink-0 hover:bg-surface-up"
+                      onClick={() => laminarAgentStore.getState().open()}
+                    >
+                      <Sparkles className="size-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipPortal>
+                    <TooltipContent side="top">Open in AI Chat</TooltipContent>
+                  </TooltipPortal>
+                </Tooltip>
               )}
               {closeButton}
             </div>
           </TooltipProvider>
+          {/* `scroll-fade-b` on the VIEWPORT, not a painted scrim over it. It is a
+              scroll-driven mask, so the fade only exists while there is more
+              payload below and is gone the moment you reach the bottom — and
+              being a mask it has no colour to keep in step with the ramp. It has
+              to sit on the element that actually scrolls, since the animation is
+              timed to `scroll(self y)`: the Radix viewport, not the root.
+
+              Both classes: `scroll-fade-b` is the mask, `scroll-fade-b-7` only
+              sets `--scroll-fade-b-size` (7 × 4px = 28px). The suffixed one alone
+              is a size for a mask that was never applied. */}
           <ScrollArea
-            className="[&>div>div]:!block [&>[data-radix-scroll-area-viewport]]:!h-full"
+            className="[&>div>div]:!block [&>[data-radix-scroll-area-viewport]]:!h-full [&>[data-radix-scroll-area-viewport]]:scroll-fade-b [&>[data-radix-scroll-area-viewport]]:scroll-fade-b-7"
             style={bodyHeight !== null ? { height: bodyHeight } : undefined}
           >
             <div ref={contentRef}>
@@ -159,16 +203,20 @@ export default function PanelBody({ traceId, onClose }: Props) {
               ))}
             </div>
           </ScrollArea>
+          {/* Absolute, and with no fill of its own: it costs the body no height,
+              and the only thing that reacts is the grip. `--color-border` is the
+              card's elevation +5, so +7 is what reads as a step up from where the
+              grip sits. */}
           <div
             role="separator"
             aria-orientation="horizontal"
             onPointerDown={handleResizePointerDown}
-            className="group h-1.5 shrink-0 cursor-row-resize flex items-center justify-center hover:bg-blue-300/10 transition-colors"
+            className="group/resize absolute inset-x-0 bottom-0 flex h-1.5 cursor-row-resize items-center justify-center"
           >
-            <div className="h-0.5 w-8 rounded-full bg-primary-foreground/20" />
+            <div className="h-0.5 w-8 rounded-full bg-border transition-colors group-hover/resize:bg-surface-up-7" />
           </div>
         </Tabs>
       )}
-    </div>
+    </ElevatedSurface>
   );
 }

--- a/frontend/components/traces/trace-view/signal-events-panel/payload-value.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/payload-value.tsx
@@ -1,0 +1,32 @@
+import { type SchemaField } from "@/components/signals/utils";
+import { type SpanReferenceCallbacks } from "@/components/traces/trace-view/span-reference";
+import Markdown from "@/components/traces/trace-view/transcript/markdown.tsx";
+
+import EnumPill from "./enum-pill";
+
+interface Props {
+  value: unknown;
+  field: SchemaField;
+  spanRefCallbacks?: SpanReferenceCallbacks;
+}
+
+/** One payload value, rendered per its schema type. */
+export default function PayloadValue({ value, field, spanRefCallbacks }: Props) {
+  if (value === null || value === undefined) {
+    return <span className="text-muted-foreground">&mdash;</span>;
+  }
+  switch (field.type) {
+    case "boolean":
+      return <span>{value ? "true" : "false"}</span>;
+    case "enum":
+      return <EnumPill value={String(value)} />;
+    case "number":
+      return <span className="tabular-nums">{String(value)}</span>;
+    case "string":
+      return (
+        <span className="whitespace-pre-wrap break-words">
+          <Markdown contentClassName="pb-0" output={String(value)} spanRefCallbacks={spanRefCallbacks} />
+        </span>
+      );
+  }
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/severity-icon.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/severity-icon.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { CircleAlert, Info, TriangleAlert } from "lucide-react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { SEVERITY_LABELS } from "@/lib/actions/alerts/types";
+import { cn } from "@/lib/utils";
+
+const ICONS = { 0: Info, 1: TriangleAlert, 2: CircleAlert } as const;
+
+const COLORS: Record<number, string> = {
+  0: "text-muted-foreground/60",
+  1: "text-orange-400/80",
+  2: "text-red-400",
+};
+
+interface Props {
+  severity: number;
+  /** Skip the tooltip. Inside a tab it would nest interactive elements and
+   *  compete for the click, and the tab's own label already names the signal. */
+  bare?: boolean;
+}
+
+/** Severity beside the signal name. A word there would be a second title, so the
+ *  label lives in a tooltip — a colour and a shape have to be learnable. */
+export default function SeverityIcon({ severity, bare }: Props) {
+  const Icon = ICONS[severity as keyof typeof ICONS] ?? Info;
+  const label = SEVERITY_LABELS[severity as keyof typeof SEVERITY_LABELS] ?? "Info";
+
+  // Sized by CLASS: lucide's `size` prop becomes an attribute, which loses to
+  // `TabsTrigger`'s `[&_svg:not([class*='size-'])]:size-4`.
+  const glyph = (
+    <span className={cn("shrink-0", COLORS[severity] ?? COLORS[0], bare && "pointer-events-none")} aria-label={label}>
+      <Icon className="size-3" />
+    </span>
+  );
+
+  if (bare) return glyph;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{glyph}</TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-details.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-details.tsx
@@ -1,160 +1,22 @@
 "use client";
 
-import { ArrowUpRight, Sparkles } from "lucide-react";
-import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { shallow } from "zustand/shallow";
 
-import { laminarAgentStore } from "@/components/agent";
-import ClusterIcon from "@/components/signal/clusters-section/cluster-icon";
-import { jsonSchemaToSchemaFields, type SchemaField } from "@/components/signals/utils";
-import { type SpanReferenceCallbacks } from "@/components/traces/trace-view/span-reference";
+import { jsonSchemaToSchemaFields } from "@/components/signals/utils";
 import { useSpanRefCallbacks } from "@/components/traces/trace-view/span-reference/use-span-ref-callbacks";
 import { useTraceViewStore } from "@/components/traces/trace-view/store";
-import { type TraceSignal, type TraceSignalEvent } from "@/components/traces/trace-view/store/base";
-import Markdown from "@/components/traces/trace-view/transcript/markdown.tsx";
-import { Badge } from "@/components/ui/badge";
-import { useFeatureFlags } from "@/contexts/feature-flags-context.tsx";
-import { SEVERITY_LABELS } from "@/lib/actions/alerts/types";
-import { getClusterColorById } from "@/lib/clusters/colors";
-import { Feature } from "@/lib/features/features.ts";
-import { cn } from "@/lib/utils";
+import { type TraceSignal } from "@/components/traces/trace-view/store/base";
 
+import SignalEvent from "./signal-event";
 import { schemaFieldsToStructuredOutput } from "./utils";
 
-const SEVERITY_STYLES: Record<number, string> = {
-  0: "text-muted-foreground/60",
-  1: "text-orange-400/80",
-  2: "text-red-400",
-};
-
-interface Props {
-  traceId: string;
-  signal: TraceSignal;
-}
-
-function parsePayload(payload: string): Record<string, unknown> {
-  try {
-    const result = JSON.parse(payload);
-    if (result == null || typeof result !== "object" || Array.isArray(result)) {
-      return {};
-    }
-    return result;
-  } catch {
-    return {};
-  }
-}
-
-function PayloadValue({
-  value,
-  field,
-  spanRefCallbacks,
-}: {
-  value: unknown;
-  field: SchemaField;
-  spanRefCallbacks?: SpanReferenceCallbacks;
-}) {
-  if (value === null || value === undefined) {
-    return <span className="text-muted-foreground">&mdash;</span>;
-  }
-  switch (field.type) {
-    case "boolean":
-      return <span>{value ? "true" : "false"}</span>;
-    case "enum":
-      return (
-        <span className="inline-flex items-center rounded-full border border-blue-400/30 px-2 py-0.5 text-xs font-medium text-secondary-foreground">
-          {String(value)}
-        </span>
-      );
-    case "number":
-      return <span className="tabular-nums">{String(value)}</span>;
-    case "string":
-      return (
-        <span className="whitespace-pre-wrap break-words">
-          <Markdown contentClassName="pb-0" output={String(value)} spanRefCallbacks={spanRefCallbacks} />
-        </span>
-      );
-  }
-}
-
-/** One finding card: the event's severity + a link per leaf cluster it belongs to,
- *  then the event payload rendered field-by-field from the signal's schema. */
-function FindingCard({
-  event,
-  projectId,
-  signalId,
-  traceId,
-  validFields,
-  spanRefCallbacks,
-  highlighted,
-}: {
-  event: TraceSignalEvent;
-  projectId: string;
-  signalId: string;
-  traceId: string;
-  validFields: SchemaField[];
-  spanRefCallbacks?: SpanReferenceCallbacks;
-  highlighted?: boolean;
-}) {
-  const parsed = useMemo(() => parsePayload(event.payload), [event.payload]);
-  const severityLabel = SEVERITY_LABELS[event.severity as keyof typeof SEVERITY_LABELS] ?? "Info";
-  const severityClassName = SEVERITY_STYLES[event.severity] ?? SEVERITY_STYLES[0];
-
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (highlighted) {
-      ref.current?.scrollIntoView({ block: "nearest" });
-    }
-  }, [highlighted]);
-
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        "flex flex-col gap-2.5 rounded-lg border p-3",
-        highlighted && "border-blue-400/60 ring-1 ring-blue-400/40 bg-blue-400/8"
-      )}
-    >
-      <div className="flex items-center gap-1.5 flex-wrap">
-        <Badge variant="outline" className={cn("rounded-full font-medium", severityClassName)}>
-          {severityLabel}
-        </Badge>
-        {event.leafClusters.map((cluster) => (
-          <Link
-            key={cluster.id}
-            href={`/project/${projectId}/signals/${signalId}?clusterId=${cluster.id}&traceId=${traceId}&eventId=${event.id}`}
-            target="_blank"
-            className="group flex items-center gap-1.5 min-w-0 rounded-full bg-blue-400/8 border-blue-400/30 border px-2 py-1 hover:bg-blue-400/12"
-          >
-            <ClusterIcon iconVariant="box" color={getClusterColorById(cluster.id)} />
-            <span className="truncate text-xs font-medium">{cluster.name}</span>
-            <ArrowUpRight className="size-3.5 shrink-0" />
-          </Link>
-        ))}
-      </div>
-      <div className="flex flex-col gap-2.5">
-        {validFields.map((field) => (
-          <div key={field.name} className="flex flex-col gap-0.5">
-            <div className="text-xs font-medium text-muted-foreground/80">{field.name}</div>
-            <div className="text-sm leading-relaxed text-secondary-foreground">
-              <PayloadValue value={parsed[field.name]} field={field} spanRefCallbacks={spanRefCallbacks} />
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-/** The per-signal body rendered inside a panel tab: the "Open in Signals" / "Open
- *  in AI Chat" actions plus one finding card per event, each rendered
- *  field-by-field from the schema. */
-export default function SignalDetails({ traceId, signal }: Props) {
+/** The per-signal body rendered inside a panel tab. */
+export default function SignalDetails({ traceId, signal }: { traceId: string; signal: TraceSignal }) {
   const { projectId } = useParams();
   const searchParams = useSearchParams();
   const highlightedEventId = searchParams.get("eventId");
-  const featureFlags = useFeatureFlags();
   const { selectSpanById, spans } = useTraceViewStore(
     (state) => ({
       selectSpanById: state.selectSpanById,
@@ -164,12 +26,6 @@ export default function SignalDetails({ traceId, signal }: Props) {
   );
 
   const events = signal.events ?? [];
-
-  // Chat is the global agent column now; open it (already scoped to this trace's context via the
-  // registered trace store). Signal-definition/payload injection was dropped with the old inline chat.
-  const handleOpenInChat = () => {
-    laminarAgentStore.getState().open();
-  };
 
   const schemaFields = useMemo(
     () => jsonSchemaToSchemaFields(schemaFieldsToStructuredOutput(signal.schemaFields)),
@@ -182,36 +38,17 @@ export default function SignalDetails({ traceId, signal }: Props) {
     onSelectSpan: selectSpanById,
   });
 
-  const signalHref = `/project/${projectId}/signals/${signal.signalId}?traceId=${traceId}`;
-
+  // No padding here: each event carries its own, so neither block is stuck with
+  // the other's inset.
   return (
-    <div className="px-2 pt-2 pb-0.5 flex flex-col gap-3">
-      <div className="flex items-center gap-1.5 flex-wrap">
-        <Link
-          href={signalHref}
-          target="_blank"
-          className="group flex items-center gap-1.5 min-w-0 rounded-full bg-blue-400/8 border-blue-400/30 border px-2 py-1 hover:bg-blue-400/12"
-        >
-          <span className="truncate text-xs font-medium">Open in Signals</span>
-          <ArrowUpRight className="size-3.5 shrink-0" />
-        </Link>
-        {featureFlags[Feature.AGENT] && (
-          <button
-            type="button"
-            onClick={handleOpenInChat}
-            className="group flex items-center gap-1.5 min-w-0 rounded-full bg-blue-400/8 border-blue-400/30 border px-2 py-1 hover:bg-blue-400/12"
-          >
-            <Sparkles className="size-3.5 shrink-0" />
-            <span className="truncate text-xs font-medium">Open in AI Chat</span>
-          </button>
-        )}
-      </div>
+    <div className="flex min-w-0 flex-col">
       {events.length === 0 ? (
-        <div className="py-2 text-sm text-muted-foreground">No events found</div>
+        <div className="px-2 py-2 text-sm text-muted-foreground">No events found</div>
       ) : (
-        <div className="flex flex-col gap-2.5">
+        // Only a per-span signal has more than one event; otherwise this never renders.
+        <div className="flex min-w-0 flex-col gap-3">
           {events.map((event) => (
-            <FindingCard
+            <SignalEvent
               key={event.id}
               event={event}
               projectId={projectId as string}

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-event.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-event.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+
+import { type SchemaField } from "@/components/signals/utils";
+import { type SpanReferenceCallbacks } from "@/components/traces/trace-view/span-reference";
+import { type TraceSignalEvent } from "@/components/traces/trace-view/store/base";
+import { cn } from "@/lib/utils";
+
+import ClusterButton from "./cluster-button";
+import { SPAN_CHIP_SURFACE } from "./constants";
+import OpenInSignalsButton from "./open-in-signals-button";
+import PayloadValue from "./payload-value";
+
+function parsePayload(payload: string): Record<string, unknown> {
+  try {
+    const result = JSON.parse(payload);
+    if (result == null || typeof result !== "object" || Array.isArray(result)) {
+      return {};
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+interface Props {
+  event: TraceSignalEvent;
+  projectId: string;
+  signalId: string;
+  traceId: string;
+  validFields: SchemaField[];
+  spanRefCallbacks?: SpanReferenceCallbacks;
+  highlighted?: boolean;
+}
+
+/** One event, with no card around it: a signal produces one event per trace in
+ *  all but a handful of cases, so the box bordered the panel's only content. */
+export default function SignalEvent({
+  event,
+  projectId,
+  signalId,
+  traceId,
+  validFields,
+  spanRefCallbacks,
+  highlighted,
+}: Props) {
+  const parsed = useMemo(() => parsePayload(event.payload), [event.payload]);
+
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (highlighted) {
+      ref.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlighted]);
+
+  return (
+    <div
+      ref={ref}
+      // A deep-linked event still has to be findable, so the highlight is a rule
+      // down the left edge rather than a ring around a box that is no longer drawn.
+      className={cn("flex min-w-0 flex-col", highlighted && "border-l-2 border-border")}
+    >
+      {/* Half the fields' inset, because a chip is a filled box with its own:
+          6 + the chip's 6 puts the LABEL on 12, level with the field labels
+          under it. The column keeps its one left edge; the text sits on it
+          rather than the box. */}
+      <div className="flex min-w-0 items-center gap-1.5 px-1.5 py-2">
+        {event.leafClusters.length > 0 ? (
+          event.leafClusters.map((cluster) => (
+            <ClusterButton
+              key={cluster.id}
+              shrinkable
+              cluster={cluster}
+              href={`/project/${projectId}/signals/${signalId}?clusterId=${cluster.id}&traceId=${traceId}&eventId=${event.id}`}
+            />
+          ))
+        ) : (
+          <OpenInSignalsButton href={`/project/${projectId}/signals/${signalId}?traceId=${traceId}`} />
+        )}
+      </div>
+
+      {/* The span-chip override rides here: the chips come out of shipping
+          markdown, so a descendant rule is the only way to reach them. The bottom
+          inset clears the resize grip, which is absolute and sits over this. */}
+      <div className={cn("flex min-w-0 flex-col gap-2.5 px-3 pb-2", SPAN_CHIP_SURFACE)}>
+        {validFields.map((field) => (
+          <div key={field.name} className="flex flex-col gap-0.5">
+            <div className="text-xs font-medium text-muted-foreground">{field.name}</div>
+            <div className="text-sm leading-relaxed text-secondary-foreground">
+              <PayloadValue value={parsed[field.name]} field={field} spanRefCallbacks={spanRefCallbacks} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-header.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-header.tsx
@@ -1,0 +1,15 @@
+import { type TraceSignal } from "@/components/traces/trace-view/store/base";
+
+import SeverityIcon from "./severity-icon";
+import { worstSeverity } from "./utils";
+
+/** The header when a trace has a single signal. The tab row replaces it when
+ *  there are several. */
+export default function SignalHeader({ signal }: { signal: TraceSignal }) {
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1.5 pl-1">
+      {signal.events.length > 0 && <SeverityIcon severity={worstSeverity(signal)} />}
+      <span className="min-w-0 truncate text-xs font-medium">{signal.signalName}</span>
+    </div>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
+++ b/frontend/components/traces/trace-view/signal-events-panel/signal-tab.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { TooltipPortal } from "@radix-ui/react-tooltip";
+
+import { type TraceSignal } from "@/components/traces/trace-view/store/base";
+import { TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+import { TOOLTIP_DELAY_MS } from "./constants";
+import SeverityIcon from "./severity-icon";
+import { worstSeverity } from "./utils";
+
+/**
+ * The active tab as a step off the card, not `bg-gray-900` — a fixed near-black
+ * that ignores the surface ladder and reads as a hole punched in the header.
+ *
+ * Both variants on ours, and `data-[state=active]:` on the overrides, because
+ * `TabsTrigger`'s own rules are variant-qualified: `dark:data-[state=active]:bg-input/30`
+ * and `dark:text-muted-foreground` outrank any plain utility, and
+ * `data-[state=active]:shadow-sm` outranks a plain `shadow-none`. Match the
+ * variant or the rule never lands.
+ */
+const TAB = cn(
+  "h-5.5 w-full min-w-0 rounded-md px-2 text-[11px]",
+  "data-[state=active]:bg-surface-up-5 dark:data-[state=active]:bg-surface-up-5",
+  "data-[state=active]:text-foreground dark:data-[state=active]:text-foreground",
+  "data-[state=active]:shadow-none",
+  "text-secondary-foreground dark:text-secondary-foreground",
+  "hover:bg-surface-up-2 hover:text-foreground dark:hover:text-foreground",
+  // The active tab is already the painted one; lighting it further on hover
+  // would promise the click does something.
+  "data-[state=active]:hover:bg-surface-up-5"
+);
+
+export default function SignalTab({ signal }: { signal: TraceSignal }) {
+  const trigger = (
+    <TabsTrigger value={signal.signalId} className={TAB}>
+      {/* The tab row replaces the header, so without this the severity glyph
+          disappears exactly when there are several severities to tell apart. */}
+      <span className="flex min-w-0 items-center justify-center gap-1.5">
+        {signal.events.length > 0 && <SeverityIcon bare severity={worstSeverity(signal)} />}
+        <span className="min-w-0 truncate">{signal.signalName}</span>
+      </span>
+    </TabsTrigger>
+  );
+
+  // The trigger is a WRAPPER, not the tab: both primitives own a `data-state` and
+  // `Tabs.Trigger` spreads props after its own, so `asChild` would clobber it.
+  return (
+    <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
+      <TooltipTrigger asChild>
+        <span className="flex min-w-0 flex-1">{trigger}</span>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side="bottom">{signal.signalName}</TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+}

--- a/frontend/components/traces/trace-view/signal-events-panel/utils.ts
+++ b/frontend/components/traces/trace-view/signal-events-panel/utils.ts
@@ -1,5 +1,10 @@
 import { type TraceSignal } from "@/components/traces/trace-view/store/base";
 
+/** The worst event's severity. With several events (a per-span signal) the header
+ *  speaks for the whole card, and the card is as bad as its worst event. */
+export const worstSeverity = (signal: TraceSignal) =>
+  signal.events.reduce((worst, e) => Math.max(worst, e.severity), 0);
+
 export function schemaFieldsToStructuredOutput(fields: TraceSignal["schemaFields"]): {
   type: string;
   properties: Record<string, { type: string; description: string }>;

--- a/frontend/components/traces/trace-view/span-reference/index.tsx
+++ b/frontend/components/traces/trace-view/span-reference/index.tsx
@@ -49,6 +49,10 @@ function SpanChip({
         e.preventDefault();
         onClick();
       }}
+      // A styling hook, not a behaviour one: the signal-events panel re-paints
+      // these onto the surface ramp, and the chip has nothing else stable to
+      // select on. Purely additive — no rule in shipping CSS matches it.
+      data-slot="span-chip"
       className="inline-flex items-center gap-1 rounded px-1 py-0.25 align-middle bg-foreground-300/20 hover:bg-foreground-300/30 transition-colors cursor-pointer"
     >
       <span

--- a/frontend/components/traces/trace-view/span-stats-shield.tsx
+++ b/frontend/components/traces/trace-view/span-stats-shield.tsx
@@ -33,7 +33,7 @@ function SpanStatsShieldInner({
     <div
       className={cn(
         "items-center gap-2 text-xs flex shrink-0",
-        !isInline && "bg-muted px-1.5 rounded-md animate-in fade-in duration-200",
+        !isInline && "h-6 bg-muted px-1.5 rounded-md animate-in fade-in duration-200",
         className
       )}
     >

--- a/frontend/components/traces/trace-view/template-view-toggle.tsx
+++ b/frontend/components/traces/trace-view/template-view-toggle.tsx
@@ -160,9 +160,9 @@ export default function TemplateViewToggle({
                     className="h-8 py-1 text-xs"
                   />
                 )}
-                {(templates?.length ?? 0) > 0 && (
-                  <CommandGroup heading="Custom" className={GROUP_CLASS}>
-                    {filteredTemplates.length === 0 ? (
+                <CommandGroup heading="Custom" className={GROUP_CLASS}>
+                  {(templates?.length ?? 0) > 0 &&
+                    (filteredTemplates.length === 0 ? (
                       <div className="px-2 py-3 text-center text-xs text-muted-foreground">No matches.</div>
                     ) : (
                       filteredTemplates.map((t) => {
@@ -189,9 +189,8 @@ export default function TemplateViewToggle({
                           </CommandItem>
                         );
                       })
-                    )}
-                  </CommandGroup>
-                )}
+                    ))}
+                </CommandGroup>
                 {(templates?.length ?? 0) > 0 && <CommandSeparator alwaysRender />}
                 <CommandGroup className={GROUP_CLASS}>
                   <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">

--- a/frontend/components/traces/trace-view/template-view-toggle.tsx
+++ b/frontend/components/traces/trace-view/template-view-toggle.tsx
@@ -132,7 +132,10 @@ export default function TemplateViewToggle({
               </CommandGroup>
               <CommandSeparator alwaysRender />
               <CommandGroup heading="Custom" className={GROUP_CLASS}>
-                <ScrollArea className="max-h-[240px] scroll-fade-t [&>div]:max-h-[240px] [&>div>div]:block!">
+                <ScrollArea
+                  className="max-h-[240px] [&>div]:max-h-[240px] [&>div>div]:block!"
+                  viewportClassName="scroll-fade-t"
+                >
                   {templates?.map((t) => {
                     const active = isCustom && selectedTemplate?.id === t.id;
                     return (

--- a/frontend/components/traces/trace-view/template-view-toggle.tsx
+++ b/frontend/components/traces/trace-view/template-view-toggle.tsx
@@ -16,6 +16,7 @@ import { type ViewTab } from "@/components/traces/trace-view/view-toggle";
 import { Button } from "@/components/ui/button.tsx";
 import { Command, CommandGroup, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTemplatePicker } from "@/components/ui/template-renderer/template-picker";
 import { cn } from "@/lib/utils";
 
@@ -108,9 +109,9 @@ export default function TemplateViewToggle({
           </Button>
         </PopoverTrigger>
         <PopoverContent align="start" className="w-[280px] p-0" onWheel={(e) => e.stopPropagation()}>
-          <Command shouldFilter={false} className="max-h-[360px]">
-            <CommandList className="flex max-h-[360px] min-h-0 flex-col overflow-hidden">
-              <CommandGroup heading="Default" className={cn(GROUP_CLASS, "shrink-0")}>
+          <Command shouldFilter={false}>
+            <CommandList className="max-h-none overflow-hidden">
+              <CommandGroup heading="Default" className={GROUP_CLASS}>
                 {viewTabs.map((option) => {
                   const view = viewOptions[option];
                   if (!view) return null;
@@ -129,38 +130,34 @@ export default function TemplateViewToggle({
                   );
                 })}
               </CommandGroup>
-              <CommandSeparator alwaysRender className="shrink-0" />
-              <CommandGroup
-                heading="Custom"
-                className={cn(
-                  GROUP_CLASS,
-                  "min-h-0 flex-1 flex flex-col [&_[cmdk-group-items]]:min-h-0 [&_[cmdk-group-items]]:overflow-y-auto [&_[cmdk-group-items]]:scroll-fade-t"
-                )}
-              >
-                {templates?.map((t) => {
-                  const active = isCustom && selectedTemplate?.id === t.id;
-                  return (
-                    <CommandItem
-                      key={t.id}
-                      value={`template:${t.id}`}
-                      onSelect={() => handlePickTemplate(t.id)}
-                      className="group text-xs"
-                    >
-                      <span className="flex-1 truncate">{t.name}</span>
-                      <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
-                        <button
-                          type="button"
-                          aria-label={`Edit ${t.name}`}
-                          onClick={(e) => handleEditTemplate(e, t.id)}
-                          className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
-                        >
-                          <PencilIcon className="size-2.5" />
-                        </button>
-                        {active && <Check className="size-3.5" />}
-                      </div>
-                    </CommandItem>
-                  );
-                })}
+              <CommandSeparator alwaysRender />
+              <CommandGroup heading="Custom" className={GROUP_CLASS}>
+                <ScrollArea className="max-h-[240px] scroll-fade-t [&>div]:max-h-[240px] [&>div>div]:block!">
+                  {templates?.map((t) => {
+                    const active = isCustom && selectedTemplate?.id === t.id;
+                    return (
+                      <CommandItem
+                        key={t.id}
+                        value={`template:${t.id}`}
+                        onSelect={() => handlePickTemplate(t.id)}
+                        className="group text-xs"
+                      >
+                        <span className="flex-1 truncate">{t.name}</span>
+                        <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
+                          <button
+                            type="button"
+                            aria-label={`Edit ${t.name}`}
+                            onClick={(e) => handleEditTemplate(e, t.id)}
+                            className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
+                          >
+                            <PencilIcon className="size-2.5" />
+                          </button>
+                          {active && <Check className="size-3.5" />}
+                        </div>
+                      </CommandItem>
+                    );
+                  })}
+                </ScrollArea>
                 {templateCount <= 5 && (
                   <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">
                     <Plus className="mr-1.5 size-3.5" />
@@ -170,8 +167,8 @@ export default function TemplateViewToggle({
               </CommandGroup>
               {templateCount > 5 && (
                 <>
-                  <CommandSeparator alwaysRender className="shrink-0" />
-                  <CommandGroup className={cn(GROUP_CLASS, "shrink-0")}>
+                  <CommandSeparator alwaysRender />
+                  <CommandGroup className={GROUP_CLASS}>
                     <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">
                       <Plus className="mr-1.5 size-3.5" />
                       New template

--- a/frontend/components/traces/trace-view/template-view-toggle.tsx
+++ b/frontend/components/traces/trace-view/template-view-toggle.tsx
@@ -10,18 +10,11 @@ import {
   PencilIcon,
   Plus,
 } from "lucide-react";
-import { type MouseEvent, useCallback, useMemo, useState } from "react";
+import { type MouseEvent, useCallback, useState } from "react";
 
 import { type ViewTab } from "@/components/traces/trace-view/view-toggle";
 import { Button } from "@/components/ui/button.tsx";
-import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from "@/components/ui/command";
+import { Command, CommandGroup, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTemplatePicker } from "@/components/ui/template-renderer/template-picker";
@@ -47,8 +40,7 @@ interface TemplateViewToggleProps {
 }
 
 /** Trace-view variant of `ViewToggle` that folds custom render templates into
- *  the same dropdown: built-in views up top, then a searchable template list
- *  and a "New template" action. Requires a `TemplatePickerProvider` above. */
+ *  the same dropdown. Requires a `TemplatePickerProvider` above. */
 export default function TemplateViewToggle({
   tab,
   onTabChange,
@@ -58,19 +50,7 @@ export default function TemplateViewToggle({
 }: TemplateViewToggleProps) {
   const { templates, selectedTemplate, selectTemplate, openCreate, openEdit } = useTemplatePicker();
   const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-
-  const handleOpenChange = useCallback((next: boolean) => {
-    setOpen(next);
-    if (!next) setSearch("");
-  }, []);
-
-  const filteredTemplates = useMemo(() => {
-    if (!templates) return [];
-    const q = search.trim().toLowerCase();
-    if (!q) return templates;
-    return templates.filter((t) => t.name.toLowerCase().includes(q));
-  }, [templates, search]);
+  const templateCount = templates?.length ?? 0;
 
   const isCustom = tab === "custom";
   const isTreeView = tab === "tree";
@@ -117,7 +97,7 @@ export default function TemplateViewToggle({
 
   return (
     <div className="flex items-center min-w-0">
-      <Popover open={open} onOpenChange={handleOpenChange}>
+      <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
             variant="ghost"
@@ -152,52 +132,49 @@ export default function TemplateViewToggle({
                   })}
                 </CommandGroup>
                 <CommandSeparator alwaysRender />
-                {(templates?.length ?? 0) > 5 && (
-                  <CommandInput
-                    placeholder="Search templates…"
-                    value={search}
-                    onValueChange={setSearch}
-                    className="h-8 py-1 text-xs"
-                  />
-                )}
                 <CommandGroup heading="Custom" className={GROUP_CLASS}>
-                  {(templates?.length ?? 0) > 0 &&
-                    (filteredTemplates.length === 0 ? (
-                      <div className="px-2 py-3 text-center text-xs text-muted-foreground">No matches.</div>
-                    ) : (
-                      filteredTemplates.map((t) => {
-                        const active = isCustom && selectedTemplate?.id === t.id;
-                        return (
-                          <CommandItem
-                            key={t.id}
-                            value={`template:${t.id}`}
-                            onSelect={() => handlePickTemplate(t.id)}
-                            className="group text-xs"
+                  {templates?.map((t) => {
+                    const active = isCustom && selectedTemplate?.id === t.id;
+                    return (
+                      <CommandItem
+                        key={t.id}
+                        value={`template:${t.id}`}
+                        onSelect={() => handlePickTemplate(t.id)}
+                        className="group text-xs"
+                      >
+                        <span className="flex-1 truncate">{t.name}</span>
+                        <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
+                          <button
+                            type="button"
+                            aria-label={`Edit ${t.name}`}
+                            onClick={(e) => handleEditTemplate(e, t.id)}
+                            className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
                           >
-                            <span className="flex-1 truncate">{t.name}</span>
-                            <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
-                              <button
-                                type="button"
-                                aria-label={`Edit ${t.name}`}
-                                onClick={(e) => handleEditTemplate(e, t.id)}
-                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
-                              >
-                                <PencilIcon className="size-2.5" />
-                              </button>
-                              {active && <Check className="size-3.5" />}
-                            </div>
-                          </CommandItem>
-                        );
-                      })
-                    ))}
+                            <PencilIcon className="size-2.5" />
+                          </button>
+                          {active && <Check className="size-3.5" />}
+                        </div>
+                      </CommandItem>
+                    );
+                  })}
+                  {templateCount <= 5 && (
+                    <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">
+                      <Plus className="mr-1.5 size-3.5" />
+                      New template
+                    </CommandItem>
+                  )}
                 </CommandGroup>
-                {(templates?.length ?? 0) > 0 && <CommandSeparator alwaysRender />}
-                <CommandGroup className={GROUP_CLASS}>
-                  <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">
-                    <Plus className="mr-1.5 size-3.5" />
-                    New template
-                  </CommandItem>
-                </CommandGroup>
+                {templateCount > 5 && (
+                  <>
+                    <CommandSeparator alwaysRender />
+                    <CommandGroup className={GROUP_CLASS}>
+                      <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">
+                        <Plus className="mr-1.5 size-3.5" />
+                        New template
+                      </CommandItem>
+                    </CommandGroup>
+                  </>
+                )}
               </ScrollArea>
             </CommandList>
           </Command>

--- a/frontend/components/traces/trace-view/template-view-toggle.tsx
+++ b/frontend/components/traces/trace-view/template-view-toggle.tsx
@@ -13,6 +13,7 @@ import {
 import { type MouseEvent, useCallback, useMemo, useState } from "react";
 
 import { type ViewTab } from "@/components/traces/trace-view/view-toggle";
+import { Button } from "@/components/ui/button.tsx";
 import {
   Command,
   CommandGroup,
@@ -118,16 +119,14 @@ export default function TemplateViewToggle({
     <div className="flex items-center min-w-0">
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
-          <button
-            className={cn(
-              "flex items-center h-6 px-1.5 text-xs border rounded-md focus-visible:outline-0",
-              isTreeView && "rounded-r-none border-r-0 outline-inset -outline-offset-1 hover:bg-secondary"
-            )}
+          <Button
+            variant="ghost"
+            className={cn("flex h-[26px] items-center hover:bg-surface-up-3", isTreeView && "rounded-r-none")}
           >
             <CurrentIcon size={14} className="mr-1 flex-shrink-0" />
             <span className={cn("truncate max-w-[160px]", !isCustom && "capitalize")}>{current.label}</span>
             <ChevronDown size={14} className="ml-1 flex-shrink-0" />
-          </button>
+          </Button>
         </PopoverTrigger>
         <PopoverContent align="start" className="w-[280px] p-0" onWheel={(e) => e.stopPropagation()}>
           <Command shouldFilter={false}>
@@ -205,16 +204,17 @@ export default function TemplateViewToggle({
       </Popover>
       {/* Content toggle (only visible in tree view) */}
       {isTreeView && (
-        <button
+        <Button
+          variant="ghost"
           onClick={onToggleContent}
           className={cn(
-            "flex items-center h-6 px-1.5 text-xs border rounded-md rounded-l-none text-muted-foreground overflow-hidden",
-            showContent ? "text-white hover:bg-muted" : "border-input hover:bg-secondary/50"
+            "flex h-[26px] items-center overflow-hidden rounded-l-none text-muted-foreground hover:bg-surface-up-3",
+            showContent && "text-foreground"
           )}
         >
           {showContent ? <Eye size={14} className="flex-shrink-0" /> : <EyeOff size={14} className="flex-shrink-0" />}
           <span className="ml-1 truncate">Content</span>
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/frontend/components/traces/trace-view/template-view-toggle.tsx
+++ b/frontend/components/traces/trace-view/template-view-toggle.tsx
@@ -152,45 +152,47 @@ export default function TemplateViewToggle({
                   })}
                 </CommandGroup>
                 <CommandSeparator alwaysRender />
-                <CommandInput
-                  placeholder="Search templates…"
-                  value={search}
-                  onValueChange={setSearch}
-                  className="h-8 py-1 text-xs"
-                />
-                <CommandGroup heading="Custom" className={GROUP_CLASS}>
-                  {filteredTemplates.length === 0 ? (
-                    <div className="px-2 py-3 text-center text-xs text-muted-foreground">
-                      {templates?.length ? "No matches." : "No templates yet."}
-                    </div>
-                  ) : (
-                    filteredTemplates.map((t) => {
-                      const active = isCustom && selectedTemplate?.id === t.id;
-                      return (
-                        <CommandItem
-                          key={t.id}
-                          value={`template:${t.id}`}
-                          onSelect={() => handlePickTemplate(t.id)}
-                          className="group text-xs"
-                        >
-                          <span className="flex-1 truncate">{t.name}</span>
-                          <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
-                            <button
-                              type="button"
-                              aria-label={`Edit ${t.name}`}
-                              onClick={(e) => handleEditTemplate(e, t.id)}
-                              className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
-                            >
-                              <PencilIcon className="size-2.5" />
-                            </button>
-                            {active && <Check className="size-3.5" />}
-                          </div>
-                        </CommandItem>
-                      );
-                    })
-                  )}
-                </CommandGroup>
-                <CommandSeparator alwaysRender />
+                {(templates?.length ?? 0) > 5 && (
+                  <CommandInput
+                    placeholder="Search templates…"
+                    value={search}
+                    onValueChange={setSearch}
+                    className="h-8 py-1 text-xs"
+                  />
+                )}
+                {(templates?.length ?? 0) > 0 && (
+                  <CommandGroup heading="Custom" className={GROUP_CLASS}>
+                    {filteredTemplates.length === 0 ? (
+                      <div className="px-2 py-3 text-center text-xs text-muted-foreground">No matches.</div>
+                    ) : (
+                      filteredTemplates.map((t) => {
+                        const active = isCustom && selectedTemplate?.id === t.id;
+                        return (
+                          <CommandItem
+                            key={t.id}
+                            value={`template:${t.id}`}
+                            onSelect={() => handlePickTemplate(t.id)}
+                            className="group text-xs"
+                          >
+                            <span className="flex-1 truncate">{t.name}</span>
+                            <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
+                              <button
+                                type="button"
+                                aria-label={`Edit ${t.name}`}
+                                onClick={(e) => handleEditTemplate(e, t.id)}
+                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
+                              >
+                                <PencilIcon className="size-2.5" />
+                              </button>
+                              {active && <Check className="size-3.5" />}
+                            </div>
+                          </CommandItem>
+                        );
+                      })
+                    )}
+                  </CommandGroup>
+                )}
+                {(templates?.length ?? 0) > 0 && <CommandSeparator alwaysRender />}
                 <CommandGroup className={GROUP_CLASS}>
                   <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">
                     <Plus className="mr-1.5 size-3.5" />

--- a/frontend/components/traces/trace-view/template-view-toggle.tsx
+++ b/frontend/components/traces/trace-view/template-view-toggle.tsx
@@ -16,7 +16,6 @@ import { type ViewTab } from "@/components/traces/trace-view/view-toggle";
 import { Button } from "@/components/ui/button.tsx";
 import { Command, CommandGroup, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTemplatePicker } from "@/components/ui/template-renderer/template-picker";
 import { cn } from "@/lib/utils";
 
@@ -109,73 +108,77 @@ export default function TemplateViewToggle({
           </Button>
         </PopoverTrigger>
         <PopoverContent align="start" className="w-[280px] p-0" onWheel={(e) => e.stopPropagation()}>
-          <Command shouldFilter={false}>
-            <CommandList className="max-h-none overflow-visible">
-              <ScrollArea className="max-h-[360px] [&>div]:max-h-[360px]">
-                <CommandGroup heading="Default" className={GROUP_CLASS}>
-                  {viewTabs.map((option) => {
-                    const view = viewOptions[option];
-                    if (!view) return null;
-                    const OptionIcon = view.icon;
-                    return (
-                      <CommandItem
-                        key={option}
-                        value={`view:${option}`}
-                        onSelect={() => handlePickView(option)}
-                        className="text-xs"
-                      >
-                        <OptionIcon className="size-3.5" />
-                        <span className="flex-1 truncate">{view.label}</span>
-                        {tab === option && <Check className="ml-2 size-3.5 shrink-0" />}
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
-                <CommandSeparator alwaysRender />
-                <CommandGroup heading="Custom" className={GROUP_CLASS}>
-                  {templates?.map((t) => {
-                    const active = isCustom && selectedTemplate?.id === t.id;
-                    return (
-                      <CommandItem
-                        key={t.id}
-                        value={`template:${t.id}`}
-                        onSelect={() => handlePickTemplate(t.id)}
-                        className="group text-xs"
-                      >
-                        <span className="flex-1 truncate">{t.name}</span>
-                        <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
-                          <button
-                            type="button"
-                            aria-label={`Edit ${t.name}`}
-                            onClick={(e) => handleEditTemplate(e, t.id)}
-                            className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
-                          >
-                            <PencilIcon className="size-2.5" />
-                          </button>
-                          {active && <Check className="size-3.5" />}
-                        </div>
-                      </CommandItem>
-                    );
-                  })}
-                  {templateCount <= 5 && (
+          <Command shouldFilter={false} className="max-h-[360px]">
+            <CommandList className="flex max-h-[360px] min-h-0 flex-col overflow-hidden">
+              <CommandGroup heading="Default" className={cn(GROUP_CLASS, "shrink-0")}>
+                {viewTabs.map((option) => {
+                  const view = viewOptions[option];
+                  if (!view) return null;
+                  const OptionIcon = view.icon;
+                  return (
+                    <CommandItem
+                      key={option}
+                      value={`view:${option}`}
+                      onSelect={() => handlePickView(option)}
+                      className="text-xs"
+                    >
+                      <OptionIcon className="size-3.5" />
+                      <span className="flex-1 truncate">{view.label}</span>
+                      {tab === option && <Check className="ml-2 size-3.5 shrink-0" />}
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+              <CommandSeparator alwaysRender className="shrink-0" />
+              <CommandGroup
+                heading="Custom"
+                className={cn(
+                  GROUP_CLASS,
+                  "min-h-0 flex-1 flex flex-col [&_[cmdk-group-items]]:min-h-0 [&_[cmdk-group-items]]:overflow-y-auto [&_[cmdk-group-items]]:scroll-fade-t"
+                )}
+              >
+                {templates?.map((t) => {
+                  const active = isCustom && selectedTemplate?.id === t.id;
+                  return (
+                    <CommandItem
+                      key={t.id}
+                      value={`template:${t.id}`}
+                      onSelect={() => handlePickTemplate(t.id)}
+                      className="group text-xs"
+                    >
+                      <span className="flex-1 truncate">{t.name}</span>
+                      <div className="ml-2 flex shrink-0 items-center justify-end gap-1">
+                        <button
+                          type="button"
+                          aria-label={`Edit ${t.name}`}
+                          onClick={(e) => handleEditTemplate(e, t.id)}
+                          className="inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 group-aria-selected:opacity-100 focus-visible:opacity-100"
+                        >
+                          <PencilIcon className="size-2.5" />
+                        </button>
+                        {active && <Check className="size-3.5" />}
+                      </div>
+                    </CommandItem>
+                  );
+                })}
+                {templateCount <= 5 && (
+                  <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">
+                    <Plus className="mr-1.5 size-3.5" />
+                    New template
+                  </CommandItem>
+                )}
+              </CommandGroup>
+              {templateCount > 5 && (
+                <>
+                  <CommandSeparator alwaysRender className="shrink-0" />
+                  <CommandGroup className={cn(GROUP_CLASS, "shrink-0")}>
                     <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">
                       <Plus className="mr-1.5 size-3.5" />
                       New template
                     </CommandItem>
-                  )}
-                </CommandGroup>
-                {templateCount > 5 && (
-                  <>
-                    <CommandSeparator alwaysRender />
-                    <CommandGroup className={GROUP_CLASS}>
-                      <CommandItem onSelect={handleCreate} className="text-xs text-muted-foreground">
-                        <Plus className="mr-1.5 size-3.5" />
-                        New template
-                      </CommandItem>
-                    </CommandGroup>
-                  </>
-                )}
-              </ScrollArea>
+                  </CommandGroup>
+                </>
+              )}
             </CommandList>
           </Command>
         </PopoverContent>

--- a/frontend/components/traces/trace-view/trace-panel.tsx
+++ b/frontend/components/traces/trace-view/trace-panel.tsx
@@ -153,11 +153,12 @@ export default function TracePanel({ traceId, handleClose, handleSpanSelect, fet
                   <div className="flex items-center gap-1 min-w-0">
                     {hasBrowserSession && (
                       <Button
+                        variant="ghost"
+                        className={cn(
+                          "flex h-[26px] items-center overflow-hidden px-1.5 hover:bg-surface-up-3",
+                          browserSession && "text-primary hover:text-primary"
+                        )}
                         disabled={!trace}
-                        className={cn("h-6 px-1.5 text-xs overflow-hidden", {
-                          "border-primary text-primary": browserSession,
-                        })}
-                        variant="outline"
                         onClick={() => setBrowserSession(!browserSession)}
                       >
                         <CirclePlay data-icon="inline-start" size={14} className="flex-shrink-0" />

--- a/frontend/components/traces/trace-view/trace-panel.tsx
+++ b/frontend/components/traces/trace-view/trace-panel.tsx
@@ -155,7 +155,7 @@ export default function TracePanel({ traceId, handleClose, handleSpanSelect, fet
                       <Button
                         variant="ghost"
                         className={cn(
-                          "flex h-[26px] items-center overflow-hidden px-1.5 hover:bg-surface-up-3",
+                          "flex h-6 items-center overflow-hidden px-1.5 hover:bg-surface-up-3",
                           browserSession && "text-primary hover:text-primary"
                         )}
                         disabled={!trace}

--- a/frontend/components/traces/trace-view/transcript/index.tsx
+++ b/frontend/components/traces/trace-view/transcript/index.tsx
@@ -471,6 +471,7 @@ const Transcript = ({ onSpanSelect, isShared = false }: TranscriptProps) => {
                 inputPreviews={inputPreviews}
                 agentNames={agentNames}
                 userInput={userInput}
+                traceStartTime={trace?.startTime}
                 selectedSpanId={selectedSpanId}
                 expandedGroupIds={transcriptExpandedGroups}
                 onSpanSelect={handleSpanSelect}

--- a/frontend/components/traces/trace-view/transcript/item/input-item.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/input-item.tsx
@@ -2,16 +2,17 @@ import { ArrowRight } from "lucide-react";
 import { memo } from "react";
 
 import { CollapsedTextWithMore } from "@/components/traces/trace-view/transcript/collapsed-text-with-more";
-import { cn } from "@/lib/utils.ts";
+import { cn, formatTimestampWithSeconds } from "@/lib/utils.ts";
 
 interface InputItemProps {
   text: string | null;
   isLoading: boolean;
   inGroup?: boolean;
   className?: string;
+  startTime?: string;
 }
 
-function InputItemInner({ text, inGroup, className }: InputItemProps) {
+function InputItemInner({ text, inGroup, className, startTime }: InputItemProps) {
   if (!text) return null;
 
   return (
@@ -31,6 +32,11 @@ function InputItemInner({ text, inGroup, className }: InputItemProps) {
             <ArrowRight size={14} />
           </div>
           <span className="font-medium text-sm whitespace-nowrap shrink-0">Input</span>
+          {startTime && (
+            <time dateTime={startTime} className="ml-auto shrink-0 text-xs text-muted-foreground">
+              {formatTimestampWithSeconds(startTime)}
+            </time>
+          )}
         </div>
         <div className="pl-7">
           <CollapsedTextWithMore text={text} lineHeight={17} />

--- a/frontend/components/traces/trace-view/transcript/item/transcript-row.tsx
+++ b/frontend/components/traces/trace-view/transcript/item/transcript-row.tsx
@@ -27,6 +27,7 @@ export interface TranscriptRowProps {
   inputPreviews: PreviewMap;
   agentNames: Record<string, string | null | undefined>;
   userInput: string | null;
+  traceStartTime?: string;
   selectedSpanId?: string;
   expandedGroupIds: Set<string>;
   onSpanSelect: (span: TraceViewListSpan) => void;
@@ -39,6 +40,7 @@ function TranscriptRowInner({
   inputPreviews,
   agentNames,
   userInput,
+  traceStartTime,
   selectedSpanId,
   expandedGroupIds,
   onSpanSelect,
@@ -47,7 +49,7 @@ function TranscriptRowInner({
   switch (row.type) {
     case "user-input":
       // Agent input is ingestion-extracted (read off the trace), never loading.
-      return <InputItem text={userInput} isLoading={false} />;
+      return <InputItem text={userInput} isLoading={false} startTime={traceStartTime} />;
 
     case "group": {
       const collapsed = !expandedGroupIds.has(row.groupId);
@@ -108,7 +110,7 @@ function areTranscriptRowPropsEqual(prev: TranscriptRowProps, next: TranscriptRo
   const row = next.row;
   switch (row.type) {
     case "user-input":
-      return prev.userInput === next.userInput;
+      return prev.userInput === next.userInput && prev.traceStartTime === next.traceStartTime;
 
     case "span":
     case "group-span": {

--- a/frontend/components/traces/trace-view/view-toggle.tsx
+++ b/frontend/components/traces/trace-view/view-toggle.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, Eye, EyeOff, LayoutTemplate, List, ListTree, type LucideIcon } from "lucide-react";
 
+import { Button } from "@/components/ui/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -48,16 +49,14 @@ export default function ViewToggle({
     <div className="flex items-center min-w-0">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <button
-            className={cn(
-              "flex items-center h-6 px-1.5 text-xs border rounded-md focus-visible:outline-0",
-              isTreeView && "rounded-r-none border-r-0 outline-inset -outline-offset-1 hover:bg-secondary"
-            )}
+          <Button
+            variant="ghost"
+            className={cn("flex h-[26px] items-center hover:bg-surface-up-3", isTreeView && "rounded-r-none")}
           >
             <CurrentIcon size={14} className="mr-1" />
             <span className="capitalize">{currentView.label}</span>
             <ChevronDown size={14} className="ml-1" />
-          </button>
+          </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
           {tabs.map((option) => {
@@ -78,16 +77,17 @@ export default function ViewToggle({
       </DropdownMenu>
       {/* Content toggle (only visible in tree view) */}
       {isTreeView && (
-        <button
+        <Button
+          variant="ghost"
           onClick={onToggleContent}
           className={cn(
-            "flex items-center h-6 px-1.5 text-xs border rounded-md rounded-l-none text-muted-foreground overflow-hidden",
-            showContent ? "text-white hover:bg-muted" : "border-input hover:bg-secondary/50"
+            "flex h-[26px] items-center overflow-hidden rounded-l-none px-1.5 text-muted-foreground hover:bg-surface-up-3",
+            showContent && "text-foreground"
           )}
         >
           {showContent ? <Eye size={14} className="flex-shrink-0" /> : <EyeOff size={14} className="flex-shrink-0" />}
           <span className="ml-1 truncate">Content</span>
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/frontend/components/ui/command.tsx
+++ b/frontend/components/ui/command.tsx
@@ -14,10 +14,7 @@ const Command = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive
     ref={ref}
-    className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
-      className
-    )}
+    className={cn("flex h-full w-full flex-col overflow-hidden rounded-md text-popover-foreground", className)}
     {...props}
   />
 ));

--- a/frontend/components/ui/tabs.tsx
+++ b/frontend/components/ui/tabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -9,17 +10,29 @@ function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive
   return <TabsPrimitive.Root data-slot="tabs" className={cn("flex flex-col gap-2", className)} {...props} />;
 }
 
-function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
-  return (
-    <TabsPrimitive.List
-      data-slot="tabs-list"
-      className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
-        className
-      )}
-      {...props}
-    />
-  );
+const tabsListVariants = cva(
+  "bg-muted text-muted-foreground inline-flex w-fit items-center justify-center rounded-lg p-[3px]",
+  {
+    variants: {
+      // `sm` drives the compact trace/span/settings tab bars: shorter list + xs
+      // triggers (the descendant selector saves every TabsTrigger a text-xs override).
+      size: {
+        default: "h-9",
+        sm: "h-7 [&_[data-slot=tabs-trigger]]:text-xs",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+);
+
+function TabsList({
+  className,
+  size,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+  return <TabsPrimitive.List data-slot="tabs-list" className={cn(tabsListVariants({ size }), className)} {...props} />;
 }
 
 function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {

--- a/frontend/components/ui/template-renderer/template-picker.tsx
+++ b/frontend/components/ui/template-renderer/template-picker.tsx
@@ -322,10 +322,7 @@ export const TemplatePickerView = ({ mode, onModeChange, modes, triggerClassName
         <Button
           size="sm"
           variant="ghost"
-          className={cn(
-            "h-5 gap-1 rounded-md border border-secondary-foreground/20 bg-muted px-1.5 text-[0.7rem] font-medium text-secondary-foreground hover:bg-muted",
-            triggerClassName
-          )}
+          className={cn("h-5 gap-1 px-1.5 text-xs font-medium text-secondary-foreground", triggerClassName)}
         >
           <span className={cn("truncate max-w-[160px]")}>
             {triggerLabel} {inCustomMode && <span className="font-semibold">(custom)</span>}
@@ -416,7 +413,7 @@ export const TemplatePickerActions = ({ className }: { className?: string }) => 
       <Button
         size="sm"
         variant="ghost"
-        className="h-6 gap-1 px-1.5 text-xs text-muted-foreground"
+        className="gap-1 text-muted-foreground"
         onClick={openEdit}
         title="Edit template"
       >


### PR DESCRIPTION
## Summary

This is a focused replacement for #2133. It rebuilds the trace-view cleanup on top of the latest `dev` and carries over only the trace-related work and its minimal shared dependencies.

### Taken from the old branch

- Trace and span-view presentation cleanup
- Trace header, metadata, navigation, and action controls
- Share, export, and labeling-queue action cleanup
- Trace tags integration
- Signal-events panel restyle and component split
- Session/transcript controls
- Shared trace-view parity
- Minimal dependencies required by those changes:
  - compact `TabsList` sizing
  - tag-dropdown open state
  - trace search dropdown/surface adjustments
  - template picker styling used by trace custom rendering

### Intentionally left behind

- The evaluations page/table rewrite and all evaluation-page styling
- Unused `human-evaluation-score.tsx`; current `dev` uses `human-evaluator-span-view.tsx`
- Broad styling changes across dashboards, datasets, settings, playground, SQL, workspace, notifications, queues, Slack, and signal pages
- Global tooltip primitive changes and their unrelated consumer churn
- Span-tag behavior/API changes that were not merely visual cleanup
- Generic data-table and JSON-tooltip styling unrelated to trace view

## Why

The original branch began with a broad 73-file design cleanup commit and later evolved into trace-view work. That made the PR appear much wider than intended. This branch starts from current `dev` and narrows the diff to the coherent trace-view work.

## Validation

- `pnpm type-check` ✅
- `pnpm lint` ✅
- `pnpm check:circular` ✅ (pre-commit)
- `pnpm test` ⚠️ 316 passed, 2 failed in pre-existing AI SDK parser tests; neither failing test nor implementation file differs from `dev`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly frontend presentation and component refactors; queue/export/share still call the same APIs with clearer dialog flows and no auth or data-model changes.
> 
> **Overview**
> Focused **trace and span-view UI refresh** aligned with the surface elevation system: headers, pills, stats shields, and message cards use `surface-up` tokens and shared controls (`HeaderIconButton`, `HeaderLinkButton`, compact `TabsList` `size="sm"`).
> 
> **Span actions** move into `SpanActionsDropdown` (copy ID, SQL, playground, queue, dataset). Add-to-queue and export-to-dataset logic is extracted to `AddToLabelingQueueForm` and opened via **dialogs** instead of inline popovers; the popover wrapper remains for other call sites.
> 
> **Trace header** is reorganized (share, tags, metadata, signals/chat as icon buttons). **Share trace** switches from a large popover to a compact dropdown with visibility select and copy link. **Trace dropdown** adds copy user ID.
> 
> **Signal events panel** is restyled and split into smaller components (severity icons, cluster/open-in-signals chips, per-event layout without heavy card chrome), uses `ElevatedSurface`, scroll-fade, and moves “Open in AI Chat” to the panel header.
> 
> **Span content** updates include conditional model/tools/schema row, LLM output messages default-expanded, overview `expandFromIndex`, transcript **input timestamp**, and tooltip provider fixes on table cells. Tag badges and dropdown open-state behavior are tweaked for the new header patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4706ac0b201ac0e56971e744ddd25c1660a043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

