### PR TITLE
Fix trace view styles

### DIFF
--- a/frontend/components/client-timestamp-formatter.tsx
+++ b/frontend/components/client-timestamp-formatter.tsx
@@ -4,7 +4,7 @@ import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { differenceInDays, differenceInHours, differenceInMinutes, differenceInSeconds, format } from "date-fns";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { cn, formatTimestamp } from "@/lib/utils.ts";
+import { cn, formatTimestamp, formatTimestampWithSeconds } from "@/lib/utils.ts";
 
 export function formatShortRelativeTime(date: Date): string {
   const now = new Date();
@@ -34,10 +34,12 @@ export default function ClientTimestampFormatter({
   timestamp,
   className,
   absolute = false,
+  seconds = false,
 }: {
   timestamp: string;
   className?: string;
   absolute?: boolean;
+  seconds?: boolean;
 }) {
   const date = new Date(timestamp);
 
@@ -47,7 +49,9 @@ export default function ClientTimestampFormatter({
 
   const days = differenceInDays(new Date(), date);
   const displayText = absolute
-    ? formatTimestamp(timestamp)
+    ? seconds
+      ? formatTimestampWithSeconds(timestamp)
+      : formatTimestamp(timestamp)
     : days < 7
       ? formatShortRelativeTime(date)
       : formatTimestamp(timestamp);

--- a/frontend/components/traces/span-actions-dropdown.tsx
+++ b/frontend/components/traces/span-actions-dropdown.tsx
@@ -45,9 +45,9 @@ export default function SpanActionsDropdown({ projectId, span }: SpanActionsDrop
           <Button
             variant="ghost"
             aria-label="Span actions"
-            className="min-w-0 justify-start gap-1 px-1 text-base font-medium hover:bg-surface-up"
+            className="min-w-0 max-w-full justify-start gap-1 overflow-hidden px-1 text-base font-medium hover:bg-surface-up"
           >
-            <span className="truncate">{span.name}</span>
+            <span className="min-w-0 truncate">{span.name}</span>
             <ChevronDown className="size-3.5 shrink-0" />
           </Button>
         </DropdownMenuTrigger>

--- a/frontend/components/traces/span-controls.tsx
+++ b/frontend/components/traces/span-controls.tsx
@@ -36,9 +36,9 @@ export function SpanControls({ children, span, onClose, isAlwaysSelectSpan }: Pr
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">
       <div className="flex flex-col px-2 pt-2 gap-2">
-        <div className="flex flex-none items-center gap-2">
+        <div className="flex flex-none items-center gap-2 overflow-hidden">
           <SpanTypeIcon spanType={span.spanType} />
-          <div className="min-w-0">
+          <div className="min-w-0 overflow-hidden">
             <SpanActionsDropdown projectId={projectId as string} span={span} />
           </div>
           <div className="ml-auto flex shrink-0 items-center gap-1">
@@ -62,6 +62,7 @@ export function SpanControls({ children, span, onClose, isAlwaysSelectSpan }: Pr
           <div className="flex h-6 w-fit items-center rounded-md bg-surface-up-2 px-2">
             <ClientTimestampFormatter
               absolute
+              seconds
               timestamp={span.startTime}
               className="text-xs text-secondary-foreground"
             />

--- a/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
+++ b/frontend/components/traces/trace-view/condensed-timeline/condensed-timeline-element.tsx
@@ -46,13 +46,12 @@ const CondensedTimelineElement = ({
 
   const backgroundColor = useMemo(() => {
     if (isCostHeatmapVisible) return undefined;
-    const color = span.status === "error" ? "rgba(204, 51, 51, 1)" : SPAN_TYPE_TO_COLOR[span.spanType];
-    return isMuted ? `color-mix(in oklch, ${color} 60%, var(--color-surface-200))` : color;
-  }, [span.status, span.spanType, isCostHeatmapVisible, isMuted]);
+    return span.status === "error" ? "rgba(204, 51, 51, 1)" : SPAN_TYPE_TO_COLOR[span.spanType];
+  }, [span.status, span.spanType, isCostHeatmapVisible]);
 
   return (
     <div
-      className={cn("@container absolute cursor-pointer", opacity)}
+      className={cn("@container absolute cursor-pointer rounded-xs", opacity, isMuted && "bg-surface-200")}
       style={{
         left: `${left}%`,
         width: `max(${width}%, 4px)`,
@@ -65,6 +64,7 @@ const CondensedTimelineElement = ({
         className={cn("relative size-full rounded-xs hover:brightness-110 @min-[5px]:w-[calc(100%-1px)]", {
           "ring-1 ring-white/70 z-20": isSelected,
           "bg-muted": isCostHeatmapVisible,
+          "opacity-60": isMuted,
         })}
         style={{ backgroundColor }}
       >

--- a/frontend/components/traces/trace-view/header/header-link-button.tsx
+++ b/frontend/components/traces/trace-view/header/header-link-button.tsx
@@ -18,7 +18,12 @@ interface HeaderLinkButtonProps {
 export const HeaderLinkButton = ({ icon, label, tooltip, onClick, className }: HeaderLinkButtonProps) => (
   <Tooltip delayDuration={400}>
     <TooltipTrigger asChild>
-      <Button variant="ghost" size="sm" onClick={onClick} className={cn("h-7 hover:bg-surface-up", className)}>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onClick}
+        className={cn("h-7 bg-surface-up-2 hover:bg-surface-up-4 active:bg-surface-up-5", className)}
+      >
         {icon}
         <span className="truncate ml-1">{label}</span>
         <ArrowUpRight size={12} className="ml-1 flex-shrink-0" />

--- a/frontend/components/traces/trace-view/header/timeline-toggle.tsx
+++ b/frontend/components/traces/trace-view/header/timeline-toggle.tsx
@@ -23,7 +23,7 @@ export default function CondensedTimelineControls({ enabled, setEnabled, classNa
         variant="ghost"
         size="icon"
         className={cn(
-          "transition-all duration-200 hover:bg-surface-up-3",
+          "bg-surface-up-2 transition-all duration-200 hover:bg-surface-up-4 active:bg-surface-up-5",
           enabled ? "size-[26px] min-w-[26px] rounded-none rounded-bl" : "h-full w-auto px-2 py-0 text-xs"
         )}
       >

--- a/frontend/components/traces/trace-view/template-view-toggle.tsx
+++ b/frontend/components/traces/trace-view/template-view-toggle.tsx
@@ -96,12 +96,15 @@ export default function TemplateViewToggle({
   );
 
   return (
-    <div className="flex items-center min-w-0">
+    <div className="flex items-center min-w-0 gap-px bg-surface-00">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
             variant="ghost"
-            className={cn("flex h-[26px] items-center hover:bg-surface-up-3", isTreeView && "rounded-r-none")}
+            className={cn(
+              "flex h-[26px] items-center bg-surface-up-2 hover:bg-surface-up-4 active:bg-surface-up-5 data-[state=open]:bg-surface-up-5",
+              isTreeView && "rounded-r-none"
+            )}
           >
             <CurrentIcon size={14} className="mr-1 flex-shrink-0" />
             <span className={cn("truncate max-w-[160px]", !isCustom && "capitalize")}>{current.label}</span>
@@ -189,7 +192,7 @@ export default function TemplateViewToggle({
           variant="ghost"
           onClick={onToggleContent}
           className={cn(
-            "flex h-[26px] items-center overflow-hidden rounded-l-none text-muted-foreground hover:bg-surface-up-3",
+            "flex h-[26px] items-center overflow-hidden rounded-l-none bg-surface-up-2 text-muted-foreground hover:bg-surface-up-4 active:bg-surface-up-5",
             showContent && "text-foreground"
           )}
         >

--- a/frontend/components/traces/trace-view/trace-panel.tsx
+++ b/frontend/components/traces/trace-view/trace-panel.tsx
@@ -155,7 +155,7 @@ export default function TracePanel({ traceId, handleClose, handleSpanSelect, fet
                       <Button
                         variant="ghost"
                         className={cn(
-                          "flex h-6 items-center overflow-hidden px-1.5 hover:bg-surface-up-3",
+                          "flex h-6 items-center overflow-hidden bg-surface-up-2 px-1.5 hover:bg-surface-up-4 active:bg-surface-up-5",
                           browserSession && "text-primary hover:text-primary"
                         )}
                         disabled={!trace}

--- a/frontend/components/traces/trace-view/view-toggle.tsx
+++ b/frontend/components/traces/trace-view/view-toggle.tsx
@@ -46,12 +46,15 @@ export default function ViewToggle({
   const isTreeView = tab === "tree";
 
   return (
-    <div className="flex items-center min-w-0">
+    <div className="flex items-center min-w-0 gap-px bg-surface-00">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            className={cn("flex h-[26px] items-center hover:bg-surface-up-3", isTreeView && "rounded-r-none")}
+            className={cn(
+              "flex h-[26px] items-center bg-surface-up-2 hover:bg-surface-up-4 active:bg-surface-up-5 data-[state=open]:bg-surface-up-5",
+              isTreeView && "rounded-r-none"
+            )}
           >
             <CurrentIcon size={14} className="mr-1" />
             <span className="capitalize">{currentView.label}</span>
@@ -81,7 +84,7 @@ export default function ViewToggle({
           variant="ghost"
           onClick={onToggleContent}
           className={cn(
-            "flex h-[26px] items-center overflow-hidden rounded-l-none px-1.5 text-muted-foreground hover:bg-surface-up-3",
+            "flex h-[26px] items-center overflow-hidden rounded-l-none bg-surface-up-2 px-1.5 text-muted-foreground hover:bg-surface-up-4 active:bg-surface-up-5",
             showContent && "text-foreground"
           )}
         >

--- a/frontend/components/ui/template-renderer/template-picker.tsx
+++ b/frontend/components/ui/template-renderer/template-picker.tsx
@@ -322,7 +322,10 @@ export const TemplatePickerView = ({ mode, onModeChange, modes, triggerClassName
         <Button
           size="sm"
           variant="ghost"
-          className={cn("h-5 gap-1 px-1.5 text-xs font-medium text-secondary-foreground", triggerClassName)}
+          className={cn(
+            "h-5 gap-1 bg-surface-up-2 px-1.5 text-xs font-medium text-secondary-foreground hover:bg-surface-up-4 active:bg-surface-up-5 data-[state=open]:bg-surface-up-5",
+            triggerClassName
+          )}
         >
           <span className={cn("truncate max-w-[160px]")}>
             {triggerLabel} {inCustomMode && <span className="font-semibold">(custom)</span>}


### PR DESCRIPTION
## Summary
- polish trace-view control surfaces and interaction states
- prevent span names from stretching or overflowing
- make muted timeline spans render over an opaque neutral background
- show seconds in trace timestamps

## Validation
- oxfmt passed
- oxlint passed
- circular dependency check passed
- type-check blocked by unrelated untracked prototype imports (`dialkit`, `heerich`)
- git diff --check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 74338b9921b9a50a29a66ebe8aa1414ac65bb681. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

