### PR TITLE
Enforce project membership on trace/span/session API routes (fixes #2343)

### DIFF
--- a/frontend/app/api/projects/[projectId]/sessions/route.ts
+++ b/frontend/app/api/projects/[projectId]/sessions/route.ts
@@ -4,10 +4,28 @@ import { prettifyError, ZodError } from "zod/v4";
 import { parseUrlParams } from "@/lib/actions/common/utils";
 import { deleteSessions, getSessions, GetSessionsSchema } from "@/lib/actions/sessions";
 import { checkDataRetentionAccess } from "@/lib/actions/usage/limits";
+import { getServerSession } from "@/lib/auth-session";
+import { isUserMemberOfProject } from "@/lib/authorization";
+
+async function assertProjectMember(projectId: string): Promise<Response | null> {
+  // No app-level middleware covers `/api/projects/...`; gate each handler.
+  const session = await getServerSession();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!(await isUserMemberOfProject(projectId, userId))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
 
 export async function GET(req: NextRequest, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
   const params = await props.params;
   const projectId = params.projectId;
+
+  const denied = await assertProjectMember(projectId);
+  if (denied) return denied;
 
   const parseResult = parseUrlParams(req.nextUrl.searchParams, GetSessionsSchema.omit({ projectId: true }));
 
@@ -40,6 +58,9 @@ export async function GET(req: NextRequest, props: { params: Promise<{ projectId
 export async function DELETE(req: NextRequest, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
   const params = await props.params;
   const projectId = params.projectId;
+
+  const denied = await assertProjectMember(projectId);
+  if (denied) return denied;
 
   const sessionIds = req.nextUrl.searchParams.getAll("id");
 

--- a/frontend/app/api/projects/[projectId]/spans/route.ts
+++ b/frontend/app/api/projects/[projectId]/spans/route.ts
@@ -4,10 +4,23 @@ import { prettifyError, ZodError } from "zod/v4";
 import { parseUrlParams } from "@/lib/actions/common/utils";
 import { deleteSpans, getSpans, GetSpansSchema } from "@/lib/actions/spans";
 import { checkDataRetentionAccess } from "@/lib/actions/usage/limits";
+import { getServerSession } from "@/lib/auth-session";
+import { isUserMemberOfProject } from "@/lib/authorization";
 
 export async function GET(req: NextRequest, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
   const params = await props.params;
   const projectId = params.projectId;
+
+  // Auth + project-membership gate: no app-level middleware covers
+  // `/api/projects/...`, so each handler must verify access to `projectId`.
+  const session = await getServerSession();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!(await isUserMemberOfProject(projectId, userId))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const parseResult = parseUrlParams(req.nextUrl.searchParams, GetSpansSchema.omit({ projectId: true }));
 
@@ -37,6 +50,16 @@ export async function GET(req: NextRequest, props: { params: Promise<{ projectId
 export async function DELETE(req: NextRequest, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
   const params = await props.params;
   const projectId = params.projectId;
+
+  const session = await getServerSession();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!(await isUserMemberOfProject(projectId, userId))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   const spanIds = req.nextUrl.searchParams.getAll("id");
 
   try {

--- a/frontend/app/api/projects/[projectId]/traces/[traceId]/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/[traceId]/route.ts
@@ -2,6 +2,21 @@ import { type NextRequest, NextResponse } from "next/server";
 import { prettifyError, ZodError } from "zod/v4";
 
 import { getTrace, updateTraceVisibility } from "@/lib/actions/trace";
+import { getServerSession } from "@/lib/auth-session";
+import { isUserMemberOfProject } from "@/lib/authorization";
+
+async function assertProjectMember(projectId: string): Promise<Response | null> {
+  // No app-level middleware covers `/api/projects/...`; gate each handler.
+  const session = await getServerSession();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!(await isUserMemberOfProject(projectId, userId))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
 
 export async function GET(
   _req: NextRequest,
@@ -10,6 +25,9 @@ export async function GET(
   const params = await props.params;
   const projectId = params.projectId;
   const traceId = params.traceId;
+
+  const denied = await assertProjectMember(projectId);
+  if (denied) return denied;
 
   try {
     const trace = await getTrace({ traceId, projectId });
@@ -38,6 +56,9 @@ export async function PUT(
 
   const projectId = params.projectId;
   const traceId = params.traceId;
+
+  const denied = await assertProjectMember(projectId);
+  if (denied) return denied;
 
   const body = (await req.json()) as { visibility: "private" | "public" };
 

--- a/frontend/app/api/projects/[projectId]/traces/route.ts
+++ b/frontend/app/api/projects/[projectId]/traces/route.ts
@@ -4,10 +4,28 @@ import { prettifyError, ZodError } from "zod/v4";
 import { parseUrlParams } from "@/lib/actions/common/utils";
 import { deleteTraces, DeleteTracesSchema, getTraces, GetTracesSchema } from "@/lib/actions/traces";
 import { checkDataRetentionAccess } from "@/lib/actions/usage/limits";
+import { getServerSession } from "@/lib/auth-session";
+import { isUserMemberOfProject } from "@/lib/authorization";
+
+async function assertProjectMember(projectId: string): Promise<Response | null> {
+  // No app-level middleware covers `/api/projects/...`; gate each handler.
+  const session = await getServerSession();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!(await isUserMemberOfProject(projectId, userId))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
 
 export async function GET(req: NextRequest, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
   const params = await props.params;
   const projectId = params.projectId;
+
+  const denied = await assertProjectMember(projectId);
+  if (denied) return denied;
 
   const parseResult = parseUrlParams(req.nextUrl.searchParams, GetTracesSchema.omit({ projectId: true }));
 
@@ -40,6 +58,10 @@ export async function GET(req: NextRequest, props: { params: Promise<{ projectId
 export async function DELETE(req: NextRequest, props: { params: Promise<{ projectId: string }> }): Promise<Response> {
   const params = await props.params;
   const projectId = params.projectId;
+
+  const denied = await assertProjectMember(projectId);
+  if (denied) return denied;
+
   const traceIds = req.nextUrl.searchParams.getAll("traceId");
 
   const parseResult = DeleteTracesSchema.safeParse({ projectId, traceIds });


### PR DESCRIPTION
Fixes #2343.

## Problem

`/api/projects/[projectId]/**` routes aren't covered by any middleware (no `middleware.ts` in `frontend/`), and most handlers don't verify project membership. A caller who knows a project id can read another project's spans/traces/sessions (LLM prompts, completions, tool calls), delete them, and flip a trace's visibility. `settings/route.ts` already gates this and notes "no app-level middleware covers `/api/projects/...`"; the sibling data routes omit it.

## Change

Apply the same gate used in `settings/route.ts` (`getServerSession` -> 401, `isUserMemberOfProject` -> 403) to the highest-impact data routes:

- `spans/route.ts` (GET, DELETE)
- `traces/route.ts` (GET, DELETE)
- `traces/[traceId]/route.ts` (GET, PUT)
- `sessions/route.ts` (GET, DELETE)

## Note

This covers the crown-jewel read/delete/visibility routes but not the full set. The remaining project-scoped routes (`datasets/**`, `evaluations/**`, `queues/**`, `api-keys`, `provider-api-keys`, `sql/**`, `dashboard-charts/**`, `signals/**`, `agents/**`, `views/**`, `playgrounds/**`, ...) need the same gate. I'd suggest centralizing it, e.g. a `middleware.ts` matching `/api/projects/:projectId/*` (Next 16 supports the Node.js middleware runtime) or a shared `withProjectAccess(handler)` wrapper, so newly added routes are protected by default. Happy to extend this PR to all routes or switch to a middleware approach if you prefer.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lmnr-ai/lmnr/pull/2344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization on routes that read and mutate sensitive LLM trace/session data; review should confirm membership checks match settings and that no sibling routes remain exposed.
> 
> **Overview**
> Closes unauthorized access to other projects’ telemetry via `/api/projects/[projectId]/**` by requiring a signed-in user and project membership before any handler runs—matching the gate already used on `settings/route.ts`.
> 
> **Sessions, traces list/delete, and single-trace GET/PUT** call a shared `assertProjectMember` helper that returns **401** without a session and **403** when `isUserMemberOfProject` fails. **Spans GET/DELETE** apply the same checks inline at the top of each handler (no shared helper yet).
> 
> Read, delete, and trace visibility updates on these routes are now blocked for non-members; other project-scoped API paths are unchanged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d13cd3031bf74699958490bde1978b524ad8849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->