### PR TITLE
fix: add wider time range hints

### DIFF
--- a/frontend/components/signal/clusters-section/cluster-stacked-chart.tsx
+++ b/frontend/components/signal/clusters-section/cluster-stacked-chart.tsx
@@ -6,6 +6,8 @@ import TimeSeriesChart from "@/components/charts/time-series-chart";
 import { type TimeSeriesChartConfig, type TimeSeriesDataPoint } from "@/components/charts/time-series-chart/types";
 import ClusterIcon, { type IconVariant } from "@/components/signal/clusters-section/cluster-icon";
 import { useSignalVersionMarkers } from "@/components/signal/hooks/use-signal-version-markers";
+import SearchWiderRangeButton from "@/components/ui/date-range-filter/search-wider-range-button";
+import { type DateRange } from "@/components/ui/date-range-filter/utils";
 import { type ClusterStatsDataPoint, type EventCluster, UNCLUSTERED_ID } from "@/lib/actions/clusters";
 import { UNCLUSTERED_COLOR, withOpacity } from "@/lib/clusters/colors";
 
@@ -29,6 +31,11 @@ interface ClusterStackedChartProps {
   colorMap: Map<string, string>;
   /** Absolutely-positioned content over the plot — the cluster readout. */
   overlay?: ReactNode;
+  pastHours?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  onSelectRange: (range: DateRange) => void;
+  showSearchWiderRange: boolean;
 }
 
 export default function ClusterStackedChart({
@@ -37,6 +44,11 @@ export default function ClusterStackedChart({
   containerWidth,
   colorMap,
   overlay,
+  pastHours,
+  startDate,
+  endDate,
+  onSelectRange,
+  showSearchWiderRange,
 }: ClusterStackedChartProps) {
   const markers = useSignalVersionMarkers();
 
@@ -84,8 +96,16 @@ export default function ClusterStackedChart({
 
   if (isEmpty) {
     return (
-      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-        No data for selected time range
+      <div className="flex flex-col items-center justify-center gap-2 h-full text-muted-foreground text-sm">
+        <span>No data for selected time range</span>
+        {showSearchWiderRange && (
+          <SearchWiderRangeButton
+            pastHours={pastHours}
+            startDate={startDate}
+            endDate={endDate}
+            onSelect={onSelectRange}
+          />
+        )}
       </div>
     );
   }

--- a/frontend/components/signal/clusters-section/clusters-section-content.tsx
+++ b/frontend/components/signal/clusters-section/clusters-section-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 import { shallow } from "zustand/shallow";
@@ -10,6 +10,7 @@ import EmergingClusterBreadcrumbs from "@/components/signal/emerging-cluster-bre
 import { useClusterId } from "@/components/signal/hooks/use-cluster-id";
 import { useEmergingClusterId } from "@/components/signal/hooks/use-emerging-cluster-id";
 import { getChartClusters, selectUnclusteredCount, useSignalStoreContext } from "@/components/signal/store.tsx";
+import { type DateRange } from "@/components/ui/date-range-filter/utils";
 import { type ClusterStatsDataPoint, UNCLUSTERED_ID } from "@/lib/actions/clusters";
 import { getClusterColorById, UNCLUSTERED_COLOR } from "@/lib/clusters/colors";
 import { useToast } from "@/lib/hooks/use-toast";
@@ -42,6 +43,8 @@ const EMPTY_HAS_CHILDREN = new Set<string>();
 
 export default function ClustersSectionContent({ className }: Props) {
   const searchParams = useSearchParams();
+  const pathName = usePathname();
+  const router = useRouter();
   const { toast } = useToast();
   const [clusterId, setClusterId] = useClusterId();
   const [emergingClusterId, setEmergingClusterId] = useEmergingClusterId();
@@ -140,6 +143,19 @@ export default function ClustersSectionContent({ className }: Props) {
   const hasChartData = chartClusters.length > 0 && clusterStatsData.length > 0;
   const showChartLoading = !hasChartData && (isClustersLoading || isStatsPending);
 
+  const searchWiderRange = useCallback(
+    (range: DateRange) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("startDate");
+      params.delete("endDate");
+      params.delete("groupByInterval");
+      params.set("pastHours", range.value);
+      params.set("pageNumber", "0");
+      router.push(`${pathName}?${params.toString()}`);
+    },
+    [pathName, router, searchParams]
+  );
+
   // The one way anything in the section changes the selection.
   const selectCluster = useCallback(
     (id: string) => {
@@ -190,6 +206,11 @@ export default function ClustersSectionContent({ className }: Props) {
               statsData={clusterStatsData}
               containerWidth={localChartWidth}
               colorMap={colorMap}
+              pastHours={pastHours}
+              startDate={startDate}
+              endDate={endDate}
+              onSelectRange={searchWiderRange}
+              showSearchWiderRange={!clusterId && !emergingClusterId}
               // With the list gone the chart has no other label for what is pinned
               // — and with nothing pinned, the readout's root list is the only way
               // to reach a folded cluster or the unclustered bucket, which has no

--- a/frontend/components/signal/create-signal-job/index.tsx
+++ b/frontend/components/signal/create-signal-job/index.tsx
@@ -132,6 +132,7 @@ const CreateSignalJobContent = () => {
           filter={filter}
           search={search}
           dateRange={dateRange}
+          onDateRangeChange={setDateRange}
           refetchRef={refetchRef}
           searchValue={searchValue}
           onSearchChange={setSearchValue}

--- a/frontend/components/signal/create-signal-job/table-contents.tsx
+++ b/frontend/components/signal/create-signal-job/table-contents.tsx
@@ -8,8 +8,10 @@ import AdvancedSearch from "@/components/common/advanced-search";
 import SelectionBanner from "@/components/signal/create-signal-job/selection-banner";
 import { columns, filters as tableFilters } from "@/components/traces/traces-table/columns";
 import { Button } from "@/components/ui/button";
+import SearchWiderRangeButton from "@/components/ui/date-range-filter/search-wider-range-button";
 import { InfiniteDataTable } from "@/components/ui/infinite-datatable";
 import { useInfiniteScroll, useSelection } from "@/components/ui/infinite-datatable/hooks";
+import { TableCell, TableRow } from "@/components/ui/table";
 import { type Filter } from "@/lib/actions/common/filters";
 import { useToast } from "@/lib/hooks/use-toast";
 import { type TraceRow } from "@/lib/traces/types";
@@ -27,6 +29,7 @@ export interface CreateSignalJobTableContentsProps {
   filter: string[];
   search: string | null;
   dateRange: { pastHours?: string; startDate?: string; endDate?: string };
+  onDateRangeChange: (range: { pastHours?: string; startDate?: string; endDate?: string }) => void;
   refetchRef: RefObject<() => void>;
   searchValue: { filters: Filter[]; search: string };
   onSearchChange: (value: { filters: Filter[]; search: string }) => void;
@@ -39,6 +42,7 @@ export const CreateSignalJobTableContents = memo(function CreateSignalJobTableCo
   filter,
   search,
   dateRange,
+  onDateRangeChange,
   refetchRef,
   searchValue,
   onSearchChange,
@@ -192,6 +196,21 @@ export const CreateSignalJobTableContents = memo(function CreateSignalJobTableCo
       state={{ rowSelection }}
       onRowSelectionChange={onRowSelectionChange}
       getRowHref={getRowHref}
+      emptyRow={
+        filter.length === 0 && !search ? (
+          <TableRow className="flex">
+            <TableCell className="w-full h-auto p-4 rounded-b text-center">
+              <div className="flex flex-col items-center gap-2">
+                <span className="text-sm text-secondary-foreground">No traces in this time range</span>
+                <SearchWiderRangeButton
+                  {...dateRange}
+                  onSelect={(range) => onDateRangeChange({ pastHours: range.value })}
+                />
+              </div>
+            </TableCell>
+          </TableRow>
+        ) : undefined
+      }
     >
       <div className="flex flex-1 w-full h-full items-center justify-between gap-2">
         {children}

--- a/frontend/components/signal/events-table/table-contents.tsx
+++ b/frontend/components/signal/events-table/table-contents.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { type ColumnDef, type Row } from "@tanstack/react-table";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { memo, type PropsWithChildren, type RefObject, useCallback, useEffect, useMemo } from "react";
 
 import { signalTraceHref, useSignalTraceParams } from "@/components/signal/hooks/use-signal-trace-params";
 import { type SchemaField } from "@/components/signals/utils";
-import { getDisplayRange, getTimeDifference } from "@/components/ui/date-range-filter/utils";
+import SearchWiderRangeButton from "@/components/ui/date-range-filter/search-wider-range-button";
+import { type DateRange, getDisplayRange, getTimeDifference } from "@/components/ui/date-range-filter/utils";
 import { InfiniteDataTable } from "@/components/ui/infinite-datatable";
 import { useInfiniteScroll } from "@/components/ui/infinite-datatable/hooks";
 import { TableCell, TableRow } from "@/components/ui/table";
@@ -20,20 +21,23 @@ function getEmptyRow({
   pastHours,
   startDate,
   endDate,
+  onSelect,
 }: {
   pastHours?: string | null;
   startDate?: string | null;
   endDate?: string | null;
+  onSelect: (range: DateRange) => void;
 }) {
   const { from, to } = getDisplayRange({ startDate, endDate, pastHours });
   return (
     <TableRow className="flex">
       <TableCell className="text-center p-4 rounded-b w-full h-auto">
         <div className="flex flex-1 justify-center">
-          <div className="max-w-md">
+          <div className="flex flex-col items-center gap-2 max-w-md">
             <h3 className="text-sm font-medium text-secondary-foreground">
               No events in the {pastHours ? `last ${getTimeDifference(from, to)}` : "time range"}
             </h3>
+            <SearchWiderRangeButton pastHours={pastHours} startDate={startDate} endDate={endDate} onSelect={onSelect} />
           </div>
         </div>
       </TableCell>
@@ -87,6 +91,7 @@ export const EventsTableContents = memo(function EventsTableContents({
   const { toast } = useToast();
   const searchParams = useSearchParams();
   const pathName = usePathname();
+  const router = useRouter();
   const [{ eventId }, setTraceParams] = useSignalTraceParams();
 
   const fetchEnabled = !!(pastHours || (startDate && endDate)) && !isViewLoading;
@@ -199,6 +204,19 @@ export const EventsTableContents = memo(function EventsTableContents({
     refetchRef.current = refetch;
   }, [refetch, refetchRef]);
 
+  const searchWiderRange = useCallback(
+    (range: DateRange) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("startDate");
+      params.delete("endDate");
+      params.delete("groupByInterval");
+      params.set("pastHours", range.value);
+      params.set("pageNumber", "0");
+      router.push(`${pathName}?${params.toString()}`);
+    },
+    [pathName, router, searchParams]
+  );
+
   const focusedRowId = useMemo(() => {
     if (!events || !eventId) return undefined;
     return events.some((e) => e.id === eventId) ? eventId : undefined;
@@ -245,7 +263,15 @@ export const EventsTableContents = memo(function EventsTableContents({
       sortBy={sortBy}
       sortDirection={sortDirection}
       onSort={onSort}
-      emptyRow={filter.length === 0 && !textSearchFilter ? getEmptyRow({ pastHours, startDate, endDate }) : undefined}
+      emptyRow={
+        filter.length === 0 &&
+        !textSearchFilter &&
+        selectedClusterIds.length === 0 &&
+        !isUnclusteredFilter &&
+        !emergingClusterId
+          ? getEmptyRow({ pastHours, startDate, endDate, onSelect: searchWiderRange })
+          : undefined
+      }
     >
       {children}
     </InfiniteDataTable>

--- a/frontend/components/signal/runs-table/table-contents.tsx
+++ b/frontend/components/signal/runs-table/table-contents.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { type Row } from "@tanstack/react-table";
-import { useParams, usePathname, useSearchParams } from "next/navigation";
+import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { memo, type PropsWithChildren, type RefObject, useCallback, useEffect, useMemo } from "react";
 
 import { signalTraceHref, useSignalTraceParams } from "@/components/signal/hooks/use-signal-trace-params";
 import { runTraceParams } from "@/components/signal/runs-table/columns/event-cell";
 import { FETCH_SIZE } from "@/components/signal/runs-table/constants";
 import { useSignalStoreContext } from "@/components/signal/store";
-import { getDisplayRange, getTimeDifference } from "@/components/ui/date-range-filter/utils";
+import SearchWiderRangeButton from "@/components/ui/date-range-filter/search-wider-range-button";
+import { type DateRange, getDisplayRange, getTimeDifference } from "@/components/ui/date-range-filter/utils";
 import { InfiniteDataTable } from "@/components/ui/infinite-datatable";
 import { useInfiniteScroll } from "@/components/ui/infinite-datatable/hooks";
 import { TableCell, TableRow } from "@/components/ui/table";
@@ -19,7 +20,17 @@ import { track } from "@/lib/posthog";
 
 import { getSignalRunsColumns } from "./columns";
 
-function getEmptyRow({ pastHours, startDate, endDate }: { pastHours?: string; startDate?: string; endDate?: string }) {
+function getEmptyRow({
+  pastHours,
+  startDate,
+  endDate,
+  onSelect,
+}: {
+  pastHours?: string;
+  startDate?: string;
+  endDate?: string;
+  onSelect: (range: DateRange) => void;
+}) {
   const { from, to } = getDisplayRange({ startDate, endDate, pastHours });
   return (
     <TableRow className="flex">
@@ -33,6 +44,7 @@ function getEmptyRow({ pastHours, startDate, endDate }: { pastHours?: string; st
               Whenever a signal is applied against a trace, a run will appear here. Runs show the results of signal
               execution on your traces.
             </p>
+            <SearchWiderRangeButton pastHours={pastHours} startDate={startDate} endDate={endDate} onSelect={onSelect} />
           </div>
         </div>
       </TableCell>
@@ -56,6 +68,7 @@ export const RunsTableContents = memo(function RunsTableContents({
   const params = useParams<{ projectId: string }>();
   const searchParams = useSearchParams();
   const pathName = usePathname();
+  const router = useRouter();
   const signal = useSignalStoreContext((state) => state.signal);
   const [{ traceId, eventId }, setTraceParams] = useSignalTraceParams();
 
@@ -113,6 +126,19 @@ export const RunsTableContents = memo(function RunsTableContents({
     refetchRef.current = refetch;
   }, [refetch, refetchRef]);
 
+  const searchWiderRange = useCallback(
+    (range: DateRange) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("startDate");
+      params.delete("endDate");
+      params.delete("groupByInterval");
+      params.set("pastHours", range.value);
+      params.set("pageNumber", "0");
+      router.push(`${pathName}?${params.toString()}`);
+    },
+    [pathName, router, searchParams]
+  );
+
   const focusedRowId = useMemo(() => {
     if (!runs) return undefined;
     if (eventId) {
@@ -149,7 +175,7 @@ export const RunsTableContents = memo(function RunsTableContents({
       isFetching={isFetching}
       isLoading={isLoading}
       fetchNextPage={fetchNextPage}
-      emptyRow={getEmptyRow(dateRange)}
+      emptyRow={filters.length === 0 ? getEmptyRow({ ...dateRange, onSelect: searchWiderRange }) : undefined}
     >
       {children}
     </InfiniteDataTable>

--- a/frontend/components/traces/sessions-table/table-contents.tsx
+++ b/frontend/components/traces/sessions-table/table-contents.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { type Row } from "@tanstack/react-table";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { memo, type PropsWithChildren, type RefObject, useCallback, useEffect } from "react";
 
 import { columns } from "@/components/traces/sessions-table/columns";
 import { FETCH_SIZE } from "@/components/traces/sessions-table/constants";
+import SearchWiderRangeButton from "@/components/ui/date-range-filter/search-wider-range-button";
+import { type DateRange } from "@/components/ui/date-range-filter/utils";
 import { InfiniteDataTable } from "@/components/ui/infinite-datatable";
 import { useInfiniteScroll } from "@/components/ui/infinite-datatable/hooks";
+import { TableCell, TableRow } from "@/components/ui/table";
 import { useToast } from "@/lib/hooks/use-toast";
 import { track } from "@/lib/posthog";
 import { type SessionRow } from "@/lib/traces/types";
@@ -39,6 +42,8 @@ export const SessionsTableContents = memo(function SessionsTableContents({
   isViewLoading,
 }: PropsWithChildren<SessionsTableContentsProps>) {
   const router = useRouter();
+  const pathName = usePathname();
+  const searchParams = useSearchParams();
   const { projectId } = useParams();
   const { toast } = useToast();
 
@@ -105,6 +110,19 @@ export const SessionsTableContents = memo(function SessionsTableContents({
     refetchRef.current = refetch;
   }, [refetch, refetchRef]);
 
+  const searchWiderRange = useCallback(
+    (range: DateRange) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("startDate");
+      params.delete("endDate");
+      params.delete("groupByInterval");
+      params.set("pastHours", range.value);
+      params.set("pageNumber", "0");
+      router.push(`${pathName}?${params.toString()}`);
+    },
+    [pathName, router, searchParams]
+  );
+
   const handleRowClick = useCallback(
     (row: Row<SessionRow>) => {
       const encodedSessionId = row.original.sessionId.split("/").map(encodeURIComponent).join("/");
@@ -129,6 +147,23 @@ export const SessionsTableContents = memo(function SessionsTableContents({
       sortBy={sortBy}
       sortDirection={sortDirection}
       onSort={onSort}
+      emptyRow={
+        filter.length === 0 && !textSearchFilter ? (
+          <TableRow className="flex">
+            <TableCell className="w-full h-auto p-4 rounded-b text-center">
+              <div className="flex flex-col items-center gap-2">
+                <span className="text-sm text-secondary-foreground">No sessions in this time range</span>
+                <SearchWiderRangeButton
+                  pastHours={pastHours}
+                  startDate={startDate}
+                  endDate={endDate}
+                  onSelect={searchWiderRange}
+                />
+              </div>
+            </TableCell>
+          </TableRow>
+        ) : undefined
+      }
     >
       {children}
     </InfiniteDataTable>

--- a/frontend/components/traces/spans-table/table-contents.tsx
+++ b/frontend/components/traces/spans-table/table-contents.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { type Row } from "@tanstack/react-table";
-import { useParams, usePathname, useSearchParams } from "next/navigation";
+import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { memo, type PropsWithChildren, type RefObject, useCallback, useEffect } from "react";
 
 import { columns } from "@/components/traces/spans-table/columns";
 import { FETCH_SIZE } from "@/components/traces/spans-table/constants";
 import { useTracesStoreContext } from "@/components/traces/traces-store";
+import SearchWiderRangeButton from "@/components/ui/date-range-filter/search-wider-range-button";
+import { type DateRange } from "@/components/ui/date-range-filter/utils";
 import { InfiniteDataTable } from "@/components/ui/infinite-datatable";
 import { useInfiniteScroll } from "@/components/ui/infinite-datatable/hooks";
+import { TableCell, TableRow } from "@/components/ui/table";
 import { useToast } from "@/lib/hooks/use-toast";
 import { type SpanRow } from "@/lib/traces/types";
 
@@ -34,6 +37,7 @@ export const SpansTableContents = memo(function SpansTableContents({
 }: PropsWithChildren<SpansTableContentsProps>) {
   const searchParams = useSearchParams();
   const pathName = usePathname();
+  const router = useRouter();
   const { projectId } = useParams();
   const { toast } = useToast();
   const setTraceId = useTracesStoreContext((s) => s.setTraceId);
@@ -111,6 +115,19 @@ export const SpansTableContents = memo(function SpansTableContents({
     [setSpanId, setTraceId]
   );
 
+  const searchWiderRange = useCallback(
+    (range: DateRange) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("startDate");
+      params.delete("endDate");
+      params.delete("groupByInterval");
+      params.set("pastHours", range.value);
+      params.set("pageNumber", "0");
+      router.push(`${pathName}?${params.toString()}`);
+    },
+    [pathName, router, searchParams]
+  );
+
   const getRowHref = useCallback(
     (row: Row<SpanRow>) => {
       const params = new URLSearchParams(searchParams.toString());
@@ -134,6 +151,23 @@ export const SpansTableContents = memo(function SpansTableContents({
       isFetching={isFetching}
       isLoading={isLoading || isViewLoading}
       fetchNextPage={fetchNextPage}
+      emptyRow={
+        filter.length === 0 && !textSearchFilter ? (
+          <TableRow className="flex">
+            <TableCell className="w-full h-auto p-4 rounded-b text-center">
+              <div className="flex flex-col items-center gap-2">
+                <span className="text-sm text-secondary-foreground">No spans in this time range</span>
+                <SearchWiderRangeButton
+                  pastHours={pastHours}
+                  startDate={startDate}
+                  endDate={endDate}
+                  onSelect={searchWiderRange}
+                />
+              </div>
+            </TableCell>
+          </TableRow>
+        ) : undefined
+      }
     >
       {children}
     </InfiniteDataTable>

--- a/frontend/components/traces/trace-picker/table-contents.tsx
+++ b/frontend/components/traces/trace-picker/table-contents.tsx
@@ -4,8 +4,10 @@ import { type Row } from "@tanstack/react-table";
 import { useParams } from "next/navigation";
 import { memo, type PropsWithChildren, type RefObject, useCallback, useEffect } from "react";
 
+import SearchWiderRangeButton from "@/components/ui/date-range-filter/search-wider-range-button";
 import { InfiniteDataTable } from "@/components/ui/infinite-datatable";
 import { useInfiniteScroll } from "@/components/ui/infinite-datatable/hooks";
+import { TableCell, TableRow } from "@/components/ui/table";
 import { type Filter } from "@/lib/actions/common/filters";
 import { type TraceRow } from "@/lib/traces/types";
 
@@ -15,6 +17,7 @@ export interface TracePickerContentsProps {
   filters: Filter[];
   search: string | null;
   dateRange: { pastHours?: string; startDate?: string; endDate?: string };
+  onDateRangeChange: (range: { pastHours?: string; startDate?: string; endDate?: string }) => void;
   refetchRef: RefObject<() => void>;
   onTraceSelect: (trace: TraceRow) => void;
   focusedTraceId?: string | null;
@@ -27,6 +30,7 @@ export const TracePickerContents = memo(function TracePickerContents({
   filters,
   search,
   dateRange,
+  onDateRangeChange,
   refetchRef,
   onTraceSelect,
   focusedTraceId,
@@ -111,6 +115,21 @@ export const TracePickerContents = memo(function TracePickerContents({
       isLoading={isLoading}
       fetchNextPage={fetchNextPage}
       estimatedRowHeight={36}
+      emptyRow={
+        filters.length === 0 && !search ? (
+          <TableRow className="flex">
+            <TableCell className="w-full h-auto p-4 rounded-b text-center">
+              <div className="flex flex-col items-center gap-2">
+                <span className="text-sm text-secondary-foreground">No traces in this time range</span>
+                <SearchWiderRangeButton
+                  {...dateRange}
+                  onSelect={(range) => onDateRangeChange({ pastHours: range.value })}
+                />
+              </div>
+            </TableCell>
+          </TableRow>
+        ) : undefined
+      }
     >
       {children}
     </InfiniteDataTable>

--- a/frontend/components/traces/trace-picker/trace-picker-content.tsx
+++ b/frontend/components/traces/trace-picker/trace-picker-content.tsx
@@ -47,6 +47,7 @@ const TracePickerContent = ({
         filters={searchValue.filters}
         search={searchValue.search.length > 0 ? searchValue.search : null}
         dateRange={dateRange}
+        onDateRangeChange={setDateRange}
         refetchRef={refetchRef}
         onTraceSelect={onTraceSelect}
         focusedTraceId={focusedTraceId}

--- a/frontend/components/traces/traces-table/empty-row.tsx
+++ b/frontend/components/traces/traces-table/empty-row.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import { differenceInHours } from "date-fns";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { getNextQuickRange } from "@/components/ui/date-range-filter/utils";
+import SearchWiderRangeButton from "@/components/ui/date-range-filter/search-wider-range-button";
+import { type DateRange } from "@/components/ui/date-range-filter/utils";
 import { TableCell, TableRow } from "@/components/ui/table";
-import { useFeatureFlags } from "@/contexts/feature-flags-context";
-import { useProjectContext } from "@/contexts/project-context";
-import { Feature } from "@/lib/features/features";
 
 const findHorizontalScrollParent = (element: HTMLElement | null): HTMLElement | null => {
   let node = element?.parentElement ?? null;
@@ -35,43 +32,37 @@ const useVisibleWidth = (element: HTMLElement | null) => {
   return width;
 };
 
-export function TracesEmptyRow() {
+interface TracesEmptyRowProps {
+  hasFilters: boolean;
+}
+
+export function TracesEmptyRow({ hasFilters }: TracesEmptyRowProps) {
   const router = useRouter();
   const pathName = usePathname();
   const searchParams = useSearchParams();
-  const { project } = useProjectContext();
-  const featureFlags = useFeatureFlags();
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const visibleWidth = useVisibleWidth(container);
 
-  const hasFilters = searchParams.get("filter") !== null;
   const pastHours = searchParams.get("pastHours");
   const startDate = searchParams.get("startDate");
   const endDate = searchParams.get("endDate");
-  const retentionDays = featureFlags[Feature.SUBSCRIPTION] ? project?.logRetentionDays : null;
-  const maxHours = retentionDays != null ? retentionDays * 24 : undefined;
-
-  const currentHours = pastHours
-    ? parseInt(pastHours, 10)
-    : startDate && endDate
-      ? differenceInHours(new Date(endDate), new Date(startDate))
-      : 24;
-  const nextRange = Number.isNaN(currentHours) ? undefined : getNextQuickRange(currentHours, maxHours);
-
-  const searchWiderRange = useCallback(() => {
-    if (!nextRange) return;
-    const sp = new URLSearchParams(searchParams.toString());
-    sp.delete("startDate");
-    sp.delete("endDate");
-    sp.delete("groupByInterval");
-    sp.set("pastHours", nextRange.value);
-    sp.set("pageNumber", "0");
-    router.push(`${pathName}?${sp.toString()}`);
-  }, [nextRange, pathName, router, searchParams]);
+  const searchWiderRange = useCallback(
+    (range: DateRange) => {
+      const sp = new URLSearchParams(searchParams.toString());
+      sp.delete("startDate");
+      sp.delete("endDate");
+      sp.delete("groupByInterval");
+      sp.set("pastHours", range.value);
+      sp.set("pageNumber", "0");
+      router.push(`${pathName}?${sp.toString()}`);
+    },
+    [pathName, router, searchParams]
+  );
 
   const clearFilters = useCallback(() => {
     const sp = new URLSearchParams(searchParams.toString());
     sp.delete("filter");
+    sp.delete("textSearch");
     router.push(`${pathName}?${sp.toString()}`);
   }, [pathName, router, searchParams]);
 
@@ -85,10 +76,13 @@ export function TracesEmptyRow() {
         >
           <span className="text-sm text-secondary-foreground">No traces in this time range</span>
           <div className="flex items-center gap-2">
-            {nextRange && (
-              <Button variant="outline" className="text-secondary-foreground" onClick={searchWiderRange}>
-                Search last {nextRange.name.replace(/^1 /, "")}
-              </Button>
+            {!hasFilters && (
+              <SearchWiderRangeButton
+                pastHours={pastHours}
+                startDate={startDate}
+                endDate={endDate}
+                onSelect={searchWiderRange}
+              />
             )}
             {hasFilters && (
               <Button variant="outline" className="text-secondary-foreground" onClick={clearFilters}>

--- a/frontend/components/traces/traces-table/empty-row.tsx
+++ b/frontend/components/traces/traces-table/empty-row.tsx
@@ -34,9 +34,10 @@ const useVisibleWidth = (element: HTMLElement | null) => {
 
 interface TracesEmptyRowProps {
   hasFilters: boolean;
+  onClearFilters: () => void;
 }
 
-export function TracesEmptyRow({ hasFilters }: TracesEmptyRowProps) {
+export function TracesEmptyRow({ hasFilters, onClearFilters }: TracesEmptyRowProps) {
   const router = useRouter();
   const pathName = usePathname();
   const searchParams = useSearchParams();
@@ -59,13 +60,6 @@ export function TracesEmptyRow({ hasFilters }: TracesEmptyRowProps) {
     [pathName, router, searchParams]
   );
 
-  const clearFilters = useCallback(() => {
-    const sp = new URLSearchParams(searchParams.toString());
-    sp.delete("filter");
-    sp.delete("textSearch");
-    router.push(`${pathName}?${sp.toString()}`);
-  }, [pathName, router, searchParams]);
-
   return (
     <TableRow className="flex">
       <TableCell className="w-full h-auto p-0 rounded-b">
@@ -85,7 +79,7 @@ export function TracesEmptyRow({ hasFilters }: TracesEmptyRowProps) {
               />
             )}
             {hasFilters && (
-              <Button variant="outline" className="text-secondary-foreground" onClick={clearFilters}>
+              <Button variant="outline" className="text-secondary-foreground" onClick={onClearFilters}>
                 Clear filters
               </Button>
             )}

--- a/frontend/components/traces/traces-table/index.tsx
+++ b/frontend/components/traces/traces-table/index.tsx
@@ -143,6 +143,10 @@ function TracesTableContent() {
     if (statsUrl) fetchStats(statsUrl);
   }, [statsUrl, fetchStats]);
 
+  const handleClearFilters = useCallback(() => {
+    setSearchAndFilters({ filters: [], search: "" });
+  }, [setSearchAndFilters]);
+
   const handleSort = useCallback(
     (columnId: string, direction: "asc" | "desc") => {
       setSort(columnId || null, columnId ? direction : null);
@@ -180,6 +184,7 @@ function TracesTableContent() {
         sortBy={sortBy}
         sortDirection={sortDirection}
         onSort={handleSort}
+        onClearFilters={handleClearFilters}
         pastHours={pastHours}
         startDate={startDate}
         endDate={endDate}

--- a/frontend/components/traces/traces-table/table-contents.tsx
+++ b/frontend/components/traces/traces-table/table-contents.tsx
@@ -319,7 +319,7 @@ export const TracesTableContents = memo(function TracesTableContents({
       isLoading={isLoading || isViewLoading}
       fetchNextPage={fetchNextPage}
       getRowHref={getRowHref}
-      emptyRow={<TracesEmptyRow />}
+      emptyRow={<TracesEmptyRow hasFilters={filter.length > 0 || !!textSearchFilter} />}
       pinnedColumns={pinnedColumns}
       sortBy={sortBy}
       sortDirection={sortDirection}

--- a/frontend/components/traces/traces-table/table-contents.tsx
+++ b/frontend/components/traces/traces-table/table-contents.tsx
@@ -30,6 +30,7 @@ export interface TracesTableContentsProps {
   sortBy?: string;
   sortDirection?: "asc" | "desc";
   onSort: (columnId: string, direction: "asc" | "desc") => void;
+  onClearFilters: () => void;
   pastHours: string | null;
   startDate: string | null;
   endDate: string | null;
@@ -49,6 +50,7 @@ export const TracesTableContents = memo(function TracesTableContents({
   sortBy,
   sortDirection,
   onSort,
+  onClearFilters,
   pastHours,
   startDate,
   endDate,
@@ -319,7 +321,7 @@ export const TracesTableContents = memo(function TracesTableContents({
       isLoading={isLoading || isViewLoading}
       fetchNextPage={fetchNextPage}
       getRowHref={getRowHref}
-      emptyRow={<TracesEmptyRow hasFilters={filter.length > 0 || !!textSearchFilter} />}
+      emptyRow={<TracesEmptyRow hasFilters={filter.length > 0 || !!textSearchFilter} onClearFilters={onClearFilters} />}
       pinnedColumns={pinnedColumns}
       sortBy={sortBy}
       sortDirection={sortDirection}

--- a/frontend/components/ui/date-range-filter/search-wider-range-button.tsx
+++ b/frontend/components/ui/date-range-filter/search-wider-range-button.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { differenceInHours } from "date-fns";
+
+import { Button } from "@/components/ui/button";
+import { useFeatureFlags } from "@/contexts/feature-flags-context";
+import { useProjectContext } from "@/contexts/project-context";
+import { Feature } from "@/lib/features/features";
+
+import { type DateRange, getNextQuickRange } from "./utils";
+
+interface SearchWiderRangeButtonProps {
+  pastHours?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  onSelect: (range: DateRange) => void;
+}
+
+export default function SearchWiderRangeButton({
+  pastHours,
+  startDate,
+  endDate,
+  onSelect,
+}: SearchWiderRangeButtonProps) {
+  const { project } = useProjectContext();
+  const featureFlags = useFeatureFlags();
+  const retentionDays = featureFlags[Feature.SUBSCRIPTION] ? project?.logRetentionDays : null;
+  const maxHours = retentionDays != null ? retentionDays * 24 : undefined;
+
+  const currentHours = pastHours
+    ? parseInt(pastHours, 10)
+    : startDate && endDate
+      ? differenceInHours(new Date(endDate), new Date(startDate))
+      : 24;
+  const nextRange = Number.isNaN(currentHours) ? undefined : getNextQuickRange(currentHours, maxHours);
+
+  if (!nextRange) return null;
+
+  return (
+    <Button variant="outline" className="text-secondary-foreground" onClick={() => onSelect(nextRange)}>
+      Search last {nextRange.name.replace(/^1 /, "")}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared retention-aware “Search last …” button to time-range empty states
- keep URL and local-state range updates owned by each surface
- hide range expansion when filters/search/cluster selection caused the empty state

## Screenshots

| Place | Before | After |
|---|---|---|
| Traces table | ![Traces before](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/before/traces.png) | ![Traces after](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/after/traces.png) |
| Spans table | ![Spans before](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/before/spans.png) | ![Spans after](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/after/spans.png) |
| Sessions table | ![Sessions before](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/before/sessions.png) | ![Sessions after](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/after/sessions.png) |
| Signal events table | ![Signal events before](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/before/signal-events-and-clusters.png) | ![Signal events after](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/after/signal-events-and-clusters.png) |
| Signal clusters graph | ![Clusters before](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/before/signal-events-and-clusters.png) | ![Clusters after](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/after/signal-events-and-clusters.png) |
| Signal runs table | ![Signal runs before](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/before/signal-runs.png) | ![Signal runs after](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/after/signal-runs.png) |
| Signal backfill trace table | ![Backfill before](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/before/signal-backfill.png) | ![Backfill after](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/after/signal-backfill.png) |
| Trace picker | ![Trace picker before](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/before/trace-picker.png) | ![Trace picker after](https://raw.githubusercontent.com/lmnr-ai/lmnr/pr-assets/time-range-hints/time-range-hints/after/trace-picker.png) |

## Verification
- browser-tested every changed surface with an empty local project
- verified button navigation changes `pastHours=24` to `pastHours=72` and preserves the page route
- `pnpm lint` (passes with existing warnings)
- `pnpm check:circular`
- `pnpm type-check`
- pre-commit checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only empty-state UX and URL/query updates; no API, auth, or data-handling changes.
> 
> **Overview**
> Introduces a shared **`SearchWiderRangeButton`** that suggests the next wider quick time range (respecting log retention) and wires it into **empty “no data in this range” states** across traces, spans, sessions, signal events/runs/clusters chart, create-signal-job trace picker, and trace picker.
> 
> URL-driven views update query params (`pastHours`, drop custom `startDate`/`endDate`/`groupByInterval`, reset `pageNumber`); modal/local flows call **`onDateRangeChange`** instead. The wider-range action is **hidden when emptiness is likely from filters, search, or cluster selection** (traces still show **Clear filters** when applicable).
> 
> The traces table empty row **drops duplicated range logic** in favor of the shared button and takes **`hasFilters` / `onClearFilters`** from the parent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f44959ec7d0f84526f331a31f8693fe2de82dc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

