### PR TITLE
chore: llm profiles ui text

### DIFF
--- a/frontend/components/workspace/llm-profiles/index.tsx
+++ b/frontend/components/workspace/llm-profiles/index.tsx
@@ -13,7 +13,9 @@ import {
 } from "@/components/settings/settings-section";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useFeatureFlags } from "@/contexts/feature-flags-context";
 import { type LlmProfile, PROVIDER_LABELS } from "@/lib/actions/llm-profiles/schema";
+import { Feature } from "@/lib/features/features";
 import { swrFetcher } from "@/lib/utils";
 
 import DeleteProfileDialog from "./delete-profile-dialog";
@@ -29,6 +31,7 @@ export default function LlmProfiles({ workspaceId }: LlmProfilesProps) {
   const [editTarget, setEditTarget] = useState<LlmProfile | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<LlmProfile | null>(null);
+  const isCloud = useFeatureFlags()[Feature.LAMINAR_CLOUD];
 
   const openEditor = (profile: LlmProfile | null) => {
     setEditTarget(profile);
@@ -39,7 +42,11 @@ export default function LlmProfiles({ workspaceId }: LlmProfilesProps) {
     <SettingsSection>
       <SettingsSectionHeader
         title="LLM Profiles"
-        description="Provider credentials and models that the playground and signals run on."
+        description={
+          isCloud
+            ? "Provider credentials and models that playgrounds run on."
+            : "Provider credentials and models that playgrounds and signals run on."
+        }
       />
       <Button variant="outline" icon="plus" className="w-fit" onClick={() => openEditor(null)}>
         Profile

--- a/frontend/components/workspace/llm-profiles/manage-profile-sheet.tsx
+++ b/frontend/components/workspace/llm-profiles/manage-profile-sheet.tsx
@@ -6,7 +6,7 @@ import { Controller, FormProvider, useForm } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { type LlmProfile } from "@/lib/actions/llm-profiles/schema";
 import { useToast } from "@/lib/hooks/use-toast";
 import { cn } from "@/lib/utils";
@@ -42,6 +42,7 @@ export default function ManageProfileSheet({
       >
         <SheetHeader className="py-4 px-4 border-b">
           <SheetTitle>{profile ? "Edit LLM profile" : "New LLM profile"}</SheetTitle>
+          <SheetDescription>API keys are encrypted at rest and stored securely.</SheetDescription>
         </SheetHeader>
         {open && (
           <ProfileForm key={profile?.id ?? "new"} workspaceId={workspaceId} profile={profile} onSaved={onSaved} />
@@ -117,7 +118,7 @@ function ProfileForm({
                   models={field.value}
                   onChange={field.onChange}
                   statuses={connection.statuses}
-                  hint="Model ids as the provider expects them (Azure: deployment names)."
+                  hint="Model ids as the provider expects them."
                   error={fieldState.error?.message}
                 />
               )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy and conditional description text only; no API, auth, or credential-handling logic changes.
> 
> **Overview**
> Updates **LLM Profiles** UI copy for cloud vs self-hosted and clarifies security messaging in the profile editor.
> 
> When `Feature.LAMINAR_CLOUD` is enabled, the section description no longer mentions **signals**—only playgrounds. The manage-profile sheet adds a **SheetDescription** stating that API keys are encrypted at rest, and the models field hint is shortened by dropping the Azure deployment-name example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ea7b0032dd68bb8bafd7482928950f4fe8e1f87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

